### PR TITLE
Switch more code from ISyntaxFactsService to ISyntaxFacts

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
@@ -6,13 +6,9 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.Editor.CSharp.ExtractMethod;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.ExtractMethod;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Text;
@@ -26,20 +22,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
     [UseExportProvider]
     public class MiscTests
     {
-        private static ISyntaxTriviaService GetSyntaxTriviaService()
-        {
-            var languageService = new MockCSharpLanguageServiceProvider();
-            var service = (ISyntaxTriviaService)new CSharpSyntaxTriviaServiceFactory().CreateLanguageService(languageService);
-
-            return service;
-        }
-
         [Fact]
         [Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void ServiceTest1()
         {
-            var service = GetSyntaxTriviaService();
-
             var markupCode = @"class A
 {
     /* test */ [|public|] void Test(int i, int b, int c)
@@ -50,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             MarkupTestFile.GetSpan(markupCode, out var code, out var span);
 
             var root = SyntaxFactory.ParseCompilationUnit(code);
-            var result = service.SaveTriviaAroundSelection(root, span);
+            var result = CSharpSyntaxTriviaService.Instance.SaveTriviaAroundSelection(root, span);
 
             var rootWithAnnotation = result.Root;
 
@@ -78,8 +64,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         [Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void ServiceTest2()
         {
-            var service = GetSyntaxTriviaService();
-
             var markupCode = @"class A
 {
 
@@ -94,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             MarkupTestFile.GetSpan(markupCode, out var code, out var span);
 
             var root = SyntaxFactory.ParseCompilationUnit(code);
-            var result = service.SaveTriviaAroundSelection(root, span);
+            var result = CSharpSyntaxTriviaService.Instance.SaveTriviaAroundSelection(root, span);
 
             var rootWithAnnotation = result.Root;
 
@@ -150,32 +134,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             handler.ExecuteCommand(new ExtractMethodCommandArgs(view, view.TextBuffer), TestCommandExecutionContext.Create());
 
             Assert.True(called);
-        }
-
-        /// <summary>
-        /// mock for the unit test. can't use Mock type since ICSharpLanguageServiceProvider is a internal type.
-        /// </summary>
-        private class MockCSharpLanguageServiceProvider : HostLanguageServices
-        {
-            public override HostWorkspaceServices WorkspaceServices
-            {
-                get
-                {
-                    throw new System.NotImplementedException();
-                }
-            }
-
-            public override string Language
-            {
-                get { return LanguageNames.CSharp; }
-            }
-
-            public override TLanguageService GetService<TLanguageService>()
-            {
-                Assert.Equal(typeof(TLanguageService), typeof(ISyntaxFactsService));
-
-                return (TLanguageService)((object)CSharpSyntaxFactsService.Instance);
-            }
         }
     }
 }

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1054,7 +1054,7 @@ End Class";
 
             var root = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseCompilationUnit(code);
             var property = root.FindToken(position).Parent.FirstAncestorOrSelf<Microsoft.CodeAnalysis.VisualBasic.Syntax.PropertyBlockSyntax>();
-            var memberId = Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxFactsService.Instance.GetMethodLevelMemberId(root, property);
+            var memberId = Microsoft.CodeAnalysis.VisualBasic.LanguageServices.VisualBasicSyntaxFacts.Instance.GetMethodLevelMemberId(root, property);
 
             Assert.Equal(0, memberId);
         }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionAllCodeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionAllCodeTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Suppression
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Suppression
@@ -32,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Suppre
                 TestResource.AllInOneVisualBasicCode,
                 VisualBasicParseOptions.Default,
                 digInto:=Function(n)
-                             Dim member = VisualBasicSyntaxFactsService.Instance.GetContainingMemberDeclaration(n, n.Span.Start)
+                             Dim member = VisualBasicSyntaxFacts.Instance.GetContainingMemberDeclaration(n, n.Span.Start)
                              If member Is Nothing OrElse member Is n Then
                                  Return True
                              End If

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         }
 
         protected override bool CanAddImportForMethod(
-            string diagnosticId, ISyntaxFactsService syntaxFacts, SyntaxNode node, out SimpleNameSyntax nameNode)
+            string diagnosticId, ISyntaxFacts syntaxFacts, SyntaxNode node, out SimpleNameSyntax nameNode)
         {
             nameNode = null;
 
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         protected override bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node)
             => diagnosticId == CS8129;
 
-        protected override bool CanAddImportForGetAwaiter(string diagnosticId, ISyntaxFactsService syntaxFactsService, SyntaxNode node)
+        protected override bool CanAddImportForGetAwaiter(string diagnosticId, ISyntaxFacts syntaxFactsService, SyntaxNode node)
             => (diagnosticId == CS1061 || // Regular cases
                 diagnosticId == CS4036 || // WinRT async interfaces
                 diagnosticId == CS1929) && // An extension `GetAwaiter()` is in scope, but for another type
@@ -597,7 +597,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             return (CompilationUnitSyntax)contextNode.SyntaxTree.GetRoot(cancellationToken);
         }
 
-        protected override bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken)
+        protected override bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
             var leftExpression =
                 syntaxFacts.GetExpressionOfMemberAccessExpression(expression) ??

