### PR TITLE
Add support for native integers to the public API

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29814.53
+# Visual Studio 15
+VisualStudioVersion = 15.0.27102.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.UnitTests", "src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -162,42 +162,24 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Compilers.Too
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
-		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
-		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
-		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\CSharpCompilerExtensions.projitems*{21b239d0-d144-430f-a394-c066d58ee267}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\CSharp\CSharpWorkspaceExtensions.projitems*{21b239d0-d144-430f-a394-c066d58ee267}*SharedItemsImports = 5
-		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 5
-		src\Analyzers\VisualBasic\Analyzers\VisualBasicAnalyzers.projitems*{2531a8c4-97dd-47bc-a79c-b7846051e137}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\VisualBasic\VisualBasicCompilerExtensions.projitems*{2531a8c4-97dd-47bc-a79c-b7846051e137}*SharedItemsImports = 5
-		src\Analyzers\Core\Analyzers\Analyzers.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
-		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 5
-		src\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems*{5018d049-5870-465a-889b-c742ce1e31cb}*SharedItemsImports = 5
+		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{54e08bf5-f819-404f-a18d-0ab9ea81ea04}*SharedItemsImports = 13
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\VisualBasic\VisualBasicCompilerExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
-		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
-		src\Analyzers\Core\CodeFixes\CodeFixes.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 5
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 5
-		src\Analyzers\CSharp\CodeFixes\CSharpCodeFixes.projitems*{a07abcf5-bc43-4ee9-8fd8-b2d77fd54d73}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\CSharp\CSharpWorkspaceExtensions.projitems*{a07abcf5-bc43-4ee9-8fd8-b2d77fd54d73}*SharedItemsImports = 5
-		src\Analyzers\CSharp\Analyzers\CSharpAnalyzers.projitems*{aa87bfed-089a-4096-b8d5-690bdc7d5b24}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\CSharpCompilerExtensions.projitems*{aa87bfed-089a-4096-b8d5-690bdc7d5b24}*SharedItemsImports = 5
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 4
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
+		src\Compilers\Server\ServerShared\ServerShared.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{ad6f474e-e6d4-4217-91f3-b7af1be31ccc}*SharedItemsImports = 13
-		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 5
+		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
+		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{d73adf7d-2c1c-42ae-b2ab-edc9497e4b71}*SharedItemsImports = 13
-		src\Analyzers\VisualBasic\Tests\VisualBasicAnalyzers.UnitTests.projitems*{e512c6c1-f085-4ad7-b0d9-e8f1a0a2a510}*SharedItemsImports = 5
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 5
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 4
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{e8f0baa5-7327-43d1-9a51-644e81ae55f1}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27102.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29814.53
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.UnitTests", "src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -162,24 +162,42 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Compilers.Too
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
-		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
-		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
-		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
+		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
+		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
+		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\CSharpCompilerExtensions.projitems*{21b239d0-d144-430f-a394-c066d58ee267}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\CSharp\CSharpWorkspaceExtensions.projitems*{21b239d0-d144-430f-a394-c066d58ee267}*SharedItemsImports = 5
+		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 5
+		src\Analyzers\VisualBasic\Analyzers\VisualBasicAnalyzers.projitems*{2531a8c4-97dd-47bc-a79c-b7846051e137}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\VisualBasic\VisualBasicCompilerExtensions.projitems*{2531a8c4-97dd-47bc-a79c-b7846051e137}*SharedItemsImports = 5
+		src\Analyzers\Core\Analyzers\Analyzers.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 5
+		src\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems*{5018d049-5870-465a-889b-c742ce1e31cb}*SharedItemsImports = 5
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{54e08bf5-f819-404f-a18d-0ab9ea81ea04}*SharedItemsImports = 13
-		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 4
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
-		src\Compilers\Server\ServerShared\ServerShared.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\VisualBasic\VisualBasicCompilerExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
+		src\Analyzers\Core\CodeFixes\CodeFixes.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 5
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 5
+		src\Analyzers\CSharp\CodeFixes\CSharpCodeFixes.projitems*{a07abcf5-bc43-4ee9-8fd8-b2d77fd54d73}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\CSharp\CSharpWorkspaceExtensions.projitems*{a07abcf5-bc43-4ee9-8fd8-b2d77fd54d73}*SharedItemsImports = 5
+		src\Analyzers\CSharp\Analyzers\CSharpAnalyzers.projitems*{aa87bfed-089a-4096-b8d5-690bdc7d5b24}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\CSharpCompilerExtensions.projitems*{aa87bfed-089a-4096-b8d5-690bdc7d5b24}*SharedItemsImports = 5
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{ad6f474e-e6d4-4217-91f3-b7af1be31ccc}*SharedItemsImports = 13
-		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
-		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
-		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
+		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 5
 		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{d73adf7d-2c1c-42ae-b2ab-edc9497e4b71}*SharedItemsImports = 13
-		src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 4
+		src\Analyzers\VisualBasic\Tests\VisualBasicAnalyzers.UnitTests.projitems*{e512c6c1-f085-4ad7-b0d9-e8f1a0a2a510}*SharedItemsImports = 5
+		src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 5
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{e8f0baa5-7327-43d1-9a51-644e81ae55f1}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NamedTypeSymbol getNativeIntType(SyntaxNode node, bool unsigned, DiagnosticBag diagnostics)
             {
                 CheckFeatureAvailability(node, MessageID.IDS_FeatureNativeInt, diagnostics);
-                return this.GetSpecialType(unsigned ? SpecialType.System_UIntPtr : SpecialType.System_IntPtr, diagnostics, node).AsNativeInt(true);
+                return this.GetSpecialType(unsigned ? SpecialType.System_UIntPtr : SpecialType.System_IntPtr, diagnostics, node).AsNativeInteger();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1109,10 +1109,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return sbyte.MinValue <= value && value <= sbyte.MaxValue;
                     case SpecialType.System_Int16:
                         return short.MinValue <= value && value <= short.MaxValue;
-                    case SpecialType.System_IntPtr when ((NamedTypeSymbol)destination).IsNativeInt:
+                    case SpecialType.System_IntPtr when destination.IsNativeIntegerType():
                         return true;
                     case SpecialType.System_UInt32:
-                    case SpecialType.System_UIntPtr when ((NamedTypeSymbol)destination).IsNativeInt:
+                    case SpecialType.System_UIntPtr when destination.IsNativeIntegerType():
                         return uint.MinValue <= value;
                     case SpecialType.System_UInt64:
                         return (int)ulong.MinValue <= value;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1109,10 +1109,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return sbyte.MinValue <= value && value <= sbyte.MaxValue;
                     case SpecialType.System_Int16:
                         return short.MinValue <= value && value <= short.MaxValue;
-                    case SpecialType.System_IntPtr when destination.IsNativeIntegerType():
+                    case SpecialType.System_IntPtr when destination.IsNativeIntegerType:
                         return true;
                     case SpecialType.System_UInt32:
-                    case SpecialType.System_UIntPtr when destination.IsNativeIntegerType():
+                    case SpecialType.System_UIntPtr when destination.IsNativeIntegerType:
                         return uint.MinValue <= value;
                     case SpecialType.System_UInt64:
                         return (int)ulong.MinValue <= value;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorFacts.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SpecialType.System_Int16:
                 case SpecialType.System_Int32:
                 case SpecialType.System_Int64:
-                case SpecialType.System_IntPtr when type.IsNativeIntegerType():
-                case SpecialType.System_UIntPtr when type.IsNativeIntegerType():
+                case SpecialType.System_IntPtr when type.IsNativeIntegerType:
+                case SpecialType.System_UIntPtr when type.IsNativeIntegerType:
                 case SpecialType.System_MulticastDelegate:
                 case SpecialType.System_Object:
                 case SpecialType.System_SByte:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorFacts.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SpecialType.System_Int16:
                 case SpecialType.System_Int32:
                 case SpecialType.System_Int64:
-                case SpecialType.System_IntPtr when ((NamedTypeSymbol)type).IsNativeInt:
-                case SpecialType.System_UIntPtr when ((NamedTypeSymbol)type).IsNativeInt:
+                case SpecialType.System_IntPtr when type.IsNativeIntegerType():
+                case SpecialType.System_UIntPtr when type.IsNativeIntegerType():
                 case SpecialType.System_MulticastDelegate:
                 case SpecialType.System_Object:
                 case SpecialType.System_SByte:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     return true;
                 case Cci.PrimitiveTypeCode.IntPtr:
                 case Cci.PrimitiveTypeCode.UIntPtr:
-                    return type.IsNativeIntegerType();
+                    return type.IsNativeIntegerType;
                 default:
                     return false;
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     return true;
                 case Cci.PrimitiveTypeCode.IntPtr:
                 case Cci.PrimitiveTypeCode.UIntPtr:
-                    return ((NamedTypeSymbol)type).IsNativeInt;
+                    return type.IsNativeIntegerType();
                 default:
                     return false;
             }

