### PR TITLE
Add lightbulb actions to bulk configure default severity for analyzer…

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/AllAnalyzersSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/AllAnalyzersSeverityConfigurationTests.cs
@@ -1,0 +1,341 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configuration.ConfigureSeverity
+{
+    public abstract partial class AllAnalyzersSeverityConfigurationTests : AbstractSuppressionDiagnosticTest
+    {
+        private sealed class CustomDiagnosticAnalyzer : DiagnosticAnalyzer
+        {
+            private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+                id: "XYZ0001",
+                title: "Title",
+                messageFormat: "Message",
+                category: "CustomCategory",
+                defaultSeverity: DiagnosticSeverity.Info,
+                isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterSyntaxNodeAction(
+                    c => c.ReportDiagnostic(Diagnostic.Create(Rule, c.Node.GetLocation())),
+                    SyntaxKind.ClassDeclaration);
+            }
+        }
+
+        protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
+            => TestWorkspace.CreateCSharp(initialMarkup, parameters.parseOptions, parameters.compilationOptions);
+
+        protected override string GetLanguage() => LanguageNames.CSharp;
+
+        protected override ParseOptions GetScriptOptions() => Options.Script;
+
+        internal override Tuple<DiagnosticAnalyzer, IConfigurationFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+        {
+            return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
+                        new CustomDiagnosticAnalyzer(), new ConfigureSeverityLevelCodeFixProvider());
+        }
+
+        public sealed class SilentConfigurationTests : AllAnalyzersSeverityConfigurationTests
+        {
+            /// <summary>
+            /// Code action ranges:
+            ///     1. (0 - 4) => Code actions for diagnostic "ID" configuration with severity None, Silent, Suggestion, Warning and Error
+            ///     2. (5 - 9) => Code actions for diagnostic "Category" configuration with severity None, Silent, Suggestion, Warning and Error
+            ///     3. (10 - 14) => Code actions for all analyzer diagnostics configuration with severity None, Silent, Suggestion, Warning and Error
+            /// </summary>
+            protected override int CodeActionIndex => 11;
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_Empty()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig""></AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RuleExists()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_analyzer_diagnostic.severity = suggestion   # Comment
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_analyzer_diagnostic.severity = silent   # Comment
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RuleIdEntryExists()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_diagnostic.XYZ0001.severity = suggestion   # Comment1
+dotnet_diagnostic.category-CustomCategory.severity = warning   # Comment2
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_diagnostic.XYZ0001.severity = suggestion   # Comment1
+dotnet_diagnostic.category-CustomCategory.severity = warning   # Comment2
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_InvalidHeader()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
+dotnet_analyzer_diagnostic.severity = suggestion
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
+dotnet_analyzer_diagnostic.severity = suggestion
+
+[*.cs]
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_MaintainExistingEntry()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, input, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_DiagnosticsSuppressed()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.severity = none
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestMissingInRegularAndScriptAsync(input);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_InvalidRule()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.XYZ1111.severity = suggestion
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.XYZ1111.severity = suggestion
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RegexHeaderMatch()
+            {
+                // NOTE: Even though we have a regex match, bulk configuration code fix is always applied to all files
+                // within the editorconfig cone, so it generates a new entry.
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\Program/file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fi*e.cs]
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = warning
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\Program/file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fi*e.cs]
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = warning
+
+[*.cs]
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RegexHeaderNonMatch()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\Program/file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fii*e.cs]
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = warning
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\Program/file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fii*e.cs]
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = warning
+
+[*.cs]
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CategoryBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CategoryBasedSeverityConfigurationTests.cs
@@ -1,0 +1,339 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configuration.ConfigureSeverity
+{
+    public abstract partial class CategoryBasedSeverityConfigurationTests : AbstractSuppressionDiagnosticTest
+    {
+        private sealed class CustomDiagnosticAnalyzer : DiagnosticAnalyzer
+        {
+            private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+                id: "XYZ0001",
+                title: "Title",
+                messageFormat: "Message",
+                category: "CustomCategory",
+                defaultSeverity: DiagnosticSeverity.Info,
+                isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterSyntaxNodeAction(
+                    c => c.ReportDiagnostic(Diagnostic.Create(Rule, c.Node.GetLocation())),
+                    SyntaxKind.ClassDeclaration);
+            }
+        }
+
+        protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
+            => TestWorkspace.CreateCSharp(initialMarkup, parameters.parseOptions, parameters.compilationOptions);
+
+        protected override string GetLanguage() => LanguageNames.CSharp;
+
+        protected override ParseOptions GetScriptOptions() => Options.Script;
+
+        internal override Tuple<DiagnosticAnalyzer, IConfigurationFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+        {
+            return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
+                        new CustomDiagnosticAnalyzer(), new ConfigureSeverityLevelCodeFixProvider());
+        }
+
+        public sealed class SilentConfigurationTests : CategoryBasedSeverityConfigurationTests
+        {
+            /// <summary>
+            /// Code action ranges:
+            ///     1. (0 - 4) => Code actions for diagnostic "ID" configuration with severity None, Silent, Suggestion, Warning and Error
+            ///     2. (5 - 9) => Code actions for diagnostic "Category" configuration with severity None, Silent, Suggestion, Warning and Error
+            ///     3. (10 - 14) => Code actions for all analyzer diagnostics configuration with severity None, Silent, Suggestion, Warning and Error
+            /// </summary>
+            protected override int CodeActionIndex => 6;
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_Empty()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig""></AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RuleExists()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = suggestion   # Comment
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent   # Comment
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RuleIdEntryExists()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_diagnostic.XYZ0001.severity = suggestion   # Comment
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_diagnostic.XYZ0001.severity = suggestion   # Comment
+
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_InvalidHeader()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = suggestion
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = suggestion
+
+[*.cs]
+
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_MaintainExistingEntry()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, input, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_DiagnosticsSuppressed()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = none
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestMissingInRegularAndScriptAsync(input);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_InvalidRule()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.category-XYZ1111Category.severity = suggestion
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
+dotnet_analyzer_diagnostic.category-XYZ1111Category.severity = suggestion
+
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RegexHeaderMatch()
+            {
+                // NOTE: Even though we have a regex match, bulk configuration code fix is always applied to all files
+                // within the editorconfig cone, so it generates a new entry.
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\Program/file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fi*e.cs]
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = warning
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\Program/file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fi*e.cs]
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = warning
+
+[*.cs]
+
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RegexHeaderNonMatch()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+        <Document FilePath=""z:\\Program/file.cs"">
+[|class Program1 { }|]
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fii*e.cs]
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = warning
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" FilePath=""z:\\Assembly1.csproj"">
+         <Document FilePath=""z:\\Program/file.cs"">
+class Program1 { }
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*am/fii*e.cs]
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = warning
+
+[*.cs]
+
+# Default severity for analyzer diagnostics with category 'CustomCategory'
+dotnet_analyzer_diagnostic.category-CustomCategory.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeFixes/AbstractConfigurationActionWithNestedActions.cs
+++ b/src/Features/Core/Portable/CodeFixes/AbstractConfigurationActionWithNestedActions.cs
@@ -21,5 +21,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         // Put configurations/suppressions at the end of everything.
         internal override CodeActionPriority Priority => CodeActionPriority.None;
