### PR TITLE
Clean up Contract

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
                 return CSharpStructureHelpers.CreateCommentBlockSpan(token.TrailingTrivia);
             }
 
-            throw Contract.Unreachable;
+            throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
@@ -34,10 +34,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
             {
                 return CSharpStructureHelpers.CreateCommentBlockSpan(token.TrailingTrivia);
             }
-            else
-            {
-                return Contract.FailWithReturn<ImmutableArray<BlockSpan>>();
-            }
+
+            throw Contract.Unreachable;
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/ViewTextSpan.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/ViewTextSpan.cs
@@ -79,8 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                     }
 
                 default:
-                    Contract.Fail();
-                    return default;
+                    throw Contract.Unreachable;
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/ViewTextSpan.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/ViewTextSpan.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                     }
 
                 default:
-                    throw Contract.Unreachable;
+                    throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
@@ -73,19 +73,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 var document = _snapshotSpan.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 var newName = _snapshotSpan.GetText();
 
-                if (document == null)
-                {
-                    Contract.Fail("Invoked rename tracking smart tag but cannot find the document for the snapshot span.");
-                }
+                Contract.ThrowIfNull(document, "Invoked rename tracking smart tag but cannot find the document for the snapshot span.");
 
                 // Get copy of solution with the original name in the place of the renamed name
                 var solutionWithOriginalName = CreateSolutionWithOriginalName(document, cancellationToken);
 
                 var symbol = await TryGetSymbolAsync(solutionWithOriginalName, document.Id, cancellationToken).ConfigureAwait(false);
-                if (symbol == null)
-                {
-                    Contract.Fail("Invoked rename tracking smart tag but cannot find the symbol.");
-                }
+                Contract.ThrowIfNull(symbol, "Invoked rename tracking smart tag but cannot find the symbol.");
 
                 var optionSet = document.Project.Solution.Workspace.Options;
 

--- a/src/EditorFeatures/Core/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 case TypeKind.Error:
                     return StandardGlyphGroup.GlyphGroupError;
                 default:
-                    throw Contract.UnexpectedValue(symbol.TypeKind);
+                    throw ExceptionUtilities.UnexpectedValue(symbol.TypeKind);
             }
         }
     }

--- a/src/EditorFeatures/Core/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 case TypeKind.Error:
                     return StandardGlyphGroup.GlyphGroupError;
                 default:
-                    return Contract.FailWithReturn<StandardGlyphGroup>("Unknown named type symbol kind!");
+                    throw Contract.UnexpectedValue(symbol.TypeKind);
             }
         }
     }

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.InKeyword.Span)
                 End With
             Else
-                Throw Contract.UnexpectedValue(forBlock.ForOrForEachStatement)
+                throw ExceptionUtilities.UnexpectedValue(forBlock.ForOrForEachStatement)
             End If
 
             highlights.AddRange(

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.InKeyword.Span)
                 End With
             Else
-                Contract.Fail("Expected ForStatementSyntax or ForEachStatementSyntax, but was " & forBlock.ForOrForEachStatement.GetTypeDisplayName())
+                Throw Contract.UnexpectedValue(forBlock.ForOrForEachStatement)
             End If
 
             highlights.AddRange(

--- a/src/EditorFeatures/VisualBasicTest/Structure/CommentStructureTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Structure/CommentStructureTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
             ElseIf token.TrailingTrivia.Contains(trivia) Then
                 Return CreateCommentsRegions(token.TrailingTrivia)
             Else
-                Return Contract.FailWithReturn(Of ImmutableArray(Of BlockSpan))()
+                Throw Contract.Unreachable
             End If
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Structure/CommentStructureTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Structure/CommentStructureTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
             ElseIf token.TrailingTrivia.Contains(trivia) Then
                 Return CreateCommentsRegions(token.TrailingTrivia)
             Else
-                Throw Contract.Unreachable
+                Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
             End If
         End Function
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     {
                         BlockSyntax blockNode => blockNode.Statements,
                         SwitchSectionSyntax switchSectionNode => switchSectionNode.Statements,
-                        _ => Contract.FailWithReturn<SyntaxList<StatementSyntax>>("unknown statements container!"),
+                        _ => throw Contract.UnexpectedValue(node),
                     };
                 }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     {
                         BlockSyntax blockNode => blockNode.Statements,
                         SwitchSectionSyntax switchSectionNode => switchSectionNode.Statements,
-                        _ => throw Contract.UnexpectedValue(node),
+                        _ => throw ExceptionUtilities.UnexpectedValue(node),
                     };
                 }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return new MultipleStatementsCodeGenerator(insertionPoint, selectionResult, analyzerResult, options, localFunction);
                 }
 
-                return Contract.FailWithReturn<CSharpCodeGenerator>("Unknown selection");
+                throw Contract.UnexpectedValue(selectionResult);
             }
 
             protected CSharpCodeGenerator(

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return new MultipleStatementsCodeGenerator(insertionPoint, selectionResult, analyzerResult, options, localFunction);
                 }
 
-                throw Contract.UnexpectedValue(selectionResult);
+                throw ExceptionUtilities.UnexpectedValue(selectionResult);
             }
 
             protected CSharpCodeGenerator(

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     TriviaLocation.BeforeEndOfSpan => body != null
                         ? body.CloseBraceToken.GetPreviousToken(includeZeroWidth: true)
                         : semicolonToken,
-                    _ => Contract.FailWithReturn<SyntaxToken>("can't happen"),
+                    _ => throw Contract.UnexpectedValue(location)
                 };
             }
 
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     TriviaLocation.AfterEndOfSpan => FilterTriviaList(list.Concat(tokenPair.NextToken.LeadingTrivia)),
                     TriviaLocation.AfterBeginningOfSpan => FilterTriviaList(AppendTrailingTrivia(tokenPair).Concat(list).Concat(tokenPair.NextToken.LeadingTrivia)),
                     TriviaLocation.BeforeEndOfSpan => FilterTriviaList(tokenPair.PreviousToken.TrailingTrivia.Concat(list).Concat(tokenPair.NextToken.LeadingTrivia)),
