### PR TITLE
Clean up and test Solution public surface argument validation

### DIFF
--- a/src/Compilers/Core/Portable/SourceCodeKind.cs
+++ b/src/Compilers/Core/Portable/SourceCodeKind.cs
@@ -33,28 +33,4 @@ namespace Microsoft.CodeAnalysis
         [EditorBrowsable(EditorBrowsableState.Never)]
         Interactive = 2,
     }
-
-    internal static partial class SourceCodeKindExtensions
-    {
-        internal static SourceCodeKind MapSpecifiedToEffectiveKind(this SourceCodeKind kind)
-        {
-            switch (kind)
-            {
-                case SourceCodeKind.Script:
-#pragma warning disable CS0618 // SourceCodeKind.Interactive is obsolete
-                case SourceCodeKind.Interactive:
-#pragma warning restore CS0618 // SourceCodeKind.Interactive is obsolete
-                    return SourceCodeKind.Script;
-
-                case SourceCodeKind.Regular:
-                default:
-                    return SourceCodeKind.Regular;
-            }
-        }
-
-        internal static bool IsValid(this SourceCodeKind value)
-        {
-            return value >= SourceCodeKind.Regular && value <= SourceCodeKind.Script;
-        }
-    }
 }

--- a/src/Compilers/Core/Portable/SourceCodeKindExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceCodeKindExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class SourceCodeKindExtensions
+    {
+        internal static SourceCodeKind MapSpecifiedToEffectiveKind(this SourceCodeKind kind)
+        {
+            switch (kind)
+            {
+                case SourceCodeKind.Script:
+#pragma warning disable CS0618 // SourceCodeKind.Interactive is obsolete
+                case SourceCodeKind.Interactive:
+#pragma warning restore CS0618 // SourceCodeKind.Interactive is obsolete
+                    return SourceCodeKind.Script;
+
+                case SourceCodeKind.Regular:
+                default:
+                    return SourceCodeKind.Regular;
+            }
+        }
+
+        internal static bool IsValid(this SourceCodeKind value)
+        {
+            return value >= SourceCodeKind.Regular && value <= SourceCodeKind.Script;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Remove="Storage\Sqlite\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\SourceCodeKindExtensions.cs" Link="Utilities\Compiler\SourceCodeKindExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AnalyzerRunner" />

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Remove="Storage\Sqlite\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
-    <Compile Include="..\..\..\Compilers\Core\Portable\SourceCodeKindExtensions.cs" Link="Utilities\Compiler\SourceCodeKindExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AnalyzerRunner" />

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (newId == Id &&
                     newName == Name &&
-                    newFolders == Folders &&
+                    newFolders.SequenceEqual(Folders) &&
                     newSourceCodeKind == SourceCodeKind &&
                     newFilePath == FilePath &&
                     newIsGenerated == IsGenerated)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -376,14 +377,23 @@ namespace Microsoft.CodeAnalysis
             return this.SetParseOptions(this.ParseOptions.WithKind(kind));
         }
 
+        // TODO: https://github.com/dotnet/roslyn/issues/37125
+        // if FilePath is null, then this will change the name of the underlying tree, but we aren't producing a new tree in that case.
         public DocumentState UpdateName(string name)
+            => UpdateAttributes(Attributes.With(name: name));
+
+        public DocumentState UpdateFolders(IReadOnlyList<string> folders)
+            => UpdateAttributes(Attributes.With(folders: folders));
+
+        private DocumentState UpdateAttributes(DocumentInfo.DocumentAttributes attributes)
         {
-            // TODO: if FilePath is null, then this will change the name of the underlying tree, but we aren't producing a new tree in that case.
+            Debug.Assert(attributes != Attributes);
+
             return new DocumentState(
                 _languageServices,
                 solutionServices,
                 Services,
-                Attributes.With(name: name),
+                attributes,
                 _options,
                 _analyzerConfigSetSource,
                 sourceText,
@@ -391,23 +401,10 @@ namespace Microsoft.CodeAnalysis
                 _treeSource);
         }
 
-        public DocumentState UpdateFolders(ImmutableArray<string> folders)
+        public DocumentState UpdateFilePath(string? filePath)
         {
-            return new DocumentState(
-                _languageServices,
-                solutionServices,
-                Services,
-                Attributes.With(folders: folders),
-                _options,
-                _analyzerConfigSetSource,
-                sourceText,
-                TextAndVersionSource,
-                _treeSource);
-        }
-
-        public DocumentState UpdateFilePath(string filePath)
-        {
-            var newAttributes = this.Attributes.With(filePath: filePath);
+            var newAttributes = Attributes.With(filePath: filePath);
+            Debug.Assert(newAttributes != Attributes);
 
             // TODO: it's overkill to fully reparse the tree if we had the tree already; all we have to do is update the
             // file path and diagnostic options for that tree.
@@ -503,14 +500,9 @@ namespace Microsoft.CodeAnalysis
                 treeSource: newTreeSource);
         }
 