+
+        /// <summary>
+        /// Additional priority associated with all configuration and suppression code actions.
+        /// This allows special code actions such as Bulk configuration to to be at the end of
+        /// all suppression and configuration actions by having a lower additional priority.
+        /// </summary>
+        internal virtual CodeActionPriority AdditionalPriority => CodeActionPriority.Medium;
+
+        internal virtual bool IsBulkConfigurationAction => false;
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -30,11 +31,15 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
         private enum ConfigurationKind
         {
             OptionValue,
-            Severity
+            Severity,
+            BulkConfigure
         }
 
         private const string DiagnosticOptionPrefix = "dotnet_diagnostic.";
-        private const string DiagnosticOptionSuffix = ".severity";
+        private const string SeveritySuffix = ".severity";
+        private const string BulkConfigureAllAnalyzerDiagnosticsOptionKey = "dotnet_analyzer_diagnostic.severity";
+        private const string BulkConfigureAnalyzerDiagnosticsByCategoryOptionPrefix = "dotnet_analyzer_diagnostic.category-";
+        private const string AllAnalyzerDiagnosticsCategory = "";
 
         // Regular expression for .editorconfig header.
         // For example: "[*.cs]    # Optional comment"
@@ -47,38 +52,46 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
         // For example: "dotnet_style_object_initializer = true:suggestion   # Optional comment"
         private static readonly Regex s_optionBasedEntryPattern = new Regex(@"([\w ]+)=([\w, ]+):[ ]*([\w]+)([ ]*[;#].*)?");
 