--- a/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
@@ -252,8 +252,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case UnaryOperatorKind.UInt: opType = _compilation.GetSpecialType(SpecialType.System_UInt32); break;
                 case UnaryOperatorKind.Long: opType = _compilation.GetSpecialType(SpecialType.System_Int64); break;
                 case UnaryOperatorKind.ULong: opType = _compilation.GetSpecialType(SpecialType.System_UInt64); break;
-                case UnaryOperatorKind.NInt: opType = _compilation.GetSpecialType(SpecialType.System_IntPtr).AsNativeInt(true); break;
-                case UnaryOperatorKind.NUInt: opType = _compilation.GetSpecialType(SpecialType.System_UIntPtr).AsNativeInt(true); break;
+                case UnaryOperatorKind.NInt: opType = _compilation.CreateNativeIntegerTypeSymbol(signed: true); break;
+                case UnaryOperatorKind.NUInt: opType = _compilation.CreateNativeIntegerTypeSymbol(signed: false); break;
                 case UnaryOperatorKind.Char: opType = _compilation.GetSpecialType(SpecialType.System_Char); break;
                 case UnaryOperatorKind.Float: opType = _compilation.GetSpecialType(SpecialType.System_Single); break;
                 case UnaryOperatorKind.Double: opType = _compilation.GetSpecialType(SpecialType.System_Double); break;
@@ -691,8 +691,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BinaryOperatorKind.UInt: return _compilation.GetSpecialType(SpecialType.System_UInt32);
                     case BinaryOperatorKind.Long: return _compilation.GetSpecialType(SpecialType.System_Int64);
                     case BinaryOperatorKind.ULong: return _compilation.GetSpecialType(SpecialType.System_UInt64);
-                    case BinaryOperatorKind.NInt: return _compilation.GetSpecialType(SpecialType.System_IntPtr).AsNativeInt(true);
-                    case BinaryOperatorKind.NUInt: return _compilation.GetSpecialType(SpecialType.System_UIntPtr).AsNativeInt(true);
+                    case BinaryOperatorKind.NInt: return _compilation.CreateNativeIntegerTypeSymbol(signed: true);
+                    case BinaryOperatorKind.NUInt: return _compilation.CreateNativeIntegerTypeSymbol(signed: false);
                     case BinaryOperatorKind.Float: return _compilation.GetSpecialType(SpecialType.System_Single);
                     case BinaryOperatorKind.Double: return _compilation.GetSpecialType(SpecialType.System_Double);
                     case BinaryOperatorKind.Decimal: return _compilation.GetSpecialType(SpecialType.System_Decimal);
@@ -723,8 +723,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BinaryOperatorKind.UInt: return _compilation.GetSpecialType(SpecialType.System_UInt32);
                     case BinaryOperatorKind.Long: return _compilation.GetSpecialType(SpecialType.System_Int64);
                     case BinaryOperatorKind.ULong: return _compilation.GetSpecialType(SpecialType.System_UInt64);
-                    case BinaryOperatorKind.NInt: return _compilation.GetSpecialType(SpecialType.System_IntPtr).AsNativeInt(true);
-                    case BinaryOperatorKind.NUInt: return _compilation.GetSpecialType(SpecialType.System_UIntPtr).AsNativeInt(true);
+                    case BinaryOperatorKind.NInt: return _compilation.CreateNativeIntegerTypeSymbol(signed: true);
+                    case BinaryOperatorKind.NUInt: return _compilation.CreateNativeIntegerTypeSymbol(signed: false);
                     case BinaryOperatorKind.Float: return _compilation.GetSpecialType(SpecialType.System_Single);
                     case BinaryOperatorKind.Double: return _compilation.GetSpecialType(SpecialType.System_Double);
                     case BinaryOperatorKind.Decimal: return _compilation.GetSpecialType(SpecialType.System_Decimal);
@@ -755,8 +755,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BinaryOperatorKind.UInt: return _compilation.GetSpecialType(SpecialType.System_UInt32);
                     case BinaryOperatorKind.Long: return _compilation.GetSpecialType(SpecialType.System_Int64);
                     case BinaryOperatorKind.ULong: return _compilation.GetSpecialType(SpecialType.System_UInt64);
-                    case BinaryOperatorKind.NInt: return _compilation.GetSpecialType(SpecialType.System_IntPtr).AsNativeInt(true);
-                    case BinaryOperatorKind.NUInt: return _compilation.GetSpecialType(SpecialType.System_UIntPtr).AsNativeInt(true);
+                    case BinaryOperatorKind.NInt: return _compilation.CreateNativeIntegerTypeSymbol(signed: true);
+                    case BinaryOperatorKind.NUInt: return _compilation.CreateNativeIntegerTypeSymbol(signed: false);
                     case BinaryOperatorKind.Float: return _compilation.GetSpecialType(SpecialType.System_Single);
                     case BinaryOperatorKind.Double: return _compilation.GetSpecialType(SpecialType.System_Double);
                     case BinaryOperatorKind.Decimal: return _compilation.GetSpecialType(SpecialType.System_Decimal);
@@ -784,8 +784,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.UInt: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_UInt32));
                 case BinaryOperatorKind.Long: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_Int64));
                 case BinaryOperatorKind.ULong: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_UInt64));
-                case BinaryOperatorKind.NInt: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_IntPtr).AsNativeInt(true));
-                case BinaryOperatorKind.NUInt: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_UIntPtr).AsNativeInt(true));
+                case BinaryOperatorKind.NInt: return nullable.Construct(_compilation.CreateNativeIntegerTypeSymbol(signed: true));
+                case BinaryOperatorKind.NUInt: return nullable.Construct(_compilation.CreateNativeIntegerTypeSymbol(signed: false));
                 case BinaryOperatorKind.Float: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_Single));
                 case BinaryOperatorKind.Double: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_Double));
                 case BinaryOperatorKind.Decimal: return nullable.Construct(_compilation.GetSpecialType(SpecialType.System_Decimal));

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3151,6 +3151,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             return CreatePointerTypeSymbol(elementType.EnsureCSharpSymbolOrNull(nameof(elementType)), elementType.NullableAnnotation.ToInternalAnnotation()).GetPublicSymbol();
         }
 
+        protected override INamedTypeSymbol CommonCreateNativeIntegerTypeSymbol(bool signed)
+        {
+            return CreateNativeIntegerTypeSymbol(signed).GetPublicSymbol();
+        }
+
+        new internal NamedTypeSymbol CreateNativeIntegerTypeSymbol(bool signed)
+        {
+            return GetSpecialType(signed ? SpecialType.System_IntPtr : SpecialType.System_UIntPtr).AsNativeInteger();
+        }
+
         protected override INamedTypeSymbol CommonCreateTupleTypeSymbol(
             ImmutableArray<ITypeSymbol> elementTypes,
             ImmutableArray<string?> elementNames,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -894,7 +894,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 }
                 else if (namedTypeSymbol.NativeIntegerUnderlyingType is NamedTypeSymbol underlyingType)
                 {
-                    return underlyingType;
+                    namedTypeSymbol = underlyingType;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -892,9 +892,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                     return typeRef;
                 }
-                else if (namedTypeSymbol.IsNativeInt)
+                else if (namedTypeSymbol.NativeIntegerUnderlyingType is NamedTypeSymbol underlyingType)
                 {
-                    return namedTypeSymbol.AsNativeInt(asNativeInt: false);
+                    return underlyingType;
                 }
             }
 
