### PR TITLE
Separate DiagnosticAnalyzer descriptor cache from host analyzers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -148,7 +148,7 @@ class C
         private void AccessSupportedDiagnostics(DiagnosticAnalyzer analyzer)
         {
             var diagnosticService = new TestDiagnosticAnalyzerService(LanguageNames.CSharp, analyzer);
-            diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference();
+            diagnosticService.GetDiagnosticDescriptorsPerReference();
         }
 
         private class ThrowingDoNotCatchDiagnosticAnalyzer<TLanguageKindEnum> : ThrowingDiagnosticAnalyzer<TLanguageKindEnum>, IBuiltInAnalyzer where TLanguageKindEnum : struct

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -548,13 +548,14 @@ dotnet_diagnostic.{DisabledByDefaultAnalyzer.s_compilationRule.Id}.severity = wa
             }
 
             internal MyDiagnosticAnalyzerService(IEnumerable<DiagnosticAnalyzer> analyzers, IAsynchronousOperationListener listener, string language = LanguageNames.CSharp)
-                : base(new DiagnosticAnalyzerInfoCache(
+                : base(new DiagnosticAnalyzerInfoCache(),
+                       new HostDiagnosticAnalyzers(
                             ImmutableArray.Create<AnalyzerReference>(
                                 new TestAnalyzerReferenceByLanguage(
                                     ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>>.Empty.Add(language, ImmutableArray.CreateRange(analyzers))))),
-                      hostDiagnosticUpdateSource: null,
-                      registrationService: new MockDiagnosticUpdateSourceRegistrationService(),
-                      listener: listener)
+                       hostDiagnosticUpdateSource: null,
+                       registrationService: new MockDiagnosticUpdateSourceRegistrationService(),
+                       listener: listener)
             {
             }
         }

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(LanguageNames.CSharp, workspaceDiagnosticAnalyzer)
 
                 ' Verify available diagnostic descriptors/analyzers
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Count())
@@ -90,7 +90,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.WithAnalyzerReferences(projectAnalyzerReferences1)
 
                 ' Verify available diagnostic descriptors/analyzers
-                descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(2, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.AddAnalyzerReference(projectAnalyzerReference2)
 
                 ' Verify available diagnostic descriptors/analyzers
-                descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(3, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.RemoveAnalyzerReference(projectAnalyzerReference1)
 
                 ' Verify available diagnostic descriptors/analyzers
-                descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(2, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -135,18 +135,18 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Assert.Equal(2, diagnostics.Count())
 
                 ' Verify available diagnostic descriptors/analyzers if not project specific
-                descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference()
+                descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference()
                 Assert.Equal(1, descriptorsMap.Count)
                 descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Count)
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
 
                 ' Add an existing workspace analyzer to the project, ensure no duplicate diagnostics.
-                Dim duplicateProjectAnalyzersReference = diagnosticService.AnalyzerInfoCache.GetHostAnalyzerReferencesMap().First().Value
+                Dim duplicateProjectAnalyzersReference = diagnosticService.HostAnalyzers.GetHostAnalyzerReferencesMap().First().Value
                 project = project.WithAnalyzerReferences({duplicateProjectAnalyzersReference})
 
                 ' Verify duplicate descriptors or diagnostics.
-                descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -182,8 +182,8 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.WithAnalyzerReferences(projectAnalyzerReferences1)
 
                 ' Query descriptors twice: second query was hitting an assert in DiagnosticAnalyzersAndStates.
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
-                descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
+                descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
 
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
@@ -218,7 +218,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
                 project = project.WithAnalyzerReferences(ImmutableArray.Create(Of AnalyzerReference)(projectAnalyzerReference))
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
 
                 ' two references in the map
                 Assert.Equal(1, descriptorsMap.Count)
@@ -247,7 +247,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(LanguageNames.CSharp, workspaceDiagnosticAnalyzer)
 
                 ' Verify available diagnostic descriptors/analyzers
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Count())
@@ -317,15 +317,15 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
                 Dim analyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
-                Dim workspaceDescriptors = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference()
+                Dim workspaceDescriptors = diagnosticService.GetDiagnosticDescriptorsPerReference()
                 Assert.Equal(0, workspaceDescriptors.Count)
 
-                Dim alphaDescriptors = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(alpha)
+                Dim alphaDescriptors = diagnosticService.GetDiagnosticDescriptorsPerReference(alpha)
                 Assert.Equal("XX0001", alphaDescriptors.Single().Value.Single().Id)
                 Dim alphaDiagnostics = diagnosticService.GetDiagnosticsForSpanAsync(alpha.Documents.Single(), New TextSpan(0, alpha.Documents.Single().GetTextAsync().Result.Length)).Result
                 Assert.Equal("XX0001", alphaDiagnostics.Single().Id)
 
-                Dim bravoDescriptors = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(bravo)
+                Dim bravoDescriptors = diagnosticService.GetDiagnosticDescriptorsPerReference(bravo)
                 Assert.Equal("XX0002", bravoDescriptors.Single().Value.Single().Id)
                 Dim bravoDiagnostics = diagnosticService.GetDiagnosticsForSpanAsync(bravo.Documents.Single(), New TextSpan(0, bravo.Documents.Single().GetTextAsync().Result.Length)).Result
                 Assert.Equal("XX0002", bravoDiagnostics.Single().Id)
@@ -351,7 +351,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 analyzersMap.Add(LanguageNames.VisualBasic, ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer2))
                 Dim diagnosticService2 = New TestDiagnosticAnalyzerService(analyzersMap.ToImmutableDictionary())
 
-                Dim descriptors = diagnosticService2.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference()
+                Dim descriptors = diagnosticService2.GetDiagnosticDescriptorsPerReference()
                 Assert.Equal(1, descriptors.Count)
                 Assert.Equal(2, descriptors.Single().Value.Count)
             End Using
@@ -398,7 +398,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(ImmutableArray.Create(Of AnalyzerReference)(analyzerReference2))
 
                 Dim analyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
 
                 ' Verify no duplicate diagnostics.
                 Dim document = project.Documents.Single()
@@ -454,7 +454,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(0, descriptors.Count())
@@ -490,7 +490,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=exceptionDiagnosticsSource, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -598,7 +598,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                     Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
                     project = project.AddAnalyzerReference(analyzerReference)
 
-                    Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                    Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                     Assert.Equal(1, descriptorsMap.Count)
 
                     Dim document = project.Documents.Single()