-                    _ => Contract.FailWithReturn<IEnumerable<SyntaxTrivia>>("Shouldn't reach here"),
+                    _ => throw Contract.UnexpectedValue(location),
                 };
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 {
                     MethodDeclarationSyntax methodDeclaration => (methodDeclaration.Body, methodDeclaration.ExpressionBody, methodDeclaration.SemicolonToken),
                     LocalFunctionStatementSyntax localFunctionDeclaration => (localFunctionDeclaration.Body, localFunctionDeclaration.ExpressionBody, localFunctionDeclaration.SemicolonToken),
-                    _ => throw new NotSupportedException("SyntaxNode expected to be MethodDeclarationSyntax or LocalFunctionStatementSyntax."),
+                    _ => throw Contract.UnexpectedValue(method)
                 };
             }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     TriviaLocation.BeforeEndOfSpan => body != null
                         ? body.CloseBraceToken.GetPreviousToken(includeZeroWidth: true)
                         : semicolonToken,
-                    _ => throw Contract.UnexpectedValue(location)
+                    _ => throw ExceptionUtilities.UnexpectedValue(location)
                 };
             }
 
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     TriviaLocation.AfterEndOfSpan => FilterTriviaList(list.Concat(tokenPair.NextToken.LeadingTrivia)),
                     TriviaLocation.AfterBeginningOfSpan => FilterTriviaList(AppendTrailingTrivia(tokenPair).Concat(list).Concat(tokenPair.NextToken.LeadingTrivia)),
                     TriviaLocation.BeforeEndOfSpan => FilterTriviaList(tokenPair.PreviousToken.TrailingTrivia.Concat(list).Concat(tokenPair.NextToken.LeadingTrivia)),
-                    _ => throw Contract.UnexpectedValue(location),
+                    _ => throw ExceptionUtilities.UnexpectedValue(location),
                 };
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 {
                     MethodDeclarationSyntax methodDeclaration => (methodDeclaration.Body, methodDeclaration.ExpressionBody, methodDeclaration.SemicolonToken),
                     LocalFunctionStatementSyntax localFunctionDeclaration => (localFunctionDeclaration.Body, localFunctionDeclaration.ExpressionBody, localFunctionDeclaration.SemicolonToken),
-                    _ => throw Contract.UnexpectedValue(method)
+                    _ => throw ExceptionUtilities.UnexpectedValue(method)
                 };
             }
 

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                                 return true;
                             }
 
-                            throw Contract.Unreachable;
+                            throw ExceptionUtilities.Unreachable;
                         }
                         else
                         {
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                         }
                     }
 
-                    throw Contract.Unreachable;
+                    throw ExceptionUtilities.Unreachable;
                 }
 
                 if ((node is EventDeclarationSyntax || node is EventFieldDeclarationSyntax) &&

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -324,10 +324,8 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                             {
                                 return true;
                             }
-                            else
-                            {
-                                Contract.Fail("Cannot reach this point");
-                            }
+
+                            throw Contract.Unreachable;
                         }
                         else
                         {
@@ -762,7 +760,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                         }
                     }
 
-                    Contract.Fail("Cannot reach this point");
+                    throw Contract.Unreachable;
                 }
 
                 if ((node is EventDeclarationSyntax || node is EventFieldDeclarationSyntax) &&

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             }
             else
             {
-                Contract.Fail($"unhandled kind {declarationContext.Kind().ToString()}");
+                throw Contract.UnexpectedValue(declarationContext.Kind());
             }
 
             if (parensDesignation is null)

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             }
             else
             {
-                throw Contract.UnexpectedValue(declarationContext.Kind());
+                throw ExceptionUtilities.UnexpectedValue(declarationContext.Kind());
             }
 
             if (parensDesignation is null)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     title = "semantic";
                     break;
                 default:
-                    throw Contract.UnexpectedValue(kind);
+                    throw ExceptionUtilities.UnexpectedValue(kind);
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -414,10 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     title = "semantic";
                     break;
                 default:
-                    functionId = FunctionId.Diagnostics_ProjectDiagnostic;
-                    title = "nonLocal";
-                    Contract.Fail("shouldn't reach here");
-                    break;
+                    throw Contract.UnexpectedValue(kind);
             }
         }
     }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                     ILocalSymbol local => local.Type,
                     IParameterSymbol parameter => parameter.Type,
                     IRangeVariableSymbol rangeVariable => GetRangeVariableType(model, rangeVariable),
-                    _ => throw Contract.UnexpectedValue(symbol)
+                    _ => throw ExceptionUtilities.UnexpectedValue(symbol)
                 };
 
             protected VariableStyle AlwaysReturn(VariableStyle style)
@@ -771,7 +771,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                             continue;
 
                         default:
-                            throw Contract.UnexpectedValue(symbol);
+                            throw ExceptionUtilities.UnexpectedValue(symbol);
                     }
                 }
             }
@@ -976,7 +976,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                         style),
                     IParameterSymbol parameter => new VariableInfo(new ParameterVariableSymbol(compilation, parameter, type), style),
                     IRangeVariableSymbol rangeVariable => new VariableInfo(new QueryVariableSymbol(compilation, rangeVariable, type), style),
-                    _ => throw Contract.UnexpectedValue(symbol)
+                    _ => throw ExceptionUtilities.UnexpectedValue(symbol)
                 };
             }
         }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -640,13 +640,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             protected virtual ITypeSymbol GetSymbolType(SemanticModel model, ISymbol symbol)