@@ -1524,7 +1524,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 return null;
             }
 
-            if ((type as NamedTypeSymbol)?.IsNativeInt == true)
+            if (type.IsNativeIntegerType())
             {
                 return SynthesizeNativeIntegerAttribute(WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor, ImmutableArray<TypedConstant>.Empty);
             }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1524,7 +1524,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 return null;
             }
 
-            if (type.IsNativeIntegerType())
+            if (type.IsNativeIntegerType)
             {
                 return SynthesizeNativeIntegerAttribute(WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor, ImmutableArray<TypedConstant>.Empty);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -1063,10 +1063,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 case BinaryOperatorKind.NInt:
                     constantOne = ConstantValue.Create(1);
-                    return (compilation.GetSpecialType(SpecialType.System_IntPtr).AsNativeInt(true), constantOne);
+                    return (compilation.CreateNativeIntegerTypeSymbol(signed: true), constantOne);
                 case BinaryOperatorKind.NUInt:
                     constantOne = ConstantValue.Create(1U);
-                    return (compilation.GetSpecialType(SpecialType.System_UIntPtr).AsNativeInt(true), constantOne);
+                    return (compilation.CreateNativeIntegerTypeSymbol(signed: false), constantOne);
                 case BinaryOperatorKind.Float:
                     constantOne = ConstantValue.Create(1f);
                     break;

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -599,9 +599,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return "int";
                 case SpecialType.System_Int64:
                     return "long";
-                case SpecialType.System_IntPtr when isNativeInt(symbol):
+                case SpecialType.System_IntPtr when symbol.IsNativeInteger:
                     return "nint";
-                case SpecialType.System_UIntPtr when isNativeInt(symbol):
+                case SpecialType.System_UIntPtr when symbol.IsNativeInteger:
                     return "nuint";
                 case SpecialType.System_Byte:
                     return "byte";
@@ -628,8 +628,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     return null;
             }
-
-            static bool isNativeInt(INamedTypeSymbol symbol) => symbol.GetSymbol<NamedTypeSymbol>()?.IsNativeInt == true;
         }
 
         private void AddTypeKind(INamedTypeSymbol symbol)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -599,9 +599,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return "int";
                 case SpecialType.System_Int64:
                     return "long";
-                case SpecialType.System_IntPtr when symbol.IsNativeInteger:
+                case SpecialType.System_IntPtr when symbol.IsNativeIntegerType:
                     return "nint";
-                case SpecialType.System_UIntPtr when symbol.IsNativeInteger:
+                case SpecialType.System_UIntPtr when symbol.IsNativeIntegerType:
                     return "nuint";
                 case SpecialType.System_Byte:
                     return "byte";

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -948,7 +948,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // For nested named types, a single false is encoded for the entire type name, followed by flags for all of the type arguments.
                         if (!isNestedNamedType)
                         {
-                            builder.Add(type.IsNativeIntegerType());
+                            builder.Add(type.IsNativeIntegerType);
                         }
                         break;
                     default:

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -948,7 +948,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // For nested named types, a single false is encoded for the entire type name, followed by flags for all of the type arguments.
                         if (!isNestedNamedType)
                         {
-                            builder.Add(((NamedTypeSymbol)type).IsNativeInt);
+                            builder.Add(type.IsNativeIntegerType());
                         }
                         break;
                     default:

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 case SpecialType.System_IntPtr:
                 case SpecialType.System_UIntPtr:
-                    return type.AsNativeInt(true);
+                    return type.AsNativeInteger();
                 default:
                     throw new ArgumentException();
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2325,13 +2325,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
             }
 
-            internal override NamedTypeSymbol AsNativeInt(bool asNativeInt)
+            internal override NamedTypeSymbol AsNativeInteger()
             {
                 Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
 
-                return asNativeInt ?
-                    ContainingAssembly.GetNativeIntegerType(this) :
-                    this;
+                return ContainingAssembly.GetNativeIntegerType(this);
             }
 
             internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null)

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -326,7 +326,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(MetadataName, Hash.Combine(_containingModule, Hash.Combine(_namespaceName, arity)));
             }
 
-            internal override NamedTypeSymbol AsNativeInt(bool asNativeInt)
+            internal override NamedTypeSymbol AsNativeInteger() => AsNativeInteger(asNativeInt: true);
+
+            private TopLevel AsNativeInteger(bool asNativeInt)
             {
                 Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
 
@@ -340,7 +342,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return other;
             }
 
-            internal override bool IsNativeInt => _isNativeInt;
+            internal override bool IsNativeInteger => _isNativeInt;
+
+            internal override NamedTypeSymbol? NativeIntegerUnderlyingType => _isNativeInt ? AsNativeInteger(asNativeInt: false) : null;
 
             internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return other;
             }
 
-            internal override bool IsNativeInteger => _isNativeInt;
+            internal override bool IsNativeIntegerType => _isNativeInt;
 
             internal override NamedTypeSymbol? NativeIntegerUnderlyingType => _isNativeInt ? AsNativeInteger(asNativeInt: false) : null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1520,14 +1520,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // PROTOTYPE: Should be abstract.
         /// <summary>
         /// True if the type represents a native integer. In C#, the types represented
-        /// by language tokens 'nint' and 'nuint'.
+        /// by language keywords 'nint' and 'nuint'.
         /// </summary>
         internal virtual bool IsNativeInteger => false;
 
         // PROTOTYPE: Should be abstract.
         /// <summary>
         /// If this is a native integer, returns the symbol for the underlying type,
-        /// either <see cref="System.IntPtr"/> or  <see cref="System.UIntPtr"/>.
+        /// either <see cref="System.IntPtr"/> or <see cref="System.UIntPtr"/>.
         /// Otherwise, returns null.
         /// </summary>
         internal virtual NamedTypeSymbol NativeIntegerUnderlyingType => null;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1511,18 +1511,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // PROTOTYPE: Should be abstract.
         /// <summary>
-        /// Returns an instance of a symbol that has <see cref="IsNativeInt"/> set to <paramref name="asNativeInt"/>
-        /// if the underlying symbol represents System.IntPtr or System.UIntPtr.
+        /// Returns an instance of a symbol that represents an native integer
+        /// if this underlying symbol represents System.IntPtr or System.UIntPtr.
         /// For other symbols, throws <see cref="System.InvalidOperationException"/>.
         /// </summary>
-        internal virtual NamedTypeSymbol AsNativeInt(bool asNativeInt) => throw ExceptionUtilities.Unreachable;
+        internal virtual NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         // PROTOTYPE: Should be abstract.
         /// <summary>
-        /// Returns true if the symbol represents a native integer
-        /// (corresponding to the language tokens nint or nuint).
+        /// True if the type represents a native integer. In C#, the types represented
+        /// by language tokens 'nint' and 'nuint'.
         /// </summary>
-        internal virtual bool IsNativeInt => false;
+        internal virtual bool IsNativeInteger => false;
+
+        // PROTOTYPE: Should be abstract.
+        /// <summary>
+        /// If this is a native integer, returns the symbol for the underlying type,
+        /// either <see cref="System.IntPtr"/> or  <see cref="System.UIntPtr"/>.
+        /// Otherwise, returns null.
+        /// </summary>
+        internal virtual NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
         protected override ISymbol CreateISymbol()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1519,13 +1519,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // PROTOTYPE: Should be abstract.
         /// <summary>
-        /// True if the type represents a native integer. In C#, the types represented
-        /// by language keywords 'nint' and 'nuint'.
-        /// </summary>
-        internal virtual bool IsNativeInteger => false;
-
-        // PROTOTYPE: Should be abstract.
-        /// <summary>
         /// If this is a native integer, returns the symbol for the underlying type,
         /// either <see cref="System.IntPtr"/> or <see cref="System.UIntPtr"/>.
         /// Otherwise, returns null.

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -79,6 +79,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) => throw ExceptionUtilities.Unreachable;
 