@@ -631,7 +631,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -666,7 +666,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
                 ' Ensure no duplicate diagnostics.
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -743,7 +743,7 @@ class AnonymousFunctions
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
                 ' Ensure no duplicate diagnostics.
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -783,7 +783,7 @@ class AnonymousFunctions
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 ' Ask for document diagnostics multiple times, and verify compilation diagnostics are reported.
@@ -940,7 +940,7 @@ class AnonymousFunctions
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 ' Verify no duplicate analysis/diagnostics.
@@ -977,7 +977,7 @@ class AnonymousFunctions
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single(Function(d) d.Name = "Test1.cs")
@@ -1032,7 +1032,7 @@ class AnonymousFunctions
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 ' Verify project diagnostics contains diagnostics reported on both partial definitions.
@@ -1081,7 +1081,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1123,7 +1123,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1165,7 +1165,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1216,7 +1216,7 @@ End Class
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1278,7 +1278,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1324,7 +1324,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1410,8 +1410,8 @@ public class B
             End Using
         End Sub
 
-        Private Shared Sub TestCompilationAnalyzerWithAnalyzerOptionsCore(project As Project, expectedDiagnosticMessage As String, diagnosticService As DiagnosticAnalyzerService)
-            Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+        Private Shared Sub TestCompilationAnalyzerWithAnalyzerOptionsCore(project As Project, expectedDiagnosticMessage As String, diagnosticService As TestDiagnosticAnalyzerService)
+            Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
             Assert.Equal(1, descriptorsMap.Count)
 
             Dim document = project.Documents.Single()
@@ -1931,7 +1931,7 @@ End Class
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1991,7 +1991,7 @@ namespace ConsoleApplication1
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -2061,7 +2061,7 @@ class MyClass
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
                 ' Verify available diagnostic descriptors/analyzers
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Assert.Equal(0, descriptorsMap.First().Value.Length)
 
@@ -2102,7 +2102,7 @@ class MyClass
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
                 ' Verify available diagnostic descriptors
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Length)
@@ -2153,7 +2153,7 @@ class MyClass
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project)
+                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)

--- a/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
@@ -147,7 +147,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             internal MyDiagnosticAnalyzerService(
                 ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzersMap,
                 IAsynchronousOperationListener listener)
