### PR TITLE
Add support for MEF based language service detection in CodeStyle layer

### DIFF
--- a/src/CodeStyle/Core/CodeFixes/Host/Mef/CodeStyleHostLanguageServices.MefHostExportProvider.cs
+++ b/src/CodeStyle/Core/CodeFixes/Host/Mef/CodeStyleHostLanguageServices.MefHostExportProvider.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Host
+{
+    internal sealed partial class CodeStyleHostLanguageServices : HostLanguageServices
+    {
+        private static readonly ConcurrentDictionary<HostLanguageServices, CodeStyleHostLanguageServices> s_mappedLanguageServices =
+            new ConcurrentDictionary<HostLanguageServices, CodeStyleHostLanguageServices>();
+
+        private readonly HostLanguageServices _hostLanguageServices;
+        private readonly HostLanguageServices _codeStyleLanguageServices;
+
+        private CodeStyleHostLanguageServices(HostLanguageServices hostLanguageServices)
+        {
+            _hostLanguageServices = hostLanguageServices;
+
+            var exportProvider = new MefHostExportProvider(hostLanguageServices.Language);
+            _codeStyleLanguageServices = new MefWorkspaceServices(exportProvider, hostLanguageServices.WorkspaceServices.Workspace)
+                .GetLanguageServices(hostLanguageServices.Language);
+        }
+
+        public static CodeStyleHostLanguageServices? GetMappedCodeStyleLanguageServices(HostLanguageServices? hostLanguageServices)
+            => hostLanguageServices != null ? s_mappedLanguageServices.GetOrAdd(hostLanguageServices, Create) : null;
+
+        public static CodeStyleHostLanguageServices GetRequiredMappedCodeStyleLanguageServices(HostLanguageServices hostLanguageServices)
+            => s_mappedLanguageServices.GetOrAdd(hostLanguageServices, Create);
+
+        private static CodeStyleHostLanguageServices Create(HostLanguageServices hostLanguageServices)
+            => new CodeStyleHostLanguageServices(hostLanguageServices);
+
+        public override HostWorkspaceServices WorkspaceServices => _hostLanguageServices.WorkspaceServices;
+
+        public override string Language => _hostLanguageServices.Language;
+
+        [return: MaybeNull]
+        public override TLanguageService GetService<TLanguageService>()
+        {
+            return _codeStyleLanguageServices.GetService<TLanguageService>() ?? _hostLanguageServices.GetService<TLanguageService>();
+        }
+    }
+}

--- a/src/CodeStyle/Core/CodeFixes/Host/Mef/CodeStyleHostLanguageServices.cs.cs
+++ b/src/CodeStyle/Core/CodeFixes/Host/Mef/CodeStyleHostLanguageServices.cs.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Composition.Hosting;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.Host
+{
+    internal sealed partial class CodeStyleHostLanguageServices : HostLanguageServices
+    {
+        private sealed class MefHostExportProvider : IMefHostExportProvider
+        {
+            private readonly CompositionHost _compositionContext;
+
+            public MefHostExportProvider(string languageName)
+            {
+                var assemblies = CreateAssemblies(languageName);
+                var compositionConfiguration = new ContainerConfiguration().WithAssemblies(assemblies);
+                _compositionContext = compositionConfiguration.CreateContainer();
+            }
+
+            private static ImmutableArray<Assembly> CreateAssemblies(string languageName)
+            {
+                using var disposer = ArrayBuilder<string>.GetInstance(out var assemblyNames);
+
+                assemblyNames.Add("Microsoft.CodeAnalysis.CodeStyle.Fixes");
+                switch (languageName)
+                {
+                    case LanguageNames.CSharp:
+                        assemblyNames.Add("Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes");
+                        break;
+
+                    case LanguageNames.VisualBasic:
+                        assemblyNames.Add("Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes");
+                        break;
+                }
+
+                return MefHostServices.DefaultAssemblies.Concat(
+                    MefHostServicesHelpers.LoadNearbyAssemblies(assemblyNames));
+            }
+
+
+            IEnumerable<Lazy<TExtension>> IMefHostExportProvider.GetExports<TExtension>()
+            {
+                return _compositionContext.GetExports<TExtension>().Select(e => new Lazy<TExtension>(() => e));
+            }
+
+            IEnumerable<Lazy<TExtension, TMetadata>> IMefHostExportProvider.GetExports<TExtension, TMetadata>()
+            {
+                var importer = new WithMetadataImporter<TExtension, TMetadata>();
+                _compositionContext.SatisfyImports(importer);
+                return importer.Exports;
+            }
+
+            private class WithMetadataImporter<TExtension, TMetadata>
+            {
+                [ImportMany]
+                public IEnumerable<Lazy<TExtension, TMetadata>> Exports { get; set; }
+            }
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/HostWorkspaceServicesExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/HostWorkspaceServicesExtensions.cs
@@ -23,8 +23,7 @@ namespace Microsoft.CodeAnalysis.Host
             var languageServices = hostWorkspaceServices.GetLanguageServices(languageName);
 
 #if CODE_STYLE
-            // TODO: Uncomment the below once we enable language service detection in CodeStyle layer.
-            //languageServices = CodeStyleHostLanguageServices.GetRequiredMappedCodeStyleLanguageServices(languageServices);
+            languageServices = CodeStyleHostLanguageServices.GetRequiredMappedCodeStyleLanguageServices(languageServices);
 #endif
             return languageServices;
         }


### PR DESCRIPTION
This unblocks porting analyzers to CodeStyle layer. #41462 tracks replacing this with a non-MEF based approach.