+        internal override DiagnosticInfo? GetUseSiteDiagnostic()
+        {
+            var diagnostic = _underlyingType.GetUseSiteDiagnostic();
+            Debug.Assert(diagnostic is null); // If assert fails, add unit test for GetUseSiteDiagnostic().
+            return diagnostic;
+        }
+
         public override bool AreLocalsZeroed => throw ExceptionUtilities.Unreachable;
 
         internal override bool IsNativeInteger => true;

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal NativeIntegerTypeSymbol(NamedTypeSymbol underlying) : base(underlying, tupleData: null)
         {
             Debug.Assert(underlying.TupleData is null);
-            Debug.Assert(!underlying.IsNativeInt);
+            Debug.Assert(!underlying.IsNativeInteger);
             Debug.Assert(underlying.SpecialType == SpecialType.System_IntPtr || underlying.SpecialType == SpecialType.System_UIntPtr);
             Debug.Assert(this.Equals(underlying));
             Debug.Assert(underlying.Equals(this));
@@ -81,9 +81,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool AreLocalsZeroed => throw ExceptionUtilities.Unreachable;
 
-        internal override bool IsNativeInt => true;
+        internal override bool IsNativeInteger => true;
 
-        internal override NamedTypeSymbol AsNativeInt(bool asNativeInt) => asNativeInt ? this : _underlyingType;
+        internal override NamedTypeSymbol NativeIntegerUnderlyingType => _underlyingType;
 
         internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null) => _underlyingType.Equals(t2, comparison, isValueTypeOverrideOpt);
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal NativeIntegerTypeSymbol(NamedTypeSymbol underlying) : base(underlying, tupleData: null)
         {
             Debug.Assert(underlying.TupleData is null);
-            Debug.Assert(!underlying.IsNativeInteger);
+            Debug.Assert(!underlying.IsNativeIntegerType);
             Debug.Assert(underlying.SpecialType == SpecialType.System_IntPtr || underlying.SpecialType == SpecialType.System_UIntPtr);
             Debug.Assert(this.Equals(underlying));
             Debug.Assert(underlying.Equals(this));
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool AreLocalsZeroed => throw ExceptionUtilities.Unreachable;
 
-        internal override bool IsNativeInteger => true;
+        internal override bool IsNativeIntegerType => true;
 
         internal override NamedTypeSymbol NativeIntegerUnderlyingType => _underlyingType;
 

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamedTypeSymbol.cs
@@ -187,6 +187,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool INamedTypeSymbol.IsSerializable => UnderlyingNamedTypeSymbol.IsSerializable;
 
+        bool INamedTypeSymbol.IsNativeInteger => UnderlyingNamedTypeSymbol.IsNativeIntegerType();
+
+        INamedTypeSymbol INamedTypeSymbol.NativeIntegerUnderlyingType => UnderlyingNamedTypeSymbol.NativeIntegerUnderlyingType.GetPublicSymbol();
+
         #region ISymbol Members
 
         protected sealed override void Accept(SymbolVisitor visitor)

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamedTypeSymbol.cs
@@ -187,8 +187,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool INamedTypeSymbol.IsSerializable => UnderlyingNamedTypeSymbol.IsSerializable;
 
-        bool INamedTypeSymbol.IsNativeInteger => UnderlyingNamedTypeSymbol.IsNativeIntegerType();
-
         INamedTypeSymbol INamedTypeSymbol.NativeIntegerUnderlyingType => UnderlyingNamedTypeSymbol.NativeIntegerUnderlyingType.GetPublicSymbol();
 
         #region ISymbol Members

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
@@ -139,6 +139,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool ITypeSymbol.IsTupleType => UnderlyingTypeSymbol.IsTupleType;
 
+        bool ITypeSymbol.IsNativeIntegerType => UnderlyingTypeSymbol.IsNativeIntegerType;
+
         string ITypeSymbol.ToDisplayString(CodeAnalysis.NullableFlowState topLevelNullability, SymbolDisplayFormat format)
         {
             return SymbolDisplay.ToDisplayString(this, topLevelNullability, format);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1367,13 +1367,11 @@ next:;
 
         #endregion
 
-        internal override NamedTypeSymbol AsNativeInt(bool asNativeInt)
+        internal override NamedTypeSymbol AsNativeInteger()
         {
             Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
 
-            return asNativeInt ?
-                ContainingAssembly.GetNativeIntegerType(this) :
-                this;
+            return ContainingAssembly.GetNativeIntegerType(this);
         }
 
         internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -557,6 +557,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public virtual bool IsTupleType => false;
 
         /// <summary>
+        /// True if the type represents a native integer. In C#, the types represented
+        /// by language keywords 'nint' and 'nuint'.
+        /// </summary>
+        internal virtual bool IsNativeIntegerType => false;
+
+        /// <summary>
         /// Verify if the given type is a tuple of a given cardinality, or can be used to back a tuple type 
         /// with the given cardinality. 
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             RoslynDebug.Assert((object)typeSymbol != null);
 
-            return typeSymbol.IsReferenceType || typeSymbol.IsEnumType() || typeSymbol.SpecialType.CanBeConst() || typeSymbol.IsNativeIntegerType();
+            return typeSymbol.IsReferenceType || typeSymbol.IsEnumType() || typeSymbol.SpecialType.CanBeConst() || typeSymbol.IsNativeIntegerType;
         }
 
         /// <summary>
@@ -188,11 +188,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var underlyingType = type.GetEnumUnderlyingType();
             // SpecialType will be None if the underlying type is invalid.
             return (underlyingType is object) && (underlyingType.SpecialType != SpecialType.None);
-        }
-
-        internal static bool IsNativeIntegerType(this TypeSymbol? type)
-        {
-            return (type as NamedTypeSymbol)?.IsNativeInteger == true;
         }
 
         /// <summary>
@@ -481,8 +476,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case SpecialType.System_UInt32:
                     case SpecialType.System_Int64:
                     case SpecialType.System_UInt64:
-                    case SpecialType.System_IntPtr when type.IsNativeIntegerType():
-                    case SpecialType.System_UIntPtr when type.IsNativeIntegerType():
+                    case SpecialType.System_IntPtr when type.IsNativeIntegerType:
+                    case SpecialType.System_UIntPtr when type.IsNativeIntegerType:
                     case SpecialType.System_Char:
                     case SpecialType.System_Boolean:
                     case SpecialType.System_Single:
@@ -911,7 +906,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static bool ContainsNativeInteger(this TypeSymbol type)
         {
-            var result = type.VisitType((type, unused1, unused2) => type.IsNativeIntegerType(), (object?)null, canDigThroughNullable: true);
+            var result = type.VisitType((type, unused1, unused2) => type.IsNativeIntegerType, (object?)null, canDigThroughNullable: true);
             return result is object;
         }
 
@@ -1732,8 +1727,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SpecialType.System_UInt16: return 9;
                 case SpecialType.System_UInt32: return 10;
                 case SpecialType.System_UInt64: return 11;
-                case SpecialType.System_IntPtr when type.IsNativeIntegerType(): return 12;
-                case SpecialType.System_UIntPtr when type.IsNativeIntegerType(): return 13;
+                case SpecialType.System_IntPtr when type.IsNativeIntegerType: return 12;
+                case SpecialType.System_UIntPtr when type.IsNativeIntegerType: return 13;
                 case SpecialType.System_Single: return 14;
                 case SpecialType.System_Double: return 15;
                 case SpecialType.System_Decimal: return 16;
@@ -1755,8 +1750,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             case SpecialType.System_UInt16: return 24;
                             case SpecialType.System_UInt32: return 25;
                             case SpecialType.System_UInt64: return 26;
-                            case SpecialType.System_IntPtr when underlyingType.IsNativeIntegerType(): return 27;
-                            case SpecialType.System_UIntPtr when underlyingType.IsNativeIntegerType(): return 28;
+                            case SpecialType.System_IntPtr when underlyingType.IsNativeIntegerType: return 27;
+                            case SpecialType.System_UIntPtr when underlyingType.IsNativeIntegerType: return 28;
                             case SpecialType.System_Single: return 29;
                             case SpecialType.System_Double: return 30;
                             case SpecialType.System_Decimal: return 31;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             RoslynDebug.Assert((object)typeSymbol != null);
 