-                : base(new DiagnosticAnalyzerInfoCache(ImmutableArray.Create<AnalyzerReference>(new TestAnalyzerReferenceByLanguage(analyzersMap))),
+                : base(new DiagnosticAnalyzerInfoCache(),
+                      new HostDiagnosticAnalyzers(ImmutableArray.Create<AnalyzerReference>(new TestAnalyzerReferenceByLanguage(analyzersMap))),
                       hostDiagnosticUpdateSource: null,
                       registrationService: new MockDiagnosticUpdateSourceRegistrationService(),
                       listener: listener)

--- a/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerDriver.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerDriver.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             var snapshotService = workspace.Services.GetService<CodeAnalysis.Execution.IRemotableDataService>();
             var assetBuilder = new CodeAnalysis.Execution.CustomAssetBuilder(workspace);
 
-            foreach (var (_, reference) in _diagnosticAnalyzerService.AnalyzerInfoCache.GetHostAnalyzerReferencesMap())
+            foreach (var (_, reference) in _diagnosticAnalyzerService.HostAnalyzers.GetHostAnalyzerReferencesMap())
             {
                 if (!(reference is AnalyzerFileReference))
                 {

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
@@ -81,7 +81,7 @@ End Class
 
     Private Sub AccessSupportedDiagnostics(analyzer As DiagnosticAnalyzer)
         Dim diagnosticService = New TestDiagnosticAnalyzerService(LanguageNames.VisualBasic, analyzer)
-        diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference()
+        diagnosticService.GetDiagnosticDescriptorsPerReference()
     End Sub
 
     <Fact>

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -13,8 +13,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -69,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public static bool IsCompilerAnalyzer(this DiagnosticAnalyzer analyzer)
         {
             // TODO: find better way.
-            var typeString = analyzer.GetType().ToString();
+            var typeString = analyzer.GetType().FullName;
             if (typeString == CSharpCompilerAnalyzerTypeName)
             {
                 return true;
@@ -416,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             // quick optimization to reduce allocations.
-            if (compilationWithAnalyzers == null || !analyzerInfoCache.SupportAnalysisKind(analyzer, document.Project.Language, kind))
+            if (compilationWithAnalyzers == null || !analyzerInfoCache.SupportAnalysisKind(analyzer, kind))
             {
                 if (kind == AnalysisKind.Syntax)
                 {
@@ -428,8 +426,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             // if project is not loaded successfully then, we disable semantic errors for compiler analyzers
-            if (kind != AnalysisKind.Syntax &&
-                analyzerInfoCache.IsCompilerDiagnosticAnalyzer(document.Project.Language, analyzer))
+            if (kind != AnalysisKind.Syntax && analyzer.IsCompilerAnalyzer())
             {
                 var isEnabled = await document.Project.HasSuccessfullyLoadedAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -386,7 +387,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             Document document,
             AnalysisKind kind,
-            DiagnosticAnalyzerInfoCache analyzerInfoCache,
             CompilationWithAnalyzers? compilationWithAnalyzers,
             TextSpan? span,
             CancellationToken cancellationToken)
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             // quick optimization to reduce allocations.
-            if (compilationWithAnalyzers == null || !analyzerInfoCache.SupportAnalysisKind(analyzer, kind))
+            if (compilationWithAnalyzers == null || !analyzer.SupportAnalysisKind(kind))
             {
                 if (kind == AnalysisKind.Syntax)
                 {

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -22,14 +22,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     [ExportIncrementalAnalyzerProvider(WellKnownSolutionCrawlerAnalyzers.Diagnostic, workspaceKinds: null)]
     internal partial class DefaultDiagnosticAnalyzerService : IIncrementalAnalyzerProvider, IDiagnosticUpdateSource
     {
-        private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
+        private readonly HostDiagnosticAnalyzers _hostAnalyzers;
 
         [ImportingConstructor]
         public DefaultDiagnosticAnalyzerService(
             IDiagnosticAnalyzerService analyzerService,
             IDiagnosticUpdateSourceRegistrationService registrationService)
         {
-            _analyzerInfoCache = analyzerService.AnalyzerInfoCache;
+            _hostAnalyzers = analyzerService.HostAnalyzers;
             registrationService.Register(this);
         }
 
@@ -155,8 +155,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return ImmutableArray.Create(DiagnosticData.Create(loadDiagnostic, document));
                 }
 
-                var analyzerInfoCache = _service._analyzerInfoCache;
-                var analyzers = GetAnalyzers(analyzerInfoCache, document.Project);
+                var analyzers = GetAnalyzers(_service._hostAnalyzers, document.Project);
 
                 var compilationWithAnalyzers = await AnalyzerHelper.CreateCompilationWithAnalyzersAsync(
                     document.Project, analyzers, includeSuppressedDiagnostics: false, cancellationToken).ConfigureAwait(false);
@@ -165,23 +164,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 foreach (var analyzer in analyzers)
                 {
                     builder.AddRange(await AnalyzerHelper.ComputeDiagnosticsAsync(analyzer,
-                        document, kind, analyzerInfoCache, compilationWithAnalyzers, span: null, cancellationToken).ConfigureAwait(false));
+                        document, kind, compilationWithAnalyzers, span: null, cancellationToken).ConfigureAwait(false));
                 }
 
                 return builder.ToImmutableAndFree();
             }
 
-            private static IEnumerable<DiagnosticAnalyzer> GetAnalyzers(DiagnosticAnalyzerInfoCache analyzerInfoCache, Project project)
+            private static IEnumerable<DiagnosticAnalyzer> GetAnalyzers(HostDiagnosticAnalyzers hostAnalyzers, Project project)
             {
                 // C# or VB document that supports compiler
-                var compilerAnalyzer = analyzerInfoCache.GetCompilerDiagnosticAnalyzer(project.Language);
+                var compilerAnalyzer = hostAnalyzers.GetCompilerDiagnosticAnalyzer(project.Language);
                 if (compilerAnalyzer != null)
                 {
                     return SpecializedCollections.SingletonEnumerable(compilerAnalyzer);
                 }
 
                 // document that doesn't support compiler diagnostics such as FSharp or TypeScript
-                return analyzerInfoCache.CreateDiagnosticAnalyzersPerReference(project).Values.SelectMany(v => v);
+                return hostAnalyzers.CreateDiagnosticAnalyzersPerReference(project).Values.SelectMany(v => v);
             }
 
             public void RemoveDocument(DocumentId documentId)

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    /// <summary>
+    /// Provides and caches information about diagnostic analyzers such as <see cref="AnalyzerReference"/>, 
+    /// <see cref="DiagnosticAnalyzer"/> instance, <see cref="DiagnosticDescriptor"/>s.
+    /// Thread-safe.
+    /// </summary>
+    internal sealed class DiagnosticAnalyzerInfoCache
+    {
+        /// <summary>
+        /// Supported descriptors of each <see cref="DiagnosticAnalyzer"/>. 
+        /// </summary>
+        /// <remarks>
+        /// Holds on <see cref="DiagnosticAnalyzer"/> instances weakly so that we don't keep analyzers coming from package references alive.
+        /// They need to be released when the project stops referencing the analyzer.
+        /// 
+        /// The purpose of this map is to avoid multiple calls to <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> that might return different values
+        /// (they should not but we need a guarantee to function correctly).
+        /// </remarks>
+        private readonly ConditionalWeakTable<DiagnosticAnalyzer, DiagnosticDescriptorsInfo> _descriptorsInfo;
+
+        private sealed class DiagnosticDescriptorsInfo
+        {
+            public readonly ImmutableArray<DiagnosticDescriptor> SupportedDescriptors;
+            public readonly bool TelemetryAllowed;
+
+            public DiagnosticDescriptorsInfo(ImmutableArray<DiagnosticDescriptor> supportedDescriptors, bool telemetryAllowed)
+            {
+                SupportedDescriptors = supportedDescriptors;
+                TelemetryAllowed = telemetryAllowed;
+            }
+        }
+
+        internal DiagnosticAnalyzerInfoCache()
+        {
+            _descriptorsInfo = new ConditionalWeakTable<DiagnosticAnalyzer, DiagnosticDescriptorsInfo>();
+        }
+
+        /// <summary>
+        /// Returns <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> of given <paramref name="analyzer"/>.
+        /// </summary>
+        public ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(DiagnosticAnalyzer analyzer)
+            => GetOrCreateDescriptorsInfo(analyzer).SupportedDescriptors;
+
+        /// <summary>
+        /// Determine whether collection of telemetry is allowed for given <paramref name="analyzer"/>.
+        /// </summary>
+        public bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer)
+            => GetOrCreateDescriptorsInfo(analyzer).TelemetryAllowed;
+
+        private DiagnosticDescriptorsInfo GetOrCreateDescriptorsInfo(DiagnosticAnalyzer analyzer)
+            => _descriptorsInfo.GetValue(analyzer, CalculateDescriptorsInfo);
+
+        private DiagnosticDescriptorsInfo CalculateDescriptorsInfo(DiagnosticAnalyzer analyzer)
+        {
+            ImmutableArray<DiagnosticDescriptor> descriptors;
+            try
+            {
+                // SupportedDiagnostics is user code and can throw an exception.
+                descriptors = analyzer.SupportedDiagnostics.NullToEmpty();
+            }
+            catch
+            {
+                // No need to report the exception to the user.
+                // Eventually, when the analyzer runs the compiler analyzer driver will report a diagnostic.
+                descriptors = ImmutableArray<DiagnosticDescriptor>.Empty;
+            }
+
+            bool telemetryAllowed = IsTelemetryCollectionAllowed(analyzer, descriptors);
+            return new DiagnosticDescriptorsInfo(descriptors, telemetryAllowed);
+        }
+
+        private static bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer, ImmutableArray<DiagnosticDescriptor> descriptors)
+            => analyzer.IsCompilerAnalyzer() ||
+               analyzer is IBuiltInAnalyzer ||
+               descriptors.Length > 0 && descriptors[0].CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry);
+
+        /// <summary>
+        /// Return true if the given <paramref name="analyzer"/> is suppressed for the given project.
+        /// NOTE: This API is intended to be used only for performance optimization.
+        /// </summary>
+        public bool IsAnalyzerSuppressed(DiagnosticAnalyzer analyzer, Project project)
+        {
+            var options = project.CompilationOptions;
+            if (options == null || analyzer == FileContentLoadAnalyzer.Instance || analyzer.IsCompilerAnalyzer())
+            {
+                return false;
+            }
+
+            // If user has disabled analyzer execution for this project, we only want to execute required analyzers
+            // that report diagnostics with category "Compiler".
+            if (!project.State.RunAnalyzers &&
+                GetDiagnosticDescriptors(analyzer).All(d => d.Category != DiagnosticCategory.Compiler))
+            {
+                return true;
+            }
+
+            // NOTE: Previously we used to return "CompilationWithAnalyzers.IsDiagnosticAnalyzerSuppressed(options)"
+            //       on this code path, which returns true if analyzer is suppressed through compilation options.
+            //       However, this check is no longer correct as analyzers can be enabled/disabled for individual
+            //       documents through .editorconfig files. So we pessimistically assume analyzer is not suppressed
+            //       and let the core analyzer driver in the compiler layer handle skipping redundant analysis callbacks.
+            return false;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerService
     {
         public DiagnosticAnalyzerInfoCache AnalyzerInfoCache { get; private set; }
+        public HostDiagnosticAnalyzers HostAnalyzers { get; private set; }
 
         private readonly AbstractHostDiagnosticUpdateSource? _hostDiagnosticUpdateSource;
 
@@ -53,7 +54,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             PrimaryWorkspace primaryWorkspace,
             IDiagnosticUpdateSourceRegistrationService registrationService,
             IAsynchronousOperationListener? listener = null)
-            : this(new DiagnosticAnalyzerInfoCache(workspaceAnalyzerPackages, hostAnalyzerAssemblyLoader, hostDiagnosticUpdateSource, primaryWorkspace),
+            : this(new DiagnosticAnalyzerInfoCache(),
+                   new HostDiagnosticAnalyzers(workspaceAnalyzerPackages, hostAnalyzerAssemblyLoader, hostDiagnosticUpdateSource, primaryWorkspace),
                    hostDiagnosticUpdateSource,
                    registrationService,
                    listener)
@@ -63,12 +65,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         // protected for testing purposes.
         protected DiagnosticAnalyzerService(
             DiagnosticAnalyzerInfoCache analyzerInfoCache,
+            HostDiagnosticAnalyzers hostAnalyzers,
             AbstractHostDiagnosticUpdateSource? hostDiagnosticUpdateSource,
             IDiagnosticUpdateSourceRegistrationService registrationService,
             IAsynchronousOperationListener? listener = null)
             : this(registrationService)
         {
             AnalyzerInfoCache = analyzerInfoCache;
+            HostAnalyzers = hostAnalyzers;
             _hostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
             Listener = listener ?? AsynchronousOperationListenerProvider.NullListener;
         }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // subscribe to active context changed event for new workspace
             workspace.DocumentActiveContextChanged += OnDocumentActiveContextChanged;
 
-            return new DiagnosticIncrementalAnalyzer(this, LogAggregator.GetNextId(), workspace, AnalyzerInfoCache, _hostDiagnosticUpdateSource);
+            return new DiagnosticIncrementalAnalyzer(this, LogAggregator.GetNextId(), workspace, HostAnalyzers, AnalyzerInfoCache, _hostDiagnosticUpdateSource);
         }
 
         private void OnDocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return new DocumentAnalysisData(version, existingData.Items, ImmutableArray<DiagnosticData>.Empty);
                     }
 
-                    var diagnostics = await AnalyzerHelper.ComputeDiagnosticsAsync(stateSet.Analyzer, document, kind, DiagnosticAnalyzerInfoCache, compilation, span: null, cancellationToken).ConfigureAwait(false);
+                    var diagnostics = await AnalyzerHelper.ComputeDiagnosticsAsync(stateSet.Analyzer, document, kind, compilation, span: null, cancellationToken).ConfigureAwait(false);
 
                     // this is no-op in product. only run in test environment
                     Logger.Log(functionId, (t, d, a, ds) => $"{GetDocumentLogMessage(t, d, a)}, {string.Join(Environment.NewLine, ds)}",
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return result;
             }
 
-            var compilerAnalyzer = DiagnosticAnalyzerInfoCache.GetCompilerDiagnosticAnalyzer(project.Language);
+            var compilerAnalyzer = HostAnalyzers.GetCompilerDiagnosticAnalyzer(project.Language);
             if (compilerAnalyzer == null)
             {
                 // this language doesn't support compiler analyzer

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeFileContentLoadAnalyzer: true);
                     VerifyUniqueStateNames(analyzerMap.Values);
 
-                    return new HostAnalyzerStateSets(analyzerInfoCache, language, analyzerMap);
+                    return new HostAnalyzerStateSets(analyzerMap);
                 }
 
                 return ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, language, CreateLanguageSpecificAnalyzerMap, _analyzerInfoCache);
@@ -40,18 +40,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 private const int BuiltInCompilerPriority = -2;
                 private const int RegularDiagnosticAnalyzerPriority = -1;
 
-                private readonly DiagnosticAnalyzer? _compilerAnalyzer;
-
                 // ordered by priority
                 public readonly ImmutableArray<StateSet> OrderedStateSets;
 
                 public readonly ImmutableDictionary<DiagnosticAnalyzer, StateSet> StateSetMap;
 
-                public HostAnalyzerStateSets(DiagnosticAnalyzerInfoCache analyzerInfoCache, string language, ImmutableDictionary<DiagnosticAnalyzer, StateSet> analyzerMap)
+                public HostAnalyzerStateSets(ImmutableDictionary<DiagnosticAnalyzer, StateSet> analyzerMap)
                 {
                     StateSetMap = analyzerMap;
-
-                    _compilerAnalyzer = analyzerInfoCache.GetCompilerDiagnosticAnalyzer(language);
 
                     // order statesets
                     // order will be in this order
@@ -67,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 private int GetPriority(StateSet state)
                 {
                     // compiler gets highest priority
-                    if (state.Analyzer == _compilerAnalyzer)
+                    if (state.Analyzer.IsCompilerAnalyzer())
                     {
                         return BuiltInCompilerPriority;
                     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private HostAnalyzerStateSets GetOrCreateHostStateSets(string language)
             {
-                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap(string language, DiagnosticAnalyzerInfoCache analyzerInfoCache)
+                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap(string language, HostDiagnosticAnalyzers hostAnalyzers)
                 {
-                    var analyzersPerReference = analyzerInfoCache.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
+                    var analyzersPerReference = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
                     var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeFileContentLoadAnalyzer: true);
                     VerifyUniqueStateNames(analyzerMap.Values);
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return new HostAnalyzerStateSets(analyzerMap);
                 }
 
-                return ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, language, CreateLanguageSpecificAnalyzerMap, _analyzerInfoCache);
+                return ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, language, CreateLanguageSpecificAnalyzerMap, _hostAnalyzers);
             }
 
             private sealed class HostAnalyzerStateSets

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return ImmutableDictionary<DiagnosticAnalyzer, StateSet>.Empty;
                 }
 
-                var analyzersPerReference = _analyzerInfoCache.CreateProjectDiagnosticAnalyzersPerReference(project);
+                var analyzersPerReference = _hostAnalyzers.CreateProjectDiagnosticAnalyzersPerReference(project);
                 if (analyzersPerReference.Count == 0)
                 {
                     return ImmutableDictionary<DiagnosticAnalyzer, StateSet>.Empty;
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// </summary>
             private ImmutableDictionary<DiagnosticAnalyzer, StateSet> UpdateProjectAnalyzerMap(Project project)
             {
-                var newAnalyzersPerReference = _analyzerInfoCache.CreateProjectDiagnosticAnalyzersPerReference(project);
+                var newAnalyzersPerReference = _hostAnalyzers.CreateProjectDiagnosticAnalyzersPerReference(project);
                 var newMap = CreateStateSetMap(project.Language, newAnalyzersPerReference.Values, includeFileContentLoadAnalyzer: false);
 
                 RaiseProjectAnalyzerReferenceChangedIfNeeded(project, newAnalyzersPerReference, newMap);
@@ -153,9 +153,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var builder = ImmutableArray.CreateBuilder<StateSet>();
                 foreach (var reference in references)
                 {
-                    var referenceIdentity = _analyzerInfoCache.GetAnalyzerReferenceIdentity(reference);
                     // check duplication
-                    if (!mapPerReference.TryGetValue(referenceIdentity, out var analyzers))
+                    if (!mapPerReference.TryGetValue(reference.Id, out var analyzers))
                     {
                         continue;
                     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// </summary>
         private partial class StateManager
         {
-            private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
             private readonly IPersistentStorageService _persistentStorageService;
+            private readonly HostDiagnosticAnalyzers _hostAnalyzers;
 
             /// <summary>
             /// Analyzers supplied by the host (IDE). These are built-in to the IDE, the compiler, or from an installed IDE extension (VSIX). 
@@ -42,9 +42,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// </summary>
             public event EventHandler<ProjectAnalyzerReferenceChangedEventArgs>? ProjectAnalyzerReferenceChanged;
 
-            public StateManager(DiagnosticAnalyzerInfoCache analyzerInfoCache, IPersistentStorageService persistentStorageService)
+            public StateManager(HostDiagnosticAnalyzers hostAnalyzers, IPersistentStorageService persistentStorageService)
             {
-                _analyzerInfoCache = analyzerInfoCache;
+                _hostAnalyzers = hostAnalyzers;
                 _persistentStorageService = persistentStorageService;
 
                 _hostAnalyzerStateMap = ImmutableDictionary<string, HostAnalyzerStateSets>.Empty;
@@ -150,14 +150,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var hostStateSetMap = hostStateSets.ToDictionary(s => s.Analyzer, s => s);
 
                 // create project analyzer reference identity map
-                var projectAnalyzerReferenceIds = project.AnalyzerReferences.Select(r => _analyzerInfoCache.GetAnalyzerReferenceIdentity(r)).ToSet();
+                var projectAnalyzerReferenceIds = project.AnalyzerReferences.Select(r => r.Id).ToSet();
 
                 // create build only stateSet array
                 var stateSets = ImmutableArray.CreateBuilder<StateSet>();
 
                 // include compiler analyzer in build only state, if available
                 StateSet? compilerStateSet = null;
-                var compilerAnalyzer = _analyzerInfoCache.GetCompilerDiagnosticAnalyzer(project.Language);
+                var compilerAnalyzer = _hostAnalyzers.GetCompilerDiagnosticAnalyzer(project.Language);
                 if (compilerAnalyzer != null && hostStateSetMap.TryGetValue(compilerAnalyzer, out compilerStateSet))
                 {
                     stateSets.Add(compilerStateSet);
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 stateSets.AddRange(GetOrUpdateProjectAnalyzerMap(project).Values);
 
                 // now add analyzers that exist in both host and project
-                var hostAnalyzersById = _analyzerInfoCache.GetOrCreateHostDiagnosticAnalyzersPerReference(project.Language);
+                var hostAnalyzersById = _hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(project.Language);
                 foreach (var (identity, analyzers) in hostAnalyzersById)
                 {
                     if (!projectAnalyzerReferenceIds.Contains(identity))

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -43,11 +43,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         internal IPersistentStorageService PersistentStorageService { get; }
         internal AbstractHostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; }
         internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache { get; }
+        internal HostDiagnosticAnalyzers HostAnalyzers { get; }
 
         public DiagnosticIncrementalAnalyzer(
             DiagnosticAnalyzerService analyzerService,
             int correlationId,
             Workspace workspace,
+            HostDiagnosticAnalyzers hostAnalyzers,
             DiagnosticAnalyzerInfoCache analyzerInfoCache,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource)
         {
@@ -55,13 +57,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             AnalyzerService = analyzerService;
             Workspace = workspace;
+            HostAnalyzers = hostAnalyzers;
             DiagnosticAnalyzerInfoCache = analyzerInfoCache;
             HostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
             PersistentStorageService = workspace.Services.GetRequiredService<IPersistentStorageService>();
 
             _correlationId = correlationId;
 
-            _stateManager = new StateManager(analyzerInfoCache, PersistentStorageService);
+            _stateManager = new StateManager(hostAnalyzers, PersistentStorageService);
             _stateManager.ProjectAnalyzerReferenceChanged += OnProjectAnalyzerReferenceChanged;
             _telemetry = new DiagnosticAnalyzerTelemetry();
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -48,7 +48,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private readonly IEnumerable<StateSet> _stateSets;
             private readonly CompilationWithAnalyzers? _compilation;
-            private readonly DiagnosticAnalyzer? _compilerAnalyzer;
 
             private readonly TextSpan _range;
             private readonly bool _blockForData;
@@ -99,7 +98,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _stateSets = stateSets;
                 _diagnosticId = diagnosticId;
                 _compilation = compilation;
-                _compilerAnalyzer = _owner.DiagnosticAnalyzerInfoCache.GetCompilerDiagnosticAnalyzer(_document.Project.Language);
 
                 _range = range;
                 _blockForData = blockForData;
@@ -160,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             {
                 // unfortunately, we need to special case compiler diagnostic analyzer so that
                 // we can do span based analysis even though we implemented it as semantic model analysis
-                if (stateSet.Analyzer == _compilerAnalyzer)
+                if (stateSet.Analyzer.IsCompilerAnalyzer())
                 {
                     return await TryGetSyntaxAndSemanticCompilerDiagnosticsAsync(stateSet, list, cancellationToken).ConfigureAwait(false);
                 }
@@ -325,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 List<DiagnosticData> list,
                 CancellationToken cancellationToken)
             {
-                if (!_owner.DiagnosticAnalyzerInfoCache.SupportAnalysisKind(stateSet.Analyzer, stateSet.Language, kind))
+                if (!_owner.DiagnosticAnalyzerInfoCache.SupportAnalysisKind(stateSet.Analyzer, kind))
                 {
                     return true;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private Task<IEnumerable<DiagnosticData>> GetSyntaxDiagnosticsAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
             {
-                return AnalyzerHelper.ComputeDiagnosticsAsync(analyzer, _document, AnalysisKind.Syntax, _owner.DiagnosticAnalyzerInfoCache, _compilation, _range, cancellationToken);
+                return AnalyzerHelper.ComputeDiagnosticsAsync(analyzer, _document, AnalysisKind.Syntax, _compilation, _range, cancellationToken);
             }
 
             private Task<IEnumerable<DiagnosticData>> GetSemanticDiagnosticsAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var supportsSemanticInSpan = analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis();
 
                 var analysisSpan = supportsSemanticInSpan ? (TextSpan?)_range : null;
-                return AnalyzerHelper.ComputeDiagnosticsAsync(analyzer, _document, AnalysisKind.Semantic, _owner.DiagnosticAnalyzerInfoCache, _compilation, analysisSpan, cancellationToken);
+                return AnalyzerHelper.ComputeDiagnosticsAsync(analyzer, _document, AnalysisKind.Semantic, _compilation, analysisSpan, cancellationToken);
             }
 
             private async Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 List<DiagnosticData> list,
                 CancellationToken cancellationToken)
             {
-                if (!_owner.DiagnosticAnalyzerInfoCache.SupportAnalysisKind(stateSet.Analyzer, kind))
+                if (!stateSet.Analyzer.SupportAnalysisKind(kind))
                 {
                     return true;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -304,8 +304,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private bool IsCandidateForFullSolutionAnalysis(DiagnosticAnalyzer analyzer, Project project)
         {
             // PERF: Don't query descriptors for compiler analyzer or file content load analyzer, always execute them.
-            if (DiagnosticAnalyzerInfoCache.IsCompilerDiagnosticAnalyzer(project.Language, analyzer) ||
-                analyzer == FileContentLoadAnalyzer.Instance)
+            if (analyzer == FileContentLoadAnalyzer.Instance || analyzer.IsCompilerAnalyzer())
             {
                 return true;
             }

--- a/src/Features/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
@@ -9,117 +9,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    /// <summary>
-    /// Provides and caches information about diagnostic analyzers such as <see cref="AnalyzerReference"/>, 
-    /// <see cref="DiagnosticAnalyzer"/> instance, <see cref="DiagnosticDescriptor"/>s.
-    /// Thread-safe.
-    /// </summary>
-    internal sealed class DiagnosticAnalyzerInfoCache
-    {
-        /// <summary>
-        /// Supported descriptors of each <see cref="DiagnosticAnalyzer"/>. 
-        /// </summary>
-        /// <remarks>
-        /// Holds on <see cref="DiagnosticAnalyzer"/> instances weakly so that we don't keep analyzers coming from package references alive.
-        /// They need to be released when the project stops referencing the analyzer.
-        /// 
-        /// The purpose of this map is to avoid multiple calls to <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> that might return different values
-        /// (they should not but we need a guarantee to function correctly).
-        /// </remarks>
-        private readonly ConditionalWeakTable<DiagnosticAnalyzer, DiagnosticDescriptorsInfo> _descriptorsInfo;
-
-        private sealed class DiagnosticDescriptorsInfo
-        {
-            public readonly ImmutableArray<DiagnosticDescriptor> SupportedDescriptors;
-            public readonly bool TelemetryAllowed;
-
-            public DiagnosticDescriptorsInfo(ImmutableArray<DiagnosticDescriptor> supportedDescriptors, bool telemetryAllowed)
-            {
-                SupportedDescriptors = supportedDescriptors;
-                TelemetryAllowed = telemetryAllowed;
-            }
-        }
-
-        internal DiagnosticAnalyzerInfoCache()
-        {
-            _descriptorsInfo = new ConditionalWeakTable<DiagnosticAnalyzer, DiagnosticDescriptorsInfo>();
-        }
-
-        /// <summary>
-        /// Returns <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> of given <paramref name="analyzer"/>.
-        /// </summary>
-        public ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(DiagnosticAnalyzer analyzer)
-            => GetOrCreateDescriptorsInfo(analyzer).SupportedDescriptors;
-
-        /// <summary>
-        /// Determine whether collection of telemetry is allowed for given <paramref name="analyzer"/>.
-        /// </summary>
-        public bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer)
-            => GetOrCreateDescriptorsInfo(analyzer).TelemetryAllowed;
-
-        private DiagnosticDescriptorsInfo GetOrCreateDescriptorsInfo(DiagnosticAnalyzer analyzer)
-            => _descriptorsInfo.GetValue(analyzer, CalculateDescriptorsInfo);
-
-        private DiagnosticDescriptorsInfo CalculateDescriptorsInfo(DiagnosticAnalyzer analyzer)
-        {
-            ImmutableArray<DiagnosticDescriptor> descriptors;
-            try
-            {
-                // SupportedDiagnostics is user code and can throw an exception.
-                descriptors = analyzer.SupportedDiagnostics.NullToEmpty();
-            }
-            catch
-            {
-                // No need to report the exception to the user.
-                // Eventually, when the analyzer runs the compiler analyzer driver will report a diagnostic.
-                descriptors = ImmutableArray<DiagnosticDescriptor>.Empty;
-            }
-
-            bool telemetryAllowed = IsTelemetryCollectionAllowed(analyzer, descriptors);
-            return new DiagnosticDescriptorsInfo(descriptors, telemetryAllowed);
-        }
-
-        private static bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer, ImmutableArray<DiagnosticDescriptor> descriptors)
-            => analyzer.IsCompilerAnalyzer() ||
-               analyzer is IBuiltInAnalyzer ||
-               descriptors.Length > 0 && descriptors[0].CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry);
-
-        /// <summary>
-        /// Return true if the given <paramref name="analyzer"/> is suppressed for the given project.
-        /// NOTE: This API is intended to be used only for performance optimization.
-        /// </summary>
-        public bool IsAnalyzerSuppressed(DiagnosticAnalyzer analyzer, Project project)
-        {
-            var options = project.CompilationOptions;
-            if (options == null || analyzer == FileContentLoadAnalyzer.Instance || analyzer.IsCompilerAnalyzer())
-            {
-                return false;
-            }
-
-            // If user has disabled analyzer execution for this project, we only want to execute required analyzers
-            // that report diagnostics with category "Compiler".
-            if (!project.State.RunAnalyzers &&
-                GetDiagnosticDescriptors(analyzer).All(d => d.Category != DiagnosticCategory.Compiler))
-            {
-                return true;
-            }
-
-            // NOTE: Previously we used to return "CompilationWithAnalyzers.IsDiagnosticAnalyzerSuppressed(options)"
-            //       on this code path, which returns true if analyzer is suppressed through compilation options.
-            //       However, this check is no longer correct as analyzers can be enabled/disabled for individual
-            //       documents through .editorconfig files. So we pessimistically assume analyzer is not suppressed
-            //       and let the core analyzer driver in the compiler layer handle skipping redundant analysis callbacks.
-            return false;
-        }
-    }
-
     internal sealed class HostDiagnosticAnalyzers
     {
         /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -21,6 +21,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         DiagnosticAnalyzerInfoCache AnalyzerInfoCache { get; }
 
         /// <summary>
+        /// Host analyzer collection.
+        /// </summary>
+        HostDiagnosticAnalyzers HostAnalyzers { get; }
+
+        /// <summary>
         /// Re-analyze given projects and documents
         /// </summary>
         void Reanalyze(Workspace workspace, IEnumerable<ProjectId>? projectIds = null, IEnumerable<DocumentId>? documentIds = null, bool highPriority = false);

--- a/src/Features/Core/Portable/Shared/Extensions/DiagnosticAnalyzerExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DiagnosticAnalyzerExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
@@ -19,6 +20,22 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 // It is not possible to know the categorization for a public analyzer, so return a worst-case categorization.
                 _ => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis
             };
+
+        public static bool SupportAnalysisKind(DiagnosticAnalyzer analyzer, AnalysisKind kind)
+        {
+            // compiler diagnostic analyzer always supports all kinds:
+            if (analyzer.IsCompilerAnalyzer())
+            {
+                return true;
+            }
+
+            return kind switch
+            {
+                AnalysisKind.Syntax => analyzer.SupportsSyntaxDiagnosticAnalysis(),
+                AnalysisKind.Semantic => analyzer.SupportsSemanticDiagnosticAnalysis(),
+                _ => throw ExceptionUtilities.UnexpectedValue(kind)
+            };
+        }
 
         public static bool SupportsSyntaxDiagnosticAnalysis(this DiagnosticAnalyzer analyzer)
         {

--- a/src/Features/Core/Portable/Shared/Extensions/DiagnosticAnalyzerExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DiagnosticAnalyzerExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 _ => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis
             };
 
-        public static bool SupportAnalysisKind(DiagnosticAnalyzer analyzer, AnalysisKind kind)
+        public static bool SupportAnalysisKind(this DiagnosticAnalyzer analyzer, AnalysisKind kind)
         {
             // compiler diagnostic analyzer always supports all kinds:
             if (analyzer.IsCompilerAnalyzer())

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -91,9 +91,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
         public IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy? hierarchy)
         {
+            var infoCache = _diagnosticService.AnalyzerInfoCache;
+            var hostAnalyzers = _diagnosticService.HostAnalyzers;
+
             if (hierarchy == null)
             {
-                return Transform(_diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference());
+                return Transform(hostAnalyzers.GetDiagnosticDescriptorsPerReference(infoCache));
             }
 
             // Analyzers are only supported for C# and VB currently.
@@ -106,11 +109,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 var project = projectsWithHierarchy.FirstOrDefault();
                 if (project == null)
                 {
-                    return Transform(_diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference());
+                    return Transform(hostAnalyzers.GetDiagnosticDescriptorsPerReference(infoCache));
                 }
                 else
                 {
-                    return Transform(_diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project));
+                    return Transform(hostAnalyzers.GetDiagnosticDescriptorsPerReference(infoCache, project));
                 }
             }
             else
@@ -120,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 var descriptorsMap = ImmutableDictionary.CreateBuilder<string, IEnumerable<DiagnosticDescriptor>>();
                 foreach (var project in projectsWithHierarchy)
                 {
-                    var descriptorsPerReference = _diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project);
+                    var descriptorsPerReference = hostAnalyzers.GetDiagnosticDescriptorsPerReference(infoCache, project);
                     foreach (var (displayName, descriptors) in descriptorsPerReference)
                     {
                         if (descriptorsMap.TryGetValue(displayName, out var existingDescriptors))

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             private readonly IAsynchronousOperationListener _listener;
             private readonly Workspace _workspace;
-            private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
+            private readonly HostDiagnosticAnalyzers _hostAnalyzers;
 
             private readonly object _gate;
 
@@ -44,14 +44,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 IThreadingContext threadingContext,
                 IAsynchronousOperationListener listener,
                 Workspace workspace,
-                DiagnosticAnalyzerInfoCache analyzerInfoCache)
+                HostDiagnosticAnalyzers hostAnalyzers)
                 : base(threadingContext)
             {
                 _gate = new object();
 
                 _listener = listener;
                 _workspace = workspace;
-                _analyzerInfoCache = analyzerInfoCache;
+                _hostAnalyzers = hostAnalyzers;
             }
 
             public Workspace Workspace => _workspace;
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     var snapshotService = _workspace.Services.GetRequiredService<IRemotableDataService>();
                     var assetBuilder = new CustomAssetBuilder(_workspace);
 
-                    foreach (var (_, reference) in _analyzerInfoCache.GetHostAnalyzerReferencesMap())
+                    foreach (var (_, reference) in _hostAnalyzers.GetHostAnalyzerReferencesMap())
                     {
                         var asset = assetBuilder.Build(reference, cancellationToken);
 
@@ -257,7 +257,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 {
                     var snapshotService = _workspace.Services.GetRequiredService<IRemotableDataService>();
 
-                    foreach (var (_, reference) in _analyzerInfoCache.GetHostAnalyzerReferencesMap())
+                    foreach (var (_, reference) in _hostAnalyzers.GetHostAnalyzerReferencesMap())
                     {
                         snapshotService.RemoveGlobalAsset(reference, CancellationToken.None);
                     }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
-            return new RemoteHostClientService(_threadingContext, _listener, workspaceServices.Workspace, _analyzerService.AnalyzerInfoCache);
+            return new RemoteHostClientService(_threadingContext, _listener, workspaceServices.Workspace, _analyzerService.HostAnalyzers);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -513,8 +513,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 // REVIEW: current design is that we special case compiler analyzer case and we accept only document level
                 //         diagnostic as live. otherwise, we let them be build errors. we changed compiler analyzer accordingly as well
                 //         so that it doesn't report project level diagnostic as live errors.
-                if (_owner._diagnosticService.AnalyzerInfoCache.IsCompilerDiagnostic(project.Language, diagnosticData) &&
-                    !IsDocumentLevelDiagnostic(diagnosticData))
+                if (!IsDocumentLevelDiagnostic(diagnosticData) &&
+                    diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Compiler))
                 {
                     // compiler error but project level error
                     return false;

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -425,7 +425,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
                     // set ids set
                     var builder = ImmutableHashSet.CreateBuilder<string>();
-                    var descriptorMap = _owner._diagnosticService.AnalyzerInfoCache.GetDiagnosticDescriptorsPerReference(project);
+                    var descriptorMap = _owner._diagnosticService.HostAnalyzers.GetDiagnosticDescriptorsPerReference(_owner._diagnosticService.AnalyzerInfoCache, project);
                     builder.UnionWith(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id)));
 
                     var set = builder.ToImmutable();
@@ -580,7 +580,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     var diagnosticService = _owner._diagnosticService;
                     var infoCache = diagnosticService.AnalyzerInfoCache;
 
-                    foreach (var analyzersPerReference in infoCache.CreateDiagnosticAnalyzersPerReference(project))
+                    foreach (var analyzersPerReference in diagnosticService.HostAnalyzers.CreateDiagnosticAnalyzersPerReference(project))
                     {
                         foreach (var analyzer in analyzersPerReference.Value)
                         {

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -265,8 +265,10 @@ End Class";
 
         private static DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner CreateAnalyzerRunner(Workspace workspace)
         {
-            var infoCache = new DiagnosticAnalyzerInfoCache(ImmutableArray<AnalyzerReference>.Empty);
-            return new DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner(AsynchronousOperationListenerProvider.NullListener, infoCache, hostDiagnosticUpdateSource: new MyUpdateSource(workspace));
+            return new DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner(
+                AsynchronousOperationListenerProvider.NullListener,
+                new DiagnosticAnalyzerInfoCache(),
+                hostDiagnosticUpdateSource: new MyUpdateSource(workspace));
         }
 
         private static async Task<DiagnosticAnalysisResult> AnalyzeAsync(TestWorkspace workspace, ProjectId projectId, Type analyzerType, CancellationToken cancellationToken = default)

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -816,10 +816,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                     analyzersMap As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticAnalyzer)),
                     registrationService As IDiagnosticUpdateSourceRegistrationService,
                     listener As IAsynchronousOperationListener)
-                MyBase.New(New DiagnosticAnalyzerInfoCache(ImmutableArray.Create(Of AnalyzerReference)(New TestAnalyzerReferenceByLanguage(analyzersMap))),
-                      hostDiagnosticUpdateSource:=Nothing,
-                      registrationService:=registrationService,
-                      listener:=listener)
+                MyBase.New(New DiagnosticAnalyzerInfoCache(),
+                           New HostDiagnosticAnalyzers(ImmutableArray.Create(Of AnalyzerReference)(New TestAnalyzerReferenceByLanguage(analyzersMap))),
+                           hostDiagnosticUpdateSource:=Nothing,
+                           registrationService:=registrationService,
+                           listener:=listener)
             End Sub
         End Class
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -435,11 +435,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
             Private ReadOnly _data As ImmutableArray(Of DiagnosticData)
             Private ReadOnly _analyzerInfoCache As DiagnosticAnalyzerInfoCache
+            Private ReadOnly _hostAnalyzers As HostDiagnosticAnalyzers
 
             Public Sub New(Optional data As ImmutableArray(Of DiagnosticData) = Nothing,
                            Optional analyzers As ImmutableArray(Of AnalyzerReference) = Nothing)
                 _data = data.NullToEmpty
-                _analyzerInfoCache = New DiagnosticAnalyzerInfoCache(analyzers.NullToEmpty)
+                _analyzerInfoCache = New DiagnosticAnalyzerInfoCache()
+                _hostAnalyzers = New HostDiagnosticAnalyzers(analyzers.NullToEmpty)
             End Sub
 
             Public ReadOnly Property SupportGetDiagnostics As Boolean Implements IDiagnosticUpdateSource.SupportGetDiagnostics
@@ -451,6 +453,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public ReadOnly Property AnalyzerInfoCache As DiagnosticAnalyzerInfoCache Implements IDiagnosticAnalyzerService.AnalyzerInfoCache
                 Get
                     Return _analyzerInfoCache
+                End Get
+            End Property
+
+            Public ReadOnly Property HostAnalyzers As HostDiagnosticAnalyzers Implements IDiagnosticAnalyzerService.HostAnalyzers
+                Get
+                    Return _hostAnalyzers
                 End Get
             End Property
 

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests.vb
@@ -54,11 +54,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim analyzerPackage = New HostDiagnosticAnalyzerPackage("MyPackage", ImmutableArray.Create(analyzerFile.Path))
                 Dim analyzerPackages = ImmutableArray.Create(analyzerPackage)
                 Dim analyzerLoader = VisualStudioDiagnosticAnalyzerProvider.GetLoader()
-                Dim hostAnalyzerManager = New DiagnosticAnalyzerInfoCache(New Lazy(Of ImmutableArray(Of HostDiagnosticAnalyzerPackage))(
-                                                                  Function() analyzerPackages), analyzerLoader,
-                                                                  hostDiagnosticUpdateSource:=Nothing,
-                                                                  primaryWorkspace:=Nothing)
-                Dim analyzerReferenceMap = hostAnalyzerManager.GetOrCreateHostDiagnosticAnalyzersPerReference(LanguageNames.CSharp)
+                Dim hostAnalyzers = New HostDiagnosticAnalyzers(New Lazy(Of ImmutableArray(Of HostDiagnosticAnalyzerPackage))(Function() analyzerPackages),
+                                                                analyzerLoader,
+                                                                hostDiagnosticUpdateSource:=Nothing,
+                                                                primaryWorkspace:=Nothing)
+                Dim analyzerReferenceMap = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(LanguageNames.CSharp)
                 Assert.Single(analyzerReferenceMap)
                 Dim analyzers = analyzerReferenceMap.Single().Value
                 Assert.Single(analyzers)

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
@@ -17,9 +17,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public CodeAnalysisService(Stream stream, IServiceProvider serviceProvider)
             : base(serviceProvider, stream)
         {
-            // TODO: currently we only use the cache for information that doesn't involve references or packages.
-            // Once we move all analysis OOP we will create the full cache.
-            _analyzerInfoCache = new DiagnosticAnalyzerInfoCache(ImmutableArray<AnalyzerReference>.Empty);
+            _analyzerInfoCache = new DiagnosticAnalyzerInfoCache();
 
             StartService();
         }


### PR DESCRIPTION
Part of the effort to move host analyzers to solution snapshot: #41127

This PR factors host analyzers out of `DiagnosticAnalyzerInfoCache` to a separate type. The data on this type will eventually be moved to the solution snapshot in some form.

Recommended review strategy - commit by commit.