-            => symbol switch
-            {
-                ILocalSymbol local => local.Type,
-                IParameterSymbol parameter => parameter.Type,
-                IRangeVariableSymbol rangeVariable => GetRangeVariableType(model, rangeVariable),
-                _ => Contract.FailWithReturn<ITypeSymbol>("Shouldn't reach here"),
-            };
+                => symbol switch
+                {
+                    ILocalSymbol local => local.Type,
+                    IParameterSymbol parameter => parameter.Type,
+                    IRangeVariableSymbol rangeVariable => GetRangeVariableType(model, rangeVariable),
+                    _ => throw Contract.UnexpectedValue(symbol)
+                };
 
             protected VariableStyle AlwaysReturn(VariableStyle style)
             {
@@ -760,18 +760,19 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                         case IParameterSymbol parameter:
                             AddTypeParametersToMap(TypeParameterCollector.Collect(parameter.Type), sortedMap);
                             continue;
+
                         case ILocalSymbol local:
                             AddTypeParametersToMap(TypeParameterCollector.Collect(local.Type), sortedMap);
                             continue;
-                        case IRangeVariableSymbol rangeVariable:
-                            {
-                                var type = GetRangeVariableType(model, rangeVariable);
-                                AddTypeParametersToMap(TypeParameterCollector.Collect(type), sortedMap);
-                                continue;
-                            }
-                    }
 
-                    Contract.Fail(FeaturesResources.Unknown_symbol_kind);
+                        case IRangeVariableSymbol rangeVariable:
+                            var type = GetRangeVariableType(model, rangeVariable);
+                            AddTypeParametersToMap(TypeParameterCollector.Collect(type), sortedMap);
+                            continue;
+
+                        default:
+                            throw Contract.UnexpectedValue(symbol);
+                    }
                 }
             }
 
@@ -975,7 +976,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                         style),
                     IParameterSymbol parameter => new VariableInfo(new ParameterVariableSymbol(compilation, parameter, type), style),
                     IRangeVariableSymbol rangeVariable => new VariableInfo(new QueryVariableSymbol(compilation, rangeVariable, type), style),
-                    _ => Contract.FailWithReturn<VariableInfo>(FeaturesResources.Unknown),
+                    _ => throw Contract.UnexpectedValue(symbol)
                 };
             }
         }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                         return 2;
 
                     default:
-                        throw Contract.UnexpectedValue(group);
+                        throw ExceptionUtilities.UnexpectedValue(group);
                 }
             }
 

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                         return 2;
 
                     default:
-                        return Contract.FailWithReturn<int>("unknown part kind");
+                        throw Contract.UnexpectedValue(group);
                 }
             }
 

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 case DeclaredSymbolInfoKind.Struct:
                     return NavigateToItemKind.Structure;
                 default:
-                    throw Contract.UnexpectedValue(declaredSymbolInfo.Kind);
+                    throw ExceptionUtilities.UnexpectedValue(declaredSymbolInfo.Kind);
             }
         }
 

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 case DeclaredSymbolInfoKind.Struct:
                     return NavigateToItemKind.Structure;
                 default:
-                    return Contract.FailWithReturn<string>("Unknown declaration kind " + declaredSymbolInfo.Kind);
+                    throw Contract.UnexpectedValue(declaredSymbolInfo.Kind);
             }
         }
 

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_Sorting.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_Sorting.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     : s1.Kind == SymbolKind.Event ? -1 : 1;
             }
 
-            throw Contract.UnexpectedValue((s1.Kind, s2.Kind));
+            throw ExceptionUtilities.UnexpectedValue((s1.Kind, s2.Kind));
         }
     }
 }

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_Sorting.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_Sorting.cs
@@ -184,8 +184,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     : s1.Kind == SymbolKind.Event ? -1 : 1;
             }
 
-            return Contract.FailWithReturn<int>(
-                string.Format("Comparing unexpected symbol kinds: {0} and {1}.", s1.Kind, s2.Kind));
+            throw Contract.UnexpectedValue((s1.Kind, s2.Kind));
         }
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return true;
                     }
 
-                    return Contract.FailWithReturn<bool>("how?");
+                    throw Contract.Unreachable;
                 }
 
                 private DocumentId GetBestDocumentId_NoLock(

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return true;
                     }
 
-                    throw Contract.Unreachable;
+                    throw ExceptionUtilities.Unreachable;
                 }
 
                 private DocumentId GetBestDocumentId_NoLock(

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return true;
                     }
 
-                    return Contract.FailWithReturn<bool>("how?");
+                    throw Contract.Unreachable;
                 }
 
                 protected override bool AddOrReplace_NoLock(WorkItem item)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return true;
                     }
 
-                    throw Contract.Unreachable;
+                    throw ExceptionUtilities.Unreachable;
                 }
 
                 protected override bool AddOrReplace_NoLock(WorkItem item)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return pair.Key;
                     }
 
-                    throw Contract.Unreachable;
+                    throw ExceptionUtilities.Unreachable;
                 }
             }
         }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return pair.Key;
                     }
 
-                    return Contract.FailWithReturn<ProjectId>("Shouldn't reach here");
+                    throw Contract.Unreachable;
                 }
             }
         }