-            return typeSymbol.IsReferenceType || typeSymbol.IsEnumType() || typeSymbol.SpecialType.CanBeConst() || (typeSymbol as NamedTypeSymbol)?.IsNativeInt == true;
+            return typeSymbol.IsReferenceType || typeSymbol.IsEnumType() || typeSymbol.SpecialType.CanBeConst() || typeSymbol.IsNativeIntegerType();
         }
 
         /// <summary>
@@ -188,6 +188,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var underlyingType = type.GetEnumUnderlyingType();
             // SpecialType will be None if the underlying type is invalid.
             return (underlyingType is object) && (underlyingType.SpecialType != SpecialType.None);
+        }
+
+        internal static bool IsNativeIntegerType(this TypeSymbol? type)
+        {
+            return (type as NamedTypeSymbol)?.IsNativeInteger == true;
         }
 
         /// <summary>
@@ -476,8 +481,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case SpecialType.System_UInt32:
                     case SpecialType.System_Int64:
                     case SpecialType.System_UInt64:
-                    case SpecialType.System_IntPtr when ((NamedTypeSymbol)type).IsNativeInt:
-                    case SpecialType.System_UIntPtr when ((NamedTypeSymbol)type).IsNativeInt:
+                    case SpecialType.System_IntPtr when type.IsNativeIntegerType():
+                    case SpecialType.System_UIntPtr when type.IsNativeIntegerType():
                     case SpecialType.System_Char:
                     case SpecialType.System_Boolean:
                     case SpecialType.System_Single:
@@ -906,7 +911,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static bool ContainsNativeInteger(this TypeSymbol type)
         {
-            var result = type.VisitType((type, unused1, unused2) => (type as NamedTypeSymbol)?.IsNativeInt == true, (object?)null, canDigThroughNullable: true);
+            var result = type.VisitType((type, unused1, unused2) => type.IsNativeIntegerType(), (object?)null, canDigThroughNullable: true);
             return result is object;
         }
 
@@ -1727,8 +1732,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SpecialType.System_UInt16: return 9;
                 case SpecialType.System_UInt32: return 10;
                 case SpecialType.System_UInt64: return 11;
-                case SpecialType.System_IntPtr when ((NamedTypeSymbol)type).IsNativeInt: return 12;
-                case SpecialType.System_UIntPtr when ((NamedTypeSymbol)type).IsNativeInt: return 13;
+                case SpecialType.System_IntPtr when type.IsNativeIntegerType(): return 12;
+                case SpecialType.System_UIntPtr when type.IsNativeIntegerType(): return 13;
                 case SpecialType.System_Single: return 14;
                 case SpecialType.System_Double: return 15;
                 case SpecialType.System_Decimal: return 16;
@@ -1750,8 +1755,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             case SpecialType.System_UInt16: return 24;
                             case SpecialType.System_UInt32: return 25;
                             case SpecialType.System_UInt64: return 26;
-                            case SpecialType.System_IntPtr when ((NamedTypeSymbol)underlyingType).IsNativeInt: return 27;
-                            case SpecialType.System_UIntPtr when ((NamedTypeSymbol)underlyingType).IsNativeInt: return 28;
+                            case SpecialType.System_IntPtr when underlyingType.IsNativeIntegerType(): return 27;
+                            case SpecialType.System_UIntPtr when underlyingType.IsNativeIntegerType(): return 28;
                             case SpecialType.System_Single: return 29;
                             case SpecialType.System_Double: return 30;
                             case SpecialType.System_Decimal: return 31;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -192,6 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             VerifyType(nativeIntegerType, signed, isNativeInt: true);
 
             Assert.Same(underlyingType.ContainingSymbol, nativeIntegerType.ContainingSymbol);
+            Assert.Same(underlyingType.Name, nativeIntegerType.Name);
 
             Assert.Empty(nativeIntegerType.GetTypeMembers());
 
@@ -223,6 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             VerifyType(nativeIntegerType, signed, isNativeInt: true);
 
             Assert.Same(underlyingType.ContainingSymbol, nativeIntegerType.ContainingSymbol);
+            Assert.Same(underlyingType.Name, nativeIntegerType.Name);
 
             Assert.Empty(nativeIntegerType.GetTypeMembers());
 
@@ -455,6 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
                 var underlyingType = type.NativeIntegerUnderlyingType;
                 Assert.NotNull(underlyingType);
+                Assert.Equal(CodeAnalysis.NullableAnnotation.NotAnnotated, underlyingType.NullableAnnotation);
                 Assert.Same(underlyingType, ((INamedTypeSymbol)type.WithNullableAnnotation(CodeAnalysis.NullableAnnotation.None)).NativeIntegerUnderlyingType);
                 Assert.Same(underlyingType, ((INamedTypeSymbol)type.WithNullableAnnotation(CodeAnalysis.NullableAnnotation.Annotated)).NativeIntegerUnderlyingType);
                 Assert.Same(underlyingType, ((INamedTypeSymbol)type.WithNullableAnnotation(CodeAnalysis.NullableAnnotation.NotAnnotated)).NativeIntegerUnderlyingType);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Equal(SymbolKind.NamedType, type.Kind);
             Assert.Equal(TypeKind.Struct, type.TypeKind);
             Assert.Same(type, type.ConstructedFrom);
-            Assert.Equal(isNativeInt, type.IsNativeInteger);
+            Assert.Equal(isNativeInt, type.IsNativeIntegerType);
             Assert.Equal(signed ? "IntPtr" : "UIntPtr", type.Name);
 
             if (isNativeInt)
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Equal(SymbolKind.NamedType, type.Kind);
             Assert.Equal(TypeKind.Struct, type.TypeKind);
             Assert.Same(type, type.ConstructedFrom);
-            Assert.Equal(isNativeInt, type.IsNativeInteger);
+            Assert.Equal(isNativeInt, type.IsNativeIntegerType);
             Assert.Equal(signed ? "IntPtr" : "UIntPtr", type.Name);
         }
 
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         {
             Assert.Equal(SymbolKind.ErrorType, type.Kind);
             Assert.Equal(TypeKind.Error, type.TypeKind);
-            Assert.Equal(isNativeInt, type.IsNativeInteger);
+            Assert.Equal(isNativeInt, type.IsNativeIntegerType);
             Assert.Equal(specialType, type.SpecialType);
         }
 
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         {
             Assert.Equal(SymbolKind.ErrorType, type.Kind);
             Assert.Equal(TypeKind.Error, type.TypeKind);
-            Assert.Equal(isNativeInt, type.IsNativeInteger);
+            Assert.Equal(isNativeInt, type.IsNativeIntegerType);
             Assert.Equal(specialType, type.SpecialType);
         }
 
@@ -539,9 +539,9 @@ interface I
                 var underlyingType0 = method.Parameters[0].Type.GetSymbol<NamedTypeSymbol>();
                 var underlyingType1 = method.Parameters[1].Type.GetSymbol<NamedTypeSymbol>();
                 Assert.Equal(SpecialType.None, underlyingType0.SpecialType);
-                Assert.False(underlyingType0.IsNativeIntegerType());
+                Assert.False(underlyingType0.IsNativeIntegerType);
                 Assert.Equal(SpecialType.System_UIntPtr, underlyingType1.SpecialType);
-                Assert.True(underlyingType1.IsNativeIntegerType());
+                Assert.True(underlyingType1.IsNativeIntegerType);
             }
         }
 
@@ -573,9 +573,9 @@ interface I
                 var underlyingType0 = (NamedTypeSymbol)method.Parameters[0].Type;
                 var underlyingType1 = (NamedTypeSymbol)method.Parameters[1].Type;
                 Assert.Equal(SpecialType.System_Int16, underlyingType0.SpecialType);
-                Assert.False(underlyingType0.IsNativeIntegerType());
+                Assert.False(underlyingType0.IsNativeIntegerType);
                 Assert.Equal(SpecialType.System_UIntPtr, underlyingType1.SpecialType);
-                Assert.True(underlyingType1.IsNativeIntegerType());
+                Assert.True(underlyingType1.IsNativeIntegerType);
             }
         }
 
@@ -951,7 +951,7 @@ False
 
                 static bool isNativeInt(TypeSymbol type, bool signed)
                 {
-                    return type.IsNativeIntegerType() &&
+                    return type.IsNativeIntegerType &&
                         type.SpecialType == (signed ? SpecialType.System_IntPtr : SpecialType.System_UIntPtr);
                 }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Equal(SymbolKind.NamedType, type.Kind);
             Assert.Equal(TypeKind.Struct, type.TypeKind);
             Assert.Same(type, type.ConstructedFrom);