-        public new DocumentState UpdateText(TextLoader loader, PreservationMode mode)
-        {
-            return UpdateText(loader, text: null, mode: mode);
-        }
-
         internal DocumentState UpdateText(TextLoader loader, SourceText? text, PreservationMode mode)
         {
-            var documentState = (DocumentState)base.UpdateText(loader, mode);
+            var documentState = (DocumentState)UpdateText(loader, mode);
 
             // If we are given a SourceText directly, fork it since we didn't pass that into the base.
             // TODO: understand why this is being called this way at all. It seems we only have a text in a specific case
@@ -535,11 +527,6 @@ namespace Microsoft.CodeAnalysis
 
         internal DocumentState UpdateTree(SyntaxNode newRoot, PreservationMode mode)
         {
-            if (newRoot == null)
-            {
-                throw new ArgumentNullException(nameof(newRoot));
-            }
-
             if (!SupportsSyntaxTree)
             {
                 throw new InvalidOperationException();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/PreservationMode.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/PreservationMode.cs
@@ -20,4 +20,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         PreserveIdentity = 1
     }
+
+    internal static class PreservationModeExtensions
+    {
+        public static bool IsValid(this PreservationMode mode)
+            => mode >= PreservationMode.PreserveValue && mode <= PreservationMode.PreserveIdentity;
+    }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1506,8 +1506,13 @@ namespace Microsoft.CodeAnalysis
             return new Solution(newState);
         }
 
-        private void CheckContainsDocument(DocumentId? documentId)
+        private void CheckContainsDocument([NotNull]DocumentId? documentId)
         {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
             if (!ContainsDocument(documentId))
             {
                 throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
@@ -1527,8 +1532,13 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private void CheckContainsAdditionalDocument(DocumentId? documentId)
+        private void CheckContainsAdditionalDocument([NotNull]DocumentId? documentId)
         {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
             if (!ContainsAdditionalDocument(documentId))
             {
                 throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
@@ -1548,8 +1558,13 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private void CheckContainsAnalyzerConfigDocument(DocumentId? documentId)
+        private void CheckContainsAnalyzerConfigDocument([NotNull]DocumentId? documentId)
         {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
             if (!ContainsAnalyzerConfigDocument(documentId))
             {
                 throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1031,7 +1031,6 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            // Note: state is currently not reused.
             var newState = _state.WithDocumentFilePath(documentId, filePath);
             if (newState == _state)
             {
@@ -1285,6 +1284,7 @@ namespace Microsoft.CodeAnalysis
             var newState = _state.UpdateDocumentTextLoader(documentId, loader, text, mode);
 
             // Note: state is currently not reused.
+            // If UpdateDocumentTextLoader is changed to reuse the state replace this assert with Solution instance reusal.
             Debug.Assert(newState != _state);
 
             return new Solution(newState);
@@ -1311,6 +1311,7 @@ namespace Microsoft.CodeAnalysis
             var newState = _state.UpdateAdditionalDocumentTextLoader(documentId, loader, mode);
 
             // Note: state is currently not reused.
+            // If UpdateAdditionalDocumentTextLoader is changed to reuse the state replace this assert with Solution instance reusal.
             Debug.Assert(newState != _state);
 
             return new Solution(newState);
@@ -1337,6 +1338,7 @@ namespace Microsoft.CodeAnalysis
             var newState = _state.UpdateAnalyzerConfigDocumentTextLoader(documentId, loader, mode);
 
             // Note: state is currently not reused.
+            // If UpdateAnalyzerConfigDocumentTextLoader is changed to reuse the state replace this assert with Solution instance reusal.
             Debug.Assert(newState != _state);
 
             return new Solution(newState);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private void CheckContainsAdditionalDocument([NotNull]DocumentId? documentId)
+        private void CheckContainsAdditionalDocument([NotNull] DocumentId? documentId)
         {
             if (documentId == null)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1560,7 +1560,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private void CheckContainsAnalyzerConfigDocument([NotNull]DocumentId? documentId)
+        private void CheckContainsAnalyzerConfigDocument([NotNull] DocumentId? documentId)
         {
             if (documentId == null)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -895,7 +895,7 @@ namespace Microsoft.CodeAnalysis
         public Solution RemoveDocument(DocumentId documentId)
         {
             CheckContainsDocument(documentId);
-            return RemoveDocuments(ImmutableArray.Create(documentId));
+            return RemoveDocumentsImpl(ImmutableArray.Create(documentId));
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1508,7 +1508,7 @@ namespace Microsoft.CodeAnalysis
             return new Solution(newState);
         }
 
-        private void CheckContainsDocument([NotNull]DocumentId? documentId)
+        private void CheckContainsDocument([NotNull] DocumentId? documentId)
         {
             if (documentId == null)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -302,18 +302,25 @@ namespace Microsoft.CodeAnalysis
                 this.GetProjectState(documentId.ProjectId)!.ContainsAnalyzerConfigDocument(documentId);
         }
 
-        private DocumentState? GetDocumentState(DocumentId? documentId)
+        private DocumentState GetRequiredDocumentState(DocumentId documentId)
         {
-            if (documentId != null)
-            {
-                var projectState = this.GetProjectState(documentId.ProjectId);
-                if (projectState != null)
-                {
-                    return projectState.GetDocumentState(documentId);
-                }
-            }
+            var state = GetProjectState(documentId.ProjectId)!.GetDocumentState(documentId);
+            Contract.ThrowIfNull(state);
+            return state;
+        }
 
-            return null;
+        private TextDocumentState GetRequiredAdditionalDocumentState(DocumentId documentId)
+        {
+            var state = GetProjectState(documentId.ProjectId)!.GetAdditionalDocumentState(documentId);
+            Contract.ThrowIfNull(state);
+            return state;
+        }
+
+        private AnalyzerConfigDocumentState GetRequiredAnalyzerConfigDocumentState(DocumentId documentId)
+        {
+            var state = GetProjectState(documentId.ProjectId)!.GetAnalyzerConfigDocumentState(documentId);
+            Contract.ThrowIfNull(state);
+            return state;
         }
 
         private DocumentState? GetDocumentState(SyntaxTree? syntaxTree, ProjectId? projectId)
@@ -325,7 +332,7 @@ namespace Microsoft.CodeAnalysis
                 if (docId != null && (projectId == null || docId.ProjectId == projectId))
                 {
                     // does this solution even have the document?
-                    var document = this.GetDocumentState(docId);
+                    var document = GetProjectState(docId.ProjectId)?.GetDocumentState(docId);
                     if (document != null)
                     {
                         // does this document really have the syntax tree?
@@ -334,34 +341,6 @@ namespace Microsoft.CodeAnalysis
                             return document;
                         }
                     }
-                }
-            }
-
-            return null;
-        }
-
-        private TextDocumentState? GetAdditionalDocumentState(DocumentId? documentId)
-        {
-            if (documentId != null)
-            {
-                var projectState = this.GetProjectState(documentId.ProjectId);
-                if (projectState != null)
-                {
-                    return projectState.GetAdditionalDocumentState(documentId);
-                }
-            }
-
-            return null;
-        }
-
-        private AnalyzerConfigDocumentState? GetAnalyzerConfigDocumentState(DocumentId? documentId)
-        {
-            if (documentId != null)
-            {
-                var projectState = this.GetProjectState(documentId.ProjectId);
-                if (projectState != null)
-                {
-                    return projectState.GetAnalyzerConfigDocumentState(documentId);
                 }
             }
 
@@ -1260,7 +1239,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
         {
             return RemoveDocumentsFromMultipleProjects(documentIds,
-                (projectState, documentId) => { CheckContainsAnalyzerConfigDocument(documentId); return projectState.GetAnalyzerConfigDocumentState(documentId)!; },
+                (projectState, documentId) => projectState.GetAnalyzerConfigDocumentState(documentId)!,
                 (oldProject, documentIds, _) =>
                 {
                     var newProject = oldProject.RemoveAnalyzerConfigDocuments(documentIds);
@@ -1274,7 +1253,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState RemoveDocuments(ImmutableArray<DocumentId> documentIds)
         {
             return RemoveDocumentsFromMultipleProjects(documentIds,
-                (projectState, documentId) => { CheckContainsDocument(documentId); return projectState.GetDocumentState(documentId)!; },
+                (projectState, documentId) => projectState.GetDocumentState(documentId)!,
                 (projectState, documentIds, documentStates) => (projectState.RemoveDocuments(documentIds), new CompilationTranslationAction.RemoveDocumentsAction(documentStates)));
         }
 
@@ -1284,11 +1263,6 @@ namespace Microsoft.CodeAnalysis
             Func<ProjectState, ImmutableArray<DocumentId>, ImmutableArray<T>, (ProjectState newState, CompilationTranslationAction? translationAction)> removeDocumentsFromProjectState)
             where T : TextDocumentState
         {
-            if (documentIds.IsDefault)
-            {
-                throw new ArgumentNullException(nameof(documentIds));
-            }
-
             if (documentIds.IsEmpty)
             {
                 return this;
@@ -1334,7 +1308,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState RemoveAdditionalDocuments(ImmutableArray<DocumentId> documentIds)
         {
             return RemoveDocumentsFromMultipleProjects(documentIds,
-                (projectState, documentId) => { CheckContainsAdditionalDocument(documentId); return projectState.GetAdditionalDocumentState(documentId)!; },
+                (projectState, documentId) => projectState.GetAdditionalDocumentState(documentId)!,
                 (projectState, documentIds, documentStates) => (projectState.RemoveAdditionalDocuments(documentIds), translationAction: null));
         }
 
@@ -1343,64 +1317,42 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithDocumentName(DocumentId documentId, string name)
         {
-            if (documentId == null)
+            var oldDocument = GetRequiredDocumentState(documentId);
+            if (oldDocument.Attributes.Name == name)
             {
-                throw new ArgumentNullException(nameof(documentId));
+                return this;
             }
 
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            var oldDocument = this.GetDocumentState(documentId)!;
-            var newDocument = oldDocument.UpdateName(name);
-
-            return this.WithDocumentState(newDocument);
+            return UpdateDocumentState(oldDocument.UpdateName(name));
         }
 
         /// <summary>
         /// Creates a new solution instance with the document specified updated to be contained in
         /// the sequence of logical folders.
         /// </summary>
-        public SolutionState WithDocumentFolders(DocumentId documentId, IEnumerable<string?> folders)
+        public SolutionState WithDocumentFolders(DocumentId documentId, IReadOnlyList<string> folders)
         {
-            if (documentId == null)
+            var oldDocument = GetRequiredDocumentState(documentId);
+            if (oldDocument.Folders.SequenceEqual(folders))
             {
-                throw new ArgumentNullException(nameof(documentId));
+                return this;
             }
 
-            if (folders == null)
-            {
-                throw new ArgumentNullException(nameof(folders));
-            }
-
-            var oldDocument = GetDocumentState(documentId)!;
-            var newDocument = oldDocument.UpdateFolders(folders.WhereNotNull().ToImmutableArray());
-
-            return WithDocumentState(newDocument);
+            return UpdateDocumentState(oldDocument.UpdateFolders(folders));
         }
 
         /// <summary>
         /// Creates a new solution instance with the document specified updated to have the specified file path.
         /// </summary>
-        public SolutionState WithDocumentFilePath(DocumentId documentId, string filePath)
+        public SolutionState WithDocumentFilePath(DocumentId documentId, string? filePath)
         {
-            if (documentId == null)
+            var oldDocument = GetRequiredDocumentState(documentId);
+            if (oldDocument.FilePath == filePath)
             {
-                throw new ArgumentNullException(nameof(documentId));
+                return this;
             }
 
-            // TODO: why? we support nullable file paths
-            if (filePath == null)
-            {
-                throw new ArgumentNullException(nameof(filePath));
-            }
-
-            var oldDocument = this.GetDocumentState(documentId)!;
-            var newDocument = oldDocument.UpdateFilePath(filePath);
-
-            return this.WithDocumentState(newDocument);
+            return UpdateDocumentState(oldDocument.UpdateFilePath(filePath));
         }
 
         /// <summary>
@@ -1409,25 +1361,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
-            {
-                throw new ArgumentNullException(nameof(documentId));
-            }
-
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            CheckContainsDocument(documentId);
-
-            var oldDocument = this.GetDocumentState(documentId)!;
+            var oldDocument = GetRequiredDocumentState(documentId);
             if (oldDocument.TryGetText(out var oldText) && text == oldText)
             {
                 return this;
             }
 
-            return this.WithDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
         }
 
         /// <summary>
@@ -1436,26 +1376,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithAdditionalDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
-            {
-                throw new ArgumentNullException(nameof(documentId));
-            }
-
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            CheckContainsAdditionalDocument(documentId);
-
-            var oldDocument = this.GetAdditionalDocumentState(documentId)!;
+            var oldDocument = GetRequiredAdditionalDocumentState(documentId);
             if (oldDocument.TryGetText(out var oldText) && text == oldText)
             {
                 return this;
             }
 
-            var newSolution = this.WithAdditionalDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
-            return newSolution;
+            return UpdateAdditionalDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
         }
 
         /// <summary>
@@ -1464,25 +1391,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithAnalyzerConfigDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
-            {
-                throw new ArgumentNullException(nameof(documentId));
-            }
-
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            CheckContainsAnalyzerConfigDocument(documentId);
-
-            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId)!;
+            var oldDocument = GetRequiredAnalyzerConfigDocumentState(documentId);
             if (oldDocument.TryGetText(out var oldText) && text == oldText)
             {
                 return this;
             }
 
-            return this.WithAnalyzerConfigDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
+            return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
         }
 
         /// <summary>
@@ -1491,21 +1406,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
+            var oldDocument = GetRequiredDocumentState(documentId);
+            if (oldDocument.TryGetTextAndVersion(out var oldTextAndVersion) && textAndVersion == oldTextAndVersion)
             {
-                throw new ArgumentNullException(nameof(documentId));
+                return this;
             }
 
-            if (textAndVersion == null)
-            {
-                throw new ArgumentNullException(nameof(textAndVersion));
-            }
-
-            CheckContainsDocument(documentId);
-
-            var oldDocument = this.GetDocumentState(documentId)!;
-
-            return WithDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
         }
 
         /// <summary>
@@ -1514,21 +1421,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithAdditionalDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
+            var oldDocument = GetRequiredAdditionalDocumentState(documentId);
+            if (oldDocument.TryGetTextAndVersion(out var oldTextAndVersion) && textAndVersion == oldTextAndVersion)
             {
-                throw new ArgumentNullException(nameof(documentId));
+                return this;
             }
 
-            if (textAndVersion == null)
-            {
-                throw new ArgumentNullException(nameof(textAndVersion));
-            }
-
-            CheckContainsAdditionalDocument(documentId);
-
-            var oldDocument = this.GetAdditionalDocumentState(documentId)!;
-
-            return WithAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
+            return UpdateAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
         }
 
         /// <summary>
@@ -1537,21 +1436,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithAnalyzerConfigDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
+            var oldDocument = GetRequiredAnalyzerConfigDocumentState(documentId);
+            if (oldDocument.TryGetTextAndVersion(out var oldTextAndVersion) && textAndVersion == oldTextAndVersion)
             {
-                throw new ArgumentNullException(nameof(documentId));
+                return this;
             }
 
-            if (textAndVersion == null)
-            {
-                throw new ArgumentNullException(nameof(textAndVersion));
-            }
-
-            CheckContainsAnalyzerConfigDocument(documentId);
-
-            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId)!;
-
-            return WithAnalyzerConfigDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
+            return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
         }
 
         /// <summary>
@@ -1560,19 +1451,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithDocumentSyntaxRoot(DocumentId documentId, SyntaxNode root, PreservationMode mode = PreservationMode.PreserveValue)
         {
-            if (documentId == null)
-            {
-                throw new ArgumentNullException(nameof(documentId));
-            }
-
-            if (root == null)
-            {
-                throw new ArgumentNullException(nameof(root));
-            }
-
-            CheckContainsDocument(documentId);
-
-            var oldDocument = this.GetDocumentState(documentId)!;
+            var oldDocument = GetRequiredDocumentState(documentId);
             if (oldDocument.TryGetSyntaxTree(out var oldTree) &&
                 oldTree.TryGetRoot(out var oldRoot) &&
                 oldRoot == root)
@@ -1580,7 +1459,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return WithDocumentState(oldDocument.UpdateTree(root, mode), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateTree(root, mode), textChanged: true);
         }
 
         private static async Task<Compilation> UpdateDocumentInCompilationAsync(
@@ -1600,138 +1479,82 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SolutionState WithDocumentSourceCodeKind(DocumentId documentId, SourceCodeKind sourceCodeKind)
         {
-            if (!Enum.IsDefined(typeof(SourceCodeKind), sourceCodeKind))
-            {
-                throw new ArgumentOutOfRangeException(nameof(sourceCodeKind));
-            }
-
-            CheckContainsDocument(documentId);
-
-            var oldDocument = this.GetDocumentState(documentId)!;
-
+            var oldDocument = GetRequiredDocumentState(documentId);
             if (oldDocument.SourceCodeKind == sourceCodeKind)
             {
                 return this;
             }
 
-            return WithDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), textChanged: true);
         }
 
-        public SolutionState WithDocumentTextLoader(DocumentId documentId, TextLoader loader, SourceText? text, PreservationMode mode)
+        public SolutionState UpdateDocumentTextLoader(DocumentId documentId, TextLoader loader, SourceText? text, PreservationMode mode)
         {
-            CheckContainsDocument(documentId);
+            var oldDocument = GetRequiredDocumentState(documentId);
 
-            var oldDocument = this.GetDocumentState(documentId)!;
-
-            // assumes that text has changed. user could have closed a doc without saving and we are loading text from closed file with
-            // old content. also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return this.WithDocumentState(oldDocument.UpdateText(loader, text, mode), textChanged: true, recalculateDependentVersions: true);
+            // Assumes that text has changed. User could have closed a doc without saving and we are loading text from closed file with
+            // old content. Also this should make sure we don't re-use latest doc version with data associated with opened document.
+            return UpdateDocumentState(oldDocument.UpdateText(loader, text, mode), textChanged: true, recalculateDependentVersions: true);
         }
 
         /// <summary>
         /// Creates a new solution instance with the additional document specified updated to have the text
         /// supplied by the text loader.
         /// </summary>
-        public SolutionState WithAdditionalDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
+        public SolutionState UpdateAdditionalDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
         {
-            CheckContainsAdditionalDocument(documentId);
+            var oldDocument = GetRequiredAdditionalDocumentState(documentId);
 
-            var oldDocument = this.GetAdditionalDocumentState(documentId)!;
-
-            // assumes that text has changed. user could have closed a doc without saving and we are loading text from closed file with
-            // old content. also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return this.WithAdditionalDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
+            // Assumes that text has changed. User could have closed a doc without saving and we are loading text from closed file with
+            // old content. Also this should make sure we don't re-use latest doc version with data associated with opened document.
+            return UpdateAdditionalDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
         }
 
         /// <summary>
         /// Creates a new solution instance with the analyzer config document specified updated to have the text
         /// supplied by the text loader.
         /// </summary>
-        public SolutionState WithAnalyzerConfigDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
+        public SolutionState UpdateAnalyzerConfigDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
         {
-            CheckContainsAnalyzerConfigDocument(documentId);
+            var oldDocument = GetRequiredAnalyzerConfigDocumentState(documentId);
 
-            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId)!;
-
-            // assumes that text has changed. user could have closed a doc without saving and we are loading text from closed file with
-            // old content. also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return this.WithAnalyzerConfigDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
+            // Assumes that text has changed. User could have closed a doc without saving and we are loading text from closed file with
+            // old content. Also this should make sure we don't re-use latest doc version with data associated with opened document.
+            return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
         }
 
-        private SolutionState WithDocumentState(DocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
+        private SolutionState UpdateDocumentState(DocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
         {
-            CheckContainsDocument(newDocument.Id);
+            var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
+            var newProject = oldProject.UpdateDocument(newDocument, textChanged, recalculateDependentVersions);
 
-            if (newDocument == this.GetDocumentState(newDocument.Id))
-            {
-                // old and new documents are the same instance
-                return this;
-            }
+            // This method shouldn't have been called if the document has not changed.
+            Debug.Assert(oldProject != newProject);
 
-            return this.TouchDocument(newDocument.Id, p => p.UpdateDocument(newDocument, textChanged, recalculateDependentVersions));
+            var oldDocument = oldProject.GetDocumentState(newDocument.Id);
+            return ForkProject(newProject, new CompilationTranslationAction.TouchDocumentAction(oldDocument, newDocument));
         }
 
-        private SolutionState TouchDocument(DocumentId documentId, Func<ProjectState, ProjectState> touchProject)
+        private SolutionState UpdateAdditionalDocumentState(TextDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
         {
-            Debug.Assert(this.ContainsDocument(documentId));
-
-            var oldProject = this.GetProjectState(documentId.ProjectId)!;
-            var newProject = touchProject(oldProject);
-
-            if (oldProject == newProject)
-            {
-                // old and new projects are the same instance
-                return this;
-            }
-
-            var oldDocument = oldProject.GetDocumentState(documentId);
-            var newDocument = newProject.GetDocumentState(documentId);
-
-            return this.ForkProject(newProject, new CompilationTranslationAction.TouchDocumentAction(oldDocument, newDocument));
-        }
-
-        private SolutionState WithAdditionalDocumentState(TextDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
-        {
-            CheckContainsAdditionalDocument(newDocument.Id);
-
-            if (newDocument == this.GetAdditionalDocumentState(newDocument.Id))
-            {
-                // old and new documents are the same instance
-                return this;
-            }
-
-            var oldProject = this.GetProjectState(newDocument.Id.ProjectId)!;
+            var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
             var newProject = oldProject.UpdateAdditionalDocument(newDocument, textChanged, recalculateDependentVersions);
 
-            if (oldProject == newProject)
-            {
-                // old and new projects are the same instance
-                return this;
-            }
+            // This method shouldn't have been called if the document has not changed.
+            Debug.Assert(oldProject != newProject);
 
-            return this.ForkProject(newProject);
+            return ForkProject(newProject);
         }
 
-        private SolutionState WithAnalyzerConfigDocumentState(AnalyzerConfigDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
+        private SolutionState UpdateAnalyzerConfigDocumentState(AnalyzerConfigDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
         {
-            CheckContainsAnalyzerConfigDocument(newDocument.Id);
-
-            if (newDocument == this.GetAnalyzerConfigDocumentState(newDocument.Id))
-            {
-                // old and new documents are the same instance
-                return this;
-            }
-
-            var oldProject = this.GetProjectState(newDocument.Id.ProjectId)!;
+            var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
             var newProject = oldProject.UpdateAnalyzerConfigDocument(newDocument, textChanged, recalculateDependentVersions);
 
-            if (oldProject == newProject)
-            {
-                // old and new projects are the same instance
-                return this;
-            }
+            // This method shouldn't have been called if the document has not changed.
+            Debug.Assert(oldProject != newProject);
 
-            return this.ForkProject(newProject, new CompilationTranslationAction.ReplaceAllSyntaxTreesAction(newProject));
+            return ForkProject(newProject, new CompilationTranslationAction.ReplaceAllSyntaxTreesAction(newProject));
         }
 
         /// <summary>
@@ -1884,7 +1707,7 @@ namespace Microsoft.CodeAnalysis
         {
             try
             {
-                var doc = this.GetDocumentState(documentId)!;
+                var doc = this.GetRequiredDocumentState(documentId);
                 var tree = doc.GetSyntaxTree(cancellationToken);
 
                 using (this.StateLock.DisposableWait(cancellationToken))
@@ -1941,23 +1764,18 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new solution instance with all the documents specified updated to have the same specified text.
         /// </summary>
-        public SolutionState WithDocumentText(IEnumerable<DocumentId> documentIds, SourceText text, PreservationMode mode)
+        public SolutionState WithDocumentText(IEnumerable<DocumentId?> documentIds, SourceText text, PreservationMode mode)
         {
-            if (documentIds == null)
-            {
-                throw new ArgumentNullException(nameof(documentIds));
-            }
-
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
             var solution = this;
 
             foreach (var documentId in documentIds)
             {
-                var doc = solution.GetDocumentState(documentId);
+                if (documentId == null)
+                {
+                    continue;
+                }
+
+                var doc = GetProjectState(documentId.ProjectId)?.GetDocumentState(documentId);
                 if (doc != null)
                 {
                     if (!doc.TryGetText(out var existingText) || existingText != text)
@@ -2213,36 +2031,6 @@ namespace Microsoft.CodeAnalysis
                 {
                     throw new InvalidOperationException(WorkspacesResources.This_submission_already_references_another_submission_project);
                 }
-            }
-        }
-
-        private void CheckContainsDocument(DocumentId documentId)
-        {
-            Debug.Assert(this.ContainsDocument(documentId));
-
-            if (!this.ContainsDocument(documentId))
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
-        }
-
-        private void CheckContainsAdditionalDocument(DocumentId documentId)
-        {
-            Debug.Assert(this.ContainsAdditionalDocument(documentId));
-
-            if (!this.ContainsAdditionalDocument(documentId))
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
-        }
-
-        private void CheckContainsAnalyzerConfigDocument(DocumentId documentId)
-        {
-            Debug.Assert(this.ContainsAnalyzerConfigDocument(documentId));
-
-            if (!this.ContainsAnalyzerConfigDocument(documentId))
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -169,6 +169,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        public bool TryGetTextAndVersion(out TextAndVersion? textAndVersion)
+            => TextAndVersionSource.TryGetValue(out textAndVersion);
+
         public async ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
         {
             if (sourceText != null)
@@ -211,11 +214,6 @@ namespace Microsoft.CodeAnalysis
 
         public TextDocumentState UpdateText(TextAndVersion newTextAndVersion, PreservationMode mode)
         {
-            if (newTextAndVersion == null)
-            {
-                throw new ArgumentNullException(nameof(newTextAndVersion));
-            }
-
             var newTextSource = mode == PreservationMode.PreserveIdentity
                 ? CreateStrongText(newTextAndVersion)
                 : CreateRecoverableText(newTextAndVersion, this.solutionServices);
@@ -225,25 +223,14 @@ namespace Microsoft.CodeAnalysis
 
         public TextDocumentState UpdateText(SourceText newText, PreservationMode mode)
         {
-            if (newText == null)
-            {
-                throw new ArgumentNullException(nameof(newText));
-            }
+            var newVersion = GetNewerVersion();
+            var newTextAndVersion = TextAndVersion.Create(newText, newVersion, FilePath);
 
-            var newVersion = this.GetNewerVersion();
-            var newTextAndVersion = TextAndVersion.Create(newText, newVersion, this.FilePath);
-
-            var newState = this.UpdateText(newTextAndVersion, mode);
-            return newState;
+            return UpdateText(newTextAndVersion, mode);
         }
 
         public TextDocumentState UpdateText(TextLoader loader, PreservationMode mode)
         {
-            if (loader == null)
-            {
-                throw new ArgumentNullException(nameof(loader));
-            }
-
             // don't blow up on non-text documents.
             var newTextSource = mode == PreservationMode.PreserveIdentity
                 ? CreateStrongText(loader, Id, solutionServices)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis
                     //
                     // Note: we pass along the newText here so that clients can easily get the text
                     // of an opened document just by calling TryGetText without any blocking.
-                    currentSolution = oldSolution.WithDocumentTextLoader(documentId,
+                    currentSolution = oldSolution.UpdateDocumentTextLoader(documentId,
                         new ReuseVersionLoader((DocumentState)oldDocument.State, newText), newText, PreservationMode.PreserveIdentity);
                 }
 

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -34,8 +34,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
     [UseExportProvider]
     public class SolutionTests : TestBase
     {
+#nullable enable
         private static readonly MetadataReference s_mscorlib = TestReferences.NetFx.v4_0_30319.mscorlib;
-        private static readonly DocumentId s_documentId = DocumentId.CreateNewId(ProjectId.CreateNewId());
+        private static readonly DocumentId s_unrelatedDocumentId = DocumentId.CreateNewId(ProjectId.CreateNewId());
 
         private Solution CreateSolution()
         {
@@ -54,54 +55,54 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void RemoveDocument()
+        public void RemoveDocument_Errors()
         {
             var solution = CreateSolution();
-            Assert.Throws<ArgumentNullException>(() => solution.RemoveDocument(null));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveDocument(s_documentId));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveDocument(null!));
+            Assert.Throws<InvalidOperationException>(() => solution.RemoveDocument(s_unrelatedDocumentId));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void RemoveDocuments()
+        public void RemoveDocuments_Errors()
         {
             var solution = CreateSolution();
             Assert.Throws<ArgumentNullException>(() => solution.RemoveDocuments(default));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveDocuments(ImmutableArray.Create(s_documentId)));
-            Assert.Throws<ArgumentNullException>(() => solution.RemoveDocuments(ImmutableArray.Create(default(DocumentId))));
+            Assert.Throws<InvalidOperationException>(() => solution.RemoveDocuments(ImmutableArray.Create(s_unrelatedDocumentId)));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveDocuments(ImmutableArray.Create(default(DocumentId)!)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void RemoveAdditionalDocument()
+        public void RemoveAdditionalDocument_Errors()
         {
             var solution = CreateSolution();
-            Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocument(null));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocument(s_documentId));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocument(null!));
+            Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocument(s_unrelatedDocumentId));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void RemoveAdditionalDocuments()
+        public void RemoveAdditionalDocuments_Errors()
         {
             var solution = CreateSolution();
             Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocuments(default));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(s_documentId)));
-            Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(default(DocumentId))));
+            Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(s_unrelatedDocumentId)));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(default(DocumentId)!)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void RemoveAnalyzerConfigDocument()
+        public void RemoveAnalyzerConfigDocument_Errors()
         {
             var solution = CreateSolution();
-            Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocument(null));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocument(s_documentId));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocument(null!));
+            Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocument(s_unrelatedDocumentId));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void RemoveAnalyzerConfigDocuments()
+        public void RemoveAnalyzerConfigDocuments_Errors()
         {
             var solution = CreateSolution();
             Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocuments(default));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(s_documentId)));
-            Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(default(DocumentId))));
+            Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(s_unrelatedDocumentId)));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(default(DocumentId)!)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -112,15 +113,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var name = "new name";
 
             var newSolution1 = solution.WithDocumentName(documentId, name);