--- a/src/Features/LanguageServer/Protocol/LanguageServerProtocol.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerProtocol.cs
@@ -46,10 +46,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         {
             Contract.ThrowIfNull(solution);
             Contract.ThrowIfNull(request);
-            if (string.IsNullOrEmpty(methodName))
-            {
-                Contract.Fail("Invalid method name");
-            }
+            Contract.ThrowIfTrue(string.IsNullOrEmpty(methodName), "Invalid method name");
 
             var handler = (IRequestHandler<RequestType, ResponseType>)_requestHandlers[methodName]?.Value;
             Contract.ThrowIfNull(handler, string.Format("Request handler not found for method {0}", methodName));

--- a/src/Features/VisualBasic/Portable/CodeFixes/Suppression/VisualBasicSuppressionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Suppression/VisualBasicSuppressionCodeFixProvider.vb
@@ -277,7 +277,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Suppression
                     Return SyntaxFactory.Trivia(newPragmaWarning)
 
                 Case Else
-                    Contract.Fail()
+                    Throw Contract.UnexpectedValue(trivia.Kind())
             End Select
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/CodeFixes/Suppression/VisualBasicSuppressionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Suppression/VisualBasicSuppressionCodeFixProvider.vb
@@ -277,7 +277,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Suppression
                     Return SyntaxFactory.Trivia(newPragmaWarning)
 
                 Case Else
-                    Throw Contract.UnexpectedValue(trivia.Kind())
+                    throw ExceptionUtilities.UnexpectedValue(trivia.Kind())
             End Select
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
@@ -284,7 +284,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
                 Return localDeclaration.RemoveNode(modifiedIdentifier, SyntaxRemoveOptions.KeepEndOfLine)
             End If
 
-            Throw Contract.Unreachable
+            throw ExceptionUtilities.Unreachable
         End Function
 
         Private Function RemoveDefinition(modifiedIdentifier As ModifiedIdentifierSyntax, newBlock As SyntaxNode) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
@@ -284,8 +284,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
                 Return localDeclaration.RemoveNode(modifiedIdentifier, SyntaxRemoveOptions.KeepEndOfLine)
             End If
 
-            Contract.Fail("Failed to update local declaration")
-            Return localDeclaration
+            Throw Contract.Unreachable
         End Function
 
         Private Function RemoveDefinition(modifiedIdentifier As ModifiedIdentifierSyntax, newBlock As SyntaxNode) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.TriviaResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.TriviaResult.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return method.EndBlockStatement.GetFirstToken(includeZeroWidth:=True).GetPreviousToken(includeZeroWidth:=True)
                 End Select
 
-                Return Contract.FailWithReturn(Of SyntaxToken)("can't happen")
+                Throw Contract.UnexpectedValue(location)
             End Function
 
             Private Function TriviaResolver(
@@ -107,7 +107,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return FilterTriviaList(RemoveTrailingElasticTrivia(tokenPair.PreviousToken, list, tokenPair.NextToken))
                 End Select
 
-                Return Contract.FailWithReturn(Of IEnumerable(Of SyntaxTrivia))("Shouldn't reach here")
+                Throw Contract.UnexpectedValue(location)
             End Function
 
             Private Function RemoveTrailingElasticTrivia(

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.TriviaResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.TriviaResult.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return method.EndBlockStatement.GetFirstToken(includeZeroWidth:=True).GetPreviousToken(includeZeroWidth:=True)
                 End Select
 
-                Throw Contract.UnexpectedValue(location)
+                throw ExceptionUtilities.UnexpectedValue(location)
             End Function
 
             Private Function TriviaResolver(
@@ -107,7 +107,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return FilterTriviaList(RemoveTrailingElasticTrivia(tokenPair.PreviousToken, list, tokenPair.NextToken))
                 End Select
 
-                Throw Contract.UnexpectedValue(location)
+                throw ExceptionUtilities.UnexpectedValue(location)
             End Function
 
             Private Function RemoveTrailingElasticTrivia(

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return New MultipleStatementsCodeGenerator(insertionPoint, selectionResult, analyzerResult)
                 End If
 
-                Throw Contract.UnexpectedValue(selectionResult)
+                throw ExceptionUtilities.UnexpectedValue(selectionResult)
             End Function
 
             Protected Sub New(insertionPoint As InsertionPoint, selectionResult As SelectionResult, analyzerResult As AnalyzerResult)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return New MultipleStatementsCodeGenerator(insertionPoint, selectionResult, analyzerResult)
                 End If
 
-                Return Contract.FailWithReturn(Of VisualBasicCodeGenerator)("Unknown selection")
+                Throw Contract.UnexpectedValue(selectionResult)
             End Function
 
             Protected Sub New(insertionPoint As InsertionPoint, selectionResult As SelectionResult, analyzerResult As AnalyzerResult)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -286,7 +286,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             ' Contract.ThrowIfFalse(last.IsParentKind(SyntaxKind.GlobalStatement))
             ' Contract.ThrowIfFalse(last.Parent.IsParentKind(SyntaxKind.CompilationUnit))
             ' Return last.Parent.Parent
-            Return Contract.FailWithReturn(Of SyntaxNode)("No REPL yet")
+            Throw Contract.Unreachable
         End Function
 
         Public Function IsUnderModuleBlock() As Boolean

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -286,7 +286,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             ' Contract.ThrowIfFalse(last.IsParentKind(SyntaxKind.GlobalStatement))
             ' Contract.ThrowIfFalse(last.Parent.IsParentKind(SyntaxKind.CompilationUnit))
             ' Return last.Parent.Parent
-            Throw Contract.Unreachable
+            throw ExceptionUtilities.Unreachable
         End Function
 
         Public Function IsUnderModuleBlock() As Boolean

--- a/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
@@ -212,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateType
                             If nameOrMemberAccessExpression.Parent IsNot Nothing AndAlso TypeOf nameOrMemberAccessExpression.Parent Is QualifiedNameSyntax Then
                                 Return True
                             Else
-                                Throw Contract.Unreachable
+                                throw ExceptionUtilities.Unreachable
                             End If
                         Else
                             ' Case : NSOrSomething.GenType

--- a/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
@@ -212,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateType
                             If nameOrMemberAccessExpression.Parent IsNot Nothing AndAlso TypeOf nameOrMemberAccessExpression.Parent Is QualifiedNameSyntax Then
                                 Return True
                             Else
-                                Contract.Fail("Cannot reach this point")
+                                Throw Contract.Unreachable
                             End If
                         Else
                             ' Case : NSOrSomething.GenType

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
@@ -118,10 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                 }
 
                 var document = textView.TextSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-                if (document == null)
-                {
-                    Contract.Fail("Event Hookup could not find the document for the IBufferView.");
-                }
+                Contract.ThrowIfNull(document, "Event Hookup could not find the document for the IBufferView.");
 
                 var position = textView.GetCaretPoint(subjectBuffer).Value.Position;
                 var solutionWithEventHandler = CreateSolutionWithEventHandler(
@@ -131,17 +128,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                     out var plusEqualTokenEndPosition,
                     cancellationToken);
 
-                if (solutionWithEventHandler == null)
-                {
-                    Contract.Fail("Event Hookup could not create solution with event handler.");
-                }
+                Contract.ThrowIfNull(solutionWithEventHandler, "Event Hookup could not create solution with event handler.");
 
                 // The new solution is created, so start user observable changes
 
-                if (!workspace.TryApplyChanges(solutionWithEventHandler))
-                {
-                    Contract.Fail("Event Hookup could not update the solution.");
-                }
+                Contract.ThrowIfFalse(workspace.TryApplyChanges(solutionWithEventHandler), "Event Hookup could not update the solution.");
 
                 // The += token will not move during this process, so it is safe to use that
                 // position as a location from which to find the identifier we're renaming.

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
                     break;
                 default:
-                    throw Contract.UnexpectedValue(e.Kind);
+                    throw ExceptionUtilities.UnexpectedValue(e.Kind);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
@@ -64,8 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
                     break;
                 default:
-                    Contract.Fail("Can't reach here");
-                    return;
+                    throw Contract.UnexpectedValue(e.Kind);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 DiagnosticSeverity.Error => __VSERRORCATEGORY.EC_ERROR,
                 DiagnosticSeverity.Warning => __VSERRORCATEGORY.EC_WARNING,
                 DiagnosticSeverity.Info => __VSERRORCATEGORY.EC_MESSAGE,
-                _ => throw Contract.UnexpectedValue(severity)
+                _ => throw ExceptionUtilities.UnexpectedValue(severity)
             };
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 DiagnosticSeverity.Error => __VSERRORCATEGORY.EC_ERROR,
                 DiagnosticSeverity.Warning => __VSERRORCATEGORY.EC_WARNING,
                 DiagnosticSeverity.Info => __VSERRORCATEGORY.EC_MESSAGE,
-                _ => Contract.FailWithReturn<__VSERRORCATEGORY>(),
+                _ => throw Contract.UnexpectedValue(severity)
             };
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     public override object Key => _source._key;
                     public override string BuildTool => PredefinedBuildTools.Build;
                     public override bool SupportSpanTracking => false;
-                    public override DocumentId TrackingDocumentId => Contract.FailWithReturn<DocumentId>("This should never be called");
+                    public override DocumentId TrackingDocumentId => throw Contract.Unreachable;
 
                     public override ImmutableArray<DiagnosticTableItem> GetItems()
                     {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     public override object Key => _source._key;
                     public override string BuildTool => PredefinedBuildTools.Build;
                     public override bool SupportSpanTracking => false;
-                    public override DocumentId TrackingDocumentId => throw Contract.Unreachable;
+                    public override DocumentId TrackingDocumentId => throw ExceptionUtilities.Unreachable;
 
                     public override ImmutableArray<DiagnosticTableItem> GetItems()
                     {

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
                     break;
                 default:
-                    throw Contract.UnexpectedValue(e.Kind);
+                    throw ExceptionUtilities.UnexpectedValue(e.Kind);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -141,8 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
                     break;
                 default:
-                    Contract.Fail("Unknown workspace events");
-                    break;
+                    throw Contract.UnexpectedValue(e.Kind);
             }
         }
 

--- a/src/VisualStudio/Core/Test/ClassView/MockVsServiceProvider.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockVsServiceProvider.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Return _navigationTool
             End If
 
-            Return Contract.FailWithReturn(Of Object)($"GetService only handles {NameOf(SVsClassView)}")
+            Throw Contract.UnexpectedValue(serviceType)
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ClassView/MockVsServiceProvider.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockVsServiceProvider.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Return _navigationTool
             End If
 
-            Throw Contract.UnexpectedValue(serviceType)
+            throw ExceptionUtilities.UnexpectedValue(serviceType)
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // for REPL, don't mess with order, just put new one at the end.
                     return 1;
                 default:
-                    throw Contract.UnexpectedValue(x.Kind());
+                    throw ExceptionUtilities.UnexpectedValue(x.Kind());
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
@@ -131,8 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // for REPL, don't mess with order, just put new one at the end.
                     return 1;
                 default:
-                    Contract.Fail("Syntax nodes x and y are not declarations");
-                    return 0;
+                    throw Contract.UnexpectedValue(x.Kind());
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/AbstractCSharpSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/AbstractCSharpSimplifier.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             {
                 CompilationUnitSyntax compilation => GetNamespaceId(compilation.Members, target, ref index),
                 NamespaceDeclarationSyntax @namespace => GetNamespaceId(@namespace.Members, target, ref index),
-                _ => throw Contract.UnexpectedValue(container)
+                _ => throw ExceptionUtilities.UnexpectedValue(container)
             };
 
         private static int GetNamespaceId(SyntaxList<MemberDeclarationSyntax> members, NamespaceDeclarationSyntax target, ref int index)

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/AbstractCSharpSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/AbstractCSharpSimplifier.cs
@@ -344,19 +344,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
         }
 
         private static int GetNamespaceId(SyntaxNode container, NamespaceDeclarationSyntax target, ref int index)
-        {
-            if (container is CompilationUnitSyntax compilation)
+            => container switch
             {
-                return GetNamespaceId(compilation.Members, target, ref index);
-            }
-
-            if (container is NamespaceDeclarationSyntax @namespace)
-            {
-                return GetNamespaceId(@namespace.Members, target, ref index);
-            }
-
-            return Contract.FailWithReturn<int>("shouldn't reach here");
-        }
+                CompilationUnitSyntax compilation => GetNamespaceId(compilation.Members, target, ref index),
+                NamespaceDeclarationSyntax @namespace => GetNamespaceId(@namespace.Members, target, ref index),
+                _ => throw Contract.UnexpectedValue(container)
+            };
 
         private static int GetNamespaceId(SyntaxList<MemberDeclarationSyntax> members, NamespaceDeclarationSyntax target, ref int index)
         {

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Options
                 return (result: editorconfigNamingStylePreferences, succeeded: true);
             }
 