-            Assert.Equal(isNativeInt, type.IsNativeIntegerType());
+            Assert.Equal(isNativeInt, type.IsNativeInteger);
 
             if (isNativeInt)
             {
@@ -181,12 +181,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Equal(SymbolKind.NamedType, type.Kind);
             Assert.Equal(TypeKind.Struct, type.TypeKind);
             Assert.Same(type, type.ConstructedFrom);
+            Assert.Equal(isNativeInt, type.IsNativeInteger);
         }
 
         private static void VerifyTypes(INamedTypeSymbol underlyingType, INamedTypeSymbol nativeIntegerType, bool signed)
         {
             VerifyType(underlyingType, signed, isNativeInt: false);
-            VerifyType(nativeIntegerType, signed, isNativeInt: false);
+            VerifyType(nativeIntegerType, signed, isNativeInt: true);
+
+            Assert.Same(underlyingType.ContainingSymbol, nativeIntegerType.ContainingSymbol);
+            Assert.Same(underlyingType.Name, nativeIntegerType.Name); // PROTOTYPE: Should Name return "nint"/"nuint" or perhaps null?
 
             Assert.Empty(nativeIntegerType.GetTypeMembers());
 
@@ -204,6 +208,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Same(underlyingType, nativeIntegerType.NativeIntegerUnderlyingType);
             Assert.Equal(underlyingType, nativeIntegerType);
             Assert.Equal(nativeIntegerType, underlyingType);
+            Assert.True(underlyingType.Equals(nativeIntegerType));
+            Assert.True(underlyingType.Equals(nativeIntegerType, SymbolEqualityComparer.Default));
+            Assert.True(underlyingType.Equals(nativeIntegerType, SymbolEqualityComparer.IncludeNullability));
+            Assert.True(underlyingType.Equals(nativeIntegerType, SymbolEqualityComparer.ConsiderEverything));
             Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
         }
 
@@ -211,6 +219,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         {
             VerifyType(underlyingType, signed, isNativeInt: false);
             VerifyType(nativeIntegerType, signed, isNativeInt: true);
+
+            Assert.Same(underlyingType.ContainingSymbol, nativeIntegerType.ContainingSymbol);
+            Assert.Same(underlyingType.Name, nativeIntegerType.Name); // PROTOTYPE: Should Name return "nint"/"nuint" or perhaps null?
 
             Assert.Empty(nativeIntegerType.GetTypeMembers());
 
@@ -227,11 +238,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Null(underlyingType.NativeIntegerUnderlyingType);
             Assert.Same(nativeIntegerType, underlyingType.AsNativeInteger());
             Assert.Same(underlyingType, nativeIntegerType.NativeIntegerUnderlyingType);
-            VerifyEqualButDistinct(underlyingType, underlyingType.AsNativeInteger());
-            VerifyEqualButDistinct(nativeIntegerType, nativeIntegerType.NativeIntegerUnderlyingType);
-            VerifyEqualButDistinct(underlyingType, nativeIntegerType);
+            verifyEqualButDistinct(underlyingType, underlyingType.AsNativeInteger());
+            verifyEqualButDistinct(nativeIntegerType, nativeIntegerType.NativeIntegerUnderlyingType);
+            verifyEqualButDistinct(underlyingType, nativeIntegerType);
 
             VerifyTypes(underlyingType.GetPublicSymbol(), nativeIntegerType.GetPublicSymbol(), signed);
+
+            static void verifyEqualButDistinct(NamedTypeSymbol underlyingType, NamedTypeSymbol nativeIntegerType)
+            {
+                Assert.NotSame(underlyingType, nativeIntegerType);
+                Assert.Equal(underlyingType, nativeIntegerType);
+                Assert.Equal(nativeIntegerType, underlyingType);
+                Assert.True(underlyingType.Equals(nativeIntegerType, TypeCompareKind.ConsiderEverything));
+                Assert.True(nativeIntegerType.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
+                Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
+            }
         }
 
         private static void VerifyMembers(NamedTypeSymbol type)
@@ -271,16 +292,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Assert.Same(type, member.ContainingSymbol);
                 Assert.Same(type, member.ContainingType);
             }