-            Assert.Equal(name, newSolution1.GetDocument(documentId).Name);
+            Assert.Equal(name, newSolution1.GetDocument(documentId)!.Name);
 
             var newSolution2 = newSolution1.WithDocumentName(documentId, name);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentName(documentId, name: null));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentName(documentId, name: null!));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentName(null, name));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentName(s_documentId, name));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentName(null!, name));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentName(s_unrelatedDocumentId, name));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -131,25 +132,25 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var folders = new[] { "folder1", "folder2" };
 
             var newSolution1 = solution.WithDocumentFolders(documentId, folders);
-            Assert.Equal(folders, newSolution1.GetDocument(documentId).Folders);
+            Assert.Equal(folders, newSolution1.GetDocument(documentId)!.Folders);
 
-            var newSolution3 = newSolution1.WithDocumentFolders(documentId, folders);
-            Assert.Same(newSolution3, newSolution1);
+            var newSolution2 = newSolution1.WithDocumentFolders(documentId, folders);
+            Assert.Same(newSolution2, newSolution1);
 
             // empty:
-            var newSolution4 = solution.WithDocumentFolders(documentId, new string[0]);
-            Assert.Equal(new string[0], newSolution4.GetDocument(documentId).Folders);
+            var newSolution3 = solution.WithDocumentFolders(documentId, new string[0]);
+            Assert.Equal(new string[0], newSolution3.GetDocument(documentId)!.Folders);
 
