### PR TITLE
Do not apply analyzer bulk configuration to compiler diagnostics

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -457,6 +459,51 @@ class C
             var analyzerDiagnostics = compilation.GetAnalyzerDiagnostics(analyzers);
             analyzerDiagnostics.Verify(expected);
             Assert.False(analyzerDiagnostics.Single().IsSuppressed);
+        }
+
+        [Fact]
+        [WorkItem(42116, "https://github.com/dotnet/roslyn/issues/42116")]
+        public async Task TestAnalyzerConfigurationDoesNotAffectCompilerDiagnostics()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        // warning CS0168:  The variable 'x' is declared but never used.
+        int x;
+    }
+}
+";
+            // Verify CS0168 reported from 'Compilation.GetDiagnostics'
+            var compilation = CreateCompilation(source);
+            var compilerDiagnostics = compilation.GetDiagnostics();
+            verifyDiagnostics(compilerDiagnostics);
+
+            // Verify CS0168 reported from 'CSharpCompilerDiagnosticAnalyzer', i.e. the diagnostic analyzer used in the IDE layer to report live compiler diagnostics.
+            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new CSharpCompilerDiagnosticAnalyzer());
+            var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty));
+            var analyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+            verifyDiagnostics(analyzerDiagnostics);
+
+            // Verify CS0168 reported by CSharpCompilerDiagnosticAnalyzer is not affected by "dotnet_analyzer_diagnostic = none"
+            var analyzerConfigOptions = new CompilerAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add("dotnet_analyzer_diagnostic.severity", "none"));
+            var analyzerConfigOptionsProvider = new CompilerAnalyzerConfigOptionsProvider(
+                ImmutableDictionary<object, AnalyzerConfigOptions>.Empty.Add(compilation.SyntaxTrees.Single(), analyzerConfigOptions));
+            var analyzerOptions = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, analyzerConfigOptionsProvider);
+            compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, analyzerOptions);
+            analyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+            verifyDiagnostics(analyzerDiagnostics);
+
+            static void verifyDiagnostics(ImmutableArray<Diagnostic> diagnostics)
+            {
+                var expected = Diagnostic(ErrorCode.WRN_UnreferencedVar, "x").WithArguments("x").WithLocation(7, 13);
+                diagnostics.Verify(expected);
+
+                var diagnostic = diagnostics.Single();
+                Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+                Assert.False(diagnostic.IsSuppressed);
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1679,9 +1679,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             diagnostic = compilation.Options.FilterDiagnostic(diagnostic);
 
-            // Apply bulk configuration from analyzer options, if applicable.
+            // Apply bulk configuration from analyzer options for analyzer diagnostics, if applicable.
             var tree = diagnostic?.Location.SourceTree;
-            if (tree == null || analyzerOptions == null)
+            if (tree == null || analyzerOptions == null || diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Compiler))
             {
                 return diagnostic;
             }


### PR DESCRIPTION
IDE layer uses a special "CompilerDiagnosticAnalyzer" for reporting compiler diagnostics, which leads to analyzer bulk configuration getting applied to compiler diagnostics reported from this analyzer in the IDE. This change ensures compiler diagnostics are explicitly skipped from analyzer bulk configuration.

Fixes #42116