-            throw Contract.UnexpectedValue(type);
+            throw ExceptionUtilities.UnexpectedValue(type);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
@@ -39,11 +39,8 @@ namespace Microsoft.CodeAnalysis.Options
                 // no existing naming styles were passed so just return the set of styles that were parsed from editorconfig
                 return (result: editorconfigNamingStylePreferences, succeeded: true);
             }
-            else
-            {
-                return Contract.FailWithReturn<(object, bool)>(
-                    $"{nameof(NamingStylePreferenceEditorConfigStorageLocation)} can only be called with {nameof(PerLanguageOption<NamingStylePreferences>)}<{nameof(NamingStylePreferences)}>.");
-            }
+
+            throw Contract.UnexpectedValue(type);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -316,8 +316,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                     case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
                         break;
                     default:
-                        Contract.Fail("Unknown event");
-                        break;
+                        throw Contract.UnexpectedValue(e.Kind);
                 }
             }
 

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                     case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
                         break;
                     default:
-                        throw Contract.UnexpectedValue(e.Kind);
+                        throw ExceptionUtilities.UnexpectedValue(e.Kind);
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticEquivalence.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticEquivalence.cs
@@ -75,11 +75,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 var b1 = e1.MoveNext();
                 var b2 = e2.MoveNext();
 