-            var newSolution5 = solution.WithDocumentFolders(documentId, ImmutableArray<string>.Empty);
-            Assert.Same(newSolution4, newSolution5);
+            var newSolution4 = solution.WithDocumentFolders(documentId, ImmutableArray<string>.Empty);
+            Assert.Same(newSolution3, newSolution4);
 
-            var newSolution6 = solution.WithDocumentFolders(documentId, null);
-            Assert.Same(newSolution4, newSolution6);
+            var newSolution5 = solution.WithDocumentFolders(documentId, null);
+            Assert.Same(newSolution3, newSolution5);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFolders(documentId, folders: new string[] { null }));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFolders(documentId, folders: new string[] { null! }));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFolders(null, folders));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFolders(s_documentId, folders));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFolders(null!, folders));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFolders(s_unrelatedDocumentId, folders));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -160,16 +161,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var path = "new path";
 
             var newSolution1 = solution.WithDocumentFilePath(documentId, path);
-            Assert.Equal(path, newSolution1.GetDocument(documentId).FilePath);
+            Assert.Equal(path, newSolution1.GetDocument(documentId)!.FilePath);
 
             var newSolution2 = newSolution1.WithDocumentFilePath(documentId, path);
             Assert.Same(newSolution1, newSolution2);
 
             // TODO: https://github.com/dotnet/roslyn/issues/37125
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFilePath(documentId, filePath: null));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFilePath(documentId, filePath: null!));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFilePath(null, path));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFilePath(s_documentId, path));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFilePath(null!, path));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFilePath(s_unrelatedDocumentId, path));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -181,12 +182,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Same(solution, solution.WithDocumentSourceCodeKind(documentId, SourceCodeKind.Regular));
 
             var newSolution1 = solution.WithDocumentSourceCodeKind(documentId, SourceCodeKind.Script);
