### PR TITLE
Add support for insertion validation

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -54,11 +54,10 @@ stages:
       condition: and(succeeded(), ne(variables['PrNumber'], ''), ne(variables['PrNumber'], 'default'))
 
     - task: tagBuildOrRelease@0
-      displayName: Tagging PR validation build
+      displayName: Tag build
       inputs:
         type: 'Build'
-        tags: 'PrValidationBuild'
-      condition: and(succeeded(), variables['IsPrValidationBuild'])
+        tags: if (variables['IsPrValidationBuild']) { 'PrValidationBuild' } else { "OfficialBuild" }
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -268,7 +268,7 @@ stages:
       queue:
         name: Hosted VS2017
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), !variables['IsPrValidationBuild']) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -48,7 +48,7 @@ stages:
           exit 1
         }
       displayName: Setup branch for insertion validation
-      condition: and(succeeded(), ne(variables['PrNumber'], Null), ne(variables['PrNumber'], 'default'))
+      condition: and(succeeded(), ne(variables['PrNumber'], ''), ne(variables['PrNumber'], 'default'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -58,7 +58,7 @@ stages:
       inputs:
         type: 'Build'
         tags: 'PrValidationBuild'
-      conditions: and(succeeded(), variables['IsPrValidationBuild'])
+      condition: and(succeeded(), variables['IsPrValidationBuild'])
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -42,7 +42,7 @@ stages:
         if ($SourceBranchname -notlike '*-vs-deps') {
           Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchname), which is not a vs-deps branch."
         }
-        git pull refs/pull/$PrNumber/merge
+        git pull origin refs/pull/$(PrNumber)/merge
         if ($?) {
           Write-Host  "##vso[task.LogIssue type=error;]Merging with branch refs/pull/$(PrNumber)/merge failed."
         }

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -43,8 +43,9 @@ stages:
           Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchname), which is not a vs-deps branch."
         }
         git pull origin refs/pull/$(PrNumber)/merge
-        if ($?) {
+        if (!$?) {
           Write-Host  "##vso[task.LogIssue type=error;]Merging with branch refs/pull/$(PrNumber)/merge failed."
+          exit 1
         }
       displayName: Setup branch for insertion validation
       condition: and(succeeded(), ne(variables['PrNumber'], ''))

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -10,6 +10,7 @@ resources:
 #  SkipApplyOptimizationData: false
 #  IbcSourceBranchName: 'default'
 #  IbcDropId: 'default'
+#  PrNumber: ''
 
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
@@ -36,6 +37,17 @@ stages:
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
+
+    - powershell: |
+        if ($SourceBranchname -notlike '*-vs-deps') {
+          Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchname), which is not a vs-deps branch."
+        }
+        git pull refs/pull/$PrNumber/merge
+        if ($?) {
+          Write-Host  "##vso[task.LogIssue type=error;]Merging with branch refs/pull/$(PrNumber)/merge failed."
+        }
+      displayName: Setup branch for insertion validation
+      condition: and(succeeded(), $PrNumber -ne '')
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -58,11 +58,9 @@ stages:
           exit 1
         }
         Write-Host "Getting the hash of refs/pull/$(PrNumber)/head..."
-        $headSha = (git ls-remote origin refs/pull/$(PrNumber)/head) | Out-String
-        Write-Host "$(headSha)."
+        Write-Host ((git ls-remote origin refs/pull/$(PrNumber)/head) | Out-String)
       displayName: Setup branch for insertion validation
       condition: and(succeeded(), variables['IsPrValidationBuild'])
-
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -47,19 +47,11 @@ stages:
         type: 'Build'
         tags: if (variables['IsPRValidationBuild']) { 'PrValidationBuild' } else { "OfficialBuild" }
 
-    - powershell: |
-        if ($SourceBranchName -notlike '*-vs-deps') {
-          Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchName), which is not a vs-deps branch."
-        }
-        Write-Host "Setting up the build for PR validation by merging refs/pull/$(PRNumber)/merge into $(SourceBranchName)..."
-        git pull origin refs/pull/$(PRNumber)/merge
-        if (!$?) {
-          Write-Host "##vso[task.LogIssue type=error;]Merging branch refs/pull/$(PRNumber)/merge failed."
-          exit 1
-        }
-        Write-Host "Getting the hash of refs/pull/$(PRNumber)/head..."
-        Write-Host ((git ls-remote origin refs/pull/$(PRNumber)/head) | Out-String)
+    - task: PowerShell@2
       displayName: Setup branch for insertion validation
+      inputs:
+        filePath: 'eng\setup-pr-validation.ps1'
+        arguments: '-sourceBranchName $(SourceBranchName) -prNumber $(PRNumber)'
       condition: and(succeeded(), variables['IsPRValidationBuild'])
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -10,7 +10,7 @@ resources:
 #  SkipApplyOptimizationData: false
 #  IbcSourceBranchName: 'default'
 #  IbcDropId: 'default'
-#  PrNumber: 'default'
+#  PRNumber: 'default'
 
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
@@ -38,29 +38,29 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
 
