### PR TITLE
Fixed SourceText.Write for spans that don't start at 0 

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -301,6 +302,18 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
 
             TestTryReadByteOrderMark(expectedEncoding: null, expectedPreambleLength: 0, data: new byte[] { 0xfe });
             TestTryReadByteOrderMark(expectedEncoding: Encoding.BigEndianUnicode, expectedPreambleLength: 2, data: new byte[] { 0xfe, 0xff });
+        }
+
+        [Fact]
+        [WorkItem(41903, "https://github.com/dotnet/roslyn/issues/41903")]
+        public void WriteWithRangeStartingLaterThanZero()
+        {
+            var sourceText = SourceText.From("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+            var writer = new StringWriter();
+            sourceText.Write(writer, TextSpan.FromBounds(1, sourceText.Length));
+
+            Assert.Equal("BCDEFGHIJKLMNOPQRSTUVWXYZ", writer.ToString());
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
@@ -315,5 +315,24 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
 
             Assert.Equal("BCDEFGHIJKLMNOPQRSTUVWXYZ", writer.ToString());
         }
+
+        public static IEnumerable<object[]> AllRanges(int totalLength) =>
+            from start in Enumerable.Range(0, totalLength)
+            from length in Enumerable.Range(0, totalLength - start)
+            select new object[] { new TextSpan(start, length) };
+
+        [Theory]
+        [MemberData(nameof(AllRanges), 10)]
+        [WorkItem(41903, "https://github.com/dotnet/roslyn/issues/41903")]
+        public void WriteWithAllRanges(TextSpan span)
+        {
+            const string Text = "0123456789";
+            var sourceText = SourceText.From(Text);
+
+            var writer = new StringWriter();
+            sourceText.Write(writer, span);
+
+            Assert.Equal(Text.Substring(span.Start, span.Length), writer.ToString());
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -333,6 +334,24 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
             sourceText.Write(writer, span);
 
             Assert.Equal(Text.Substring(span.Start, span.Length), writer.ToString());
+        }
+
+        [Fact]
+        public void WriteWithSpanStartingAfterEndThrowsOutOfRange()
+        {
+            var ex = Assert.ThrowsAny<ArgumentOutOfRangeException>(() =>
+                SourceText.From("ABC").Write(TextWriter.Null, TextSpan.FromBounds(4, 4)));
+
+            Assert.Equal("span", ex.ParamName);
+        }
+
+        [Fact]
+        public void WriteWithSpanEndingAfterEndThrowsOutOfRange()
+        {
+            var ex = Assert.ThrowsAny<ArgumentOutOfRangeException>(() =>
+                SourceText.From("ABC").Write(TextWriter.Null, TextSpan.FromBounds(2, 4)));
+
+            Assert.Equal("span", ex.ParamName);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -469,8 +469,8 @@ namespace Microsoft.CodeAnalysis.Text
 
         internal void CheckSubSpan(TextSpan span)
         {
-            // TextSpan guarantees that Start >= 0.
-            if (span.Start > this.Length || span.End > this.Length)
+            // TextSpan guarantees that Start >= 0 and that Start <= End.
+            if (span.End > this.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(span));
             }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -469,7 +469,8 @@ namespace Microsoft.CodeAnalysis.Text
 
         internal void CheckSubSpan(TextSpan span)
         {
-            if (span.Start < 0 || span.Start > this.Length || span.End > this.Length)
+            // TextSpan guarantees that Start >= 0.
+            if (span.Start > this.Length || span.End > this.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(span));
             }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -535,8 +535,8 @@ namespace Microsoft.CodeAnalysis.Text
             var buffer = s_charArrayPool.Allocate();
             try
             {
-                int offset = Math.Min(this.Length, span.Start);
-                int end = Math.Min(this.Length, span.End);
+                int offset = span.Start;
+                int end = span.End;
                 while (offset < end)
                 {
                     cancellationToken.ThrowIfCancellationRequested();

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -536,12 +536,12 @@ namespace Microsoft.CodeAnalysis.Text
             try
             {
                 int offset = Math.Min(this.Length, span.Start);
-                int length = Math.Min(this.Length, span.End) - offset;
-                while (offset < length)
+                int end = Math.Min(this.Length, span.End);
+                while (offset < end)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    int count = Math.Min(buffer.Length, length - offset);
+                    int count = Math.Min(buffer.Length, end - offset);
                     this.CopyTo(offset, buffer, 0, count);
                     writer.Write(buffer, 0, count);
                     offset += count;

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -469,7 +469,8 @@ namespace Microsoft.CodeAnalysis.Text
 
         internal void CheckSubSpan(TextSpan span)
         {
-            // TextSpan guarantees that Start >= 0 and that Start <= End.
+            Debug.Assert(0 <= span.Start && span.Start <= span.End);
+
             if (span.End > this.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(span));


### PR DESCRIPTION
Fixes #41903. Three simplification commits follow.