### PR TITLE
Make assignment left nodes reflect the state after assignment.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3325,6 +3325,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Join(ref this.State, ref leftState);
             TypeWithState resultType = GetNullCoalescingResultType(rightResult, targetType.Type);
             SetResultType(node, resultType);
+            SetResult(node.LeftOperand, resultType, targetType, isLvalue: true);
             return null;
         }
 
@@ -6491,16 +6492,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AdjustSetValue(left, declaredType, leftLValueType, ref rightState);
                 TrackNullableStateForAssignment(right, leftLValueType, MakeSlot(left), rightState, MakeSlot(right));
 
+                TypeWithAnnotations lvalueType;
+                TypeWithState resultState;
                 if (left is BoundDiscardExpression)
                 {
-                    var lvalueType = rightState.ToTypeWithAnnotations();
-                    SetResult(left, rightState, lvalueType, isLvalue: true);
-                    SetResult(node, rightState, lvalueType);
+                    lvalueType = rightState.ToTypeWithAnnotations();
+                    resultState = rightState;
                 }
                 else
                 {
-                    SetResult(node, TypeWithState.Create(leftLValueType.Type, rightState.State), leftLValueType);
+                    resultState = TypeWithState.Create(leftLValueType.Type, rightState.State);
+                    lvalueType = leftLValueType;
                 }
+
+                SetResult(left, resultState, lvalueType, isLvalue: true);
+                SetResult(node, resultState, lvalueType);
             }
 
             return null;
@@ -7111,6 +7117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TrackNullableStateForAssignment(node, leftLValueType, MakeSlot(node.Left), resultType);
 
             SetResultType(node, resultType);
+            SetResult(node.Left, TypeWithState.Create(node.Left.Type, resultType.State), leftLValueType, isLvalue: true);
             return null;
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -2661,7 +2661,7 @@ class C
 {
     public string? M()
     {
-        string? x = {|Rename:NewMethod|}();
+        string x = {|Rename:NewMethod|}();
 
         return x;
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -2771,7 +2771,7 @@ class C
 {
     public string? M()
     {
-        [|string? x = null;
+        [|string x = null;
         Func<string?> returnNull = () =>
         {
             return null;

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -2771,7 +2771,7 @@ class C
 {
     public string? M()
     {
-        [|string x = null;
+        [|string? x = null;
         Func<string?> returnNull = () =>
         {
             return null;
@@ -2790,7 +2790,7 @@ class C
 {
     public string? M()
     {
-        string? x = {|Rename:NewMethod|}();
+        string x = {|Rename:NewMethod|}();
 
         return x;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41488.