-        // Regular expression for .editorconfig diagnosticID severity configuration entry.
-        // For example: "dotnet_diagnostic.CA2000.severity = suggestion   # Optional comment"
-        private static readonly Regex s_severityBasedEntryPattern = new Regex(@"([\w \.]+)=[ ]*([\w]+)([ ]*[;#].*)?");
+        // Regular expression for .editorconfig diagnostic severity configuration entry.
+        // For example:
+        //  1. "dotnet_diagnostic.CA2000.severity = suggestion   # Optional comment"
+        //  2. "dotnet_analyzer_diagnostic.category-Security.severity = suggestion   # Optional comment"
+        //  3. "dotnet_analyzer_diagnostic.severity = suggestion   # Optional comment"
+        private static readonly Regex s_severityBasedEntryPattern = new Regex(@"([\w- \.]+)=[ ]*([\w]+)([ ]*[;#].*)?");
 
-        private readonly string _optionNameOpt;
-        private readonly string _newOptionValueOpt;
+        private readonly string? _optionNameOpt;
+        private readonly string? _newOptionValueOpt;
         private readonly string _newSeverity;
         private readonly ConfigurationKind _configurationKind;
-        private readonly Diagnostic _diagnostic;
+        private readonly Diagnostic? _diagnostic;
+        private readonly string? _categoryToBulkConfigure;
         private readonly bool _isPerLanguage;
         private readonly Project _project;
         private readonly CancellationToken _cancellationToken;
         private readonly string _language;
 
         private ConfigurationUpdater(
-            string optionNameOpt,
-            string newOptionValueOpt,
+            string? optionNameOpt,
+            string? newOptionValueOpt,
             string newSeverity,
             ConfigurationKind configurationKind,
-            Diagnostic diagnostic,
+            Diagnostic? diagnosticToConfigure,
+            string? categoryToBulkConfigure,
             bool isPerLanguage,
             Project project,
             CancellationToken cancellationToken)
         {
             Debug.Assert(configurationKind != ConfigurationKind.OptionValue || !string.IsNullOrEmpty(newOptionValueOpt));
             Debug.Assert(!string.IsNullOrEmpty(newSeverity));
+            Debug.Assert(diagnosticToConfigure != null ^ categoryToBulkConfigure != null);
+            Debug.Assert((categoryToBulkConfigure != null) == (configurationKind == ConfigurationKind.BulkConfigure));
 
             _optionNameOpt = optionNameOpt;
             _newOptionValueOpt = newOptionValueOpt;
             _newSeverity = newSeverity;
             _configurationKind = configurationKind;
-            _diagnostic = diagnostic;
+            _diagnostic = diagnosticToConfigure;
+            _categoryToBulkConfigure = categoryToBulkConfigure;
             _isPerLanguage = isPerLanguage;
             _project = project;
             _cancellationToken = cancellationToken;
@@ -129,9 +142,49 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             else
             {
                 updater = new ConfigurationUpdater(optionNameOpt: null, newOptionValueOpt: null, editorConfigSeverity,
-                    configurationKind: ConfigurationKind.Severity, diagnostic, isPerLanguage: false, project, cancellationToken);
+                    configurationKind: ConfigurationKind.Severity, diagnostic, categoryToBulkConfigure: null, isPerLanguage: false, project, cancellationToken);
                 return updater.ConfigureAsync();
             }
+        }
+
+        /// <summary>
+        /// Updates or adds an .editorconfig <see cref="AnalyzerConfigDocument"/> to the given <paramref name="project"/>
+        /// so that the default severity of the diagnostics with the given <paramref name="category"/> is configured to be the given
+        /// <paramref name="editorConfigSeverity"/>.
+        /// </summary>
+        public static Task<Solution> BulkConfigureSeverityAsync(
+            string editorConfigSeverity,
+            string category,
+            Project project,
+            CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfFalse(!string.IsNullOrEmpty(category));
+            return BulkConfigureSeverityCoreAsync(editorConfigSeverity, category, project, cancellationToken);
+        }
+
+        /// <summary>
+        /// Updates or adds an .editorconfig <see cref="AnalyzerConfigDocument"/> to the given <paramref name="project"/>
+        /// so that the default severity of all diagnostics is configured to be the given
+        /// <paramref name="editorConfigSeverity"/>.
+        /// </summary>
+        public static Task<Solution> BulkConfigureSeverityAsync(
+            string editorConfigSeverity,
+            Project project,
+            CancellationToken cancellationToken)
+        {
+            return BulkConfigureSeverityCoreAsync(editorConfigSeverity, category: AllAnalyzerDiagnosticsCategory, project, cancellationToken);
+        }
+
+        private static Task<Solution> BulkConfigureSeverityCoreAsync(
+            string editorConfigSeverity,
+            string category,
+            Project project,
+            CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(category);
+            var updater = new ConfigurationUpdater(optionNameOpt: null, newOptionValueOpt: null, editorConfigSeverity,
+                configurationKind: ConfigurationKind.BulkConfigure, diagnosticToConfigure: null, category, isPerLanguage: false, project, cancellationToken);
+            return updater.ConfigureAsync();
         }
 
         /// <summary>