-                if (b1 != b2)
-                {
-                    Contract.Fail();
-                    return false;
-                }
+                Contract.ThrowIfTrue(b1 != b2);
 
                 if (b1 == false)
                 {

--- a/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
+++ b/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
                 }
                 else
                 {
-                    throw Contract.Unreachable;
+                    throw Contract.UnexpectedValue(checksum);
                 }
             }
 

--- a/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
+++ b/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
                 }
                 else
                 {
-                    throw Contract.UnexpectedValue(checksum);
+                    throw ExceptionUtilities.UnexpectedValue(checksum);
                 }
             }
 

--- a/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
+++ b/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
                 }
                 else
                 {
-                    Contract.Fail($"Unable to find asset for {checksum}");
+                    throw Contract.Unreachable;
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     return false;
                 }
 
-                return Contract.FailWithReturn<bool>("This can't happen");
+                throw Contract.Unreachable;
             }
 
             private bool OnRegion(SyntaxTrivia trivia, int currentIndex)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     return false;
                 }
 
-                throw Contract.Unreachable;
+                throw ExceptionUtilities.Unreachable;
             }
 
             private bool OnRegion(SyntaxTrivia trivia, int currentIndex)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.Node.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.Node.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
                 }
                 else
                 {
-                    throw Contract.Unreachable;
+                    throw ExceptionUtilities.Unreachable;
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.Node.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.Node.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
                 }
                 else
                 {
-                    Contract.Fail("We have no MaxEndNode? Huh?");
+                    throw Contract.Unreachable;
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                         break;
 
                     default:
-                        throw Contract.UnexpectedValue(operation.Option);
+                        throw ExceptionUtilities.UnexpectedValue(operation.Option);
                 }
 
                 ApplyIndentationChangesToDependentTokens(tokenData, previousChangesMap, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
@@ -274,29 +274,23 @@ namespace Microsoft.CodeAnalysis.Formatting
                 switch (operation.Option)
                 {
                     case AlignTokensOption.AlignIndentationOfTokensToBaseToken:
+                        if (!ApplyAlignment(operation.BaseToken, operation.Tokens, previousChangesMap, out tokenData, cancellationToken))
                         {
-                            if (!ApplyAlignment(operation.BaseToken, operation.Tokens, previousChangesMap, out tokenData, cancellationToken))
-                            {
-                                return false;
-                            }
-
-                            break;
+                            return false;
                         }
+
+                        break;
 
                     case AlignTokensOption.AlignIndentationOfTokensToFirstTokenOfBaseTokenLine:
+                        if (!ApplyAlignment(_context.TokenStream.FirstTokenOfBaseTokenLine(operation.BaseToken), operation.Tokens, previousChangesMap, out tokenData, cancellationToken))
                         {
-                            if (!ApplyAlignment(_context.TokenStream.FirstTokenOfBaseTokenLine(operation.BaseToken), operation.Tokens, previousChangesMap, out tokenData, cancellationToken))
-                            {
-                                return false;
-                            }
-
-                            break;
+                            return false;
                         }
+
+                        break;
 
                     default:
-                        {
-                            return Contract.FailWithReturn<bool>("Unknown option");
-                        }
+                        throw Contract.UnexpectedValue(operation.Option);
                 }
 
                 ApplyIndentationChangesToDependentTokens(tokenData, previousChangesMap, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return this;
                 }
 
-                throw Contract.Unreachable;
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override TriviaData WithLine(
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     }
                 }
 
-                throw Contract.Unreachable;
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override TriviaData WithIndentation(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return this;
                 }
 
-                return Contract.FailWithReturn<TriviaData>("Can not reach here");
+                throw Contract.Unreachable;
             }
 
             public override TriviaData WithLine(
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     }
                 }
 
-                return Contract.FailWithReturn<TriviaData>("Can not reach here");
+                throw Contract.Unreachable;
             }
 
             public override TriviaData WithIndentation(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CommonFormattingHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CommonFormattingHelpers.cs
@@ -309,11 +309,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             }
 
             var parentNode = GetParentThatContainsGivenSpan(token.Parent, forwardPosition, forward: true);
