### PR TITLE
Make ReplaceTypeParametersBasedOnTypeConstraints asynchronous

### DIFF
--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateConversionService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateConversionService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     return ImmutableArray<CodeAction>.Empty;
                 }
 
-                return GetActions(document, state, cancellationToken);
+                return await GetActionsAsync(document, state, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 var state = await State.GenerateDeconstructMethodStateAsync(
                     (TService)this, semanticDocument, leftSide, typeToGenerateIn, cancellationToken).ConfigureAwait(false);
 
-                return state != null ? GetActions(document, state, cancellationToken) : ImmutableArray<CodeAction>.Empty;
+                return state != null ? await GetActionsAsync(document, state, cancellationToken).ConfigureAwait(false) : ImmutableArray<CodeAction>.Empty;
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     return ImmutableArray<CodeAction>.Empty;
                 }
 
-                return GetActions(document, state, cancellationToken);
+                return await GetActionsAsync(document, state, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
 
                 if (_generateProperty)
                 {
-                    var property = _state.SignatureInfo.GenerateProperty(syntaxFactory, _isAbstract, _state.IsWrittenTo, cancellationToken);
+                    var property = await _state.SignatureInfo.GeneratePropertyAsync(syntaxFactory, _isAbstract, _state.IsWrittenTo, cancellationToken).ConfigureAwait(false);
 
                     var result = await CodeGenerator.AddPropertyDeclarationAsync(
                         _document.Project.Solution,
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 }
                 else
                 {
-                    var method = _state.SignatureInfo.GenerateMethod(syntaxFactory, _isAbstract, cancellationToken);
+                    var method = await _state.SignatureInfo.GenerateMethodAsync(syntaxFactory, _isAbstract, cancellationToken).ConfigureAwait(false);
 
                     var result = await CodeGenerator.AddMethodDeclarationAsync(
                         _document.Project.Solution,

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             private async ValueTask<ImmutableArray<IParameterSymbol>> DetermineParametersAsync(CancellationToken cancellationToken)
             {
                 var modifiers = DetermineParameterModifiers(cancellationToken);
-                var types = (await Task.WhenAll(DetermineParameterTypes(cancellationToken).Select(t => FixTypeAsync(t, cancellationToken).AsTask())).ConfigureAwait(false)).ToList();
+                var types = await SpecializedTasks.WhenAll(DetermineParameterTypes(cancellationToken).Select(t => FixTypeAsync(t, cancellationToken))).ConfigureAwait(false);
                 var optionality = DetermineParameterOptionality(cancellationToken);
                 var names = DetermineParameterNames(cancellationToken);
 

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editing;
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             protected abstract ImmutableArray<ITypeParameterSymbol> DetermineTypeParametersWorker(CancellationToken cancellationToken);
             protected abstract RefKind DetermineRefKind(CancellationToken cancellationToken);
 
-            public ITypeSymbol DetermineReturnType(CancellationToken cancellationToken)
+            public ValueTask<ITypeSymbol> DetermineReturnTypeAsync(CancellationToken cancellationToken)
             {
                 var type = DetermineReturnTypeWorker(cancellationToken);
                 if (State.IsInConditionalAccessExpression)
@@ -54,7 +55,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     type = type.RemoveNullableIfPresent();
                 }
 
-                return FixType(type, cancellationToken);
+                return FixTypeAsync(type, cancellationToken);
             }
 
             protected abstract ImmutableArray<ITypeSymbol> DetermineTypeArguments(CancellationToken cancellationToken);
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             protected abstract ImmutableArray<bool> DetermineParameterOptionality(CancellationToken cancellationToken);
             protected abstract ImmutableArray<ParameterName> DetermineParameterNames(CancellationToken cancellationToken);
 
-            internal IPropertySymbol GenerateProperty(
+            internal async ValueTask<IPropertySymbol> GeneratePropertyAsync(
                 SyntaxGenerator factory,
                 bool isAbstract, bool includeSetter,
                 CancellationToken cancellationToken)
@@ -81,22 +82,22 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     attributes: default,
                     accessibility: accessibility,
                     modifiers: new DeclarationModifiers(isStatic: State.IsStatic, isAbstract: isAbstract),
-                    type: DetermineReturnType(cancellationToken),
+                    type: await DetermineReturnTypeAsync(cancellationToken).ConfigureAwait(false),
                     refKind: DetermineRefKind(cancellationToken),
                     explicitInterfaceImplementations: default,
                     name: State.IdentifierToken.ValueText,
-                    parameters: DetermineParameters(cancellationToken),
+                    parameters: await DetermineParametersAsync(cancellationToken).ConfigureAwait(false),
                     getMethod: getMethod,
                     setMethod: setMethod);
             }
 
-            public IMethodSymbol GenerateMethod(
+            public async ValueTask<IMethodSymbol> GenerateMethodAsync(
                 SyntaxGenerator factory,
                 bool isAbstract,
                 CancellationToken cancellationToken)
             {
-                var parameters = DetermineParameters(cancellationToken);
-                var returnType = DetermineReturnType(cancellationToken);
+                var parameters = await DetermineParametersAsync(cancellationToken).ConfigureAwait(false);
+                var returnType = await DetermineReturnTypeAsync(cancellationToken).ConfigureAwait(false);
                 var isUnsafe = false;
                 if (!State.IsContainedInUnsafeType)
                 {
@@ -134,7 +135,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 return method.RenameTypeParameters(newTypeParameterNames);
             }
 
-            private ITypeSymbol FixType(
+            private async ValueTask<ITypeSymbol> FixTypeAsync(
                 ITypeSymbol typeSymbol,
                 CancellationToken cancellationToken)
             {
@@ -148,9 +149,9 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
 
                 var typeArgumentToTypeParameterMap = GetTypeArgumentToTypeParameterMap(cancellationToken);
 
-                return typeSymbol.RemoveAnonymousTypes(compilation)
-                                 .ReplaceTypeParametersBasedOnTypeConstraints(compilation, allTypeParameters, Document.Document.Project.Solution, cancellationToken)
-                                 .RemoveUnavailableTypeParameters(compilation, allTypeParameters)
+                typeSymbol = typeSymbol.RemoveAnonymousTypes(compilation);
+                typeSymbol = await typeSymbol.ReplaceTypeParametersBasedOnTypeConstraintsAsync(compilation, allTypeParameters, Document.Document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                return typeSymbol.RemoveUnavailableTypeParameters(compilation, allTypeParameters)
                                  .RemoveUnnamedErrorTypes(compilation)
                                  .SubstituteTypes(typeArgumentToTypeParameterMap, new TypeGenerator());
             }
@@ -196,10 +197,10 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     : ImmutableArray.Create(throwStatement);
             }
 
-            private ImmutableArray<IParameterSymbol> DetermineParameters(CancellationToken cancellationToken)
+            private async ValueTask<ImmutableArray<IParameterSymbol>> DetermineParametersAsync(CancellationToken cancellationToken)
             {
                 var modifiers = DetermineParameterModifiers(cancellationToken);
-                var types = DetermineParameterTypes(cancellationToken).Select(t => FixType(t, cancellationToken)).ToList();
+                var types = (await Task.WhenAll(DetermineParameterTypes(cancellationToken).Select(t => FixTypeAsync(t, cancellationToken).AsTask())).ConfigureAwait(false)).ToList();
                 var optionality = DetermineParameterOptionality(cancellationToken);
                 var names = DetermineParameterNames(cancellationToken);
 

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 var syntaxFacts = destinationProvider.GetService<ISyntaxFactsService>();
                 var syntaxFactory = destinationProvider.GetService<SyntaxGenerator>();
                 IsContainedInUnsafeType = service.ContainingTypesOrSelfHasUnsafeKeyword(TypeToGenerateIn);
-                var generatedMethod = SignatureInfo.GenerateMethod(syntaxFactory, false, cancellationToken);
+                var generatedMethod = await SignatureInfo.GenerateMethodAsync(syntaxFactory, false, cancellationToken).ConfigureAwait(false);
                 return !existingMethods.Any(m => SignatureComparer.Instance.HaveSameSignature(m, generatedMethod, caseSensitive: syntaxFacts.IsCaseSensitive, compareParameterName: true, isParameterCaseSensitive: syntaxFacts.IsCaseSensitive));
             }
         }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             return string.Empty;
         }
 
-        protected ImmutableArray<CodeAction> GetActions(Document document, State state, CancellationToken cancellationToken)
+        protected async ValueTask<ImmutableArray<CodeAction>> GetActionsAsync(Document document, State state, CancellationToken cancellationToken)
         {
             var result = ArrayBuilder<CodeAction>.GetInstance();
             result.Add(new GenerateParameterizedMemberCodeAction((TService)this, document, state, isAbstract: false, generateProperty: false));
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 state.InvocationExpressionOpt != null)
             {
                 var typeParameters = state.SignatureInfo.DetermineTypeParameters(cancellationToken);
-                var returnType = state.SignatureInfo.DetermineReturnType(cancellationToken);
+                var returnType = await state.SignatureInfo.DetermineReturnTypeAsync(cancellationToken).ConfigureAwait(false);
 
                 if (typeParameters.Length == 0 && returnType.SpecialType != SpecialType.System_Void)
                 {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Roslyn.Utilities;
@@ -15,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal partial class ITypeSymbolExtensions
     {
-        private class ReplaceTypeParameterBasedOnTypeConstraintVisitor : SymbolVisitor<ITypeSymbol>
+        private class ReplaceTypeParameterBasedOnTypeConstraintVisitor : SymbolVisitor<ValueTask<ITypeSymbol>>
         {
             private readonly CancellationToken _cancellationToken;
             private readonly Compilation _compilation;
@@ -30,19 +31,27 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 _cancellationToken = cancellationToken;
             }
 
-            public override ITypeSymbol DefaultVisit(ISymbol node)
+            public override ValueTask<ITypeSymbol> Visit(ISymbol symbol)
+            {
+                if (symbol is null)
+                    throw new NotImplementedException();
+
+                return base.Visit(symbol);
+            }
+
+            public override ValueTask<ITypeSymbol> DefaultVisit(ISymbol node)
             {
                 throw new NotImplementedException();
             }
 
-            public override ITypeSymbol VisitDynamicType(IDynamicTypeSymbol symbol)
+            public override ValueTask<ITypeSymbol> VisitDynamicType(IDynamicTypeSymbol symbol)
             {
-                return symbol;
+                return new ValueTask<ITypeSymbol>(symbol);
             }
 
-            public override ITypeSymbol VisitArrayType(IArrayTypeSymbol symbol)
+            public override async ValueTask<ITypeSymbol> VisitArrayType(IArrayTypeSymbol symbol)
             {
-                var elementType = symbol.ElementType.Accept(this);
+                var elementType = await symbol.ElementType.Accept(this).ConfigureAwait(false);
                 if (elementType != null && elementType.Equals(symbol.ElementType))
                 {
                     return symbol;
@@ -51,9 +60,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return _compilation.CreateArrayTypeSymbol(elementType, symbol.Rank);
             }
 
-            public override ITypeSymbol VisitNamedType(INamedTypeSymbol symbol)
+            public override async ValueTask<ITypeSymbol> VisitNamedType(INamedTypeSymbol symbol)
             {
-                var arguments = symbol.TypeArguments.Select(t => t.Accept(this)).ToArray();
+                var arguments = (await Task.WhenAll(symbol.TypeArguments.Select(t => t.Accept(this).AsTask())).ConfigureAwait(false)).ToArray();
                 if (arguments.SequenceEqual(symbol.TypeArguments))
                 {
                     return symbol;
@@ -62,9 +71,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return symbol.ConstructedFrom.Construct(arguments.ToArray());
             }
 
-            public override ITypeSymbol VisitPointerType(IPointerTypeSymbol symbol)
+            public override async ValueTask<ITypeSymbol> VisitPointerType(IPointerTypeSymbol symbol)
             {
-                var elementType = symbol.PointedAtType.Accept(this);
+                var elementType = await symbol.PointedAtType.Accept(this).ConfigureAwait(false);
                 if (elementType != null && elementType.Equals(symbol.PointedAtType))
                 {
                     return symbol;
@@ -73,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return _compilation.CreatePointerTypeSymbol(elementType);
             }
 
-            public override ITypeSymbol VisitTypeParameter(ITypeParameterSymbol symbol)
+            public override async ValueTask<ITypeSymbol> VisitTypeParameter(ITypeParameterSymbol symbol)
             {
                 if (_availableTypeParameterNames.Contains(symbol.Name))
                 {
@@ -98,13 +107,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                         if (symbol.ConstraintTypes.All(t => t is INamedTypeSymbol))
                         {
                             var immutableProjects = _solution.Projects.ToImmutableHashSet();
-                            var derivedImplementedTypesOfEachConstraintType = symbol.ConstraintTypes.Select(ct =>
+                            var derivedImplementedTypesOfEachConstraintType = (await Task.WhenAll(symbol.ConstraintTypes.Select(async ct =>
                             {
                                 var derivedAndImplementedTypes = new List<INamedTypeSymbol>();
-                                var derivedClasses = SymbolFinder.FindDerivedClassesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).WaitAndGetResult(_cancellationToken);
-                                var implementedTypes = DependentTypeFinder.FindTransitivelyImplementingStructuresAndClassesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).WaitAndGetResult(_cancellationToken);
+                                var derivedClasses = await SymbolFinder.FindDerivedClassesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).ConfigureAwait(false);
+                                var implementedTypes = await DependentTypeFinder.FindTransitivelyImplementingStructuresAndClassesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).ConfigureAwait(false);
                                 return derivedClasses.Concat(implementedTypes.Select(s => s.Symbol)).ToList();
-                            }).ToList();
+                            })).ConfigureAwait(false)).ToList();
 
                             var intersectingTypes = derivedImplementedTypesOfEachConstraintType.Aggregate((x, y) => x.Intersect(y).ToList());
 
@@ -115,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
                                 // If the resultant intersecting type contains any Type arguments that could be replaced 
                                 // using the type constraints then recursively update the type until all constraints are appropriately handled
-                                var typeConstraintConvertedType = resultantIntersectingType.Accept(this);
+                                var typeConstraintConvertedType = await resultantIntersectingType.Accept(this).ConfigureAwait(false);
                                 var knownSimilarTypesInCompilation = SymbolFinder.FindSimilarSymbols(typeConstraintConvertedType, _compilation, _cancellationToken);
                                 if (knownSimilarTypesInCompilation.Any())
                                 {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal partial class ITypeSymbolExtensions
     {
-        private class ReplaceTypeParameterBasedOnTypeConstraintVisitor : SymbolVisitor<ValueTask<ITypeSymbol>>
+        private class ReplaceTypeParameterBasedOnTypeConstraintVisitor : AsyncSymbolVisitor<ITypeSymbol>
         {
             private readonly CancellationToken _cancellationToken;
             private readonly Compilation _compilation;
@@ -31,18 +31,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 _cancellationToken = cancellationToken;
             }
 
-            public override ValueTask<ITypeSymbol> Visit(ISymbol symbol)
-            {
-                if (symbol is null)
-                    throw new NotImplementedException();
-
-                return base.Visit(symbol);
-            }
-
-            public override ValueTask<ITypeSymbol> DefaultVisit(ISymbol node)
-            {
-                throw new NotImplementedException();
-            }
+            protected override ITypeSymbol DefaultResult => throw new NotImplementedException();
 
             public override ValueTask<ITypeSymbol> VisitDynamicType(IDynamicTypeSymbol symbol)
             {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -237,14 +237,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         [return: NotNullIfNotNull(parameterName: "type")]
-        public static ITypeSymbol? ReplaceTypeParametersBasedOnTypeConstraints(
+        public static ValueTask<ITypeSymbol?> ReplaceTypeParametersBasedOnTypeConstraintsAsync(
             this ITypeSymbol? type,
             Compilation compilation,
             IEnumerable<ITypeParameterSymbol> availableTypeParameters,
             Solution solution,
             CancellationToken cancellationToken)
         {
-            return type?.Accept(new ReplaceTypeParameterBasedOnTypeConstraintVisitor(compilation, availableTypeParameters.Select(t => t.Name).ToSet(), solution, cancellationToken));
+            return type?.Accept(new ReplaceTypeParameterBasedOnTypeConstraintVisitor(compilation, availableTypeParameters.Select(t => t.Name).ToSet(), solution, cancellationToken))
+                ?? new ValueTask<ITypeSymbol?>((ITypeSymbol?)null);
         }
 
         [return: NotNullIfNotNull(parameterName: "type")]

--- a/src/Workspaces/CoreTest/UtilityTest/SpecializedTasksTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SpecializedTasksTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    [SuppressMessage("Usage", "VSTHRD104:Offer async methods", Justification = "This class tests specific behavior of tasks.")]
+    public class SpecializedTasksTests
+    {
+        [Fact]
+        public void WhenAll_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => SpecializedTasks.WhenAll<int>(null));
+        }
+
+        [Fact]
+        public void WhenAll_Empty()
+        {
+            var whenAll = SpecializedTasks.WhenAll(SpecializedCollections.EmptyEnumerable<ValueTask<int>>());
+            Assert.True(whenAll.IsCompletedSuccessfully);
+            Assert.Same(Array.Empty<int>(), whenAll.Result);
+        }
+
+        [Fact]
+        public void WhenAll_AllCompletedSuccessfully()
+        {
+            var whenAll = SpecializedTasks.WhenAll(new[] { new ValueTask<int>(0), new ValueTask<int>(1) });
+            Assert.True(whenAll.IsCompletedSuccessfully);
+            Assert.Equal(new[] { 0, 1 }, whenAll.Result);
+        }
+
+        [Fact]
+        public void WhenAll_CompletedButCanceled()
+        {
+            var whenAll = SpecializedTasks.WhenAll(new[] { new ValueTask<int>(Task.FromCanceled<int>(new CancellationToken(true))) });
+            Assert.True(whenAll.IsCompleted);
+            Assert.False(whenAll.IsCompletedSuccessfully);
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await whenAll);
+        }
+
+        [Fact]
+        public void WhenAll_NotYetCompleted()
+        {
+            var completionSource = new TaskCompletionSource<int>();
+            var whenAll = SpecializedTasks.WhenAll(new[] { new ValueTask<int>(completionSource.Task) });
+            Assert.False(whenAll.IsCompleted);
+            completionSource.SetResult(0);
+            Assert.True(whenAll.IsCompleted);
+            Assert.Equal(new[] { 0 }, whenAll.Result);
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/AsyncSymbolVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/AsyncSymbolVisitor.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal abstract class AsyncSymbolVisitor : SymbolVisitor<ValueTask>
+    {
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/AsyncSymbolVisitor`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/AsyncSymbolVisitor`1.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal abstract class AsyncSymbolVisitor<TResult> : SymbolVisitor<ValueTask<TResult>>
+    {
+        protected abstract TResult DefaultResult { get; }
+
+        public override ValueTask<TResult> Visit(ISymbol symbol)
+        {
+            return symbol?.Accept(this) ?? new ValueTask<TResult>(DefaultResult);
+        }
+
+        public override ValueTask<TResult> DefaultVisit(ISymbol symbol)
+        {
+            return new ValueTask<TResult>(DefaultResult);
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
@@ -52,6 +52,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rename\Annotations\RenameTokenSimplificationAnnotation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\AbstractSpeculationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\MefHostServicesHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\AsyncSymbolVisitor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\AsyncSymbolVisitor`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\IProgressTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SemanticDocument.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SyntacticDocument.cs" />


### PR DESCRIPTION
Fixes an exception caused by calling `WaitAndGetResult` on a background thread. Rather than use a blocking wait, the entire stack is made asynchronous.