@@ -164,9 +217,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                 Debug.Assert(optionValue != null);
                 Debug.Assert(!string.IsNullOrEmpty(severity));
 
-                var updater = new ConfigurationUpdater(optionName, optionValue, severity, configurationKind, diagnostic, isPerLanguage, currentProject, cancellationToken);
+                var updater = new ConfigurationUpdater(optionName, optionValue, severity, configurationKind,
+                    diagnostic, categoryToBulkConfigure: null, isPerLanguage, currentProject, cancellationToken);
                 var solution = await updater.ConfigureAsync().ConfigureAwait(false);
-                currentProject = solution.GetProject(project.Id);
+                currentProject = solution.GetProject(project.Id)!;
             }
 
             return currentProject.Solution;
@@ -201,9 +255,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             return solution.WithAnalyzerConfigDocumentText(editorConfigDocument.Id, newText);
         }
 
-        private AnalyzerConfigDocument FindOrGenerateEditorConfig()
+        private AnalyzerConfigDocument? FindOrGenerateEditorConfig()
         {
-            var analyzerConfigPath = _project.TryGetAnalyzerConfigPathForDiagnosticConfiguration(_diagnostic);
+            var analyzerConfigPath = _diagnostic != null
+                ? _project.TryGetAnalyzerConfigPathForDiagnosticConfiguration(_diagnostic)
+                : _project.TryGetAnalyzerConfigPathForProjectConfiguration();
             if (analyzerConfigPath == null)
             {
                 return null;
@@ -217,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             }
 
             // Otherwise, add analyzer config document to all applicable projects for the current project's solution.
-            AnalyzerConfigDocument analyzerConfigDocument = null;
+            AnalyzerConfigDocument? analyzerConfigDocument = null;
             var analyzerConfigDirectory = PathUtilities.GetDirectoryName(analyzerConfigPath);
             var currentSolution = _project.Solution;
             foreach (var projectId in _project.Solution.ProjectIds)
@@ -338,7 +394,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             return ImmutableArray<(OptionKey, ICodeStyleOption, IEditorConfigStorageLocation2, bool)>.Empty;
         }
 
