### PR TITLE
Reenable CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -257,6 +257,9 @@ dotnet_diagnostic.IDE0036.severity = %value%
 # IDE0037
 dotnet_diagnostic.IDE0037.severity = %value%
 
+# IDE0038
+dotnet_diagnostic.IDE0038.severity = %value%
+
 # IDE0039
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 
@@ -732,6 +735,9 @@ dotnet_style_prefer_inferred_tuple_names = true:suggestion
 
 # IDE0037, PreferInferredAnonymousTypeMemberNames
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+
+# IDE0038
+No editorconfig based code style option
 
 # IDE0039, PreferLocalOverAnonymousFunction
 csharp_style_pattern_local_over_anonymous_function = true:suggestion

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -28,11 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
     /// but only for code cases where the user has provided an appropriate variable name in
     /// code that can be used).
     /// </summary>
-    //
-    // disabled for preview 1 due to some perf issue. 
-    // we will re-enable it once the issue is addressed.
-    // https://devdiv.visualstudio.com/DevDiv/_workitems?id=504089&_a=edit&triage=true 
-    // [DiagnosticAnalyzer(LanguageNames.CSharp), Shared]
+    [DiagnosticAnalyzer(LanguageNames.CSharp), Shared]
     internal class CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
         private const string CS0165 = nameof(CS0165); // Use of unassigned local variable 's'


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/22531

This feature was disabled because is triggered poor behavior in NameGenerator (where tons of memory was used due to inefficient linq calls).  That behavior was fixed by me in https://github.com/dotnet/roslyn/pull/39974.  As such, I'm reenabling the feature.