--- a/src/Features/CSharp/Portable/AddObsoleteAttribute/CSharpAddObsoleteAttributeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddObsoleteAttribute/CSharpAddObsoleteAttributeCodeFixProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.AddObsoleteAttribute;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.CSharp.AddObsoleteAttribute
 {
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddObsoleteAttribute
 
         [ImportingConstructor]
         public CSharpAddObsoleteAttributeCodeFixProvider()
-            : base(CSharpSyntaxFactsService.Instance, CSharpFeaturesResources.Add_Obsolete)
+            : base(CSharpSyntaxFacts.Instance, CSharpFeaturesResources.Add_Obsolete)
         {
         }
     }

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.OrderModifiers;
 using Microsoft.CodeAnalysis.OrderModifiers;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
 {
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
 
             private async Task<SyntaxNode> GetNewNodeAsync(SyntaxNode node, CancellationToken cancellationToken)
             {
-                var syntaxFacts = CSharpSyntaxFactsService.Instance;
+                var syntaxFacts = CSharpSyntaxFacts.Instance;
                 var modifiers = syntaxFacts.GetModifiers(node);
                 var newModifiers = modifiers.Add(SyntaxFactory.Token(SyntaxKind.NewKeyword));
 

--- a/src/Features/CSharp/Portable/CodeLens/CSharpCodeLensDisplayInfoService.cs
+++ b/src/Features/CSharp/Portable/CodeLens/CSharpCodeLensDisplayInfoService.cs
@@ -5,6 +5,7 @@
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeLens;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -81,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeLens
                 return FeaturesResources.paren_Unknown_paren;
             }
 
-            if (CSharpSyntaxFactsService.Instance.IsGlobalAttribute(node))
+            if (CSharpSyntaxFacts.Instance.IsGlobalAttribute(node))
             {
                 return "assembly: " + node.ConvertToSingleLine();
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
@@ -227,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                             var name = rule.NamingStyle.CreateName(baseName).EscapeIdentifier(context.IsInQuery);
 
                             // Don't add multiple items for the same name and only add valid identifiers
-                            if (name.Length > 1 && CSharpSyntaxFactsService.Instance.IsValidIdentifier(name) && !result.ContainsKey(name))
+                            if (name.Length > 1 && CSharpSyntaxFacts.Instance.IsValidIdentifier(name) && !result.ContainsKey(name))
                             {
                                 var targetToken = context.TargetToken;
                                 var uniqueName = semanticFactsService.GenerateUniqueName(

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
     {
         private sealed class CSharpAnalyzer : Analyzer
         {
-            public CSharpAnalyzer(ISyntaxFactsService syntaxFacts, Feature features)
+            public CSharpAnalyzer(ISyntaxFacts syntaxFacts, Feature features)
                 : base(syntaxFacts, features)
             {
             }

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
                 ? CSharpFeaturesResources.Convert_to_switch_expression
                 : CSharpFeaturesResources.Convert_to_switch_statement;
 
-        public override Analyzer CreateAnalyzer(ISyntaxFactsService syntaxFacts, ParseOptions options)
+        public override Analyzer CreateAnalyzer(ISyntaxFacts syntaxFacts, ParseOptions options)
         {
             var version = ((CSharpParseOptions)options).LanguageVersion;
             var features =

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSyntaxTriviaService.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSyntaxTriviaService.cs
@@ -2,16 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.ExtractMethod;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 {
     internal class CSharpSyntaxTriviaService : AbstractSyntaxTriviaService
     {
-        public CSharpSyntaxTriviaService(HostLanguageServices provider)
-            : base(provider.GetService<ISyntaxFactsService>(), (int)SyntaxKind.EndOfLineTrivia)
+        public static readonly CSharpSyntaxTriviaService Instance = new CSharpSyntaxTriviaService();
+
+        private CSharpSyntaxTriviaService()
+            : base(CSharpSyntaxFacts.Instance, (int)SyntaxKind.EndOfLineTrivia)
         {
         }
     }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSyntaxTriviaServiceFactory.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSyntaxTriviaServiceFactory.cs
@@ -18,8 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-        {
-            return new CSharpSyntaxTriviaService(provider);
-        }
+            => CSharpSyntaxTriviaService.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/InitializeParameterHelpers.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/InitializeParameterHelpers.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
@@ -113,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 //          a => {
                 //              if (...) {
                 //              } };
-                if (CSharpSyntaxFactsService.Instance.IsOnSingleLine(block, fullSpan: false))
+                if (CSharpSyntaxFacts.Instance.IsOnSingleLine(block, fullSpan: false))
                 {
                     editor.ReplaceNode(
                         block,

--- a/src/Features/CSharp/Portable/OrderModifiers/CSharpOrderModifiersCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/OrderModifiers/CSharpOrderModifiersCodeFixProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.OrderModifiers;
 
 namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
 
         [ImportingConstructor]
         public CSharpOrderModifiersCodeFixProvider()
-            : base(CSharpSyntaxFactsService.Instance, CSharpCodeStyleOptions.PreferredModifierOrder, CSharpOrderModifiersHelper.Instance)
+            : base(CSharpSyntaxFacts.Instance, CSharpCodeStyleOptions.PreferredModifierOrder, CSharpOrderModifiersHelper.Instance)
         {
         }
 

--- a/src/Features/CSharp/Portable/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.OrderModifiers;
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
     internal class CSharpOrderModifiersDiagnosticAnalyzer : AbstractOrderModifiersDiagnosticAnalyzer
     {
         public CSharpOrderModifiersDiagnosticAnalyzer()
-            : base(CSharpSyntaxFactsService.Instance,
+            : base(CSharpSyntaxFacts.Instance,
                    CSharpCodeStyleOptions.PreferredModifierOrder,
                    CSharpOrderModifiersHelper.Instance,
                    LanguageNames.CSharp)

--- a/src/Features/CSharp/Portable/RemoveUnnecessaryParentheses/CSharpRemoveUnnecessaryParenthesesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/RemoveUnnecessaryParentheses/CSharpRemoveUnnecessaryParenthesesDiagnosticAnalyzer.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -16,8 +17,8 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryParentheses
     internal class CSharpRemoveUnnecessaryParenthesesDiagnosticAnalyzer
         : AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer<SyntaxKind, ParenthesizedExpressionSyntax>
     {
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
 
         protected override bool CanRemoveParentheses(
             ParenthesizedExpressionSyntax parenthesizedExpression, SemanticModel semanticModel,

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
@@ -136,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             }
 
             property = SetLeadingTrivia(
-                CSharpSyntaxFactsService.Instance, getAndSetMethods, property);
+                CSharpSyntaxFacts.Instance, getAndSetMethods, property);
 
             var accessorList = SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(getAccessor));
             if (setAccessor != null)

--- a/src/Features/CSharp/Portable/SimplifyThisOrMe/CSharpSimplifyThisOrMeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/SimplifyThisOrMe/CSharpSimplifyThisOrMeDiagnosticAnalyzer.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -26,8 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.SimplifyThisOrMe
         protected override string GetLanguageName()
             => LanguageNames.CSharp;
 
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
 
         protected override bool CanSimplifyTypeNameExpression(
             SemanticModel model, MemberAccessExpressionSyntax node, OptionSet optionSet,

--- a/src/Features/CSharp/Portable/Structure/Providers/DocumentationCommentStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DocumentationCommentStructureProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var span = TextSpan.FromBounds(startPos, endPos);
 
             var bannerLength = options.GetOption(BlockStructureOptions.MaximumBannerLength, LanguageNames.CSharp);
-            var bannerText = CSharpSyntaxFactsService.Instance.GetBannerText(
+            var bannerText = CSharpSyntaxFacts.Instance.GetBannerText(
                 documentationComment, bannerLength, cancellationToken);
 
             spans.Add(new BlockSpan(

--- a/src/Features/CSharp/Portable/UseCoalesceExpression/CSharpUseCoalesceExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseCoalesceExpression/CSharpUseCoalesceExpressionDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCoalesceExpression
             ConditionalExpressionSyntax,
             BinaryExpressionSyntax>
     {
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseCoalesceExpression/CSharpUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseCoalesceExpression/CSharpUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -21,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCoalesceExpression
             MemberAccessExpressionSyntax,
             PrefixUnaryExpressionSyntax>
     {
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -26,6 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
         protected override bool AreCollectionInitializersSupported(SyntaxNodeAnalysisContext context)
             => ((CSharpParseOptions)context.Node.SyntaxTree.Options).LanguageVersion >= LanguageVersion.CSharp3;
 
-        protected override ISyntaxFactsService GetSyntaxFactsService() => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts() => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseCompoundAssignment/CSharpUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseCompoundAssignment/CSharpUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.UseCompoundAssignment;
@@ -15,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
         : AbstractUseCompoundAssignmentDiagnosticAnalyzer<SyntaxKind, AssignmentExpressionSyntax, BinaryExpressionSyntax>
     {
         public CSharpUseCompoundAssignmentDiagnosticAnalyzer()
-            : base(CSharpSyntaxFactsService.Instance, Utilities.Kinds)
+            : base(CSharpSyntaxFacts.Instance, Utilities.Kinds)
         {
         }
 

--- a/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
         {
         }
 
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
         {
         }
 
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             // same as the right side of the subtraction.
             var startOperation = invocation.Arguments[0].Value;
 
-            if (CSharpSyntaxFactsService.Instance.AreEquivalent(startOperation.Syntax, subtraction.RightOperand.Syntax))
+            if (CSharpSyntaxFacts.Instance.AreEquivalent(startOperation.Syntax, subtraction.RightOperand.Syntax))
             {
                 return new Result(
                     ResultKind.Computed, option,

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/Helpers.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/Helpers.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             => operation is IPropertyReferenceOperation propertyRef &&
                propertyRef.Instance != null &&
                lengthLikeProperty.Equals(propertyRef.Property) &&
-               CSharpSyntaxFactsService.Instance.AreEquivalent(instance.Syntax, propertyRef.Instance.Syntax);
+               CSharpSyntaxFacts.Instance.AreEquivalent(instance.Syntax, propertyRef.Instance.Syntax);
 
         /// <summary>
         /// Checks if <paramref name="operation"/> is a binary subtraction operator. If so, it

--- a/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.UseIsNullCheck;
@@ -21,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
         protected override bool IsLanguageVersionSupported(ParseOptions options)
             => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp7;
 
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseNullPropagation/CSharpUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseNullPropagation/CSharpUseNullPropagationDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -26,14 +27,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseNullPropagation
         protected override bool ShouldAnalyze(ParseOptions options)
             => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp6;
 
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
 
         protected override ISemanticFactsService GetSemanticFactsService()
             => CSharpSemanticFactsService.Instance;
 
         protected override bool TryAnalyzePatternCondition(
-            ISyntaxFactsService syntaxFacts, SyntaxNode conditionNode,
+            ISyntaxFacts syntaxFacts, SyntaxNode conditionNode,
             out SyntaxNode? conditionPartToCheck, out bool isEquals)
         {
             conditionPartToCheck = null;

--- a/src/Features/CSharp/Portable/UseObjectInitializer/CSharpUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseObjectInitializer/CSharpUseObjectInitializerDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -31,6 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
             return ((CSharpParseOptions)context.Node.SyntaxTree.Options).LanguageVersion >= LanguageVersion.CSharp3;
         }
 
-        protected override ISyntaxFactsService GetSyntaxFactsService() => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts() => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
@@ -93,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
             {
                 var lastStatement = result[result.Count - 1];
                 result[result.Count - 1] = lastStatement.WithAppendedTrailingTrivia(
-                    remainingTrivia.Insert(0, CSharpSyntaxFactsService.Instance.ElasticCarriageReturnLineFeed));
+                    remainingTrivia.Insert(0, CSharpSyntaxFacts.Instance.ElasticCarriageReturnLineFeed));
             }
 
             for (int i = 0, n = result.Count; i < n; i++)

--- a/src/Features/CSharp/Portable/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
@@ -23,9 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseThrowExpression
             return csOptions.LanguageVersion >= LanguageVersion.CSharp7;
         }
 
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
-
         protected override ISemanticFactsService GetSemanticFactsService()
             => CSharpSemanticFactsService.Instance;
     }

--- a/src/Features/CSharp/Portable/ValidateFormatString/CSharpValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/ValidateFormatString/CSharpValidateFormatStringDiagnosticAnalyzer.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -16,8 +17,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ValidateFormatString
     internal class CSharpValidateFormatStringDiagnosticAnalyzer :
         AbstractValidateFormatStringDiagnosticAnalyzer<SyntaxKind>
     {
-        protected override ISyntaxFactsService GetSyntaxFactsService()
-            => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
 
         protected override SyntaxNode? TryGetMatchingNamedArgument(
             SeparatedSyntaxList<SyntaxNode> arguments,

--- a/src/Features/CSharp/Portable/Wrapping/BinaryExpression/CSharpBinaryExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/BinaryExpression/CSharpBinaryExpressionWrapper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CSharp.Indentation;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Wrapping.BinaryExpression;
 
@@ -11,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.BinaryExpression
     internal class CSharpBinaryExpressionWrapper : AbstractBinaryExpressionWrapper<BinaryExpressionSyntax>
     {
         public CSharpBinaryExpressionWrapper()
-            : base(CSharpIndentationService.Instance, CSharpSyntaxFactsService.Instance, CSharpPrecedenceService.Instance)
+            : base(CSharpIndentationService.Instance, CSharpSyntaxFacts.Instance, CSharpPrecedenceService.Instance)
         {
         }
 

--- a/src/Features/CSharp/Portable/Wrapping/ChainedExpression/CSharpChainedExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/ChainedExpression/CSharpChainedExpressionWrapper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CSharp.Indentation;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Wrapping.ChainedExpression;
 
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.ChainedExpression
         AbstractChainedExpressionWrapper<NameSyntax, BaseArgumentListSyntax>
     {
         public CSharpChainedExpressionWrapper()
-            : base(CSharpIndentationService.Instance, CSharpSyntaxFactsService.Instance)
+            : base(CSharpIndentationService.Instance, CSharpSyntaxFacts.Instance)
         {
         }
 

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpArgumentWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpArgumentWrapper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -76,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
             {
                 for (var current = token.Parent; current != listSyntax; current = current.Parent)
                 {
-                    if (CSharpSyntaxFactsService.Instance.IsAnonymousFunction(current))
+                    if (CSharpSyntaxFacts.Instance.IsAnonymousFunction(current))
                     {
                         return false;
                     }

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -29,17 +29,17 @@ namespace Microsoft.CodeAnalysis.AddImport
         where TSimpleNameSyntax : SyntaxNode
     {
         protected abstract bool CanAddImport(SyntaxNode node, CancellationToken cancellationToken);
-        protected abstract bool CanAddImportForMethod(string diagnosticId, ISyntaxFactsService syntaxFacts, SyntaxNode node, out TSimpleNameSyntax nameNode);
+        protected abstract bool CanAddImportForMethod(string diagnosticId, ISyntaxFacts syntaxFacts, SyntaxNode node, out TSimpleNameSyntax nameNode);
         protected abstract bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
         protected abstract bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node);
-        protected abstract bool CanAddImportForGetAwaiter(string diagnosticId, ISyntaxFactsService syntaxFactsService, SyntaxNode node);
+        protected abstract bool CanAddImportForGetAwaiter(string diagnosticId, ISyntaxFacts syntaxFactsService, SyntaxNode node);
         protected abstract bool CanAddImportForQuery(string diagnosticId, SyntaxNode node);
         protected abstract bool CanAddImportForType(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
 
         protected abstract ISet<INamespaceSymbol> GetImportNamespacesInScope(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract ITypeSymbol GetDeconstructInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract ITypeSymbol GetQueryClauseInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
-        protected abstract bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken);
+        protected abstract bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken);
 
         protected abstract Task<Document> AddImportAsync(SyntaxNode contextNode, INamespaceOrTypeSymbol symbol, Document document, bool specialCaseSystem, CancellationToken cancellationToken);
         protected abstract Task<Document> AddImportAsync(SyntaxNode contextNode, IReadOnlyList<string> nameSpaceParts, Document document, bool specialCaseSystem, CancellationToken cancellationToken);
@@ -541,7 +541,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 _ => throw ExceptionUtilities.Unreachable,
             };
 
-        private ITypeSymbol GetAwaitInfo(SemanticModel semanticModel, ISyntaxFactsService syntaxFactsService, SyntaxNode node)
+        private ITypeSymbol GetAwaitInfo(SemanticModel semanticModel, ISyntaxFacts syntaxFactsService, SyntaxNode node)
         {
             var awaitExpression = FirstAwaitExpressionAncestor(syntaxFactsService, node);
 
@@ -550,10 +550,10 @@ namespace Microsoft.CodeAnalysis.AddImport
             return semanticModel.GetTypeInfo(innerExpression).Type;
         }
 
-        protected bool AncestorOrSelfIsAwaitExpression(ISyntaxFactsService syntaxFactsService, SyntaxNode node)
+        protected bool AncestorOrSelfIsAwaitExpression(ISyntaxFacts syntaxFactsService, SyntaxNode node)
             => FirstAwaitExpressionAncestor(syntaxFactsService, node) != null;
 
-        private SyntaxNode FirstAwaitExpressionAncestor(ISyntaxFactsService syntaxFactsService, SyntaxNode node)
+        private SyntaxNode FirstAwaitExpressionAncestor(ISyntaxFacts syntaxFactsService, SyntaxNode node)
             => node.FirstAncestorOrSelf<SyntaxNode>(n => syntaxFactsService.IsAwaitExpression(n));
     }
 }

--- a/src/Features/Core/Portable/AddObsoleteAttribute/AbstractAddObsoleteAttributeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddObsoleteAttribute/AbstractAddObsoleteAttributeCodeFixProvider.cs
@@ -19,11 +19,11 @@ namespace Microsoft.CodeAnalysis.AddObsoleteAttribute
     internal abstract class AbstractAddObsoleteAttributeCodeFixProvider
         : SyntaxEditorBasedCodeFixProvider
     {
-        private readonly ISyntaxFactsService _syntaxFacts;
+        private readonly ISyntaxFacts _syntaxFacts;
         private readonly string _title;
 
         protected AbstractAddObsoleteAttributeCodeFixProvider(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             string title)
         {
             _syntaxFacts = syntaxFacts;

--- a/src/Features/Core/Portable/AddRequiredParentheses/AddRequiredParenthesesCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddRequiredParentheses/AddRequiredParenthesesCodeFixProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.AddRequiredParentheses
             Document document, ImmutableArray<Diagnostic> diagnostics,
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var generator = SyntaxGenerator.GetGenerator(document);
 
             foreach (var diagnostic in diagnostics)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.AddRequiredParentheses
                 // Do not add the simplifier annotation.  We do not want the simplifier undoing the 
                 // work we just did.
                 editor.ReplaceNode(node,
-                    (current, _) => syntaxFacts.Parenthesize(
+                    (current, _) => generator.AddParentheses(
                         current, includeElasticTrivia: false, addSimplifierAnnotation: false));
             }
 

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
@@ -59,10 +59,10 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             /// Note that this is initially unset until we find a non-constant expression.
             /// </remarks>
             private SyntaxNode _switchTargetExpression = null!;
-            private readonly ISyntaxFactsService _syntaxFacts;
+            private readonly ISyntaxFacts _syntaxFacts;
             private readonly Feature _features;
 
-            protected Analyzer(ISyntaxFactsService syntaxFacts, Feature features)
+            protected Analyzer(ISyntaxFacts syntaxFacts, Feature features)
             {
                 _syntaxFacts = syntaxFacts;
                 _features = features;

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
         TIfStatementSyntax, TExpressionSyntax, TIsExpressionSyntax, TPatternSyntax> : CodeRefactoringProvider
     {
         public abstract string GetTitle(bool forSwitchExpression);
-        public abstract Analyzer CreateAnalyzer(ISyntaxFactsService syntaxFacts, ParseOptions options);
+        public abstract Analyzer CreateAnalyzer(ISyntaxFacts syntaxFacts, ParseOptions options);
 
         public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
@@ -179,8 +179,8 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             return document.WithSyntaxRoot(newRoot);
         }
 
-        private string GetArgumentName(TArgumentSyntax argument, ISyntaxFactsService syntaxFactsService)
-            => syntaxFactsService.GetNameForArgument(argument);
+        private string GetArgumentName(TArgumentSyntax argument, ISyntaxFacts syntaxFacts)
+            => syntaxFacts.GetNameForArgument(argument);
 
         private SyntaxNode GetParamsArgument(SeparatedSyntaxList<TArgumentSyntax> arguments, ISyntaxFactsService syntaxFactsService)
         => arguments.FirstOrDefault(argument => string.Equals(GetArgumentName(argument, syntaxFactsService), StringFormatArguments.FormatArgumentName, StringComparison.OrdinalIgnoreCase)) ?? arguments[1];
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
         private TArgumentSyntax GetFormatArgument(SeparatedSyntaxList<TArgumentSyntax> arguments, ISyntaxFactsService syntaxFactsService)
             => arguments.FirstOrDefault(argument => string.Equals(GetArgumentName(argument, syntaxFactsService), StringFormatArguments.FormatArgumentName, StringComparison.OrdinalIgnoreCase)) ?? arguments[0];
 
-        private TArgumentSyntax GetArgument(SeparatedSyntaxList<TArgumentSyntax> arguments, int index, ISyntaxFactsService syntaxFactsService)
+        private TArgumentSyntax GetArgument(SeparatedSyntaxList<TArgumentSyntax> arguments, int index, ISyntaxFacts syntaxFacts)
         {
             if (arguments.Count > 4)
             {
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             }
 
             return arguments.FirstOrDefault(
-                argument => string.Equals(GetArgumentName(argument, syntaxFactsService), StringFormatArguments.ParamsArgumentNames[index], StringComparison.OrdinalIgnoreCase))
+                argument => string.Equals(GetArgumentName(argument, syntaxFacts), StringFormatArguments.ParamsArgumentNames[index], StringComparison.OrdinalIgnoreCase))
                 ?? arguments[index];
         }
 
@@ -204,20 +204,20 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             SemanticModel semanticModel,
             SeparatedSyntaxList<TArgumentSyntax> arguments,
             SyntaxGenerator syntaxGenerator,
-            ISyntaxFactsService syntaxFactsService)
+            ISyntaxFacts syntaxFacts)
         {
             var builder = ArrayBuilder<TExpressionSyntax>.GetInstance();
             for (var i = 1; i < arguments.Count; i++)
             {
-                var argumentExpression = syntaxFactsService.GetExpressionOfArgument(GetArgument(arguments, i, syntaxFactsService));
+                var argumentExpression = syntaxFacts.GetExpressionOfArgument(GetArgument(arguments, i, syntaxFacts));
                 var convertedType = semanticModel.GetTypeInfo(argumentExpression).ConvertedType;
                 if (convertedType == null)
                 {
-                    builder.Add(syntaxFactsService.Parenthesize(argumentExpression) as TExpressionSyntax);
+                    builder.Add(syntaxGenerator.AddParentheses(argumentExpression) as TExpressionSyntax);
                 }
                 else
                 {
-                    var castExpression = syntaxGenerator.CastExpression(convertedType, syntaxFactsService.Parenthesize(argumentExpression)).WithAdditionalAnnotations(Simplifier.Annotation);
+                    var castExpression = syntaxGenerator.CastExpression(convertedType, syntaxGenerator.AddParentheses(argumentExpression)).WithAdditionalAnnotations(Simplifier.Annotation);
                     builder.Add(castExpression as TExpressionSyntax);
                 }
             }

--- a/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
     {
         private const int TriviaLocationsCount = 4;
 
-        private readonly ISyntaxFactsService _syntaxFactsService;
+        private readonly ISyntaxFacts _syntaxFacts;
         private readonly int _endOfLineKind;
 
-        protected AbstractSyntaxTriviaService(ISyntaxFactsService syntaxFactsService, int endOfLineKind)
+        protected AbstractSyntaxTriviaService(ISyntaxFacts syntaxFacts, int endOfLineKind)
         {
-            _syntaxFactsService = syntaxFactsService;
+            _syntaxFacts = syntaxFacts;
             _endOfLineKind = endOfLineKind;
         }
 
@@ -111,9 +111,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         private Dictionary<TriviaLocation, SyntaxToken> GetTokensAtEdges(SyntaxNode root, TextSpan textSpan)
         {
             var tokens = new Dictionary<TriviaLocation, SyntaxToken>();
-            tokens[TriviaLocation.AfterBeginningOfSpan] = _syntaxFactsService.FindTokenOnRightOfPosition(root, textSpan.Start, includeSkipped: false);
+            tokens[TriviaLocation.AfterBeginningOfSpan] = _syntaxFacts.FindTokenOnRightOfPosition(root, textSpan.Start, includeSkipped: false);
             tokens[TriviaLocation.BeforeBeginningOfSpan] = tokens[TriviaLocation.AfterBeginningOfSpan].GetPreviousToken(includeZeroWidth: true);
-            tokens[TriviaLocation.BeforeEndOfSpan] = _syntaxFactsService.FindTokenOnLeftOfPosition(root, textSpan.End, includeSkipped: false);
+            tokens[TriviaLocation.BeforeEndOfSpan] = _syntaxFacts.FindTokenOnLeftOfPosition(root, textSpan.End, includeSkipped: false);
             tokens[TriviaLocation.AfterEndOfSpan] = tokens[TriviaLocation.BeforeEndOfSpan].GetNextToken(includeZeroWidth: true);
             return tokens;
         }

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -260,7 +261,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             bool isConstant,
             CancellationToken cancellationToken)
         {
-            var syntaxFacts = semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
             var semanticFacts = semanticDocument.Document.GetLanguageService<ISemanticFactsService>();
 
             var semanticModel = semanticDocument.SemanticModel;
@@ -271,8 +271,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             var declaringType = semanticModel.GetEnclosingNamedType(expression.SpanStart, cancellationToken);
             var reservedNames = declaringType.GetMembers().Select(m => m.Name);
 
-            return syntaxFacts.ToIdentifierToken(
-                NameGenerator.EnsureUniqueness(baseName, reservedNames, syntaxFacts.IsCaseSensitive));
+            return semanticFacts.GenerateUniqueName(baseName, reservedNames);
         }
 
         protected static SyntaxToken GenerateUniqueLocalName(
@@ -384,13 +383,13 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             CancellationToken cancellationToken)
             where TNode : SyntaxNode
         {
-            var syntaxFacts = originalDocument.Project.LanguageServices.GetService<ISyntaxFactsService>();
+            var generator = SyntaxGenerator.GetGenerator(originalDocument.Document);
             var matches = FindMatches(originalDocument, expressionInOriginal, currentDocument, withinNodeInCurrent, allOccurrences, cancellationToken);
 
             // Parenthesize the variable, and go and replace anything we find with it.
             // NOTE: we do not want elastic trivia as we want to just replace the existing code 
             // as is, while preserving the trivia there.  We do not want to update it.
-            var replacement = syntaxFacts.Parenthesize(variableName, includeElasticTrivia: false)
+            var replacement = generator.AddParentheses(variableName, includeElasticTrivia: false)
                                          .WithAdditionalAnnotations(Formatter.Annotation);
 
             return RewriteCore(withinNodeInCurrent, replacement, matches);

--- a/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersCodeFixProvider.cs
+++ b/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersCodeFixProvider.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
 {
     internal abstract class AbstractOrderModifiersCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
-        private readonly ISyntaxFactsService _syntaxFacts;
+        private readonly ISyntaxFacts _syntaxFacts;
         private readonly Option<CodeStyleOption<string>> _option;
         private readonly AbstractOrderModifiersHelpers _helpers;
 
         protected AbstractOrderModifiersCodeFixProvider(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             Option<CodeStyleOption<string>> option,
             AbstractOrderModifiersHelpers helpers)
         {

--- a/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -13,12 +13,12 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
 {
     internal abstract class AbstractOrderModifiersDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
-        private readonly ISyntaxFactsService _syntaxFacts;
+        private readonly ISyntaxFacts _syntaxFacts;
         private readonly Option<CodeStyleOption<string>> _option;
         private readonly AbstractOrderModifiersHelpers _helpers;
 
         protected AbstractOrderModifiersDiagnosticAnalyzer(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             Option<CodeStyleOption<string>> option,
             AbstractOrderModifiersHelpers helpers,
             string language)

--- a/src/Features/Core/Portable/RemoveUnnecessaryParentheses/AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryParentheses/AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer.cs
@@ -46,14 +46,14 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryParentheses
         {
         }
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         protected sealed override void InitializeWorker(AnalysisContext context)
         {
-            var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+            var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
             context.RegisterSyntaxNodeAction(AnalyzeSyntax,
                 syntaxKinds.Convert<TLanguageKindEnum>(syntaxKinds.ParenthesizedExpression));
         }
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryParentheses
                 case PrecedenceKind.Shift:
                 case PrecedenceKind.Bitwise:
                 case PrecedenceKind.Coalesce:
-                    var syntaxFacts = GetSyntaxFactsService();
+                    var syntaxFacts = GetSyntaxFacts();
                     var child = syntaxFacts.GetExpressionOfParenthesizedExpression(parenthesizedExpression);
 
                     var parentKind = parenthesizedExpression.Parent?.RawKind;

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         }
 
         protected static TPropertyDeclaration SetLeadingTrivia<TPropertyDeclaration>(
-            ISyntaxFactsService syntaxFacts, GetAndSetMethods getAndSetMethods, TPropertyDeclaration property) where TPropertyDeclaration : SyntaxNode
+            ISyntaxFacts syntaxFacts, GetAndSetMethods getAndSetMethods, TPropertyDeclaration property) where TPropertyDeclaration : SyntaxNode
         {
             var getMethodDeclaration = getAndSetMethods.GetMethodDeclaration;
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration;

--- a/src/Features/Core/Portable/SimplifyThisOrMe/AbstractSimplifyThisOrMeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/SimplifyThisOrMe/AbstractSimplifyThisOrMeDiagnosticAnalyzer.cs
@@ -35,13 +35,13 @@ namespace Microsoft.CodeAnalysis.SimplifyThisOrMe
                    new LocalizableResourceString(nameof(FeaturesResources.Remove_qualification), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
                    new LocalizableResourceString(nameof(WorkspacesResources.Name_can_be_simplified), WorkspacesResources.ResourceManager, typeof(WorkspacesResources)))
         {
-            var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+            var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
             _kindsOfInterest = ImmutableArray.Create(
                 syntaxKinds.Convert<TLanguageKindEnum>(syntaxKinds.SimpleMemberAccessExpression));
         }
 
         protected abstract string GetLanguageName();
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         protected abstract bool CanSimplifyTypeNameExpression(
             SemanticModel model, TMemberAccessExpressionSyntax memberAccess, OptionSet optionSet, out TextSpan issueSpan, CancellationToken cancellationToken);
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.SimplifyThisOrMe
             var cancellationToken = context.CancellationToken;
             var node = (TMemberAccessExpressionSyntax)context.Node;
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             var expr = syntaxFacts.GetExpressionOfMemberAccessExpression(node);
             if (!(expr is TThisExpressionSyntax))
             {

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionDiagnosticAnalyzer.cs
@@ -35,11 +35,11 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         protected override void InitializeWorker(AnalysisContext context)
         {
-            var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+            var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
             context.RegisterSyntaxNodeAction(AnalyzeSyntax,
                 syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.TernaryConditionalExpression));
         }
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 return;
             }
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             syntaxFacts.GetPartsOfConditionalExpression(
                 conditionalExpression, out var conditionNode, out var whenTrueNodeHigh, out var whenFalseNodeHigh);
 

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
@@ -36,11 +36,11 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         protected override void InitializeWorker(AnalysisContext context)
         {
-            var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+            var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
             context.RegisterSyntaxNodeAction(AnalyzeSyntax,
                 syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.TernaryConditionalExpression));
         }
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 return;
             }
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             syntaxFacts.GetPartsOfConditionalExpression(
                 conditionalExpression, out var conditionNode, out var whenTrueNodeHigh, out var whenFalseNodeHigh);
 

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         where TVariableDeclaratorSyntax : SyntaxNode
     {
         protected SemanticModel _semanticModel;
-        protected ISyntaxFactsService _syntaxFacts;
+        protected ISyntaxFacts _syntaxFacts;
         protected TObjectCreationExpressionSyntax _objectCreationExpression;
         protected CancellationToken _cancellationToken;
 
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 
         public void Initialize(
             SemanticModel semanticModel,
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             TObjectCreationExpressionSyntax objectCreationExpression,
             CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             var ienumerableType = context.Compilation.GetTypeByMetadataName(typeof(IEnumerable).FullName);
             if (ienumerableType != null)
             {
-                var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+                var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
                 context.RegisterSyntaxNodeAction(
                     nodeContext => AnalyzeNode(nodeContext, ienumerableType),
                     syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.ObjectCreationExpression));
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             }
 
             var matches = ObjectCreationExpressionAnalyzer<TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
-                semanticModel, GetSyntaxFactsService(), objectCreationExpression, cancellationToken);
+                semanticModel, GetSyntaxFacts(), objectCreationExpression, cancellationToken);
 
             if (matches == null || matches.Value.Length == 0)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             }
 
             var nodes = ImmutableArray.Create<SyntaxNode>(containingStatement).AddRange(matches.Value);
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             if (syntaxFacts.ContainsInterleavedDirective(nodes, cancellationToken))
             {
                 return;
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 return;
             }
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
 
             foreach (var match in matches)
             {
@@ -161,6 +161,6 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             }
         }
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
     }
 }

--- a/src/Features/Core/Portable/UseCollectionInitializer/ObjectCreationExpressionAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/ObjectCreationExpressionAnalyzer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 
         public static ImmutableArray<TExpressionStatementSyntax>? Analyze(
             SemanticModel semanticModel,
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             TObjectCreationExpressionSyntax objectCreationExpression,
             CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
         where TAssignmentSyntax : SyntaxNode
         where TBinaryExpressionSyntax : SyntaxNode
     {
-        private readonly ISyntaxFactsService _syntaxFacts;
+        private readonly ISyntaxFacts _syntaxFacts;
 
         /// <summary>
         /// Maps from a binary expression kind (like AddExpression) to the corresponding assignment
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
         private readonly ImmutableDictionary<TSyntaxKind, TSyntaxKind> _assignmentToTokenMap;
 
         protected AbstractUseCompoundAssignmentDiagnosticAnalyzer(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             ImmutableArray<(TSyntaxKind exprKind, TSyntaxKind assignmentKind, TSyntaxKind tokenKind)> kinds)
             : base(IDEDiagnosticIds.UseCompoundAssignmentDiagnosticId,
                    CodeStyleOptions.PreferCompoundAssignment,

--- a/src/Features/Core/Portable/UseConditionalExpression/AbstractUseConditionalExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/AbstractUseConditionalExpressionDiagnosticAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
             _option = option;
         }
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
         protected abstract bool TryMatchPattern(IConditionalOperation ifOperation);
 
         protected sealed override void InitializeWorker(AnalysisContext context)

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
@@ -23,6 +23,6 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
 
         protected override bool TryMatchPattern(IConditionalOperation ifOperation)
             => UseConditionalExpressionForAssignmentHelpers.TryMatchPattern(
-                GetSyntaxFactsService(), ifOperation, out _, out _);
+                GetSyntaxFacts(), ifOperation, out _, out _);
     }
 }

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/UseConditionalExpressionForAssignmentHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/UseConditionalExpressionForAssignmentHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
     internal static class UseConditionalExpressionForAssignmentHelpers
     {
         public static bool TryMatchPattern(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             IConditionalOperation ifOperation,
             out ISimpleAssignmentOperation trueAssignment,
             out ISimpleAssignmentOperation falseAssignment)

--- a/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
@@ -23,6 +23,6 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
 
         protected override bool TryMatchPattern(IConditionalOperation ifOperation)
             => UseConditionalExpressionForReturnHelpers.TryMatchPattern(
-                    GetSyntaxFactsService(), ifOperation, out _, out _);
+                    GetSyntaxFacts(), ifOperation, out _, out _);
     }
 }

--- a/src/Features/Core/Portable/UseConditionalExpression/ForReturn/UseConditionalExpressionForReturnHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForReturn/UseConditionalExpressionForReturnHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
     internal static class UseConditionalExpressionForReturnHelpers
     {
         public static bool TryMatchPattern(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             IConditionalOperation ifOperation,
             out IReturnOperation trueReturn,
             out IReturnOperation falseReturn)

--- a/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionHelpers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
         public static readonly SyntaxAnnotation SpecializedFormattingAnnotation = new SyntaxAnnotation();
 
         public static bool CanConvert(
-            ISyntaxFactsService syntaxFacts, IConditionalOperation ifOperation,
+            ISyntaxFacts syntaxFacts, IConditionalOperation ifOperation,
             IOperation whenTrue, IOperation whenFalse)
         {
             // Will likely screw things up if the if directive spans any preprocessor directives. So
@@ -78,11 +78,11 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
             return removeOptions;
         }
 
-        private static bool HasRegularComments(ISyntaxFactsService syntaxFacts, SyntaxNode syntax)
+        private static bool HasRegularComments(ISyntaxFacts syntaxFacts, SyntaxNode syntax)
             => HasRegularCommentTrivia(syntaxFacts, syntax.GetLeadingTrivia()) ||
                HasRegularCommentTrivia(syntaxFacts, syntax.GetTrailingTrivia());
 
-        private static bool HasRegularCommentTrivia(ISyntaxFactsService syntaxFacts, SyntaxTriviaList triviaList)
+        private static bool HasRegularCommentTrivia(ISyntaxFacts syntaxFacts, SyntaxTriviaList triviaList)
         {
             foreach (var trivia in triviaList)
             {

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsDiagnosticAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                                                                                m.Parameters.Length == 2);
                     if (referenceEqualsMethod != null)
                     {
-                        var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+                        var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
                         context.RegisterSyntaxNodeAction(
                             c => AnalyzeSyntax(c, referenceEqualsMethod),
                             syntaxKinds.Convert<TLanguageKindEnum>(syntaxKinds.InvocationExpression));
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             });
 
         protected abstract bool IsLanguageVersionSupported(ParseOptions options);
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         private void AnalyzeSyntax(SyntaxNodeAnalysisContext context, IMethodSymbol referenceEqualsMethod)
         {
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             }
 
             var invocation = context.Node;
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
 
             var expression = syntaxFacts.GetExpressionOfInvocationExpression(invocation);
             var nameNode = syntaxFacts.IsIdentifierName(expression)
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                     additionalLocations, properties));
         }
 
-        private static ITypeParameterSymbol? GetGenericParameterSymbol(ISyntaxFactsService syntaxFacts, SemanticModel semanticModel, SyntaxNode node1, SyntaxNode node2, CancellationToken cancellationToken)
+        private static ITypeParameterSymbol? GetGenericParameterSymbol(ISyntaxFacts syntaxFacts, SemanticModel semanticModel, SyntaxNode node1, SyntaxNode node2, CancellationToken cancellationToken)
         {
             var valueNode = syntaxFacts.IsNullLiteralExpression(syntaxFacts.GetExpressionOfArgument(node1)) ? node2 : node1;
             var argumentExpression = syntaxFacts.GetExpressionOfArgument(valueNode);
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             return null;
         }
 
-        private static bool MatchesPattern(ISyntaxFactsService syntaxFacts, SyntaxNode node1, SyntaxNode node2)
+        private static bool MatchesPattern(ISyntaxFacts syntaxFacts, SyntaxNode node1, SyntaxNode node2)
             => syntaxFacts.IsNullLiteralExpression(syntaxFacts.GetExpressionOfArgument(node1)) &&
                !syntaxFacts.IsNullLiteralExpression(syntaxFacts.GetExpressionOfArgument(node2));
     }

--- a/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
@@ -49,11 +49,11 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
 
         protected abstract bool ShouldAnalyze(ParseOptions options);
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
         protected abstract ISemanticFactsService GetSemanticFactsService();
 
         protected abstract bool TryAnalyzePatternCondition(
-            ISyntaxFactsService syntaxFacts, SyntaxNode conditionNode,
+            ISyntaxFacts syntaxFacts, SyntaxNode conditionNode,
             out SyntaxNode? conditionPartToCheck, out bool isEquals);
 
         protected override void InitializeWorker(AnalysisContext context)
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                                                           .FirstOrDefault(m => m.DeclaredAccessibility == Accessibility.Public &&
                                                                                m.Parameters.Length == 2);
 
-                var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+                var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
                 startContext.RegisterSyntaxNodeAction(
                     c => AnalyzeSyntax(c, expressionTypeOpt, referenceEqualsMethodOpt),
                     syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.TernaryConditionalExpression));
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                 return;
             }
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             syntaxFacts.GetPartsOfConditionalExpression(
                 conditionalExpression, out var conditionNode, out var whenTrueNode, out var whenFalseNode);
 
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
 
         private bool TryAnalyzeCondition(
             SyntaxNodeAnalysisContext context,
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             IMethodSymbol? referenceEqualsMethodOpt,
             SyntaxNode conditionNode,
             [NotNullWhen(true)] out SyntaxNode? conditionPartToCheck,
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
         }
 
         private bool TryAnalyzeBinaryExpressionCondition(
-            ISyntaxFactsService syntaxFacts, TBinaryExpressionSyntax condition,
+            ISyntaxFacts syntaxFacts, TBinaryExpressionSyntax condition,
             out SyntaxNode? conditionPartToCheck, out bool isEquals)
         {
             var syntaxKinds = syntaxFacts.SyntaxKinds;
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
 
         private static bool TryAnalyzeInvocationCondition(
             SyntaxNodeAnalysisContext context,
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             IMethodSymbol? referenceEqualsMethodOpt,
             TInvocationExpression invocation,
             [NotNullWhen(true)] out SyntaxNode? conditionPartToCheck,
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
             return referenceEqualsMethodOpt != null && referenceEqualsMethodOpt.Equals(symbol);
         }
 
-        private static SyntaxNode? GetConditionPartToCheck(ISyntaxFactsService syntaxFacts, SyntaxNode conditionLeft, SyntaxNode conditionRight)
+        private static SyntaxNode? GetConditionPartToCheck(ISyntaxFacts syntaxFacts, SyntaxNode conditionLeft, SyntaxNode conditionRight)
         {
             var conditionLeftIsNull = syntaxFacts.IsNullLiteralExpression(conditionLeft);
             var conditionRightIsNull = syntaxFacts.IsNullLiteralExpression(conditionRight);
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
         }
 
         internal static SyntaxNode? GetWhenPartMatch(
-            ISyntaxFactsService syntaxFacts, ISemanticFactsService semanticFacts, SemanticModel semanticModel, SyntaxNode expressionToMatch, SyntaxNode whenPart)
+            ISyntaxFacts syntaxFacts, ISemanticFactsService semanticFacts, SemanticModel semanticModel, SyntaxNode expressionToMatch, SyntaxNode whenPart)
         {
             expressionToMatch = RemoveObjectCastIfAny(syntaxFacts, semanticModel, expressionToMatch);
             var current = whenPart;
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
             }
         }
 
-        private static SyntaxNode RemoveObjectCastIfAny(ISyntaxFactsService syntaxFacts, SemanticModel semanticModel, SyntaxNode node)
+        private static SyntaxNode RemoveObjectCastIfAny(ISyntaxFacts syntaxFacts, SemanticModel semanticModel, SyntaxNode node)
         {
             if (syntaxFacts.IsCastExpression(node))
             {
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
             return node;
         }
 
-        private static SyntaxNode? Unwrap(ISyntaxFactsService syntaxFacts, SyntaxNode node)
+        private static SyntaxNode? Unwrap(ISyntaxFacts syntaxFacts, SyntaxNode node)
         {
             if (node is TInvocationExpression invocation)
             {

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
 
         protected override void InitializeWorker(AnalysisContext context)
         {
-            var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+            var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
             context.RegisterSyntaxNodeAction(
                 AnalyzeNode, syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.ObjectCreationExpression));
         }
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 return;
             }
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             var matches = ObjectCreationExpressionAnalyzer<TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
                 context.SemanticModel, syntaxFacts, objectCreationExpression, context.CancellationToken);
 
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 return;
             }
 
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
 
             foreach (var match in matches)
             {
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             }
         }
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;

--- a/src/Features/Core/Portable/UseObjectInitializer/ObjectCreationExpressionAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/ObjectCreationExpressionAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
 
         public static ImmutableArray<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>>? Analyze(
             SemanticModel semanticModel,
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             TObjectCreationExpressionSyntax objectCreationExpression,
             CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -173,7 +173,6 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                    exprDataFlow.WrittenInside.Contains(localOrParameter);
         }
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
         protected abstract ISemanticFactsService GetSemanticFactsService();
 
         private bool TryFindAssignmentExpression(

--- a/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
         private const string NameOfArgsParameter = "args";
         private const string NameOfFormatStringParameter = "format";
 
-        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+        protected abstract ISyntaxFacts GetSyntaxFacts();
         protected abstract SyntaxNode GetArgumentExpression(SyntaxNode syntaxNode);
         protected abstract SyntaxNode? TryGetMatchingNamedArgument(SeparatedSyntaxList<SyntaxNode> arguments, string searchArgumentName);
 
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
                     return;
                 }
 
-                var syntaxKinds = GetSyntaxFactsService().SyntaxKinds;
+                var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
                 startContext.RegisterSyntaxNodeAction(
                     c => AnalyzeNode(c, formatProviderType),
                     syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.InvocationExpression));
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
             Constraint = nameof(AnalyzerHelper.GetOption) + " is expensive and should be avoided if a syntax-based fast path exists.")]
         private void AnalyzeNode(SyntaxNodeAnalysisContext context, INamedTypeSymbol formatProviderType)
         {
-            var syntaxFacts = GetSyntaxFactsService();
+            var syntaxFacts = GetSyntaxFacts();
             var expression = syntaxFacts.GetExpressionOfInvocationExpression(context.Node);
 
             if (!IsValidFormatMethod(syntaxFacts, expression))
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
                 formatString, formatStringLiteralExpressionSyntax.SpanStart);
         }
 
-        private bool IsValidFormatMethod(ISyntaxFactsService syntaxFacts, SyntaxNode expression)
+        private bool IsValidFormatMethod(ISyntaxFacts syntaxFacts, SyntaxNode expression)
         {
             // When calling string.Format(...), the expression will be MemberAccessExpressionSyntax
             if (syntaxFacts.IsSimpleMemberAccessExpression(expression))
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
             SemanticModel semanticModel,
             SeparatedSyntaxList<SyntaxNode> arguments,
             ImmutableArray<IParameterSymbol> parameters,
-            ISyntaxFactsService syntaxFacts)
+            ISyntaxFacts syntaxFacts)
         {
             var argsArgumentType = TryGetArgsArgumentType(semanticModel, arguments, parameters, syntaxFacts);
             return argsArgumentType is IArrayTypeSymbol arrayType && arrayType.ElementType.IsReferenceType;
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
             SemanticModel semanticModel,
             SeparatedSyntaxList<SyntaxNode> arguments,
             ImmutableArray<IParameterSymbol> parameters,
-            ISyntaxFactsService syntaxFacts)
+            ISyntaxFacts syntaxFacts)
         {
             var argsArgument = TryGetArgument(NameOfArgsParameter, arguments, parameters);
             if (argsArgument == null)
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
         protected SyntaxNode? TryGetFormatStringLiteralExpressionSyntax(
             SeparatedSyntaxList<SyntaxNode> arguments,
             ImmutableArray<IParameterSymbol> parameters,
-            ISyntaxFactsService syntaxFacts)
+            ISyntaxFacts syntaxFacts)
         {
             var formatArgumentSyntax = TryGetArgument(
                 NameOfFormatStringParameter,

--- a/src/Features/Core/Portable/Wrapping/BinaryExpression/AbstractBinaryExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/BinaryExpression/AbstractBinaryExpressionWrapper.cs
@@ -16,12 +16,12 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
     internal abstract partial class AbstractBinaryExpressionWrapper<TBinaryExpressionSyntax> : AbstractSyntaxWrapper
         where TBinaryExpressionSyntax : SyntaxNode
     {
-        private readonly ISyntaxFactsService _syntaxFacts;
+        private readonly ISyntaxFacts _syntaxFacts;
         private readonly IPrecedenceService _precedenceService;
 
         protected AbstractBinaryExpressionWrapper(
             IIndentationService indentationService,
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             IPrecedenceService precedenceService) : base(indentationService)
         {
             _syntaxFacts = syntaxFacts;

--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
@@ -48,13 +48,13 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
         where TNameSyntax : SyntaxNode
         where TBaseArgumentListSyntax : SyntaxNode
     {
-        private readonly ISyntaxFactsService _syntaxFacts;
+        private readonly ISyntaxFacts _syntaxFacts;
         private readonly int _dotToken;
         private readonly int _questionToken;
 
         protected AbstractChainedExpressionWrapper(
             Indentation.IIndentationService indentationService,
-            ISyntaxFactsService syntaxFacts) : base(indentationService)
+            ISyntaxFacts syntaxFacts) : base(indentationService)
         {
             _syntaxFacts = syntaxFacts;
             _dotToken = syntaxFacts.SyntaxKinds.DotToken;

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
 
         Protected Overrides Function CanAddImportForMethod(
                 diagnosticId As String,
-                syntaxFacts As ISyntaxFactsService,
+                syntaxFacts As ISyntaxFacts,
                 node As SyntaxNode,
                 ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnosticId
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             Return False
         End Function
 
-        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, syntaxFactsService As ISyntaxFactsService, node As SyntaxNode) As Boolean
+        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, syntaxFactsService As ISyntaxFacts, node As SyntaxNode) As Boolean
             Return diagnosticId = AddImportDiagnosticIds.BC36930 AndAlso
                 AncestorOrSelfIsAwaitExpression(syntaxFactsService, node)
         End Function
@@ -323,7 +323,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
         Protected Overrides Function IsViableExtensionMethod(method As IMethodSymbol,
                                                              expression As SyntaxNode,
                                                              semanticModel As SemanticModel,
-                                                             syntaxFacts As ISyntaxFactsService,
+                                                             syntaxFacts As ISyntaxFacts,
                                                              cancellationToken As CancellationToken) As Boolean
             Dim leftExpressionType As ITypeSymbol = Nothing
             If syntaxFacts.IsInvocationExpression(expression) Then

--- a/src/Features/VisualBasic/Portable/AddObsoleteAttribute/VisualBasicAddObsoleteAttributeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddObsoleteAttribute/VisualBasicAddObsoleteAttributeCodeFixProvider.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.AddObsoleteAttribute
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddObsoleteAttribute
     <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicAddObsoleteAttributeCodeFixProvider)), [Shared]>
@@ -20,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddObsoleteAttribute
 
         <ImportingConstructor>
         Public Sub New()
-            MyBase.New(VisualBasicSyntaxFactsService.Instance, VBFeaturesResources.Add_Obsolete)
+            MyBase.New(VisualBasicSyntaxFacts.Instance, VBFeaturesResources.Add_Obsolete)
         End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeLens/VisualBasicDisplayInfoService.vb
+++ b/src/Features/VisualBasic/Portable/CodeLens/VisualBasicDisplayInfoService.vb
@@ -5,6 +5,7 @@ Imports System.Composition
 Imports System.Globalization
 Imports Microsoft.CodeAnalysis.CodeLens
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeLens
@@ -115,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeLens
         ''' Gets the DisplayName for the given node.
         ''' </summary>
         Public Function GetDisplayName(semanticModel As SemanticModel, node As SyntaxNode) As String Implements ICodeLensDisplayInfoService.GetDisplayName
-            If VisualBasicSyntaxFactsService.Instance.IsGlobalAttribute(node) Then
+            If VisualBasicSyntaxFacts.Instance.IsGlobalAttribute(node) Then
                 Return node.ToString()
             End If
 

--- a/src/Features/VisualBasic/Portable/ConvertIfToSwitch/VisualBasicConvertIfToSwitchCodeRefactoringProvider.Analyzer.vb
+++ b/src/Features/VisualBasic/Portable/ConvertIfToSwitch/VisualBasicConvertIfToSwitchCodeRefactoringProvider.Analyzer.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertIfToSwitch
         Private NotInheritable Class VisualBasicAnalyzer
             Inherits Analyzer
 
-            Public Sub New(syntaxFacts As ISyntaxFactsService, features As Feature)
+            Public Sub New(syntaxFacts As ISyntaxFacts, features As Feature)
                 MyBase.New(syntaxFacts, features)
             End Sub
 

--- a/src/Features/VisualBasic/Portable/ConvertIfToSwitch/VisualBasicConvertIfToSwitchCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertIfToSwitch/VisualBasicConvertIfToSwitchCodeRefactoringProvider.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertIfToSwitch
             Return VBFeaturesResources.Convert_to_Select_Case
         End Function
 
-        Public Overrides Function CreateAnalyzer(syntaxFacts As ISyntaxFactsService, options As ParseOptions) As Analyzer
+        Public Overrides Function CreateAnalyzer(syntaxFacts As ISyntaxFacts, options As ParseOptions) As Analyzer
             Return New VisualBasicAnalyzer(syntaxFacts, Feature.RangePattern Or Feature.RelationalPattern)
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSyntaxTriviaService.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSyntaxTriviaService.vb
@@ -3,15 +3,16 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.ExtractMethod
-Imports Microsoft.CodeAnalysis.Host
-Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
     Friend Class VisualBasicSyntaxTriviaService
         Inherits AbstractSyntaxTriviaService
 
-        Friend Sub New(provider As HostLanguageServices)
-            MyBase.New(provider.GetService(Of ISyntaxFactsService)(), SyntaxKind.EndOfLineTrivia)
+        Public Shared ReadOnly Instance As New VisualBasicSyntaxTriviaService
+
+        Private Sub New()
+            MyBase.New(VisualBasicSyntaxFacts.Instance, SyntaxKind.EndOfLineTrivia)
         End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSyntaxTriviaServiceFactory.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSyntaxTriviaServiceFactory.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
         End Sub
 
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-            Return New VisualBasicSyntaxTriviaService(provider)
+            Return VisualBasicSyntaxTriviaService.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/OrderModifiers/VisualBasicOrderModifiersCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/OrderModifiers/VisualBasicOrderModifiersCodeFixProvider.vb
@@ -7,6 +7,7 @@ Imports System.Composition
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.OrderModifiers
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
     <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
@@ -15,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
 
         <ImportingConstructor>
         Public Sub New()
-            MyBase.New(VisualBasicSyntaxFactsService.Instance,
+            MyBase.New(VisualBasicSyntaxFacts.Instance,
                        VisualBasicCodeStyleOptions.PreferredModifierOrder,
                        VisualBasicOrderModifiersHelper.Instance)
         End Sub

--- a/src/Features/VisualBasic/Portable/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.OrderModifiers
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
         Inherits AbstractOrderModifiersDiagnosticAnalyzer
 
         Public Sub New()
-            MyBase.New(VisualBasicSyntaxFactsService.Instance,
+            MyBase.New(VisualBasicSyntaxFacts.Instance,
                        VisualBasicCodeStyleOptions.PreferredModifierOrder,
                        VisualBasicOrderModifiersHelper.Instance,
                        LanguageNames.VisualBasic)

--- a/src/Features/VisualBasic/Portable/RemoveUnnecessaryParentheses/VisualBasicRemoveUnnecessaryParenthesesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnnecessaryParentheses/VisualBasicRemoveUnnecessaryParenthesesDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.RemoveUnnecessaryParentheses
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryParentheses
@@ -12,8 +13,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryParentheses
     Friend Class VisualBasicRemoveUnnecessaryParenthesesDiagnosticAnalyzer
         Inherits AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer(Of SyntaxKind, ParenthesizedExpressionSyntax)
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
 
         Protected Overrides Function CanRemoveParentheses(

--- a/src/Features/VisualBasic/Portable/ReplaceMethodWithProperty/VisualBasicReplaceMethodWithPropertyService.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceMethodWithProperty/VisualBasicReplaceMethodWithPropertyService.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.ReplaceMethodWithProperty
     <ExportLanguageService(GetType(IReplaceMethodWithPropertyService), LanguageNames.VisualBasic), [Shared]>
@@ -123,7 +124,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.ReplaceMethodWithP
             End If
 
             newPropertyDeclaration = SetLeadingTrivia(
-                VisualBasicSyntaxFactsService.Instance, getAndSetMethods, newPropertyDeclaration)
+                VisualBasicSyntaxFacts.Instance, getAndSetMethods, newPropertyDeclaration)
 
             Return newPropertyDeclaration.WithAdditionalAnnotations(Formatter.Annotation)
         End Function

--- a/src/Features/VisualBasic/Portable/SimplifyThisOrMe/VisualBasicSimplifyThisOrMeDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/SimplifyThisOrMe/VisualBasicSimplifyThisOrMeDiagnosticAnalyzer.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.SimplifyThisOrMe
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Simplification.Simplifiers
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -25,8 +26,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SimplifyThisOrMe
             Return LanguageNames.VisualBasic
         End Function
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
 
         Protected Overrides Function CanSimplifyTypeNameExpression(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
@@ -33,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             Dim fullSpan = TextSpan.FromBounds(startPos, endPos)
 
             Dim maxBannerLength = options.GetOption(BlockStructureOptions.MaximumBannerLength, LanguageNames.VisualBasic)
-            Dim bannerText = VisualBasicSyntaxFactsService.Instance.GetBannerText(
+            Dim bannerText = VisualBasicSyntaxFacts.Instance.GetBannerText(
                 documentationComment, maxBannerLength, cancellationToken)
 
             spans.AddIfNotNull(CreateBlockSpan(

--- a/src/Features/VisualBasic/Portable/UseCoalesceExpression/VisualBasicUseCoalesceExpressionDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseCoalesceExpression/VisualBasicUseCoalesceExpressionDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseCoalesceExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression
@@ -16,8 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression
             TernaryConditionalExpressionSyntax,
             BinaryExpressionSyntax)
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForNullableDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForNullableDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseCoalesceExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression
@@ -18,8 +19,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression
             MemberAccessExpressionSyntax,
             UnaryExpressionSyntax)
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseCollectionInitializer
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
@@ -24,8 +25,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             Return True
         End Function
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseCompoundAssignment/VisualBasicUseCompoundAssignmentDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseCompoundAssignment/VisualBasicUseCompoundAssignmentDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.UseCompoundAssignment
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseCompoundAssignment
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
@@ -12,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCompoundAssignment
         Inherits AbstractUseCompoundAssignmentDiagnosticAnalyzer(Of SyntaxKind, AssignmentStatementSyntax, BinaryExpressionSyntax)
 
         Public Sub New()
-            MyBase.New(VisualBasicSyntaxFactsService.Instance, Kinds)
+            MyBase.New(VisualBasicSyntaxFacts.Instance, Kinds)
         End Sub
 
         Protected Overrides Function GetAnalysisKind() As SyntaxKind

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
@@ -16,8 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
             MyBase.New(New LocalizableResourceString(NameOf(VBFeaturesResources.If_statement_can_be_simplified), VBFeaturesResources.ResourceManager, GetType(VBFeaturesResources)))
         End Sub
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
@@ -16,8 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
             MyBase.New(New LocalizableResourceString(NameOf(VBFeaturesResources.If_statement_can_be_simplified), VBFeaturesResources.ResourceManager, GetType(VBFeaturesResources)))
         End Sub
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseIsNullCheck
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNullCheck
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
@@ -19,8 +20,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNullCheck
             Return True
         End Function
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseNullPropagation/VisualBasicUseNullPropagationDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseNullPropagation/VisualBasicUseNullPropagationDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseNullPropagation
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseNullPropagation
@@ -24,15 +25,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseNullPropagation
             Return DirectCast(options, VisualBasicParseOptions).LanguageVersion >= LanguageVersion.VisualBasic14
         End Function
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
 
         Protected Overrides Function GetSemanticFactsService() As ISemanticFactsService
-            Return VisualBasicSemanticFactsService.instance
+            Return VisualBasicSemanticFactsService.Instance
         End Function
 
-        Protected Overrides Function TryAnalyzePatternCondition(syntaxFacts As ISyntaxFactsService, conditionNode As SyntaxNode, ByRef conditionPartToCheck As SyntaxNode, ByRef isEquals As Boolean) As Boolean
+        Protected Overrides Function TryAnalyzePatternCondition(syntaxFacts As ISyntaxFacts, conditionNode As SyntaxNode, ByRef conditionPartToCheck As SyntaxNode, ByRef isEquals As Boolean) As Boolean
             conditionPartToCheck = Nothing
             isEquals = False
             Return False

--- a/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.UseObjectInitializer
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseObjectInitializer
@@ -30,8 +31,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseObjectInitializer
             Return True
         End Function
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/ValidateFormatString/VisualBasicValidateFormatStringDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/ValidateFormatString/VisualBasicValidateFormatStringDiagnosticAnalyzer.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.ValidateFormatString
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ValidateFormatString
@@ -13,8 +14,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ValidateFormatString
     Friend Class VisualBasicValidateFormatStringDiagnosticAnalyzer
         Inherits AbstractValidateFormatStringDiagnosticAnalyzer(Of SyntaxKind)
 
-        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
-            Return VisualBasicSyntaxFactsService.Instance
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
 
         Protected Overrides Function TryGetMatchingNamedArgument(

--- a/src/Features/VisualBasic/Portable/Wrapping/BinaryExpression/VisualBasicBinaryExpressionWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/BinaryExpression/VisualBasicBinaryExpressionWrapper.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.VisualBasic.Indentation
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Wrapping.BinaryExpression
 
@@ -15,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.BinaryExpression
             ' align parameters.  But that's what we're actually trying to control, so we need
             ' to remove this.
             MyBase.New(VisualBasicIndentationService.WithoutParameterAlignmentInstance,
-                       VisualBasicSyntaxFactsService.Instance,
+                       VisualBasicSyntaxFacts.Instance,
                        VisualBasicPrecedenceService.Instance)
         End Sub
 

--- a/src/Features/VisualBasic/Portable/Wrapping/ChainedExpression/VisualBasicChainedExpressionWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/ChainedExpression/VisualBasicChainedExpressionWrapper.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.VisualBasic.Indentation
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Wrapping.ChainedExpression
 
@@ -11,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.ChainedExpression
         Inherits AbstractChainedExpressionWrapper(Of NameSyntax, ArgumentListSyntax)
 
         Public Sub New()
-            MyBase.New(VisualBasicIndentationService.WithoutParameterAlignmentInstance, VisualBasicSyntaxFactsService.Instance)
+            MyBase.New(VisualBasicIndentationService.WithoutParameterAlignmentInstance, VisualBasicSyntaxFacts.Instance)
         End Sub
 
         Protected Overrides Function GetNewLineBeforeOperatorTrivia(newLine As SyntaxTriviaList) As SyntaxTriviaList

--- a/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicArgumentWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicArgumentWrapper.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
@@ -58,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
             If token.Parent.Ancestors().Contains(listSyntax) Then
                 Dim current = token.Parent
                 While current IsNot listSyntax
-                    If VisualBasicSyntaxFactsService.Instance.IsAnonymousFunction(current) Then
+                    If VisualBasicSyntaxFacts.Instance.IsAnonymousFunction(current) Then
                         Return False
                     End If
 

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
@@ -14,14 +14,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 {
     class MoveToNamespaceDialogViewModel : AbstractNotifyPropertyChanged, IDataErrorInfo
     {
-        private readonly ISyntaxFactsService _syntaxFactsService;
+        private readonly ISyntaxFacts _syntaxFacts;
 
         public MoveToNamespaceDialogViewModel(
             string defaultNamespace,
             ImmutableArray<string> availableNamespaces,
-            ISyntaxFactsService syntaxFactsService)
+            ISyntaxFacts syntaxFacts)
         {
-            _syntaxFactsService = syntaxFactsService ?? throw new ArgumentNullException(nameof(syntaxFactsService));
+            _syntaxFacts = syntaxFacts ?? throw new ArgumentNullException(nameof(syntaxFacts));
             NamespaceName = defaultNamespace;
             AvailableNamespaces = availableNamespaces;
 
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 
             foreach (var identifier in namespaceName.Split('.'))
             {
-                if (_syntaxFactsService.IsValidIdentifier(identifier))
+                if (_syntaxFacts.IsValidIdentifier(identifier))
                 {
                     continue;
                 }

--- a/src/VisualStudio/Core/Test/MoveToNamespace/MoveToNamespaceDialogViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/MoveToNamespace/MoveToNamespaceDialogViewModelTests.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CSharp
+Imports Microsoft.CodeAnalysis.CSharp.LanguageServices
 Imports Microsoft.CodeAnalysis.MoveToNamespace
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
@@ -85,7 +86,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
                                                             defaultNamespace & "2"})
             End If
 
-            Return New MoveToNamespaceDialogViewModel(defaultNamespace, availableNamespaces, CSharpSyntaxFactsService.Instance)
+            Return New MoveToNamespaceDialogViewModel(defaultNamespace, availableNamespaces, CSharpSyntaxFacts.Instance)
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         internal override bool RequiresExplicitImplementationForInterfaceMembers => false;
 
-        internal override ISyntaxFactsService SyntaxFacts => CSharpSyntaxFactsService.Instance;
+        internal override ISyntaxFacts SyntaxFacts => CSharpSyntaxFacts.Instance;
 
         internal override SyntaxTrivia EndOfLine(string text)
             => SyntaxFactory.EndOfLine(text);
@@ -3434,14 +3435,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return DefaultExpression(type.GenerateTypeSyntax());
         }
 
-        internal override SyntaxNode AddParentheses(SyntaxNode expression)
+        internal override SyntaxNode AddParentheses(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
         {
-            return Parenthesize(expression);
+            return Parenthesize(expression, includeElasticTrivia, addSimplifierAnnotation);
         }
 
-        private static ExpressionSyntax Parenthesize(SyntaxNode expression)
+        private static ExpressionSyntax Parenthesize(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
         {
-            return ((ExpressionSyntax)expression).Parenthesize();
+            return ((ExpressionSyntax)expression).Parenthesize(includeElasticTrivia, addSimplifierAnnotation);
         }
 
         public override SyntaxNode IsTypeExpression(SyntaxNode expression, SyntaxNode type)

--- a/src/Workspaces/CSharp/Portable/EmbeddedLanguages/LanguageServices/CSharpEmbeddedLanguagesProvider.cs
+++ b/src/Workspaces/CSharp/Portable/EmbeddedLanguages/LanguageServices/CSharpEmbeddedLanguagesProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.LanguageServices
         public static EmbeddedLanguageInfo Info = new EmbeddedLanguageInfo(
             (int)SyntaxKind.StringLiteralToken,
             (int)SyntaxKind.InterpolatedStringTextToken,
-            CSharpSyntaxFactsService.Instance,
+            CSharpSyntaxFacts.Instance,
             CSharpSemanticFactsService.Instance,
             CSharpVirtualCharService.Instance);
 

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -419,10 +420,10 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         }
 
         private string GetContainerDisplayName(SyntaxNode node)
-            => CSharpSyntaxFactsService.Instance.GetDisplayName(node, DisplayNameOptions.IncludeTypeParameters);
+            => CSharpSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeTypeParameters);
 
         private string GetFullyQualifiedContainerName(SyntaxNode node)
-            => CSharpSyntaxFactsService.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces);
+            => CSharpSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces);
 
         private Accessibility GetAccessibility(SyntaxNode node, SyntaxTokenList modifiers)
         {

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesesReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesesReducer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 // cases if elastic trivia is there -- and it's not clear why.
                 // Specifically remove the elastic trivia formatting rule doesn't
                 // have any effect.
-                var resultNode = CSharpSyntaxFactsService.Instance.Unparenthesize(node);
+                var resultNode = CSharpSyntaxFacts.Instance.Unparenthesize(node);
                 return SimplificationHelpers.CopyAnnotations(from: node, to: resultNode);
             }
 

--- a/src/Workspaces/CSharpTest/CSharpSyntaxFactsServiceTests.cs
+++ b/src/Workspaces/CSharpTest/CSharpSyntaxFactsServiceTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             MarkupTestFile.GetPosition(markup, out var code, out int position);
             var tree = SyntaxFactory.ParseSyntaxTree(code);
             var token = tree.GetRoot().FindToken(position);
-            var service = CSharpSyntaxFactsService.Instance;
+            var service = CSharpSyntaxFacts.Instance;
 
             return service.IsQueryKeyword(token);
         }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editing
         internal abstract SyntaxTrivia CarriageReturnLineFeed { get; }
         internal abstract SyntaxTrivia ElasticCarriageReturnLineFeed { get; }
         internal abstract bool RequiresExplicitImplementationForInterfaceMembers { get; }
-        internal abstract ISyntaxFactsService SyntaxFacts { get; }
+        internal abstract ISyntaxFacts SyntaxFacts { get; }
 
         internal abstract SyntaxTrivia EndOfLine(string text);
         internal abstract SyntaxTrivia Whitespace(string text);
@@ -2276,7 +2276,7 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <summary>
         /// Wraps with parens.
         /// </summary>
-        internal abstract SyntaxNode AddParentheses(SyntaxNode expression);
+        internal abstract SyntaxNode AddParentheses(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true);
 
         /// <summary>
         /// Creates an nameof expression.

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/EmbeddedLanguageInfo.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/EmbeddedLanguageInfo.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
     {
         public readonly int StringLiteralTokenKind;
         public readonly int InterpolatedTextTokenKind;
-        public readonly ISyntaxFactsService SyntaxFacts;
+        public readonly ISyntaxFacts SyntaxFacts;
         public readonly ISemanticFactsService SemanticFacts;
         public readonly IVirtualCharService VirtualCharService;
 
-        public EmbeddedLanguageInfo(int stringLiteralTokenKind, int interpolatedTextTokenKind, ISyntaxFactsService syntaxFacts, ISemanticFactsService semanticFacts, IVirtualCharService virtualCharService)
+        public EmbeddedLanguageInfo(int stringLiteralTokenKind, int interpolatedTextTokenKind, ISyntaxFacts syntaxFacts, ISemanticFactsService semanticFacts, IVirtualCharService virtualCharService)
         {
             StringLiteralTokenKind = stringLiteralTokenKind;
             InterpolatedTextTokenKind = interpolatedTextTokenKind;

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexPatternDetector.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexPatternDetector.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
                 semanticModel, info, regexType, methodNamesOfInterest);
         }
 
-        public static bool IsDefinitelyNotPattern(SyntaxToken token, ISyntaxFactsService syntaxFacts)
+        public static bool IsDefinitelyNotPattern(SyntaxToken token, ISyntaxFacts syntaxFacts)
         {
             if (!syntaxFacts.IsStringLiteral(token))
             {
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
         }
 
         private static bool HasRegexLanguageComment(
-            SyntaxToken token, ISyntaxFactsService syntaxFacts, out RegexOptions options)
+            SyntaxToken token, ISyntaxFacts syntaxFacts, out RegexOptions options)
         {
             if (HasRegexLanguageComment(token.GetPreviousToken().TrailingTrivia, syntaxFacts, out options))
             {
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
         }
 
         private static bool HasRegexLanguageComment(
-            SyntaxTriviaList list, ISyntaxFactsService syntaxFacts, out RegexOptions options)
+            SyntaxTriviaList list, ISyntaxFacts syntaxFacts, out RegexOptions options)
         {
             foreach (var trivia in list)
             {
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
         }
 
         private static bool HasRegexLanguageComment(
-            SyntaxTrivia trivia, ISyntaxFactsService syntaxFacts, out RegexOptions options)
+            SyntaxTrivia trivia, ISyntaxFacts syntaxFacts, out RegexOptions options)
         {
             if (syntaxFacts.IsRegularComment(trivia))
             {
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
             return (true, options);
         }
 
-        private static bool IsMethodOrConstructorArgument(SyntaxToken token, ISyntaxFactsService syntaxFacts)
+        private static bool IsMethodOrConstructorArgument(SyntaxToken token, ISyntaxFacts syntaxFacts)
             => syntaxFacts.IsLiteralExpression(token.Parent) &&
                syntaxFacts.IsArgument(token.Parent.Parent);
 
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
         /// where at least one (but not necessarily more) of the parameters should be treated as a
         /// pattern.
         /// </summary>
-        private static HashSet<string> GetMethodNamesOfInterest(INamedTypeSymbol regexType, ISyntaxFactsService syntaxFacts)
+        private static HashSet<string> GetMethodNamesOfInterest(INamedTypeSymbol regexType, ISyntaxFacts syntaxFacts)
         {
             var result = syntaxFacts.IsCaseSensitive
                 ? new HashSet<string>()
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
             return RegexOptions.None;
         }
 
-        private string GetNameOfType(SyntaxNode typeNode, ISyntaxFactsService syntaxFacts)
+        private string GetNameOfType(SyntaxNode typeNode, ISyntaxFacts syntaxFacts)
         {
             if (syntaxFacts.IsQualifiedName(typeNode))
             {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var syntaxFacts = generator.SyntaxFacts;
             if (syntaxFacts.IsParenthesizedExpression(expression))
             {
-                return syntaxFacts.Parenthesize(
+                return generator.AddParentheses(
                     generator.Negate(
                         syntaxFacts.GetExpressionOfParenthesizedExpression(expression),
                         semanticModel,
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         private static SyntaxNode GetNegationOfLogicalNotExpression(
             SyntaxNode expression,
-            ISyntaxFactsService syntaxFacts)
+            ISyntaxFacts syntaxFacts)
         {
             var operatorToken = syntaxFacts.GetOperatorTokenOfPrefixUnaryExpression(expression);
             var operand = syntaxFacts.GetOperandOfPrefixUnaryExpression(expression);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -96,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             Contract.ThrowIfFalse(preference == ExpressionBodyPreference.WhenOnSingleLine);
-            return CSharpSyntaxFactsService.Instance.IsOnSingleLine(expression, fullSpan: false);
+            return CSharpSyntaxFacts.Instance.IsOnSingleLine(expression, fullSpan: false);
         }
 
         private static bool TryGetExpression(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
@@ -130,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             if (root.Externs.Count == 0)
             {
                 root = AddImportHelpers.MoveTrivia(
-                    CSharpSyntaxFactsService.Instance, root, root.Usings, usings);
+                    CSharpSyntaxFacts.Instance, root, root.Usings, usings);
             }
 
             return root.WithUsings(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsService.cs
@@ -8,8 +8,10 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -22,11 +24,14 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal static readonly CSharpSemanticFactsService Instance = new CSharpSemanticFactsService();
 
-        protected override ISyntaxFactsService SyntaxFactsService => CSharpSyntaxFactsService.Instance;
+        protected override ISyntaxFacts SyntaxFacts => CSharpSyntaxFacts.Instance;
 
         private CSharpSemanticFactsService()
         {
         }
+
+        protected override SyntaxToken ToIdentifierToken(string identifier)
+            => identifier.ToIdentifierToken();
 
         protected override IEnumerable<ISymbol> GetCollidableSymbols(SemanticModel semanticModel, SyntaxNode location, SyntaxNode container, CancellationToken cancellationToken)
         {
@@ -48,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool ShouldDescendInto(SyntaxNode node)
             {
                 var isLanguageVersionGreaterOrEqualToCSharp8 = (semanticModel.Compilation as CSharpCompilation)?.LanguageVersion >= LanguageVersion.CSharp8;
-                return isLanguageVersionGreaterOrEqualToCSharp8 ? !SyntaxFactsService.IsAnonymousOrLocalFunction(node) : !SyntaxFactsService.IsLocalFunctionStatement(node);
+                return isLanguageVersionGreaterOrEqualToCSharp8 ? !SyntaxFacts.IsAnonymousOrLocalFunction(node) : !SyntaxFacts.IsLocalFunctionStatement(node);
             }
         }
 
@@ -164,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // If we hit an executable statement syntax and didn't find anything yet, we can just stop now -- anything higher would be a member declaration which won't be defined by something inside a statement.
-                if (SyntaxFactsService.IsExecutableStatement(ancestor))
+                if (SyntaxFacts.IsExecutableStatement(ancestor))
                 {
                     return null;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsService.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.LanguageServices;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -17,125 +16,120 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal sealed class CSharpSyntaxFactsService : CSharpSyntaxFacts, ISyntaxFactsService
+    internal sealed partial class CSharpSyntaxFactsServiceFactory
     {
-        internal static readonly new CSharpSyntaxFactsService Instance = new CSharpSyntaxFactsService();
-
-        public bool IsInInactiveRegion(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
+        private sealed class CSharpSyntaxFactsService : CSharpSyntaxFacts, ISyntaxFactsService
         {
-            if (syntaxTree == null)
+            internal static readonly new CSharpSyntaxFactsService Instance = new CSharpSyntaxFactsService();
+
+            public bool IsInInactiveRegion(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
             {
-                return false;
-            }
-
-            return syntaxTree.IsInInactiveRegion(position, cancellationToken);
-        }
-
-        public bool IsInNonUserCode(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
-        {
-            if (syntaxTree == null)
-            {
-                return false;
-            }
-
-            return syntaxTree.IsInNonUserCode(position, cancellationToken);
-        }
-
-        public SyntaxToken ToIdentifierToken(string name)
-        {
-            return name.ToIdentifierToken();
-        }
-
-        public SyntaxNode Parenthesize(SyntaxNode expression, bool includeElasticTrivia, bool addSimplifierAnnotation)
-            => ((ExpressionSyntax)expression).Parenthesize(includeElasticTrivia, addSimplifierAnnotation);
-
-        private static readonly SyntaxAnnotation s_annotation = new SyntaxAnnotation();
-
-        public void AddFirstMissingCloseBrace<TContextNode>(
-            SyntaxNode root, TContextNode contextNode,
-            out SyntaxNode newRoot, out TContextNode newContextNode) where TContextNode : SyntaxNode
-        {
-            newRoot = new AddFirstMissingCloseBraceRewriter(contextNode).Visit(root);
-            newContextNode = (TContextNode)newRoot.GetAnnotatedNodes(s_annotation).Single();
-        }
-
-        public bool IsPossibleTupleContext(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
-        {
-            var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
-            return syntaxTree.IsPossibleTupleContext(token, position);
-        }
-
-        private class AddFirstMissingCloseBraceRewriter : CSharpSyntaxRewriter
-        {
-            private readonly SyntaxNode _contextNode;
-            private bool _seenContextNode = false;
-            private bool _addedFirstCloseCurly = false;
-
-            public AddFirstMissingCloseBraceRewriter(SyntaxNode contextNode)
-            {
-                _contextNode = contextNode;
-            }
-
-            public override SyntaxNode Visit(SyntaxNode node)
-            {
-                if (node == _contextNode)
+                if (syntaxTree == null)
                 {
-                    _seenContextNode = true;
-
-                    // Annotate the context node so we can find it again in the new tree
-                    // after we've added the close curly.
-                    return node.WithAdditionalAnnotations(s_annotation);
+                    return false;
                 }
 
-                // rewrite this node normally.
-                var rewritten = base.Visit(node);
-                if (rewritten == node)
+                return syntaxTree.IsInInactiveRegion(position, cancellationToken);
+            }
+
+            public bool IsInNonUserCode(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
+            {
+                if (syntaxTree == null)
                 {
-                    return rewritten;
+                    return false;
                 }
 
-                // This node changed.  That means that something underneath us got
-                // rewritten.  (i.e. we added the annotation to the context node).
-                Debug.Assert(_seenContextNode);
+                return syntaxTree.IsInNonUserCode(position, cancellationToken);
+            }
 
-                // Ok, we're past the context node now.  See if this is a node with 
-                // curlies.  If so, if it has a missing close curly then add in the 
-                // missing curly.  Also, even if it doesn't have missing curlies, 
-                // then still ask to format its close curly to make sure all the 
-                // curlies up the stack are properly formatted.
-                var braces = rewritten.GetBraces();
-                if (braces.openBrace.Kind() == SyntaxKind.None &&
-                    braces.closeBrace.Kind() == SyntaxKind.None)
+            private static readonly SyntaxAnnotation s_annotation = new SyntaxAnnotation();
+
+            public void AddFirstMissingCloseBrace<TContextNode>(
+                SyntaxNode root, TContextNode contextNode,
+                out SyntaxNode newRoot, out TContextNode newContextNode) where TContextNode : SyntaxNode
+            {
+                newRoot = new AddFirstMissingCloseBraceRewriter(contextNode).Visit(root);
+                newContextNode = (TContextNode)newRoot.GetAnnotatedNodes(s_annotation).Single();
+            }
+
+            public bool IsPossibleTupleContext(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
+            {
+                var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
+                return syntaxTree.IsPossibleTupleContext(token, position);
+            }
+
+            private class AddFirstMissingCloseBraceRewriter : CSharpSyntaxRewriter
+            {
+                private readonly SyntaxNode _contextNode;
+                private bool _seenContextNode = false;
+                private bool _addedFirstCloseCurly = false;
+
+                public AddFirstMissingCloseBraceRewriter(SyntaxNode contextNode)
                 {
-                    // Not an item with braces.  Just pass it up.
-                    return rewritten;
+                    _contextNode = contextNode;
                 }
 
-                // See if the close brace is missing.  If it's the first missing one 
-                // we're seeing then definitely add it.
-                if (braces.closeBrace.IsMissing)
+                public override SyntaxNode Visit(SyntaxNode node)
                 {
-                    if (!_addedFirstCloseCurly)
+                    if (node == _contextNode)
                     {
-                        var closeBrace = SyntaxFactory.Token(SyntaxKind.CloseBraceToken)
-                            .WithAdditionalAnnotations(Formatter.Annotation);
-                        rewritten = rewritten.ReplaceToken(braces.closeBrace, closeBrace);
-                        _addedFirstCloseCurly = true;
+                        _seenContextNode = true;
+
+                        // Annotate the context node so we can find it again in the new tree
+                        // after we've added the close curly.
+                        return node.WithAdditionalAnnotations(s_annotation);
                     }
-                }
-                else
-                {
-                    // Ask for the close brace to be formatted so that all the braces
-                    // up the spine are in the right location.
-                    rewritten = rewritten.ReplaceToken(braces.closeBrace,
-                        braces.closeBrace.WithAdditionalAnnotations(Formatter.Annotation));
-                }
 
-                return rewritten;
+                    // rewrite this node normally.
+                    var rewritten = base.Visit(node);
+                    if (rewritten == node)
+                    {
+                        return rewritten;
+                    }
+
+                    // This node changed.  That means that something underneath us got
+                    // rewritten.  (i.e. we added the annotation to the context node).
+                    Debug.Assert(_seenContextNode);
+
+                    // Ok, we're past the context node now.  See if this is a node with 
+                    // curlies.  If so, if it has a missing close curly then add in the 
+                    // missing curly.  Also, even if it doesn't have missing curlies, 
+                    // then still ask to format its close curly to make sure all the 
+                    // curlies up the stack are properly formatted.
+                    var braces = rewritten.GetBraces();
+                    if (braces.openBrace.Kind() == SyntaxKind.None &&
+                        braces.closeBrace.Kind() == SyntaxKind.None)
+                    {
+                        // Not an item with braces.  Just pass it up.
+                        return rewritten;
+                    }
+
+                    // See if the close brace is missing.  If it's the first missing one 
+                    // we're seeing then definitely add it.
+                    if (braces.closeBrace.IsMissing)
+                    {
+                        if (!_addedFirstCloseCurly)
+                        {
+                            var closeBrace = SyntaxFactory.Token(SyntaxKind.CloseBraceToken)
+                                .WithAdditionalAnnotations(Formatter.Annotation);
+                            rewritten = rewritten.ReplaceToken(braces.closeBrace, closeBrace);
+                            _addedFirstCloseCurly = true;
+                        }
+                    }
+                    else
+                    {
+                        // Ask for the close brace to be formatted so that all the braces
+                        // up the spine are in the right location.
+                        rewritten = rewritten.ReplaceToken(braces.closeBrace,
+                            braces.closeBrace.WithAdditionalAnnotations(Formatter.Annotation));
+                    }
+
+                    return rewritten;
+                }
             }
-        }
 
-        public ImmutableArray<SyntaxNode> GetSelectedFieldsAndProperties(SyntaxNode root, TextSpan textSpan, bool allowPartialSelection)
-            => ImmutableArray<SyntaxNode>.CastUp(root.GetFieldsAndPropertiesInSpan(textSpan, allowPartialSelection));
+            public ImmutableArray<SyntaxNode> GetSelectedFieldsAndProperties(SyntaxNode root, TextSpan textSpan, bool allowPartialSelection)
+                => ImmutableArray<SyntaxNode>.CastUp(root.GetFieldsAndPropertiesInSpan(textSpan, allowPartialSelection));
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsServiceFactory.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 namespace Microsoft.CodeAnalysis.CSharp
 {
     [ExportLanguageServiceFactory(typeof(ISyntaxFactsService), LanguageNames.CSharp), Shared]
-    internal class CSharpSyntaxFactsServiceFactory : ILanguageServiceFactory
+    internal sealed partial class CSharpSyntaxFactsServiceFactory : ILanguageServiceFactory
     {
         [ImportingConstructor]
         public CSharpSyntaxFactsServiceFactory()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.AddImports
     internal static class AddImportHelpers
     {
         public static TRootSyntax MoveTrivia<TRootSyntax, TImportDirectiveSyntax>(
-            ISyntaxFactsService syntaxFacts,
+            ISyntaxFacts syntaxFacts,
             TRootSyntax root,
             SyntaxList<TImportDirectiveSyntax> existingImports,
             List<TImportDirectiveSyntax> newImports)
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.AddImports
             return root;
         }
 
-        private static bool IsDocCommentOrElastic(ISyntaxFactsService syntaxFacts, SyntaxTrivia t)
+        private static bool IsDocCommentOrElastic(ISyntaxFacts syntaxFacts, SyntaxTrivia t)
             => syntaxFacts.IsDocumentationComment(t) || syntaxFacts.IsElastic(t);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -121,6 +121,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             SemanticModel semanticModel, SyntaxNode location,
             SyntaxNode containerOpt, string baseName, CancellationToken cancellationToken);
 
+        SyntaxToken GenerateUniqueName(string baseName, IEnumerable<string> usedNames);
+
         bool IsInsideNameOfExpression(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -17,16 +17,13 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         bool IsPossibleTupleContext(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken);
 
-        SyntaxNode Parenthesize(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true);
-
-        SyntaxToken ToIdentifierToken(string name);
-
         ImmutableArray<SyntaxNode> GetSelectedFieldsAndProperties(SyntaxNode root, TextSpan textSpan, bool allowPartialSelection);
 
         // Walks the tree, starting from contextNode, looking for the first construct
         // with a missing close brace.  If found, the close brace will be added and the
         // updates root will be returned.  The context node in that new tree will also
         // be returned.
+        // TODO: This method should be moved out of ISyntaxFactsService.
         void AddFirstMissingCloseBrace<TContextNode>(
             SyntaxNode root, TContextNode contextNode,
             out SyntaxNode newRoot, out TContextNode newContextNode) where TContextNode : SyntaxNode;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
@@ -7,6 +7,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.AddImports
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
@@ -70,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             End If
 
             root = AddImportHelpers.MoveTrivia(
-                VisualBasicSyntaxFactsService.Instance, root, root.Imports, [imports])
+                VisualBasicSyntaxFacts.Instance, root, root.Imports, [imports])
 
             Return root.WithImports(
                 [imports].Select(Function(u) u.WithAdditionalAnnotations(annotations)).ToSyntaxList())

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -6,11 +6,13 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Runtime.InteropServices
 Imports System.Threading
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
@@ -33,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Shared ReadOnly Instance As New VisualBasicSemanticFactsService()
 
-        Protected Overrides ReadOnly Property SyntaxFactsService As ISyntaxFactsService = VisualBasicSyntaxFactsService.Instance
+        Protected Overrides ReadOnly Property SyntaxFacts As ISyntaxFacts = VisualBasicSyntaxFacts.Instance
 
         Private Sub New()
         End Sub
@@ -49,6 +51,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End Get
         End Property
+
+        Protected Overrides Function ToIdentifierToken(identifier As String) As SyntaxToken
+            Return identifier.ToIdentifierToken
+        End Function
 
         Public Function IsExpressionContext(semanticModel As SemanticModel,
                                             position As Integer,
@@ -165,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     ' If we hit an executable statement syntax and didn't find anything yet, we can just stop now -- anything higher would be a member declaration which won't be defined by something inside a statement.
-                    If SyntaxFactsService.IsExecutableStatement(ancestor) Then
+                    If SyntaxFacts.IsExecutableStatement(ancestor) Then
                         Return Nothing
                     End If
                 End If
@@ -347,6 +353,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function ISemanticFactsService_GenerateUniqueName(semanticModel As SemanticModel, location As SyntaxNode, containerOpt As SyntaxNode, baseName As String, filter As Func(Of ISymbol, Boolean), usedNames As IEnumerable(Of String), cancellationToken As CancellationToken) As SyntaxToken Implements ISemanticFactsService.GenerateUniqueName
             Return MyBase.GenerateUniqueName(semanticModel, location, containerOpt, baseName, filter, usedNames, cancellationToken)
+        End Function
+
+        Private Function ISemanticFactsService_GenerateUniqueName(baseName As String, usedNames As IEnumerable(Of String)) As SyntaxToken Implements ISemanticFactsService.GenerateUniqueName
+            Return MyBase.GenerateUniqueName(baseName, usedNames)
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -8,61 +8,54 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
-    Friend Class VisualBasicSyntaxFactsService
-        Inherits VisualBasicSyntaxFacts
-        Implements ISyntaxFactsService
+    Partial Friend NotInheritable Class VisualBasicSyntaxFactsServiceFactory
+        Private NotInheritable Class VisualBasicSyntaxFactsService
+            Inherits VisualBasicSyntaxFacts
+            Implements ISyntaxFactsService
 
-        Public Shared Shadows ReadOnly Property Instance As New VisualBasicSyntaxFactsService
+            Public Shared Shadows ReadOnly Property Instance As New VisualBasicSyntaxFactsService
 
-        Private Sub New()
-        End Sub
+            Private Sub New()
+            End Sub
 
-        Public Function IsInInactiveRegion(syntaxTree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.IsInInactiveRegion
-            If syntaxTree Is Nothing Then
-                Return False
-            End If
+            Public Function IsInInactiveRegion(syntaxTree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.IsInInactiveRegion
+                If syntaxTree Is Nothing Then
+                    Return False
+                End If
 
-            Return syntaxTree.IsInInactiveRegion(position, cancellationToken)
-        End Function
+                Return syntaxTree.IsInInactiveRegion(position, cancellationToken)
+            End Function
 
-        Public Function IsInNonUserCode(syntaxTree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.IsInNonUserCode
-            If syntaxTree Is Nothing Then
-                Return False
-            End If
+            Public Function IsInNonUserCode(syntaxTree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.IsInNonUserCode
+                If syntaxTree Is Nothing Then
+                    Return False
+                End If
 
-            Return syntaxTree.IsInNonUserCode(position, cancellationToken)
-        End Function
+                Return syntaxTree.IsInNonUserCode(position, cancellationToken)
+            End Function
 
-        Public Function IsPossibleTupleContext(
-            syntaxTree As SyntaxTree,
-            position As Integer,
-            cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.IsPossibleTupleContext
+            Public Function IsPossibleTupleContext(
+                syntaxTree As SyntaxTree,
+                position As Integer,
+                cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.IsPossibleTupleContext
 
-            Dim token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
-            Return syntaxTree.IsPossibleTupleContext(token, position)
-        End Function
+                Dim token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
+                Return syntaxTree.IsPossibleTupleContext(token, position)
+            End Function
 
-        Public Function ToIdentifierToken(name As String) As SyntaxToken Implements ISyntaxFactsService.ToIdentifierToken
-            Return name.ToIdentifierToken()
-        End Function
+            Public Sub AddFirstMissingCloseBrace(Of TContextNode As SyntaxNode)(
+                    root As SyntaxNode, contextNode As TContextNode,
+                    ByRef newRoot As SyntaxNode, ByRef newContextNode As TContextNode) Implements ISyntaxFactsService.AddFirstMissingCloseBrace
+                ' Nothing to be done.  VB doesn't have close braces
+                newRoot = root
+                newContextNode = contextNode
+            End Sub
 
-        Public Function Parenthesize(expression As SyntaxNode, Optional includeElasticTrivia As Boolean = True, Optional addSimplifierAnnotation As Boolean = True) As SyntaxNode Implements ISyntaxFactsService.Parenthesize
-            Return DirectCast(expression, ExpressionSyntax).Parenthesize(addSimplifierAnnotation)
-        End Function
-
-        Public Sub AddFirstMissingCloseBrace(Of TContextNode As SyntaxNode)(
-                root As SyntaxNode, contextNode As TContextNode,
-                ByRef newRoot As SyntaxNode, ByRef newContextNode As TContextNode) Implements ISyntaxFactsService.AddFirstMissingCloseBrace
-            ' Nothing to be done.  VB doesn't have close braces
-            newRoot = root
-            newContextNode = contextNode
-        End Sub
-
-        Public Function GetSelectedFieldsAndProperties(root As SyntaxNode, textSpan As TextSpan, allowPartialSelection As Boolean) As ImmutableArray(Of SyntaxNode) Implements ISyntaxFactsService.GetSelectedFieldsAndProperties
-            Return ImmutableArray(Of SyntaxNode).CastUp(root.GetSelectedFieldsAndPropertiesInSpan(textSpan, allowPartialSelection))
-        End Function
+            Public Function GetSelectedFieldsAndProperties(root As SyntaxNode, textSpan As TextSpan, allowPartialSelection As Boolean) As ImmutableArray(Of SyntaxNode) Implements ISyntaxFactsService.GetSelectedFieldsAndProperties
+                Return ImmutableArray(Of SyntaxNode).CastUp(root.GetSelectedFieldsAndPropertiesInSpan(textSpan, allowPartialSelection))
+            End Function
+        End Class
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxFactsServiceFactory.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxFactsServiceFactory.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
     <ExportLanguageServiceFactory(GetType(ISyntaxFactsService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicSyntaxFactsServiceFactory
+    Partial Friend NotInheritable Class VisualBasicSyntaxFactsServiceFactory
         Implements ILanguageServiceFactory
 
         <ImportingConstructor>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Utilities/ImportsOrganizer.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Utilities/ImportsOrganizer.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -61,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                     Dim name1 = simpleClause1.Name.GetFirstToken().ValueText
                     Dim name2 = simpleClause2.Name.GetFirstToken().ValueText
 
-                    Return Not VisualBasicSyntaxFactsService.Instance.StringComparer.Equals(name1, name2)
+                    Return Not VisualBasicSyntaxFacts.Instance.StringComparer.Equals(name1, name2)
                 End If
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/VisualBasicCodeCleanerService.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/VisualBasicCodeCleanerService.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.CodeCleanup
 Imports Microsoft.CodeAnalysis.CodeCleanup.Providers
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeCleanup
     Partial Friend Class VisualBasicCodeCleanerService
@@ -89,7 +90,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeCleanup
                 Function(t)
                     If t.Kind() = SyntaxKind.StringLiteralToken OrElse
                        t.Kind() = SyntaxKind.InterpolatedStringTextToken Then
-                        Return Not VisualBasicSyntaxFactsService.Instance.IsOnSingleLine(t.Parent, fullSpan:=False)
+                        Return Not VisualBasicSyntaxFacts.Instance.IsOnSingleLine(t.Parent, fullSpan:=False)
                     End If
 
                     Return False
@@ -101,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeCleanup
                 Return Nothing
             End If
 
-            If Not VisualBasicSyntaxFactsService.Instance.IsOnSingleLine(node, fullSpan:=False) Then
+            If Not VisualBasicSyntaxFacts.Instance.IsOnSingleLine(node, fullSpan:=False) Then
                 Return node
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
@@ -482,7 +483,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Dim newBlock As SyntaxNode
             If options.BeforeThisLocation IsNot Nothing Then
                 Dim strippedTrivia As ImmutableArray(Of SyntaxTrivia) = Nothing
-                Dim newStatement = VisualBasicSyntaxFactsService.Instance.GetNodeWithoutLeadingBannerAndPreprocessorDirectives(
+                Dim newStatement = VisualBasicSyntaxFacts.Instance.GetNodeWithoutLeadingBannerAndPreprocessorDirectives(
                     oldStatement, strippedTrivia)
 
                 statementArray(0) = statementArray(0).WithLeadingTrivia(strippedTrivia)

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Simplification
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
@@ -28,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Friend Overrides ReadOnly Property RequiresExplicitImplementationForInterfaceMembers As Boolean = True
 
-        Friend Overrides ReadOnly Property SyntaxFacts As ISyntaxFactsService = VisualBasicSyntaxFactsService.Instance
+        Friend Overrides ReadOnly Property SyntaxFacts As ISyntaxFacts = VisualBasicSyntaxFacts.Instance
 
         Friend Overrides Function EndOfLine(text As String) As SyntaxTrivia
             Return SyntaxFactory.EndOfLine(text)
@@ -64,12 +65,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return SyntaxFactory.TupleExpression(SyntaxFactory.SeparatedList(arguments.Select(AddressOf AsSimpleArgument)))
         End Function
 
-        Friend Overrides Function AddParentheses(expression As SyntaxNode) As SyntaxNode
-            Return Parenthesize(expression)
+        Friend Overrides Function AddParentheses(expression As SyntaxNode, Optional includeElasticTrivia As Boolean = True, Optional addSimplifierAnnotation As Boolean = True) As SyntaxNode
+            Return Parenthesize(expression, addSimplifierAnnotation)
         End Function
 
-        Private Function Parenthesize(expression As SyntaxNode) As ParenthesizedExpressionSyntax
-            Return DirectCast(expression, ExpressionSyntax).Parenthesize()
+        Private Function Parenthesize(expression As SyntaxNode, Optional addSimplifierAnnotation As Boolean = True) As ParenthesizedExpressionSyntax
+            Return DirectCast(expression, ExpressionSyntax).Parenthesize(addSimplifierAnnotation)
         End Function
 
         Public Overrides Function AddExpression(left As SyntaxNode, right As SyntaxNode) As SyntaxNode

--- a/src/Workspaces/VisualBasic/Portable/EmbeddedLanguages/LanguageServices/VisualBasicEmbeddedLanguagesProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/EmbeddedLanguages/LanguageServices/VisualBasicEmbeddedLanguagesProvider.vb
@@ -6,6 +6,7 @@ Imports System.Composition
 Imports Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.VirtualChars
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.LanguageServices
     <ExportLanguageService(GetType(IEmbeddedLanguagesProvider), LanguageNames.VisualBasic, ServiceLayer.Default), [Shared]>
@@ -15,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.LanguageServices
         Public Shared Info As New EmbeddedLanguageInfo(
             SyntaxKind.StringLiteralToken,
             SyntaxKind.InterpolatedStringTextToken,
-            VisualBasicSyntaxFactsService.Instance,
+            VisualBasicSyntaxFacts.Instance,
             VisualBasicSemanticFactsService.Instance,
             VisualBasicVirtualCharService.Instance)
 

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
@@ -108,11 +109,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
         End Function
 
         Private Function GetContainerDisplayName(node As SyntaxNode) As String
-            Return VisualBasicSyntaxFactsService.Instance.GetDisplayName(node, DisplayNameOptions.IncludeTypeParameters)
+            Return VisualBasicSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeTypeParameters)
         End Function
 
         Private Function GetFullyQualifiedContainerName(node As SyntaxNode, rootNamespace As String) As String
-            Return VisualBasicSyntaxFactsService.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces, rootNamespace)
+            Return VisualBasicSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces, rootNamespace)
         End Function
 
         Public Overrides Function TryGetDeclaredSymbolInfo(stringTable As StringTable, node As SyntaxNode, rootNamespace As String, ByRef declaredSymbolInfo As DeclaredSymbolInfo) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Simplification
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
@@ -32,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 ' cases if elastic trivia is there -- and it's not clear why.
                 ' Specifically removing the elastic trivia formatting rule doesn't
                 ' have any effect.
-                Dim resultNode = VisualBasicSyntaxFactsService.Instance.Unparenthesize(node)
+                Dim resultNode = VisualBasicSyntaxFacts.Instance.Unparenthesize(node)
                 resultNode = SimplificationHelpers.CopyAnnotations(node, resultNode)
 
                 Return resultNode

--- a/src/Workspaces/VisualBasicTest/VisualBasicSyntaxFactsServiceTests.vb
+++ b/src/Workspaces/VisualBasicTest/VisualBasicSyntaxFactsServiceTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
@@ -508,9 +509,7 @@ Loop $$While index < 10")))
             MarkupTestFile.GetSpan(markup, code, span)
             Dim tree = SyntaxFactory.ParseSyntaxTree(code)
             Dim node = tree.GetRoot().FindNode(span)
-            Dim service = VisualBasicSyntaxFactsService.Instance
-
-            Return service.IsMethodLevelMember(node)
+            Return VisualBasicSyntaxFacts.Instance.IsMethodLevelMember(node)
         End Function
 
         Private Function WrapInMethod(methodBody As String) As String
@@ -528,9 +527,7 @@ End Class"
             MarkupTestFile.GetPosition(markup, code, position)
             Dim tree = SyntaxFactory.ParseSyntaxTree(code)
             Dim token = tree.GetRoot().FindToken(position)
-            Dim service = VisualBasicSyntaxFactsService.Instance
-
-            Return service.IsQueryKeyword(token)
+            Return VisualBasicSyntaxFacts.Instance.IsQueryKeyword(token)
         End Function
 
         <Fact, WorkItem(40917, "https://github.com/dotnet/roslyn/issues/40917")>
@@ -546,9 +543,7 @@ $$index += 1")))
             MarkupTestFile.GetPosition(markup, code, position)
             Dim tree = SyntaxFactory.ParseSyntaxTree(code)
             Dim node = tree.GetRoot().FindToken(position).Parent
-            Dim service = VisualBasicSyntaxFactsService.Instance
-
-            Return service.IsLeftSideOfCompoundAssignment(node)
+            Return VisualBasicSyntaxFacts.Instance.IsLeftSideOfCompoundAssignment(node)
         End Function
     End Class
 


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/42015/files#r385741503

This change allows couple of things:
1. Make C# and VB ISyntaxFactsService implementation private nested types, as mentioned in the above comment.
2. Aid future porting of analyzers to CodeStyle layer by moving bunch of our analyzers/fixers/helpers to use ISyntaxFacts as opposed to ISyntaxFactsService, latter is not available in CodeStyle analyzer layer.

**NOTE:** Majority of changes in this PR are pretty mechanical. I have added explicit comments at places where there are non-mechanical changes.