-            if (parentNode == null)
-            {
-                return Contract.FailWithReturn<int>("This can't happen");
-            }
-
+            Contract.ThrowIfNull(parentNode);
             Contract.ThrowIfFalse(parentNode.FullSpan.Start < forwardPosition);
 
             previousToken = parentNode.FindToken(forwardPosition + 1);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -13,6 +13,12 @@ namespace Roslyn.Utilities
 {
     internal static class Contract
     {
+        // Guidance on inlining:
+        // ThrowXxx methods are used heavily across the code base. 
+        // Inline their implementation of condition checking but don't inline the code that is only executed on failure.
+        // This approach makes the common path efficient (both execution time and code size) 
+        // while keeping the rarely executed code in a separate method.
+
         public static Exception Unreachable
             => ExceptionUtilities.Unreachable;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -7,21 +7,41 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Roslyn.Utilities
 {
     internal static class Contract
     {
+        public static Exception Unreachable
+            => ExceptionUtilities.Unreachable;
+
+        public static Exception UnexpectedValue(object? o)
+            => ExceptionUtilities.UnexpectedValue(o);
+
         /// <summary>
         /// Throws a non-accessible exception if the provided value is null.  This method executes in
         /// all builds
         /// </summary>
-        public static void ThrowIfNull<T>([NotNull] T value, string? message = null) where T : class?
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T value) where T : class?
         {
-            if (value == null)
+            if (value is null)
             {
-                message ??= "Unexpected Null";
-                Fail(message);
+                Fail("Unexpected null");
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is null.  This method executes in
+        /// all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T value, string? message) where T : class?
+        {
+            if (value is null)
+            {
+                Fail(message ?? "Unexpected null");
             }
         }
 
@@ -29,11 +49,24 @@ namespace Roslyn.Utilities
         /// Throws a non-accessible exception if the provided value is false.  This method executes
         /// in all builds
         /// </summary>
-        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string? message = null)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition)
         {
             if (!condition)
             {
-                message ??= "Unexpected false";
+                Fail("Unexpected false");
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is false.  This method executes
+        /// in all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string message)
+        {
+            if (!condition)
+            {
                 Fail(message);
             }
         }
@@ -42,32 +75,34 @@ namespace Roslyn.Utilities
         /// Throws a non-accessible exception if the provided value is true. This method executes in
         /// all builds.
         /// </summary>
-        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, string? message = null)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition)
         {
             if (condition)
             {
-                message ??= "Unexpected true";
+                Fail("Unexpected true");
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is true. This method executes in
+        /// all builds.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, string message)
+        {
+            if (condition)
+            {
                 Fail(message);
             }
         }
 
         [DebuggerHidden]
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void Fail(string message = "Unexpected")
         {
             throw new InvalidOperationException(message);
-        }
-
-        [DebuggerHidden]
-        [DoesNotReturn]
-        public static T FailWithReturn<T>(string message = "Unexpected")
-        {
-            throw new InvalidOperationException(message);
-        }
-
-        public static void InvalidEnumValue<T>(T value)
-        {
-            Fail(string.Format("Invalid Enumeration value {0}", value));
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -37,11 +37,11 @@ namespace Roslyn.Utilities
         /// all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull<T>([NotNull] T value, string? message) where T : class?
+        public static void ThrowIfNull<T>([NotNull] T value, string message) where T : class?
         {
             if (value is null)
             {
-                Fail(message ?? "Unexpected null");
+                Fail(message);
             }
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -19,12 +19,6 @@ namespace Roslyn.Utilities
         // This approach makes the common path efficient (both execution time and code size) 
         // while keeping the rarely executed code in a separate method.
 
-        public static Exception Unreachable
-            => ExceptionUtilities.Unreachable;
-
-        public static Exception UnexpectedValue(object? o)
-            => ExceptionUtilities.UnexpectedValue(o);
-
         /// <summary>
         /// Throws a non-accessible exception if the provided value is null.  This method executes in
         /// all builds

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SyntaxPath.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SyntaxPath.cs
@@ -79,7 +79,7 @@ namespace Roslyn.Utilities
                     }
                 }
 
-                throw Contract.Unreachable;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SyntaxPath.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SyntaxPath.cs
@@ -79,7 +79,7 @@ namespace Roslyn.Utilities
                     }
                 }
 
-                Contract.Fail();
+                throw Contract.Unreachable;
             }
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
@@ -193,7 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return multiLineLambdaExpression.Statements
             End If
 
-            Throw Contract.UnexpectedValue(node)
+            throw ExceptionUtilities.UnexpectedValue(node)
         End Function
 
         <Extension()>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
@@ -193,7 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return multiLineLambdaExpression.Statements
             End If
 
-            Return Contract.FailWithReturn(Of SyntaxList(Of StatementSyntax))("unknown statements container!")
+            Throw Contract.UnexpectedValue(node)
         End Function
 
         <Extension()>

--- a/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
             ElseIf token.IsKind(SyntaxKind.None, SyntaxKind.BadToken) Then
                 Return Nothing
             Else
-                Throw Contract.UnexpectedValue(token.Kind())
+                throw ExceptionUtilities.UnexpectedValue(token.Kind())
             End If
         End Function
 
@@ -313,7 +313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 Case SyntaxKind.StructureStatement
                     Return ClassificationTypeNames.StructName
                 Case Else
-                    Throw Contract.UnexpectedValue(identifier.Parent.Kind)
+                    throw ExceptionUtilities.UnexpectedValue(identifier.Parent.Kind)
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
             ElseIf token.IsKind(SyntaxKind.None, SyntaxKind.BadToken) Then
                 Return Nothing
             Else
-                Return Contract.FailWithReturn(Of String)("Unhandled token kind: " & token.Kind().ToString())
+                Throw Contract.UnexpectedValue(token.Kind())
             End If
         End Function
 
@@ -313,7 +313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 Case SyntaxKind.StructureStatement
                     Return ClassificationTypeNames.StructName
                 Case Else
-                    Return Contract.FailWithReturn(Of String)("Unhandled type declaration")
+                    Throw Contract.UnexpectedValue(identifier.Parent.Kind)
             End Select
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                                                       Return lastTokenWithTrailingTrivia
                                                   End If
 
-                                                  Throw Contract.UnexpectedValue(o)
+                                                  throw ExceptionUtilities.UnexpectedValue(o)
                                               End Function)
 
                 Return True

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                                                       Return lastTokenWithTrailingTrivia
                                                   End If
 
-                                                  Return Contract.UnexpectedValue(o)
+                                                  Throw Contract.UnexpectedValue(o)
                                               End Function)
 
                 Return True

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                                                       Return lastTokenWithTrailingTrivia
                                                   End If
 
