### PR TITLE
Move macOS_Test to 10.14

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCorePublic-Pool
-    queue: buildpool.windows.10.amd64.vs2019.pre.open
+    queue: buildpool.windows.10.amd64.vs2019.open
   strategy:
     maxParallel: 2
     matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -229,7 +229,7 @@ jobs:
 
 - job: macOS_Test
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   timeoutInMinutes: 90
 
   steps:


### PR DESCRIPTION
The 10.13 image is being retired on March 23rd. Thought I would be proactive and target 16.4 in case we needed to service it.