### PR TITLE
Handle null coalescing in the finally block of a constructor.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -3007,7 +3007,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitReceiverAfterCall(left.ReceiverOpt, readMethod);
 
                 var savedState = this.State.Clone();
-                VisitUnassignedLeftOfNullCoalescingAssignment(node);
+                AdjustStateForNullCoalescingAssignmentNonNullCase(node);
                 leftState = this.State.Clone();
                 SetState(savedState);
                 VisitAssignmentOfNullCoalescingAssignment(node, left);
@@ -3016,7 +3016,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 VisitRvalue(node.LeftOperand, isKnownToBeAnLvalue: true);
                 var savedState = this.State.Clone();
-                VisitUnassignedLeftOfNullCoalescingAssignment(node);
+                AdjustStateForNullCoalescingAssignmentNonNullCase(node);
                 leftState = this.State.Clone();
                 SetState(savedState);
                 VisitAssignmentOfNullCoalescingAssignment(node, propertyAccessOpt: null);
@@ -3053,7 +3053,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// This visitor represents just the non-assignment part of the null coalescing assignment
         /// operator (when the left operand is non-null).
         /// </summary>
-        protected virtual void VisitUnassignedLeftOfNullCoalescingAssignment(BoundNullCoalescingAssignmentOperator node)
+        protected virtual void AdjustStateForNullCoalescingAssignmentNonNullCase(BoundNullCoalescingAssignmentOperator node)
         {
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2995,7 +2995,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitNullCoalescingAssignmentOperator(BoundNullCoalescingAssignmentOperator node)
         {
-            TLocalState savedState;
+            TLocalState leftState;
             if (RegularPropertyAccess(node.LeftOperand) &&
                 (BoundPropertyAccess)node.LeftOperand is var left &&
                 left.PropertySymbol is var property &&
@@ -3006,17 +3006,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitReceiverBeforeCall(left.ReceiverOpt, readMethod);
                 VisitReceiverAfterCall(left.ReceiverOpt, readMethod);
 
-                savedState = this.State.Clone();
+                var savedState = this.State.Clone();
+                VisitUnassignedLeftOfNullCoalescingAssignment(node);
+                leftState = this.State.Clone();
+                SetState(savedState);
                 VisitAssignmentOfNullCoalescingAssignment(node, left);
             }
             else
             {
                 VisitRvalue(node.LeftOperand, isKnownToBeAnLvalue: true);
-                savedState = this.State.Clone();
+                var savedState = this.State.Clone();
+                VisitUnassignedLeftOfNullCoalescingAssignment(node);
+                leftState = this.State.Clone();
+                SetState(savedState);
                 VisitAssignmentOfNullCoalescingAssignment(node, propertyAccessOpt: null);
             }
 
-            Join(ref this.State, ref savedState);
+            Join(ref this.State, ref leftState);
             return null;
         }
 
@@ -3041,6 +3047,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var writeMethod = symbol.GetOwnOrInheritedSetMethod();
                 PropertySetter(node, propertyAccessOpt.ReceiverOpt, writeMethod);
             }
+        }
+
+        /// <summary>
+        /// This visitor represents just the non-assignment part of the null coalescing assignment
+        /// operator (when the left operand is non-null).
+        /// </summary>
+        protected virtual void VisitUnassignedLeftOfNullCoalescingAssignment(BoundNullCoalescingAssignmentOperator node)
+        {
         }
 
         private void VisitMethodBodies(BoundBlock blockBody, BoundBlock expressionBody)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2069,7 +2069,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Assign(node.LeftOperand, node.RightOperand);
         }
 
-        protected override void VisitUnassignedLeftOfNullCoalescingAssignment(BoundNullCoalescingAssignmentOperator node)
+        protected override void AdjustStateForNullCoalescingAssignmentNonNullCase(BoundNullCoalescingAssignmentOperator node)
         {
             // For the purposes of definite assignment in try/finally, we need to treat the left as having been assigned
             // in the left-side state. If LeftOperand was not definitely assigned before this call, we will have already

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2069,6 +2069,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Assign(node.LeftOperand, node.RightOperand);
         }
 
+        protected override void VisitUnassignedLeftOfNullCoalescingAssignment(BoundNullCoalescingAssignmentOperator node)
+        {
+            // For the purposes of definite assignment in try/finally, we need to treat the left as having been assigned
+            // in the left-side state. If LeftOperand was not definitely assigned before this call, we will have already
+            // reported an error for use before assignment.
+            Assign(node.LeftOperand, node.LeftOperand);
+        }
+
         #endregion Visitors
 
         protected override string Dump(LocalState state)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -2595,9 +2595,6 @@ class C
 }";
 
             CreateCompilation(source).VerifyDiagnostics(
-                // (4,10): error CS0177: The out parameter 'o2' must be assigned to before control leaves the current method
-                //     void M(in object o1, out object o2)
-                Diagnostic(ErrorCode.ERR_ParamUnassigned, "M").WithArguments("o2").WithLocation(4, 10),
                 // (6,9): error CS8331: Cannot assign to variable 'in object' because it is a readonly variable
                 //         o1 ??= null;
                 Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "o1").WithArguments("variable", "in object").WithLocation(6, 9),


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41273.