-    - powershell: Write-Host "##vso[task.setvariable variable=IsPrValidationBuild]($(PrNumber) -ne '') -and ($(PrNumber) -ne 'default')"
-      displayName: Setting IsPrValidationBuild variable
+    - powershell: Write-Host "##vso[task.setvariable variable=IsPRValidationBuild]($(PRNumber) -ne '') -and ($(PRNumber) -ne 'default')"
+      displayName: Setting IsPRValidationBuild variable
 
     - task: tagBuildOrRelease@0
       displayName: Tag build
       inputs:
         type: 'Build'
-        tags: if (variables['IsPrValidationBuild']) { 'PrValidationBuild' } else { "OfficialBuild" }
+        tags: if (variables['IsPRValidationBuild']) { 'PrValidationBuild' } else { "OfficialBuild" }
 
     - powershell: |
         if ($SourceBranchName -notlike '*-vs-deps') {
           Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchName), which is not a vs-deps branch."
         }
-        Write-Host "Setting up the build for PR validation by merging refs/pull/$(PrNumber)/merge into $(SourceBranchName)..."
-        git pull origin refs/pull/$(PrNumber)/merge
+        Write-Host "Setting up the build for PR validation by merging refs/pull/$(PRNumber)/merge into $(SourceBranchName)..."
+        git pull origin refs/pull/$(PRNumber)/merge
         if (!$?) {
-          Write-Host "##vso[task.LogIssue type=error;]Merging branch refs/pull/$(PrNumber)/merge failed."
+          Write-Host "##vso[task.LogIssue type=error;]Merging branch refs/pull/$(PRNumber)/merge failed."
           exit 1
         }
-        Write-Host "Getting the hash of refs/pull/$(PrNumber)/head..."
-        Write-Host ((git ls-remote origin refs/pull/$(PrNumber)/head) | Out-String)
+        Write-Host "Getting the hash of refs/pull/$(PRNumber)/head..."
+        Write-Host ((git ls-remote origin refs/pull/$(PRNumber)/head) | Out-String)
       displayName: Setup branch for insertion validation
-      condition: and(succeeded(), variables['IsPrValidationBuild'])
+      condition: and(succeeded(), variables['IsPRValidationBuild'])
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
@@ -270,7 +270,7 @@ stages:
       queue:
         name: Hosted VS2017
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsPrValidationBuild'], false)) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsPRValidationBuild'], false)) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -268,7 +268,7 @@ stages:
       queue:
         name: Hosted VS2017
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), !variables['IsPrValidationBuild']) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), !(variables['IsPrValidationBuild'])) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -10,7 +10,7 @@ resources:
 #  SkipApplyOptimizationData: false
 #  IbcSourceBranchName: 'default'
 #  IbcDropId: 'default'
-#  PrNumber: ''
+#  PrNumber: 'default'
 
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
@@ -48,7 +48,7 @@ stages:
           exit 1
         }
       displayName: Setup branch for insertion validation
-      condition: and(succeeded(), ne(variables['PrNumber'], ''))
+      condition: and(succeeded(), ne(variables['PrNumber'], 'default'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -270,7 +270,7 @@ stages:
       queue:
         name: Hosted VS2017
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsPrValidationBuild'], true)) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsPrValidationBuild'], false)) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -39,8 +39,9 @@ stages:
       displayName: Setting SourceBranchName variable
 
     - powershell: |
-        if ($SourceBranchname -notlike '*-vs-deps') {
-          Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchname), which is not a vs-deps branch."
+        Write-Host "Setting up the build for PR validation by merging refs/pull/$(PrNumber)/merge into $(SourceBranchName)."
+        if ($SourceBranchName -notlike '*-vs-deps') {
+          Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchName), which is not a vs-deps branch."
         }
         git pull origin refs/pull/$(PrNumber)/merge
         if (!$?) {

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -48,7 +48,7 @@ stages:
           exit 1
         }
       displayName: Setup branch for insertion validation