-            Assert.Equal(SourceCodeKind.Script, newSolution1.GetDocument(documentId).SourceCodeKind);
+            Assert.Equal(SourceCodeKind.Script, newSolution1.GetDocument(documentId)!.SourceCodeKind);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentSourceCodeKind(documentId, (SourceCodeKind)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentSourceCodeKind(null, SourceCodeKind.Script));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSourceCodeKind(s_documentId, SourceCodeKind.Script));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentSourceCodeKind(null!, SourceCodeKind.Script));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSourceCodeKind(s_unrelatedDocumentId, SourceCodeKind.Script));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace), Obsolete]
@@ -196,7 +197,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var documentId = solution.Projects.Single().DocumentIds.Single();
 
             var newSolution = solution.WithDocumentSourceCodeKind(documentId, SourceCodeKind.Interactive);
-            Assert.Equal(SourceCodeKind.Script, newSolution.GetDocument(documentId).SourceCodeKind);
+            Assert.Equal(SourceCodeKind.Script, newSolution.GetDocument(documentId)!.SourceCodeKind);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -206,9 +207,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var documentId = solution.Projects.Single().DocumentIds.Single();
             var root = CS.SyntaxFactory.ParseSyntaxTree("class NewClass {}").GetRoot();
 
-            var newSolution1 = solution.WithDocumentSyntaxRoot(documentId, root);
-            Assert.True(newSolution1.GetDocument(documentId).TryGetSyntaxRoot(out var actualRoot));
-            Assert.Equal(root.ToString(), actualRoot.ToString());
+            var newSolution1 = solution.WithDocumentSyntaxRoot(documentId, root, PreservationMode.PreserveIdentity);
+            Assert.True(newSolution1.GetDocument(documentId)!.TryGetSyntaxRoot(out var actualRoot));
+            Assert.Equal(root.ToString(), actualRoot!.ToString());
 
             // the actual root has a new parent SyntaxTree:
             Assert.NotSame(root, actualRoot);
