### PR TITLE
Add explicit AnalyzerRunner reference to Newtonsoft.Json

### DIFF
--- a/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
+++ b/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
@@ -18,10 +18,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
-    
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
Fixes failure to resolve NuGet SDKs:

> Msbuild failed when processing the file 'C:\\dev\\roslyn\\src\\Deployment\\RoslynDeployment.csproj' with message: C:\\dev\\roslyn\\Directory.Build.props: (3, 31): The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.