### PR TITLE
Show <remarks> documentation in Quick Info

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6799,6 +6799,49 @@ class Program
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         [WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")]
+        public async Task QuickInfoWithRemarksOnMethod()
+        {
+            await TestAsync(@"
+class Program
+{
+    /// <summary>
+    /// Summary text
+    /// </summary>
+    /// <remarks>
+    /// Remarks text
+    /// </remarks>
+    int M()
+    {
+        return $$M();
+    }
+}",
+                MainDescription("int Program.M()"),
+                Documentation("Summary text"),
+                Remarks("\r\nRemarks text"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")]
+        public async Task QuickInfoWithRemarksOnPropertyAccessor()
+        {
+            await TestAsync(@"
+class Program
+{
+    /// <summary>
+    /// Summary text
+    /// </summary>
+    /// <remarks>
+    /// Remarks text
+    /// </remarks>
+    int M { $$get; }
+}",
+                MainDescription("int Program.M.get"),
+                Documentation("Summary text"),
+                Remarks("\r\nRemarks text"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")]
         public async Task QuickInfoWithReturnsOnMethod()
         {
             await TestAsync(@"

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
@@ -394,6 +394,54 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
+        Public Async Sub QuickInfoShowsMethodRemarks()
+            Dim workspace =
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            class MyClass {
+                                /// &lt;summary&gt;
+                                /// Summary text.
+                                /// &lt;/summary&gt;
+                                /// &lt;remarks&gt;
+                                /// Remarks text.
+                                /// &lt;/remarks&gt;
+                                int Me$$thod() => throw null;
+                            }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+            Dim intellisenseQuickInfo = Await GetQuickInfoItemAsync(workspace, LanguageNames.CSharp)
+            Assert.NotNull(intellisenseQuickInfo)
+
+            Dim container = Assert.IsType(Of ContainerElement)(intellisenseQuickInfo.Item)
+
+            Dim expected = New ContainerElement(
+                ContainerElementStyle.Stacked Or ContainerElementStyle.VerticalPadding,
+                New ContainerElement(
+                    ContainerElementStyle.Stacked,
+                    New ContainerElement(
+                        ContainerElementStyle.Wrapped,
+                        New ImageElement(New ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.MethodPrivate)),
+                        New ClassifiedTextElement(
+                            New ClassifiedTextRun(ClassificationTypeNames.Keyword, "int", navigationAction:=Sub() Return, "int"),
+                            New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
+                            New ClassifiedTextRun(ClassificationTypeNames.ClassName, "MyClass", navigationAction:=Sub() Return, "MyClass"),
+                            New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "."),
+                            New ClassifiedTextRun(ClassificationTypeNames.MethodName, "Method", navigationAction:=Sub() Return, "int MyClass.Method()"),
+                            New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "("),
+                            New ClassifiedTextRun(ClassificationTypeNames.Punctuation, ")"))),
+                    New ClassifiedTextElement(
+                        New ClassifiedTextRun(ClassificationTypeNames.Text, "Summary text."))),
+                New ClassifiedTextElement(
+                    New ClassifiedTextRun(ClassificationTypeNames.Text, "Remarks text.")))
+
+            AssertEqualAdornments(expected, container)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
         Public Async Sub QuickInfoShowsMethodReturns()
             Dim workspace =
                 <Workspace>

--- a/src/EditorFeatures/TestUtilities/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/TestUtilities/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
@@ -85,6 +85,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
             return item => AssertSection(expectedText, item.Sections, QuickInfoSectionKinds.DocumentationComments, expectedClassifications);
         }
 
+        protected Action<QuickInfoItem> Remarks(
+            string expectedText,
+            FormattedClassification[] expectedClassifications = null)
+        {
+            return item => AssertSection(expectedText, item.Sections, QuickInfoSectionKinds.RemarksDocumentationComments, expectedClassifications);
+        }
+
         protected Action<QuickInfoItem> Returns(
             string expectedText,
             FormattedClassification[] expectedClassifications = null)

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -2504,6 +2504,48 @@ End Class",
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
+        Public Async Function QuickInfoWithRemarksOnFunction() As Task
+            Await TestAsync("
+Class C
+    ''' <summary>
+    ''' Summary text
+    ''' </summary>
+    ''' <remarks>
+    ''' Remarks text
+    ''' </remarks>
+    Function M() As Integer
+        Return $$M()
+    End Function
+End Class",
+                MainDescription("Function C.M() As Integer"),
+                Documentation("Summary text"),
+                Remarks($"{vbCrLf}Remarks text"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
+        Public Async Function QuickInfoWithRemarksOnPropertyAccessor() As Task
+            Await TestAsync("
+Class C
+    ''' <summary>
+    ''' Summary text
+    ''' </summary>
+    ''' <remarks>
+    ''' Remarks text
+    ''' </remarks>
+    ReadOnly Property M As Integer
+        $$Get
+            Return 0
+        End Get
+    End Property
+End Class",
+                MainDescription("Property Get C.M() As Integer"),
+                Documentation("Summary text"),
+                Remarks($"{vbCrLf}Remarks text"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
         Public Async Function QuickInfoWithReturnsOnFunction() As Task
             Await TestAsync("
 Class C

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -353,6 +353,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                         return 0;
 
                     case SymbolDescriptionGroups.Documentation:
+                    case SymbolDescriptionGroups.RemarksDocumentation:
                     case SymbolDescriptionGroups.ReturnsDocumentation:
                     case SymbolDescriptionGroups.ValueDocumentation:
                         return 1;

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/SymbolDescriptionGroups.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/SymbolDescriptionGroups.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         Captures = 1 << 6,
         ReturnsDocumentation = 1 << 7,
         ValueDocumentation = 1 << 8,
-        All = MainDescription | AwaitableUsageText | Documentation | TypeParameterMap | AnonymousTypes | Exceptions | Captures | ReturnsDocumentation | ValueDocumentation,
+        RemarksDocumentation = 1 << 9,
+        All = MainDescription | AwaitableUsageText | Documentation | TypeParameterMap | AnonymousTypes | Exceptions | Captures | ReturnsDocumentation | ValueDocumentation | RemarksDocumentation,
     }
 }

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+const Microsoft.CodeAnalysis.QuickInfo.QuickInfoSectionKinds.RemarksDocumentationComments = "RemarksDocumentationComments" -> string
 const Microsoft.CodeAnalysis.QuickInfo.QuickInfoSectionKinds.ReturnsDocumentationComments = "ReturnsDocumentationComments" -> string
 const Microsoft.CodeAnalysis.QuickInfo.QuickInfoSectionKinds.ValueDocumentationComments = "ValueDocumentationComments" -> string

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
@@ -218,6 +218,19 @@ namespace Microsoft.CodeAnalysis.QuickInfo
                 AddSection(QuickInfoSectionKinds.DocumentationComments, documentationContent);
             }
 
+            var remarksDocumentationContent = GetRemarksDocumentationContent(documentedSymbol, groups, semanticModel, token, formatter, cancellationToken);
+            if (!remarksDocumentationContent.IsDefaultOrEmpty)
+            {
+                var builder = ImmutableArray.CreateBuilder<TaggedText>();
+                if (!documentationContent.IsDefaultOrEmpty)
+                {
+                    builder.AddLineBreak();
+                }
+
+                builder.AddRange(remarksDocumentationContent);
+                AddSection(QuickInfoSectionKinds.RemarksDocumentationComments, builder.ToImmutable());
+            }
+
             var returnsDocumentationContent = GetReturnsDocumentationContent(documentedSymbol, groups, semanticModel, token, formatter, cancellationToken);
             if (!returnsDocumentationContent.IsDefaultOrEmpty)
             {
@@ -321,6 +334,30 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             else if (documentedSymbol is object)
             {
                 var documentation = documentedSymbol.GetDocumentationParts(semanticModel, token.SpanStart, formatter, cancellationToken);
+                if (documentation != null)
+                {
+                    return documentation.ToImmutableArray();
+                }
+            }
+
+            return default;
+        }
+
+        private ImmutableArray<TaggedText> GetRemarksDocumentationContent(
+            ISymbol? documentedSymbol,
+            IDictionary<SymbolDescriptionGroups, ImmutableArray<TaggedText>> sections,
+            SemanticModel semanticModel,
+            SyntaxToken token,
+            IDocumentationCommentFormattingService formatter,
+            CancellationToken cancellationToken)
+        {
+            if (sections.TryGetValue(SymbolDescriptionGroups.RemarksDocumentation, out var parts))
+            {
+                return parts;
+            }
+            else if (documentedSymbol is object)
+            {
+                var documentation = documentedSymbol.GetRemarksDocumentationParts(semanticModel, token.SpanStart, formatter, cancellationToken);
                 if (documentation != null)
                 {
                     return documentation.ToImmutableArray();

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoSectionKinds.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoSectionKinds.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     {
         public const string Description = nameof(Description);
         public const string DocumentationComments = nameof(DocumentationComments);
+        public const string RemarksDocumentationComments = nameof(RemarksDocumentationComments);
         public const string ReturnsDocumentationComments = nameof(ReturnsDocumentationComments);
         public const string ValueDocumentationComments = nameof(ValueDocumentationComments);
         public const string TypeParameters = nameof(TypeParameters);

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
@@ -185,6 +185,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 : SpecializedCollections.EmptyEnumerable<TaggedText>();
         }
 
+        public static IEnumerable<TaggedText> GetRemarksDocumentationParts(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter, CancellationToken cancellationToken)
+        {
+            var documentation = GetRemarksDocumentation(symbol, semanticModel.Compilation, cancellationToken);
+            return documentation != null
+                ? formatter.Format(documentation, semanticModel, position, CrefFormat)
+                : SpecializedCollections.EmptyEnumerable<TaggedText>();
+        }
+
         public static IEnumerable<TaggedText> GetReturnsDocumentationParts(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter, CancellationToken cancellationToken)
         {
             var documentation = GetReturnsDocumentation(symbol, semanticModel.Compilation, cancellationToken);
@@ -209,6 +217,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 IMethodSymbol method => GetMethodDocumentation(method, compilation, cancellationToken).SummaryText,
                 IAliasSymbol alias => alias.Target.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).SummaryText,
                 _ => symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).SummaryText,
+            };
+
+        private static string? GetRemarksDocumentation(ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)
+            => symbol switch
+            {
+                IMethodSymbol method => GetMethodDocumentation(method, compilation, cancellationToken).RemarksText,
+                _ => symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).RemarksText,
             };
 
         private static string? GetReturnsDocumentation(ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)


### PR DESCRIPTION
Builds on #42128 

Originally I was more concerned that this would clutter the Quick Info presentation. However, I found that the core library does not include any `<remarks>` documentation (at least in **mscorlib.xml**). The presentation used in this pull request has `<remarks>` rendered exactly the same way as additional `<para>` elements within a `<summary>` section.

![image](https://user-images.githubusercontent.com/1408396/75796721-edec9000-5d28-11ea-9537-0191e5dc60fa.png)