-        }
-
-        private static void VerifyEqualButDistinct(NamedTypeSymbol underlyingType, NamedTypeSymbol nativeIntegerType)
-        {
-            Assert.NotSame(underlyingType, nativeIntegerType);
-            Assert.Equal(underlyingType, nativeIntegerType);
-            Assert.Equal(nativeIntegerType, underlyingType);
-            Assert.True(underlyingType.Equals(nativeIntegerType, TypeCompareKind.ConsiderEverything));
-            Assert.True(nativeIntegerType.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
-            Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
         }
 
         [Fact]
@@ -348,7 +359,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         {
             Assert.Equal(SymbolKind.ErrorType, type.Kind);
             Assert.Equal(TypeKind.Error, type.TypeKind);
-            Assert.Equal(isNativeInt, type.IsNativeIntegerType());
+            Assert.Equal(isNativeInt, type.IsNativeInteger);
             Assert.Equal(specialType, type.SpecialType);
         }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -937,6 +937,16 @@ namespace Microsoft.CodeAnalysis
 
         protected abstract IPointerTypeSymbol CommonCreatePointerTypeSymbol(ITypeSymbol elementType);
 
+        /// <summary>
+        /// Returns a new INamedTypeSymbol representing a native integer.
+        /// </summary>
+        public INamedTypeSymbol CreateNativeIntegerTypeSymbol(bool signed)
+        {
+            return CommonCreateNativeIntegerTypeSymbol(signed);
+        }
+
+        protected abstract INamedTypeSymbol CommonCreateNativeIntegerTypeSymbol(bool signed);
+
         // PERF: ETW Traces show that analyzers may use this method frequently, often requesting
         // the same symbol over and over again. XUnit analyzers, in particular, were consuming almost
         // 1% of CPU time when building Roslyn itself. This is an extremely simple cache that evicts on

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -5,9 +5,9 @@ Microsoft.CodeAnalysis.ErrorLogOptions
 Microsoft.CodeAnalysis.ErrorLogOptions.ErrorLogOptions(string path, Microsoft.CodeAnalysis.SarifVersion sarifVersion) -> void
 Microsoft.CodeAnalysis.ErrorLogOptions.Path.get -> string
 Microsoft.CodeAnalysis.ErrorLogOptions.SarifVersion.get -> Microsoft.CodeAnalysis.SarifVersion
-Microsoft.CodeAnalysis.INamedTypeSymbol.IsNativeInteger.get -> bool
 Microsoft.CodeAnalysis.INamedTypeSymbol.NativeIntegerUnderlyingType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.IParameterSymbol.IsDiscard.get -> bool
+Microsoft.CodeAnalysis.ITypeSymbol.IsNativeIntegerType.get -> bool
 Microsoft.CodeAnalysis.OperationKind.UsingDeclaration = 108 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.IUsingDeclarationOperation
 Microsoft.CodeAnalysis.Operations.IUsingDeclarationOperation.DeclarationGroup.get -> Microsoft.CodeAnalysis.Operations.IVariableDeclarationGroupOperation

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,9 +1,12 @@
 Microsoft.CodeAnalysis.CommandLineArguments.ErrorLogOptions.get -> Microsoft.CodeAnalysis.ErrorLogOptions
 *REMOVED*Microsoft.CodeAnalysis.CommandLineArguments.ErrorLogPath.get -> string
+Microsoft.CodeAnalysis.Compilation.CreateNativeIntegerTypeSymbol(bool signed) -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.ErrorLogOptions
 Microsoft.CodeAnalysis.ErrorLogOptions.ErrorLogOptions(string path, Microsoft.CodeAnalysis.SarifVersion sarifVersion) -> void
 Microsoft.CodeAnalysis.ErrorLogOptions.Path.get -> string
 Microsoft.CodeAnalysis.ErrorLogOptions.SarifVersion.get -> Microsoft.CodeAnalysis.SarifVersion
+Microsoft.CodeAnalysis.INamedTypeSymbol.IsNativeInteger.get -> bool
+Microsoft.CodeAnalysis.INamedTypeSymbol.NativeIntegerUnderlyingType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.IParameterSymbol.IsDiscard.get -> bool
 Microsoft.CodeAnalysis.OperationKind.UsingDeclaration = 108 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.IUsingDeclarationOperation

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -192,6 +192,6 @@ namespace Microsoft.CodeAnalysis
         /// either <see cref="System.IntPtr"/> or <see cref="System.UIntPtr"/>.
         /// Otherwise, returns null.
         /// </summary>
-        INamedTypeSymbol NativeIntegerUnderlyingType { get; }
+        INamedTypeSymbol? NativeIntegerUnderlyingType { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -189,13 +189,13 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// True if the type represents a native integer. In C#, the types represented
-        /// by language tokens 'nint' and 'nuint'.
+        /// by language keywords 'nint' and 'nuint'.
         /// </summary>
         bool IsNativeInteger { get; }
 
         /// <summary>
         /// If this is a native integer, returns the symbol for the underlying type,
-        /// either <see cref="System.IntPtr"/> or  <see cref="System.UIntPtr"/>.
+        /// either <see cref="System.IntPtr"/> or <see cref="System.UIntPtr"/>.
         /// Otherwise, returns null.
         /// </summary>
         INamedTypeSymbol NativeIntegerUnderlyingType { get; }

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -188,12 +188,6 @@ namespace Microsoft.CodeAnalysis
         bool IsSerializable { get; }
 
         /// <summary>
-        /// True if the type represents a native integer. In C#, the types represented
-        /// by language keywords 'nint' and 'nuint'.
-        /// </summary>
-        bool IsNativeInteger { get; }
-
-        /// <summary>
         /// If this is a native integer, returns the symbol for the underlying type,
         /// either <see cref="System.IntPtr"/> or <see cref="System.UIntPtr"/>.
         /// Otherwise, returns null.

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -186,5 +186,18 @@ namespace Microsoft.CodeAnalysis
         /// True if the type is serializable (has Serializable metadata flag).
         /// </summary>
         bool IsSerializable { get; }
+
+        /// <summary>
+        /// True if the type represents a native integer. In C#, the types represented
+        /// by language tokens 'nint' and 'nuint'.
+        /// </summary>
+        bool IsNativeInteger { get; }
+
+        /// <summary>
+        /// If this is a native integer, returns the symbol for the underlying type,
+        /// either <see cref="System.IntPtr"/> or  <see cref="System.UIntPtr"/>.
+        /// Otherwise, returns null.
+        /// </summary>
+        INamedTypeSymbol NativeIntegerUnderlyingType { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -78,6 +78,12 @@ namespace Microsoft.CodeAnalysis
         bool IsTupleType { get; }
 
         /// <summary>
+        /// True if the type represents a native integer. In C#, the types represented
+        /// by language keywords 'nint' and 'nuint'.
+        /// </summary>
+        bool IsNativeIntegerType { get; }
+
+        /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
         /// symbol by type substitution then <see cref="OriginalDefinition"/> gets the original symbol as it was defined in
         /// source or metadata.

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2721,6 +2721,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Throw New NotSupportedException(VBResources.ThereAreNoPointerTypesInVB)
         End Function
 
+        Protected Overrides Function CommonCreateNativeIntegerTypeSymbol(signed As Boolean) As INamedTypeSymbol
+            Throw New NotSupportedException(VBResources.ThereAreNoNativeIntegerTypesInVB)
+        End Function
+
         Protected Overrides Function CommonCreateAnonymousTypeSymbol(
                 memberTypes As ImmutableArray(Of ITypeSymbol),
                 memberNames As ImmutableArray(Of String),

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1221,12 +1221,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private ReadOnly Property INamedTypeSymbol_IsNativeInteger As Boolean Implements INamedTypeSymbol.IsNativeInteger
-            Get
-                Return False
-            End Get
-        End Property
-
         Private ReadOnly Property INamedTypeSymbol_NativeIntegerUnderlyingType As INamedTypeSymbol Implements INamedTypeSymbol.NativeIntegerUnderlyingType
             Get
                 Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -192,18 +192,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public MustOverride ReadOnly Property IsSerializable As Boolean Implements INamedTypeSymbol.IsSerializable
 
-        Public ReadOnly Property IsNativeInteger As Boolean Implements INamedTypeSymbol.IsNativeInteger
-            Get
-                Return False
-            End Get
-        End Property
-
-        Public ReadOnly Property NativeIntegerUnderlyingType As INamedTypeSymbol Implements INamedTypeSymbol.NativeIntegerUnderlyingType
-            Get
-                Return Nothing
-            End Get
-        End Property
-
         ''' <summary>
         ''' Type layout information (ClassLayout metadata and layout kind flags).
         ''' </summary>
@@ -1230,6 +1218,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property INamedTypeSymbol_IsComImport As Boolean Implements INamedTypeSymbol.IsComImport
             Get
                 Return IsComImport
+            End Get
+        End Property
+
+        Private ReadOnly Property INamedTypeSymbol_IsNativeInteger As Boolean Implements INamedTypeSymbol.IsNativeInteger
+            Get
+                Return False
+            End Get
+        End Property
+
+        Private ReadOnly Property INamedTypeSymbol_NativeIntegerUnderlyingType As INamedTypeSymbol Implements INamedTypeSymbol.NativeIntegerUnderlyingType
+            Get
+                Return Nothing
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -192,6 +192,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public MustOverride ReadOnly Property IsSerializable As Boolean Implements INamedTypeSymbol.IsSerializable
 
+        Public ReadOnly Property IsNativeInteger As Boolean Implements INamedTypeSymbol.IsNativeInteger
+            Get
+                Return False
+            End Get
+        End Property
+
+        Public ReadOnly Property NativeIntegerUnderlyingType As INamedTypeSymbol Implements INamedTypeSymbol.NativeIntegerUnderlyingType
+            Get
+                Return Nothing
+            End Get
+        End Property
+
         ''' <summary>
         ''' Type layout information (ClassLayout metadata and layout kind flags).
         ''' </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -559,6 +559,12 @@ Done:
             End Get
         End Property
 
+        Private ReadOnly Property ITypeSymbol_IsNativeIntegerType As Boolean Implements ITypeSymbol.IsNativeIntegerType
+            Get
+                Return False
+            End Get
+        End Property
+
         Private ReadOnly Property ITypeSymbol_TypeKind As TypeKind Implements ITypeSymbol.TypeKind, ITypeSymbolInternal.TypeKind
             Get
                 Return Me.TypeKind

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -12711,6 +12711,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to There are no native integer types in VB..
+        '''</summary>
+        Friend ReadOnly Property ThereAreNoNativeIntegerTypesInVB() As String
+            Get
+                Return ResourceManager.GetString("ThereAreNoNativeIntegerTypesInVB", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to There are no pointer types in VB..
         '''</summary>
         Friend ReadOnly Property ThereAreNoPointerTypesInVB() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -4979,6 +4979,9 @@
   <data name="ThereIsNoDynamicTypeInVB" xml:space="preserve">
     <value>There is no dynamic type in VB.</value>
   </data>
+  <data name="ThereAreNoNativeIntegerTypesInVB" xml:space="preserve">
+    <value>There are no native integer types in VB.</value>
+  </data>
   <data name="VariableSyntaxNotWithinSyntaxTree" xml:space="preserve">
     <value>variableSyntax not within syntax tree</value>
   </data>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">stromy({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">Bäume({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">árboles({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">arborescences({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">alberi ({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">ツリー ({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">트리({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">trees({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">árvores({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">деревья({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">ağaçlar({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -376,6 +376,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">树({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -375,6 +375,11 @@
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="ThereAreNoNativeIntegerTypesInVB">
+        <source>There are no native integer types in VB.</source>
+        <target state="new">There are no native integer types in VB.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">trees({0})</target>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NativeIntegerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NativeIntegerTests.vb
@@ -1,0 +1,72 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+
+    Public Class NativeIntegerTests
+        Inherits BasicTestBase
+
+        <Fact>
+        Public Sub TypeDefinitions_FromMetadata()
+            Dim source0 =
+"public interface I
+{
+    public void F1(System.IntPtr x, nint y);
+    public void F2(System.UIntPtr x, nuint y);
+}"
+            Dim comp As Compilation = CreateCSharpCompilation(source0, parseOptions:=New CSharp.CSharpParseOptions(CSharp.LanguageVersion.Preview))
+            Dim ref0 = comp.EmitToImageReference()
+
+            Dim type = comp.GlobalNamespace.GetTypeMembers("I").Single()
+            Dim method = DirectCast(type.GetMembers("F1").Single(), IMethodSymbol)
+            VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=False)
+            VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=True)
+
+            method = DirectCast(type.GetMembers("F2").Single(), IMethodSymbol)
+            VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=False)
+            VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=True)
+
+            comp = CreateCompilation("", references:={ref0})
+            comp.VerifyDiagnostics()
+
+            type = comp.GlobalNamespace.GetTypeMembers("I").Single()
+            method = DirectCast(type.GetMembers("F1").Single(), IMethodSymbol)
+            VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=False)
+            VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=False)
+
+            method = DirectCast(type.GetMembers("F2").Single(), IMethodSymbol)
+            VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=False)
+            VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=False)
+        End Sub
+
+        Private Shared Sub VerifyType(type As INamedTypeSymbol, signed As Boolean, isNativeInteger As Boolean)
+            Assert.Equal(If(signed, SpecialType.System_IntPtr, SpecialType.System_UIntPtr), type.SpecialType)
+            Assert.Equal(SymbolKind.NamedType, type.Kind)
+            Assert.Equal(TypeKind.Struct, type.TypeKind)
+            Assert.Same(type, type.ConstructedFrom)
+            Assert.Equal(isNativeInteger, type.IsNativeInteger)
+
+            Dim underlyingType = type.NativeIntegerUnderlyingType
+            If isNativeInteger Then
+                Assert.NotNull(underlyingType)
+                VerifyType(underlyingType, signed, isNativeInteger:=False)
+            Else
+                Assert.Null(underlyingType)
+            End If
+        End Sub
+
+        <Fact>
+        Public Sub CreateNativeIntegerTypeSymbol()
+            Dim comp = VisualBasicCompilation.Create(assemblyName:=GetUniqueName(), references:=TargetFrameworkUtil.GetReferences(TargetFramework.DefaultVb), options:=TestOptions.ReleaseDll)
+            comp.AssertNoDiagnostics()
+            Assert.Throws(Of NotSupportedException)(Function() comp.CreateNativeIntegerTypeSymbol(signed:=True))
+            Assert.Throws(Of NotSupportedException)(Function() comp.CreateNativeIntegerTypeSymbol(signed:=False))
+        End Sub
+
+    End Class
+
+End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NativeIntegerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NativeIntegerTests.vb
@@ -23,10 +23,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
             Dim type = comp.GlobalNamespace.GetTypeMembers("I").Single()
             Dim method = DirectCast(type.GetMembers("F1").Single(), IMethodSymbol)
+            Assert.Equal("Sub I.F1(x As System.IntPtr, y As System.IntPtr)", SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.TestFormat))
             VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=False)
             VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=True)
 
             method = DirectCast(type.GetMembers("F2").Single(), IMethodSymbol)
+            Assert.Equal("Sub I.F2(x As System.UIntPtr, y As System.UIntPtr)", SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.TestFormat))
             VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=False)
             VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=True)
 
@@ -35,10 +37,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
             type = comp.GlobalNamespace.GetTypeMembers("I").Single()
             method = DirectCast(type.GetMembers("F1").Single(), IMethodSymbol)
+            Assert.Equal("Sub I.F1(x As System.IntPtr, y As System.IntPtr)", SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.TestFormat))
             VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=False)
             VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=True, isNativeInteger:=False)
 
             method = DirectCast(type.GetMembers("F2").Single(), IMethodSymbol)