@@ -218,8 +219,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentSyntaxRoot(documentId, root, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentSyntaxRoot(null, root));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSyntaxRoot(s_documentId, root));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentSyntaxRoot(null!, root));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSyntaxRoot(s_unrelatedDocumentId, root));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -247,17 +248,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var text = SourceText.From("new text");
 
             var newSolution1 = solution.WithDocumentText(documentId, text, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetDocument(documentId).TryGetText(out var actualText));
+            Assert.True(newSolution1.GetDocument(documentId)!.TryGetText(out var actualText));
             Assert.Equal(text, actualText);
 
             var newSolution2 = newSolution1.WithDocumentText(documentId, text, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(documentId, (SourceText)null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentText(documentId, text, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText(s_documentId, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId)null!, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText(s_unrelatedDocumentId, text, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -268,19 +269,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var textAndVersion = TextAndVersion.Create(SourceText.From("new text"), VersionStamp.Default);
 
             var newSolution1 = solution.WithDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetDocument(documentId).TryGetText(out var actualText));
-            Assert.True(newSolution1.GetDocument(documentId).TryGetTextVersion(out var actualVersion));
-            Assert.Equal(textAndVersion.Text, actualText);
+            Assert.True(newSolution1.GetDocument(documentId)!.TryGetText(out var actualText));
+            Assert.True(newSolution1.GetDocument(documentId)!.TryGetTextVersion(out var actualVersion));
+            Assert.Same(textAndVersion.Text, actualText);
             Assert.Equal(textAndVersion.Version, actualVersion);
 
             var newSolution2 = newSolution1.WithDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(documentId, (SourceText)null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentText(documentId, textAndVersion, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText(s_documentId, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId)null!, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText(s_unrelatedDocumentId, textAndVersion, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -291,18 +292,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var text = SourceText.From("new text");
 
             var newSolution1 = solution.WithDocumentText(new[] { documentId }, text, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetDocument(documentId).TryGetText(out var actualText));
+            Assert.True(newSolution1.GetDocument(documentId)!.TryGetText(out var actualText));
             Assert.Equal(text, actualText);
 
             var newSolution2 = newSolution1.WithDocumentText(new[] { documentId }, text, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            // documents not in solution are skipped:
-            Assert.Same(solution, solution.WithDocumentText(new DocumentId[] { null }, text));
-            Assert.Same(solution, solution.WithDocumentText(new DocumentId[] { s_documentId }, text));
+            // documents not in solution are skipped: https://github.com/dotnet/roslyn/issues/42029
+            Assert.Same(solution, solution.WithDocumentText(new DocumentId[] { null! }, text));
+            Assert.Same(solution, solution.WithDocumentText(new DocumentId[] { s_unrelatedDocumentId }, text));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId[])null, text, PreservationMode.PreserveIdentity));
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(new[] { documentId }, null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId[])null!, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(new[] { documentId }, null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentText(new[] { documentId }, text, (PreservationMode)(-1)));
         }
 
@@ -314,17 +315,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var text = SourceText.From("new text");
 
             var newSolution1 = solution.WithAdditionalDocumentText(documentId, text, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetAdditionalDocument(documentId).TryGetText(out var actualText));
-            Assert.Equal(text, actualText);
+            Assert.True(newSolution1.GetAdditionalDocument(documentId)!.TryGetText(out var actualText));
+            Assert.Same(text, actualText);
 
             var newSolution2 = newSolution1.WithAdditionalDocumentText(documentId, text, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText(documentId, (SourceText)null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAdditionalDocumentText(documentId, text, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText(s_documentId, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText((DocumentId)null!, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText(s_unrelatedDocumentId, text, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -335,19 +336,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var textAndVersion = TextAndVersion.Create(SourceText.From("new text"), VersionStamp.Default);
 
             var newSolution1 = solution.WithAdditionalDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetAdditionalDocument(documentId).TryGetText(out var actualText));
-            Assert.True(newSolution1.GetAdditionalDocument(documentId).TryGetTextVersion(out var actualVersion));
-            Assert.Equal(textAndVersion.Text, actualText);
+            Assert.True(newSolution1.GetAdditionalDocument(documentId)!.TryGetText(out var actualText));
+            Assert.True(newSolution1.GetAdditionalDocument(documentId)!.TryGetTextVersion(out var actualVersion));
+            Assert.Same(textAndVersion.Text, actualText);
             Assert.Equal(textAndVersion.Version, actualVersion);
 
             var newSolution2 = newSolution1.WithAdditionalDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText(documentId, (SourceText)null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAdditionalDocumentText(documentId, textAndVersion, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText(s_documentId, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText((DocumentId)null!, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText(s_unrelatedDocumentId, textAndVersion, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -358,17 +359,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var text = SourceText.From("new text");
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, text, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetAnalyzerConfigDocument(documentId).TryGetText(out var actualText));
-            Assert.Equal(text, actualText);
+            Assert.True(newSolution1.GetAnalyzerConfigDocument(documentId)!.TryGetText(out var actualText));
+            Assert.Same(text, actualText);
 
             var newSolution2 = newSolution1.WithAnalyzerConfigDocumentText(documentId, text, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText(documentId, (SourceText)null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAnalyzerConfigDocumentText(documentId, text, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText(s_documentId, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null!, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText(s_unrelatedDocumentId, text, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -379,19 +380,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var textAndVersion = TextAndVersion.Create(SourceText.From("new text"), VersionStamp.Default);
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
-            Assert.True(newSolution1.GetAnalyzerConfigDocument(documentId).TryGetText(out var actualText));
-            Assert.True(newSolution1.GetAnalyzerConfigDocument(documentId).TryGetTextVersion(out var actualVersion));
-            Assert.Equal(textAndVersion.Text, actualText);
+            Assert.True(newSolution1.GetAnalyzerConfigDocument(documentId)!.TryGetText(out var actualText));
+            Assert.True(newSolution1.GetAnalyzerConfigDocument(documentId)!.TryGetTextVersion(out var actualVersion));
+            Assert.Same(textAndVersion.Text, actualText);
             Assert.Equal(textAndVersion.Version, actualVersion);
 
             var newSolution2 = newSolution1.WithAnalyzerConfigDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText(documentId, (SourceText)null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAnalyzerConfigDocumentText(documentId, textAndVersion, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText(s_documentId, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null!, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText(s_unrelatedDocumentId, textAndVersion, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -402,17 +403,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var loader = new TestTextLoader("new text");
 
             var newSolution1 = solution.WithDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);
-            Assert.Equal("new text", newSolution1.GetDocument(documentId).GetTextSynchronously(CancellationToken.None).ToString());
+            Assert.Equal("new text", newSolution1.GetDocument(documentId)!.GetTextSynchronously(CancellationToken.None).ToString());
 
-            // Reusal is not currently implemented:
+            // Reusal is not currently implemented: https://github.com/dotnet/roslyn/issues/42028
             var newSolution2 = solution.WithDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);
             Assert.NotSame(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentTextLoader(documentId, null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentTextLoader(documentId, null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentTextLoader(documentId, loader, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentTextLoader(s_documentId, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentTextLoader(null!, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentTextLoader(s_unrelatedDocumentId, loader, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -423,17 +424,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var loader = new TestTextLoader("new text");
 
             var newSolution1 = solution.WithAdditionalDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);
-            Assert.Equal("new text", newSolution1.GetAdditionalDocument(documentId).GetTextSynchronously(CancellationToken.None).ToString());
+            Assert.Equal("new text", newSolution1.GetAdditionalDocument(documentId)!.GetTextSynchronously(CancellationToken.None).ToString());
 
-            // Reusal is not currently implemented:
+            // Reusal is not currently implemented: https://github.com/dotnet/roslyn/issues/42028
             var newSolution2 = solution.WithAdditionalDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);
             Assert.NotSame(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentTextLoader(documentId, null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentTextLoader(documentId, null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAdditionalDocumentTextLoader(documentId, loader, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentTextLoader(s_documentId, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentTextLoader(null!, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentTextLoader(s_unrelatedDocumentId, loader, PreservationMode.PreserveIdentity));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -444,19 +445,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var loader = new TestTextLoader("new text");
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);
-            Assert.Equal("new text", newSolution1.GetAnalyzerConfigDocument(documentId).GetTextSynchronously(CancellationToken.None).ToString());
+            Assert.Equal("new text", newSolution1.GetAnalyzerConfigDocument(documentId)!.GetTextSynchronously(CancellationToken.None).ToString());
 
-            // Reusal is not currently implemented:
+            // Reusal is not currently implemented: https://github.com/dotnet/roslyn/issues/42028
             var newSolution2 = solution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);
             Assert.NotSame(newSolution1, newSolution2);
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentTextLoader(documentId, null, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentTextLoader(documentId, null!, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, (PreservationMode)(-1)));
 
-            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
-            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentTextLoader(s_documentId, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentTextLoader(null!, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentTextLoader(s_unrelatedDocumentId, loader, PreservationMode.PreserveIdentity));
         }
-
+#nullable restore
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestAddProject()
         {

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void RemoveDocument()
         {
             var solution = CreateSolution();
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveDocument(null));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveDocument(null));
             Assert.Throws<InvalidOperationException>(() => solution.RemoveDocument(s_documentId));
         }
 
@@ -67,14 +67,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var solution = CreateSolution();
             Assert.Throws<ArgumentNullException>(() => solution.RemoveDocuments(default));
             Assert.Throws<InvalidOperationException>(() => solution.RemoveDocuments(ImmutableArray.Create(s_documentId)));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveDocuments(ImmutableArray.Create(default(DocumentId))));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveDocuments(ImmutableArray.Create(default(DocumentId))));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void RemoveAdditionalDocument()
         {
             var solution = CreateSolution();
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocument(null));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocument(null));
             Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocument(s_documentId));
         }
 
@@ -84,14 +84,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var solution = CreateSolution();
             Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocuments(default));
             Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(s_documentId)));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(default(DocumentId))));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAdditionalDocuments(ImmutableArray.Create(default(DocumentId))));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void RemoveAnalyzerConfigDocument()
         {
             var solution = CreateSolution();
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocument(null));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocument(null));
             Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocument(s_documentId));
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var solution = CreateSolution();
             Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocuments(default));
             Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(s_documentId)));
-            Assert.Throws<InvalidOperationException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(default(DocumentId))));
+            Assert.Throws<ArgumentNullException>(() => solution.RemoveAnalyzerConfigDocuments(ImmutableArray.Create(default(DocumentId))));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Throws<ArgumentNullException>(() => solution.WithDocumentName(documentId, name: null));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentName(null, name));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentName(null, name));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentName(s_documentId, name));
         }
 
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFolders(documentId, folders: new string[] { null }));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFolders(null, folders));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFolders(null, folders));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFolders(s_documentId, folders));
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // TODO: https://github.com/dotnet/roslyn/issues/37125
             Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFilePath(documentId, filePath: null));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFilePath(null, path));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentFilePath(null, path));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentFilePath(s_documentId, path));
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentSourceCodeKind(documentId, (SourceCodeKind)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSourceCodeKind(null, SourceCodeKind.Script));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentSourceCodeKind(null, SourceCodeKind.Script));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSourceCodeKind(s_documentId, SourceCodeKind.Script));
         }
 
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentSyntaxRoot(documentId, root, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSyntaxRoot(null, root));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentSyntaxRoot(null, root));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentSyntaxRoot(s_documentId, root));
         }
 
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentText(documentId, text, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText(s_documentId, text, PreservationMode.PreserveIdentity));
         }
 
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentText(documentId, textAndVersion, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentText(s_documentId, textAndVersion, PreservationMode.PreserveIdentity));
         }
 
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAdditionalDocumentText(documentId, text, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText(s_documentId, text, PreservationMode.PreserveIdentity));
         }
 
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAdditionalDocumentText(documentId, textAndVersion, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentText(s_documentId, textAndVersion, PreservationMode.PreserveIdentity));
         }
 
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAnalyzerConfigDocumentText(documentId, text, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null, text, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText(s_documentId, text, PreservationMode.PreserveIdentity));
         }
 
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText(documentId, (SourceText)null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAnalyzerConfigDocumentText(documentId, textAndVersion, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentText((DocumentId)null, textAndVersion, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentText(s_documentId, textAndVersion, PreservationMode.PreserveIdentity));
         }
 
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithDocumentTextLoader(documentId, null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithDocumentTextLoader(documentId, loader, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithDocumentTextLoader(s_documentId, loader, PreservationMode.PreserveIdentity));
         }
 
@@ -432,7 +432,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentTextLoader(documentId, null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAdditionalDocumentTextLoader(documentId, loader, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAdditionalDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithAdditionalDocumentTextLoader(s_documentId, loader, PreservationMode.PreserveIdentity));
         }
 
@@ -453,7 +453,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentTextLoader(documentId, null, PreservationMode.PreserveIdentity));
             Assert.Throws<ArgumentOutOfRangeException>(() => solution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, (PreservationMode)(-1)));
 
