### PR TITLE
Fix issue #42014 typo in VisualBasic\Portable\Binder CheckOverflow Property.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -746,7 +746,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         ''' <summary>
-        ''' True if integer overflow checking is off.
+        ''' True if integer overflow checking is On.
         ''' </summary>
         Public Overridable ReadOnly Property CheckOverflow As Boolean
             Get


### PR DESCRIPTION
Just a comment change