### PR TITLE
Disable Navigate-To filtering of previous results.

### DIFF
--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/23051
Fixes: https://github.com/dotnet/roslyn/issues/40828

This filtering is broken *by design*.  Here's the fundamental issue the previous 'optimization' failed to recognize:

NavigateTo results for a string `S1S2...Sn` are not a subset of the results for a string `S1S2...Sn-1`.  A very simple example of htat are 'fuzzy' matches.  Fuzzy matches can produce *more* results as you add more data (since you're now close enough to consider the hits fuzzily-close.  Similarly, everything we do matching-wise that uses edit-distances is very length dependent.  If the lengths are too far apart, we don't even bother (for perf reasons).  

This could lead to a really bad experience where, depending on your typing speed, you might end up with no results in nav-to *and then stay there as you continued to add more text*.  

-- 

Another case this hits is typing out (manually) `Foo.Bar`.  As you type `Foo` it's doing a normal symbol search for variables with that name.  but whne you add the `.Bar` it wants to find symbols called `.Bar` off of symbols called `Foo`.  If we keep filtering the list down, this can't work.