-            Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
+            Assert.Throws<ArgumentNullException>(() => solution.WithAnalyzerConfigDocumentTextLoader(null, loader, PreservationMode.PreserveIdentity));
             Assert.Throws<InvalidOperationException>(() => solution.WithAnalyzerConfigDocumentTextLoader(s_documentId, loader, PreservationMode.PreserveIdentity));
         }
 

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var newSolution1 = solution.WithDocumentText(new[] { documentId }, text, PreservationMode.PreserveIdentity);
             Assert.True(newSolution1.GetDocument(documentId)!.TryGetText(out var actualText));
-            Assert.Equal(text, actualText);
+            Assert.Same(text, actualText);
 
             var newSolution2 = newSolution1.WithDocumentText(new[] { documentId }, text, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var newSolution1 = solution.WithDocumentText(documentId, text, PreservationMode.PreserveIdentity);
             Assert.True(newSolution1.GetDocument(documentId)!.TryGetText(out var actualText));
-            Assert.Equal(text, actualText);
+            Assert.Same(text, actualText);
 
             var newSolution2 = newSolution1.WithDocumentText(documentId, text, PreservationMode.PreserveIdentity);
             Assert.Same(newSolution1, newSolution2);

--- a/src/Workspaces/CoreTest/TestUtilities/TestTextLoader.cs
+++ b/src/Workspaces/CoreTest/TestUtilities/TestTextLoader.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Roslyn.Test.Utilities
+{
+    internal class TestTextLoader : TextLoader
+    {
+        private readonly string _text;
+
+        public TestTextLoader(string text = "test")
+        {
+            _text = text;
+        }
+
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+            => Task.FromResult(TextAndVersion.Create(SourceText.From(_text), VersionStamp.Create()));
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -44,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Serialization\ObjectBinderSnapshot.cs" Link="Serialization\ObjectBinderSnapshot.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Serialization\ObjectReader.cs" Link="Serialization\ObjectReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Serialization\ObjectWriter.cs" Link="Serialization\ObjectWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\SourceCodeKindExtensions.cs" Link="Utilities\Compiler\SourceCodeKindExtensions.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Shared\DesktopAnalyzerAssemblyLoader.cs">
       <Link>Execution\Desktop\DesktopAnalyzerAssemblyLoader.cs</Link>
     </Compile>


### PR DESCRIPTION
Adds missing tests and argument validation. Moves argument validation closer to exposed public surface.

Fixes bugs where we didn't reuse Solution instances when calling With- methods that didn't change values.
The only exception is `WithDocumentTextLoader`, where we don't explicitly hold on the loader instance so we can't compare the new value with the current one. (The loader instance is captured in a lambda).