+            Assert.Equal("Sub I.F2(x As System.UIntPtr, y As System.UIntPtr)", SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.TestFormat))
             VerifyType(DirectCast(method.Parameters(0).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=False)
             VerifyType(DirectCast(method.Parameters(1).Type, INamedTypeSymbol), signed:=False, isNativeInteger:=False)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NativeIntegerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NativeIntegerTests.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal(SymbolKind.NamedType, type.Kind)
             Assert.Equal(TypeKind.Struct, type.TypeKind)
             Assert.Same(type, type.ConstructedFrom)
-            Assert.Equal(isNativeInteger, type.IsNativeInteger)
+            Assert.Equal(isNativeInteger, type.IsNativeIntegerType)
 
             Dim underlyingType = type.NativeIntegerUnderlyingType
             If isNativeInteger Then

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -179,6 +179,10 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsReadOnly => _symbol.IsReadOnly;
 
+            public bool IsNativeInteger => _symbol.IsNativeInteger;
+
+            public INamedTypeSymbol NativeIntegerUnderlyingType => _symbol.NativeIntegerUnderlyingType;
+
             NullableAnnotation ITypeSymbol.NullableAnnotation => throw new System.NotImplementedException();
 
             ITypeSymbol ITypeSymbol.WithNullableAnnotation(NullableAnnotation nullableAnnotation)

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsReadOnly => _symbol.IsReadOnly;
 
-            public bool IsNativeInteger => _symbol.IsNativeInteger;
+            public bool IsNativeIntegerType => _symbol.IsNativeIntegerType;
 
             public INamedTypeSymbol NativeIntegerUnderlyingType => _symbol.NativeIntegerUnderlyingType;
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -114,8 +114,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsRefLikeType => Modifiers.IsRef;
 
-        public bool IsNativeIntegerType => false;
-
         public INamedTypeSymbol NativeIntegerUnderlyingType => null;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsRefLikeType => Modifiers.IsRef;
 
-        public bool IsNativeInteger => false;
+        public bool IsNativeIntegerType => false;
 
         public INamedTypeSymbol NativeIntegerUnderlyingType => null;
     }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -113,5 +113,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public bool IsUnmanagedType => throw new NotImplementedException();
 
         public bool IsRefLikeType => Modifiers.IsRef;
+
+        public bool IsNativeInteger => false;
+
+        public INamedTypeSymbol NativeIntegerUnderlyingType => null;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -43,6 +43,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsTupleType => false;
 
+        public bool IsNativeIntegerType => false;
+
         public ImmutableArray<ITypeSymbol> TupleElementTypes => default;
 
         public ImmutableArray<string> TupleElementNames => default;


### PR DESCRIPTION
Native integer type symbols implement `INamedTypeSymbol`.

- Members are added to `ITypeSymbol` and `INamedTypeSymbol`:
```C#
public interface ITypeSymbol
{
    bool IsNativeIntegerType { get; }
}

public interface INamedTypeSymbol : ITypeSymbol
{
    INamedTypeSymbol NativeIntegerUnderlyingType { get; }
}
```

- `NativeIntegerUnderlyingType` returns an instance that has no nullable annotation, even if the native integer symbol was created with an annotation.

- `ContainingSymbol` returns the containing symbol of the underlying type: the `INamespaceSymbol` for the `System` namespace.

- `Name` returns the name of the underlying type: "IntPtr" or "UIntPtr".


Symbols for native integers and the underlying types do not compare `Equals()`. This applies to all public `Equals()` overloads.

- `object.Equals(object other)`

- `IEquatable<ISymbol>.Equals(ISymbol other)`

- `ISymbol.Equals(ISymbol other, SymbolEqualityComparer equalityComparer)`

- A new `SymbolEqualityComparer` instance could be added later to ignore differences between native integers and underlying types. If we did that, we'd probably also add comparers that ignore differences between tuple element names and differences between `dynamic` and `object`.

`Compilation` includes a method for getting native integer type symbols:
```C#
public abstract class Compilation
{
    public INamedTypeSymbol CreateNativeIntegerTypeSymbol(bool signed);
}
```

- `VisualBasicCompilation` implementation of `CreateNativeIntegerTypeSymbol()` throws `NotSupportedException`.

`SymbolDisplay` uses "nint" or "nuint" always, regardless of `SymbolDisplayFormat`. _(Not implemented in this PR.)_