### PR TITLE
Exclude Workspaces assembly from Managedlangs optprof test

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -35,10 +35,6 @@
               "testCases":[ "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" ]
             },
             {
-              "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
-              "testCases":[ "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" ]
-            },
-            {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.dll",
               "testCases":[ "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" ]
             },


### PR DESCRIPTION
As discussed in email thread, this is to avoid partial ngen crash when compile Workspaces assembly.
FYI @chsienki @vatsalyaagrawal 

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1060264/