-      condition: and(succeeded(), ne(variables['PrNumber'], 'default'))
+      condition: and(succeeded(), ne(variables['PrNumber'], Null), ne(variables['PrNumber'], 'default'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -45,7 +45,7 @@ stages:
       displayName: Tag build
       inputs:
         type: 'Build'
-        tags: if (variables['IsPRValidationBuild']) { 'PrValidationBuild' } else { "OfficialBuild" }
+        tags: if (variables['IsPRValidationBuild']) { 'PRValidationBuild' } else { "OfficialBuild" }
 
     - task: PowerShell@2
       displayName: Setup branch for insertion validation

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -38,26 +38,31 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
 
-    - powershell: |
-        Write-Host "Setting up the build for PR validation by merging refs/pull/$(PrNumber)/merge into $(SourceBranchName)."
-        if ($SourceBranchName -notlike '*-vs-deps') {
-          Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchName), which is not a vs-deps branch."
-        }
-        git pull origin refs/pull/$(PrNumber)/merge
-        if (!$?) {
-          Write-Host  "##vso[task.LogIssue type=error;]Merging with branch refs/pull/$(PrNumber)/merge failed."
-          exit 1
-        } else {
-          Write-Host "##vso[task.setvariable variable=IsPrValidationBuild]$true"
-        }
-      displayName: Setup branch for insertion validation
-      condition: and(succeeded(), ne(variables['PrNumber'], ''), ne(variables['PrNumber'], 'default'))
+    - powershell: Write-Host "##vso[task.setvariable variable=IsPrValidationBuild]($(PrNumber) -ne '') -and ($(PrNumber) -ne 'default')"
+      displayName: Setting IsPrValidationBuild variable
 
     - task: tagBuildOrRelease@0
       displayName: Tag build
       inputs:
         type: 'Build'
         tags: if (variables['IsPrValidationBuild']) { 'PrValidationBuild' } else { "OfficialBuild" }
+
+    - powershell: |
+        if ($SourceBranchName -notlike '*-vs-deps') {
+          Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $(SourceBranchName), which is not a vs-deps branch."
+        }
+        Write-Host "Setting up the build for PR validation by merging refs/pull/$(PrNumber)/merge into $(SourceBranchName)..."
+        git pull origin refs/pull/$(PrNumber)/merge
+        if (!$?) {
+          Write-Host "##vso[task.LogIssue type=error;]Merging branch refs/pull/$(PrNumber)/merge failed."
+          exit 1
+        }
+        Write-Host "Getting the hash of refs/pull/$(PrNumber)/head..."
+        $headSha = (git ls-remote origin refs/pull/$(PrNumber)/head) | Out-String
+        Write-Host "$(headSha)."
+      displayName: Setup branch for insertion validation
+      condition: and(succeeded(), variables['IsPrValidationBuild'])
+
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -47,9 +47,18 @@ stages:
         if (!$?) {
           Write-Host  "##vso[task.LogIssue type=error;]Merging with branch refs/pull/$(PrNumber)/merge failed."
           exit 1
+        } else {
+          Write-Host "##vso[task.setvariable variable=IsPrValidationBuild]$true"
         }
       displayName: Setup branch for insertion validation
       condition: and(succeeded(), ne(variables['PrNumber'], ''), ne(variables['PrNumber'], 'default'))
+
+    - task: tagBuildOrRelease@0
+      displayName: Tagging PR validation build
+      inputs:
+        type: 'Build'
+        tags: 'PrValidationBuild'
+      conditions: and(succeeded(), variables['IsPrValidationBuild'])
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -47,7 +47,7 @@ stages:
           Write-Host  "##vso[task.LogIssue type=error;]Merging with branch refs/pull/$(PrNumber)/merge failed."
         }
       displayName: Setup branch for insertion validation
-      condition: and(succeeded(), $PrNumber -ne '')
+      condition: and(succeeded(), ne(variables['PrNumber'], ''))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -268,7 +268,7 @@ stages:
       queue:
         name: Hosted VS2017
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), !(variables['IsPrValidationBuild'])) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsPrValidationBuild'], true)) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until

--- a/eng/setup-pr-validation.ps1
+++ b/eng/setup-pr-validation.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+  [string]$sourceBranchName,
+  [string]$prNumber)
+
+try {
+    if ($sourceBranchName -notlike '*-vs-deps') {
+      Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $sourceBranchName, which is not a vs-deps branch."
+    }
+    Write-Host "Setting up the build for PR validation by merging refs/pull/$prNumber/merge into $sourceBranchName..."
+    git pull origin refs/pull/$prNumber/merge
+    if (!$?) {
+      Write-Host "##vso[task.LogIssue type=error;]Merging branch refs/pull/$prNumber/merge failed."
+      exit 1
+    }
+    Write-Host "Getting the hash of refs/pull/$prNumber/head..."
+    Write-Host ((git ls-remote origin refs/pull/$prNumber/head) | Out-String)
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  exit 1
+}


### PR DESCRIPTION
This would queue a signed build from merging a PR merge branch into the specified base branch, if a PR number is provided.

Here's how it works:
1. Go to AzDO and queue a new signed build
   - set 'Branch/tag' to the insertion base branch (e.g. if you PR is targeting master, but VS insertion is done from master-vs-deps, you want to set this to master-vs-deps)
   - set `PrNumber` to the PR containing the change to be validated 
2. The pipeline would automatically merge from `refs/pull/$(PrNumber)/merge` branch. If `PrNumber` not set, it will just proceed as a normal signed build; if set to invalid PR number or there's merge conflict, build would fail immediately.
3. It would also tag regular build with "OfficialBuild" and validation build with "PrValidationBuild", post-build tasks (validations and publishing) are bypassed by validation build.


todos:
1. Bypass publishing steps once validation is done (right now all post-build tasks are bypassed, including validation)
2. Create a draft VS insertion for PR validation build. Right now, the insertion pipeline for the base branch would trigger, which creates a regular PR which can't be distinguished from real insertion. I will probably just create another insertion pipeline that triggered by build with "PrValidationBuild" tag (also change existing ones to be triggered on "OfficialBuild" tag)