-                                                  Return Contract.FailWithReturn(Of SyntaxToken)("Shouldn't reach here")
+                                                  Return Contract.UnexpectedValue(o)
                                               End Function)
 
                 Return True

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
@@ -509,7 +509,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                                            Return newPreviousToken
                                        End If
 
-                                       Return Contract.FailWithReturn(Of SyntaxToken)("shouldn't reach here")
+                                       Return Contract.UnexpectedValue(o)
                                    End Function)
             End Function
 

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
@@ -509,7 +509,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                                            Return newPreviousToken
                                        End If
 
-                                       Throw Contract.UnexpectedValue(o)
+                                       throw ExceptionUtilities.UnexpectedValue(o)
                                    End Function)
             End Function
 

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
@@ -509,7 +509,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                                            Return newPreviousToken
                                        End If
 
-                                       Return Contract.UnexpectedValue(o)
+                                       Throw Contract.UnexpectedValue(o)
                                    End Function)
             End Function
 

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
@@ -121,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     Return Compare(DirectCast(x, TypeStatementSyntax), DirectCast(y, TypeStatementSyntax))
             End Select
 
-            Throw Contract.UnexpectedValue(x.Kind)
+            throw ExceptionUtilities.UnexpectedValue(x.Kind)
         End Function
 
         Private Shared Function ConvertBlockToStatement(node As SyntaxNode) As SyntaxNode

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
@@ -121,8 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     Return Compare(DirectCast(x, TypeStatementSyntax), DirectCast(y, TypeStatementSyntax))
             End Select
 
-            Contract.Fail("Syntax nodes x and y are not declarations")
-            Return 0
+            Throw Contract.UnexpectedValue(x.Kind)
         End Function
 
         Private Shared Function ConvertBlockToStatement(node As SyntaxNode) As SyntaxNode

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
@@ -42,14 +42,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Protected MustOverride Function CreateStringFromState() As String
 
             Public Overrides Function WithSpace(space As Integer, context As FormattingContext, formattingRules As ChainedFormattingRules) As TriviaData
-                Return Contract.FailWithReturn(Of TriviaData)("Should never happen")
+                Throw Contract.Unreachable
             End Function
 
             Public Overrides Function WithLine(line As Integer, indentation As Integer,
                                                context As FormattingContext,
                                                formattingRules As ChainedFormattingRules,
                                                cancellationToken As CancellationToken) As TriviaData
-                Return Contract.FailWithReturn(Of TriviaData)("Should never happen")
+                Throw Contract.Unreachable
             End Function
 
             Public Overrides ReadOnly Property ContainsChanges As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
@@ -42,14 +42,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Protected MustOverride Function CreateStringFromState() As String
 
             Public Overrides Function WithSpace(space As Integer, context As FormattingContext, formattingRules As ChainedFormattingRules) As TriviaData
-                Throw Contract.Unreachable
+                throw ExceptionUtilities.Unreachable
             End Function
 
             Public Overrides Function WithLine(line As Integer, indentation As Integer,
                                                context As FormattingContext,
                                                formattingRules As ChainedFormattingRules,
                                                cancellationToken As CancellationToken) As TriviaData
-                Throw Contract.Unreachable
+                throw ExceptionUtilities.Unreachable
             End Function
 
             Public Overrides ReadOnly Property ContainsChanges As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.vb
@@ -243,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                     Return False
                 End If
 
-                Return Contract.FailWithReturn(Of Boolean)("This can't happen")
+                Throw Contract.UnexpectedValue(trivia.Kind)
             End Function
 
             Private Function OnRegion(trivia As SyntaxTrivia, currentIndex As Integer) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.CodeShapeAnalyzer.vb
@@ -243,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                     Return False
                 End If
 
-                Throw Contract.UnexpectedValue(trivia.Kind)
+                throw ExceptionUtilities.UnexpectedValue(trivia.Kind)
             End Function
 
             Private Function OnRegion(trivia As SyntaxTrivia, currentIndex As Integer) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/BaseFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/BaseFormattingRule.vb
@@ -69,11 +69,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         End Function
 
         Protected Sub AddSuppressWrappingIfOnSingleLineOperation(operations As List(Of SuppressOperation), startToken As SyntaxToken, endToken As SyntaxToken)
-            Contract.Fail("VB doesn't need to use this operation")
+            ' VB doesn't need to use this operation
+            Throw Contract.Unreachable
         End Sub
 
         Protected Sub AddSuppressAllOperationIfOnMultipleLine(operations As List(Of SuppressOperation), startToken As SyntaxToken, endToken As SyntaxToken)
-            Contract.Fail("VB doesn't need to use this operation")
+            ' VB doesn't need to use this operation
+            Throw Contract.Unreachable
         End Sub
 
         Protected Sub AddAnchorIndentationOperation(operations As List(Of AnchorIndentationOperation), startToken As SyntaxToken, endToken As SyntaxToken)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/BaseFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/BaseFormattingRule.vb
@@ -70,12 +70,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         Protected Sub AddSuppressWrappingIfOnSingleLineOperation(operations As List(Of SuppressOperation), startToken As SyntaxToken, endToken As SyntaxToken)
             ' VB doesn't need to use this operation
-            Throw Contract.Unreachable
+            throw ExceptionUtilities.Unreachable
         End Sub
 
         Protected Sub AddSuppressAllOperationIfOnMultipleLine(operations As List(Of SuppressOperation), startToken As SyntaxToken, endToken As SyntaxToken)
             ' VB doesn't need to use this operation
-            Throw Contract.Unreachable
+            throw ExceptionUtilities.Unreachable
         End Sub
 
         Protected Sub AddAnchorIndentationOperation(operations As List(Of AnchorIndentationOperation), startToken As SyntaxToken, endToken As SyntaxToken)


### PR DESCRIPTION
Optimize for inlining: the goal is to get the condition inlined while the `throw` is not inlined. This leads to optimal code (perf and size). 

BTW, turns out that JIT also doesn't emit the load of the message string that's passed to `Contract.Throw(..., message)` until it's needed (the condition evaluated to false).

Remove FailWithReturn - it's not needed since `throw` can be used as an expression.