-        private SourceText GetNewAnalyzerConfigDocumentText(SourceText originalText, AnalyzerConfigDocument editorConfigDocument)
+        private SourceText? GetNewAnalyzerConfigDocumentText(SourceText originalText, AnalyzerConfigDocument editorConfigDocument)
         {
             // Check if an entry to configure the rule severity already exists in the .editorconfig file.
             // If it does, we update the existing entry with the new severity.
@@ -353,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             return AddMissingRule(originalText, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
         }
 
-        private (SourceText newText, TextLine? lastValidHeaderSpanEnd, TextLine? lastValidSpecificHeaderSpanEnd) CheckIfRuleExistsAndReplaceInFile(
+        private (SourceText? newText, TextLine? lastValidHeaderSpanEnd, TextLine? lastValidSpecificHeaderSpanEnd) CheckIfRuleExistsAndReplaceInFile(
             SourceText result,
             AnalyzerConfigDocument editorConfigDocument)
         {
@@ -367,8 +423,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             var relativePath = string.Empty;
             var diagnosticFilePath = string.Empty;
 
-            // If diagnostic SourceTree is null, it means Location.None, and thus no relative path.
-            var diagnosticSourceTree = _diagnostic.Location.SourceTree;
+            // If diagnostic SourceTree is null, it means either Location.None or Bulk configuration at root editorconfig, and thus no relative path.
+            var diagnosticSourceTree = _diagnostic?.Location.SourceTree;
             if (diagnosticSourceTree != null)
             {
                 // Finds the relative path between editorconfig directory and diagnostic filepath.
@@ -394,7 +450,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                 // s_severityBasedEntryPattern. Both of these are considered valid severity configurations
                 // and should be detected here.
                 var isOptionBasedMatch = s_optionBasedEntryPattern.IsMatch(curLineText);
-                var isSeverityBasedMatch = _configurationKind == ConfigurationKind.Severity &&
+                var isSeverityBasedMatch = _configurationKind != ConfigurationKind.OptionValue &&
                     !isOptionBasedMatch &&
                     s_severityBasedEntryPattern.IsMatch(curLineText);
                 if (isOptionBasedMatch || isSeverityBasedMatch)
@@ -427,22 +483,52 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                         {
                             // We found a rule configuration entry of severity based form:
                             //      "dotnet_diagnostic.<%DiagnosticId%>.severity = %severity%
-                            var diagIdLength = -1;
-                            if (key.StartsWith(DiagnosticOptionPrefix, StringComparison.Ordinal) &&
-                                key.EndsWith(DiagnosticOptionSuffix, StringComparison.Ordinal))
-                            {
-                                diagIdLength = key.Length - (DiagnosticOptionPrefix.Length + DiagnosticOptionSuffix.Length);
-                            }
+                            //              OR
+                            //      "dotnet_analyzer_diagnostic.severity = %severity%
+                            //              OR
+                            //      "dotnet_analyzer_diagnostic.category-<%DiagnosticCategory%>.severity = %severity%
 
-                            if (diagIdLength >= 0)
+                            switch (_configurationKind)
                             {
-                                var diagId = key.Substring(
-                                    DiagnosticOptionPrefix.Length,
-                                    diagIdLength);
-                                if (string.Equals(diagId, _diagnostic.Id, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    textChange = new TextChange(curLine.Span, $"{key} = {_newSeverity}{commentValue}");
-                                }
+                                case ConfigurationKind.Severity:
+                                    RoslynDebug.Assert(_diagnostic != null);
+                                    if (key.StartsWith(DiagnosticOptionPrefix, StringComparison.Ordinal) &&
+                                        key.EndsWith(SeveritySuffix, StringComparison.Ordinal))
+                                    {
+                                        var diagIdLength = key.Length - (DiagnosticOptionPrefix.Length + SeveritySuffix.Length);
+                                        var diagId = key.Substring(DiagnosticOptionPrefix.Length, diagIdLength);
+                                        if (string.Equals(diagId, _diagnostic.Id, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            textChange = new TextChange(curLine.Span, $"{key} = {_newSeverity}{commentValue}");
+                                        }
+                                    }
+
+                                    break;
+
+                                case ConfigurationKind.BulkConfigure:
+                                    RoslynDebug.Assert(_categoryToBulkConfigure != null);
+                                    if (_categoryToBulkConfigure == AllAnalyzerDiagnosticsCategory)
+                                    {
+                                        if (key == BulkConfigureAllAnalyzerDiagnosticsOptionKey)
+                                        {
+                                            textChange = new TextChange(curLine.Span, $"{key} = {_newSeverity}{commentValue}");
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (key.StartsWith(BulkConfigureAnalyzerDiagnosticsByCategoryOptionPrefix, StringComparison.Ordinal) &&
+                                            key.EndsWith(SeveritySuffix, StringComparison.Ordinal))
+                                        {
+                                            var categoryLength = key.Length - (BulkConfigureAnalyzerDiagnosticsByCategoryOptionPrefix.Length + SeveritySuffix.Length);
+                                            var category = key.Substring(BulkConfigureAnalyzerDiagnosticsByCategoryOptionPrefix.Length, categoryLength);
+                                            if (string.Equals(category, _categoryToBulkConfigure, StringComparison.OrdinalIgnoreCase))
+                                            {
+                                                textChange = new TextChange(curLine.Span, $"{key} = {_newSeverity}{commentValue}");
+                                            }
+                                        }
+                                    }
+
+                                    break;
                             }
                         }
                     }
@@ -499,7 +585,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                                 // Thus, we want to keep track of whether there is an existing header that only contains [*.cs] or only
                                 // [*.vb], depending on the language.
                                 // We also keep track of the last valid header for the language.
-                                var isLanguageAgnosticEntry = !SuppressionHelpers.IsCompilerDiagnostic(_diagnostic) && _isPerLanguage;
+                                var isLanguageAgnosticEntry = (_diagnostic == null || !SuppressionHelpers.IsCompilerDiagnostic(_diagnostic)) && _isPerLanguage;
                                 if (isLanguageAgnosticEntry)
                                 {
                                     if ((_language.Equals(LanguageNames.CSharp) || _language.Equals(LanguageNames.VisualBasic)) &&
@@ -557,23 +643,37 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             return (null, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
         }
 
-        private SourceText AddMissingRule(
+        private SourceText? AddMissingRule(
             SourceText result,
             TextLine? lastValidHeaderSpanEnd,
             TextLine? lastValidSpecificHeaderSpanEnd)
         {
-            // Create a new rule configuration entry for the given diagnostic ID.
+            // Create a new rule configuration entry for the given diagnostic ID or bulk configuration category.
             // If optionNameOpt and optionValueOpt are non-null, it indicates an option based diagnostic ID
             // which can be configured by a new entry such as: "%option_name% = %option_value%:%severity%
-            // Otherwise, it indicates a non-option diagnostic ID,
+            // Otherwise, if diagnostic is non-null, it indicates a non-option diagnostic ID,
             // which can be configured by a new entry such as: "dotnet_diagnostic.<%DiagnosticId%>.severity = %severity%
+            // Otherwise, it indicates a bulk configuration entry for default severity of a specific diagnostic category or all analyzer diagnostics,
+            // which can be configured by a new entry such as:
+            //  1. All analyzer diagnostics: "dotnet_analyzer_diagnostic.severity = %severity%
+            //  2. Category configuration: "dotnet_analyzer_diagnostic.category-<%DiagnosticCategory%>.severity = %severity%
 
             var newEntry = !string.IsNullOrEmpty(_optionNameOpt) && !string.IsNullOrEmpty(_newOptionValueOpt)
                 ? $"{_optionNameOpt} = {_newOptionValueOpt}:{_newSeverity}"
-                : $"{DiagnosticOptionPrefix}{_diagnostic.Id}{DiagnosticOptionSuffix} = {_newSeverity}";
+                : _diagnostic != null
+                    ? $"{DiagnosticOptionPrefix}{_diagnostic.Id}{SeveritySuffix} = {_newSeverity}"
+                    : _categoryToBulkConfigure == AllAnalyzerDiagnosticsCategory
+                        ? $"{BulkConfigureAllAnalyzerDiagnosticsOptionKey} = {_newSeverity}"
+                        : $"{BulkConfigureAnalyzerDiagnosticsByCategoryOptionPrefix}{_categoryToBulkConfigure}{SeveritySuffix} = {_newSeverity}";
 
-            // Insert a new line and comment text with diagnostic title above the new entry
-            newEntry = $"\r\n# {_diagnostic.Id}: {_diagnostic.Descriptor.Title}\r\n{newEntry}\r\n";
+            // Insert a new line and comment text above the new entry
+            var commentPrefix = _diagnostic != null
+                ? $"{_diagnostic.Id}: {_diagnostic.Descriptor.Title}"
+                : _categoryToBulkConfigure == AllAnalyzerDiagnosticsCategory
+                    ? "Default severity for all analyzer diagnostics"
+                    : $"Default severity for analyzer diagnostics with category '{_categoryToBulkConfigure}'";
+
+            newEntry = $"\r\n# {commentPrefix}\r\n{newEntry}\r\n";
 
             // Check if have a correct existing header for the new entry.
             //      - If the diagnostic's isPerLanguage = true, it means the rule is valid for both C# and VB.
@@ -623,7 +723,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                     prefix += "\r\n";
                 }
 
-                var compilerDiagOrNotPerLang = SuppressionHelpers.IsCompilerDiagnostic(_diagnostic) || !_isPerLanguage;
+                var compilerDiagOrNotPerLang = (_diagnostic != null && SuppressionHelpers.IsCompilerDiagnostic(_diagnostic)) || !_isPerLanguage;
                 if (_language.Equals(LanguageNames.CSharp) && compilerDiagOrNotPerLang)
                 {
                     prefix += "[*.cs]\r\n";

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelBulkConfigureSeverityCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelBulkConfigureSeverityCodeAction.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeActions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 {

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelBulkConfigureSeverityCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelBulkConfigureSeverityCodeAction.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeActions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
+{
+    internal sealed partial class ConfigureSeverityLevelCodeFixProvider : IConfigurationFixProvider
+    {
+        private sealed class TopLevelBulkConfigureSeverityCodeAction : AbstractConfigurationActionWithNestedActions
+        {
+            public TopLevelBulkConfigureSeverityCodeAction(ImmutableArray<CodeAction> nestedActions, string? category)
+                : base(nestedActions,
+                      category != null
+                        ? string.Format(FeaturesResources.Configure_severity_for_all_0_analyzers, category)
+                        : FeaturesResources.Configure_severity_for_all_analyzers)
+            {
+                // Ensure that 'Category' based bulk configuration actions are shown above
+                // the 'All analyzer diagnostics' bulk configuration actions.
+                AdditionalPriority = category != null ? CodeActionPriority.Low : CodeActionPriority.None;
+            }
+
+            internal override CodeActionPriority AdditionalPriority { get; }
+
+            internal override bool IsBulkConfigurationAction => true;
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
             }
 
             var result = ArrayBuilder<CodeFix>.GetInstance();
-            var anayzerDiagnosticsByCategory = new SortedDictionary<string, ArrayBuilder<Diagnostic>>();
+            var analyzerDiagnosticsByCategory = new SortedDictionary<string, ArrayBuilder<Diagnostic>>();
             using var disposer = ArrayBuilder<Diagnostic>.GetInstance(out var analyzerDiagnostics);
             foreach (var diagnostic in diagnostics)
             {
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
                     // Ensure diagnostic has a valid non-empty 'Category' for category based configuration.
                     if (!string.IsNullOrEmpty(diagnostic.Descriptor.Category))
                     {
-                        var diagnosticsForCategory = anayzerDiagnosticsByCategory.GetOrAdd(diagnostic.Descriptor.Category, _ => ArrayBuilder<Diagnostic>.GetInstance());
+                        var diagnosticsForCategory = analyzerDiagnosticsByCategory.GetOrAdd(diagnostic.Descriptor.Category, _ => ArrayBuilder<Diagnostic>.GetInstance());
                         diagnosticsForCategory.Add(diagnostic);
                     }
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
                 }
             }
 
-            foreach (var (category, diagnosticsWithCategory) in anayzerDiagnosticsByCategory)
+            foreach (var (category, diagnosticsWithCategory) in analyzerDiagnosticsByCategory)
             {
                 AddBulkConfigurationCodeFixes(diagnosticsWithCategory.ToImmutableAndFree(), category);
             }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -12,6 +14,7 @@ using Microsoft.CodeAnalysis.CodeFixes.Suppression;
 using Microsoft.CodeAnalysis.Options.EditorConfig;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
@@ -33,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
         public bool IsFixableDiagnostic(Diagnostic diagnostic)
             => !diagnostic.IsSuppressed && !SuppressionHelpers.IsNotConfigurableDiagnostic(diagnostic);
 
-        public FixAllProvider GetFixAllProvider()
+        public FixAllProvider? GetFixAllProvider()
             => null;
 
         public Task<ImmutableArray<CodeFix>> GetFixesAsync(Document document, TextSpan span, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
@@ -51,6 +54,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
             }
 
             var result = ArrayBuilder<CodeFix>.GetInstance();
+            var anayzerDiagnosticsByCategory = new SortedDictionary<string, ArrayBuilder<Diagnostic>>();
+            using var disposer = ArrayBuilder<Diagnostic>.GetInstance(out var analyzerDiagnostics);
             foreach (var diagnostic in diagnostics)
             {
                 var nestedActions = ArrayBuilder<CodeAction>.GetInstance();
@@ -62,9 +67,49 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 
                 var codeAction = new TopLevelConfigureSeverityCodeAction(diagnostic, nestedActions.ToImmutableAndFree());
                 result.Add(new CodeFix(project, codeAction, diagnostic));
+
+                // Bulk configuration is only supported for analyzer diagnostics.
+                if (!SuppressionHelpers.IsCompilerDiagnostic(diagnostic))
+                {
+                    // Ensure diagnostic has a valid non-empty 'Category' for category based configuration.
+                    if (!string.IsNullOrEmpty(diagnostic.Descriptor.Category))
+                    {
+                        var diagnosticsForCategory = anayzerDiagnosticsByCategory.GetOrAdd(diagnostic.Descriptor.Category, _ => ArrayBuilder<Diagnostic>.GetInstance());
+                        diagnosticsForCategory.Add(diagnostic);
+                    }
+
+                    analyzerDiagnostics.Add(diagnostic);
+                }
+            }
+
+            foreach (var (category, diagnosticsWithCategory) in anayzerDiagnosticsByCategory)
+            {
+                AddBulkConfigurationCodeFixes(diagnosticsWithCategory.ToImmutableAndFree(), category);
+            }
+
+            if (analyzerDiagnostics.Count > 0)
+            {
+                AddBulkConfigurationCodeFixes(analyzerDiagnostics.ToImmutable(), category: null);
             }
 
             return result.ToImmutableAndFree();
+
+            void AddBulkConfigurationCodeFixes(ImmutableArray<Diagnostic> diagnostics, string? category)
+            {
+                var nestedActions = ArrayBuilder<CodeAction>.GetInstance();
+                foreach (var (name, value) in s_editorConfigSeverityStrings)
+                {
+                    nestedActions.Add(
+                        new SolutionChangeAction(
+                            name,
+                            solution => category != null
+                                ? ConfigurationUpdater.BulkConfigureSeverityAsync(value, category, project, cancellationToken)
+                                : ConfigurationUpdater.BulkConfigureSeverityAsync(value, project, cancellationToken)));
+                }
+
+                var codeAction = new TopLevelBulkConfigureSeverityCodeAction(nestedActions.ToImmutableAndFree(), category);
+                result.Add(new CodeFix(project, codeAction, diagnostics));
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -691,6 +691,12 @@ Do you want to continue?</value>
   <data name="Configure_0_code_style" xml:space="preserve">
     <value>Configure {0} code style</value>
   </data>
+  <data name="Configure_severity_for_all_0_analyzers" xml:space="preserve">
+    <value>Configure severity for all '{0}' analyzers</value>
+  </data>
+  <data name="Configure_severity_for_all_analyzers" xml:space="preserve">
+    <value>Configure severity for all analyzers</value>
+  </data>
   <data name="Pending" xml:space="preserve">
     <value>&lt;Pending&gt;</value>
   </data>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Nakonfigurovat závažnost {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Převést na LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Schweregrad "{0}" konfigurieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">In LINQ konvertieren</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Configurar la gravedad de {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Convertir a LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Configurer la gravité {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Convertir en LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Configura la gravità di {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Converti in LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -137,6 +137,16 @@
         <target state="translated">{0} の重要度の構成</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">LINQ に変換</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -137,6 +137,16 @@
         <target state="translated">{0} 심각도 구성</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">LINQ로 변환</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Konfiguruj ważność {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Konwertuj na składnię LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Configurar severidade de {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Converter para LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Настройка серьезности {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Преобразовать в LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -137,6 +137,16 @@
         <target state="translated">{0} önem derecesini yapılandır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">LINQ to dönüştürme</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -137,6 +137,16 @@
         <target state="translated">配置 {0} 严重性</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">转换为 LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -137,6 +137,16 @@
         <target state="translated">設定 {0} 嚴重性</target>
         <note />
       </trans-unit>
+      <trans-unit id="Configure_severity_for_all_0_analyzers">
+        <source>Configure severity for all '{0}' analyzers</source>
+        <target state="new">Configure severity for all '{0}' analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Configure_severity_for_all_analyzers">
+        <source>Configure severity for all analyzers</source>
+        <target state="new">Configure severity for all analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">轉換至 LINQ</target>

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -696,6 +696,18 @@ public class Program
                         "Suggestion",
                         "Warning",
                         "Error",
+                    "Configure severity for all 'Style' analyzers",
+                        "None",
+                        "Silent",
+                        "Suggestion",
+                        "Warning",
+                        "Error",
+                    "Configure severity for all analyzers",
+                        "None",
+                        "Silent",
+                        "Suggestion",
+                        "Warning",
+                        "Error",
             };
 
             VisualStudio.Editor.Verify.CodeActions(expectedItems, ensureExpectedItemsAreOrdered: true);

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFix.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFix.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         internal CodeFix(Project project, CodeAction action, ImmutableArray<Diagnostic> diagnostics)
         {
-            Debug.Assert(!diagnostics.IsDefault);
+            Debug.Assert(!diagnostics.IsDefaultOrEmpty);
             Project = project;
             Action = action;
             Diagnostics = diagnostics;


### PR DESCRIPTION
… diagnostics

Fixes #41910

We recently added .editorconfig support in compiler layer to allow bulk configuring analyzer diagnostics (#38886). It supports two modes of bulk configuration:

1. Category based: Configure default severity/disable by default all analyzer diagnostics of a specific diagnostic `category`. Note each diagnostic has a diagnostic category, which is also shown in the `Category` column in error list.
2. All analyzer diagnostics: Configure default severity/disable by default all analyzer diagnostics.

Rule ID based editorconfig/ruleset configuration takes precedence over category based configuration, which in turn takes precedence over all analyzer diagnostics configuration.

This PR enhances the `Suppress or Configure issues` light bulb actions menu to include new bulk configuration actions towards the bottom of this sub-menu:

1. Two new nested sub-menu items at the bottom of “Suppress or Configure issues” actions.
![TopLevel](https://user-images.githubusercontent.com/10605811/75190181-99cc2500-5704-11ea-9894-f31e38eb1c53.png)

2. Actions will be de-duped, so if there are multiple diagnostics with same category on the line, say ‘Style’, still only one menu for ‘Style’ analyzers will appear.

3. Expanding the first category-based configuration menu item will add/update the following entry with a comment:
![CategoryBased](https://user-images.githubusercontent.com/10605811/75190211-ab153180-5704-11ea-942b-6f2cea6f709d.png)

4. Expanding the last ‘all’ analyzers configuration menu will add/update the following entry with a comment:
![AllAnalzyers](https://user-images.githubusercontent.com/10605811/75190236-b700f380-5704-11ea-87d2-e4fefaec38af.png)