### PR TITLE
Properly generate 'nameof' expressions that bind correctly in the compiler

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeGeneration
+{
+    [UseExportProvider]
+    public class SyntaxGeneratorTests
+    {
+        [Fact]
+        public async Task TestNameOfBindsWithoutErrors()
+        {
+            var g = CSharpSyntaxGenerator.Instance;
+
+            using var workspace = TestWorkspace.CreateCSharp(@"
+class C
+{
+    string M()
+    {
+        return ""a"";
+    }
+}");
+
+            var solution = workspace.CurrentSolution;
+            var document = solution.Projects.Single().Documents.Single();
+            var root = await document.GetSyntaxRootAsync();
+
+            // validate that if we change `return "a";` to `return nameof(M);` that this binds
+            // without a problem.  We need to do special work in SyntaxGenerator.NameOfExpression to
+            // make this happen.
+            var statement = root.DescendantNodes().Single(n => n is ReturnStatementSyntax);
+            var replacement = g.ReturnStatement(g.NameOfExpression(g.IdentifierName("M")));
+
+            var newRoot = root.ReplaceNode(statement, replacement);
+            var newDocument = document.WithSyntaxRoot(newRoot);
+
+            var semanticModel = await newDocument.GetSemanticModelAsync();
+            var diagnostics = semanticModel.GetDiagnostics();
+
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -46,6 +47,50 @@ class C
             var diagnostics = semanticModel.GetDiagnostics();
 
             Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task TestNameOfBindsWithoutErrors_SpeculativeModel()
+        {
+            var g = CSharpSyntaxGenerator.Instance;
+
+            using var workspace = TestWorkspace.CreateCSharp(@"
+class C
+{
+    string M()
+    {
+        return ""a"";
+    }
+}");
+
+            var solution = workspace.CurrentSolution;
+            var document = solution.Projects.Single().Documents.Single();
+            var root = await document.GetSyntaxRootAsync();
+
+            // validate that if we change `return "a";` to `return nameof(M);` that this binds
+            // without a problem.  We need to do special work in SyntaxGenerator.NameOfExpression to
+            // make this happen.
+            var statement = root.DescendantNodes().Single(n => n is ReturnStatementSyntax);
+
+            var semanticModel = await document.GetSemanticModelAsync();
+            var diagnostics = semanticModel.GetDiagnostics();
+
+            Assert.Empty(diagnostics);
+
+            var replacement = (ReturnStatementSyntax)g.ReturnStatement(g.NameOfExpression(g.IdentifierName("M")));
+            Assert.True(semanticModel.TryGetSpeculativeSemanticModel(
+                statement.SpanStart, replacement,
+                out var speculativeModel));
+
+            // Make sure even in the speculative model that the compiler understands that this is a
+            // the special `nameof` construct.
+            var typeInfo = speculativeModel.GetTypeInfo(replacement.Expression);
+            Assert.Equal(SpecialType.System_String, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+
+            var constantValue = speculativeModel.GetConstantValue(replacement.Expression);
+            Assert.True(constantValue.HasValue);
+            Assert.Equal("M", constantValue.Value);
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private static readonly IdentifierNameSyntax s_nameOfIdentifier =
             SyntaxFactory.IdentifierName(SyntaxFactory.ParseToken("nameof"));
 
-
         [ImportingConstructor]
         public CSharpSyntaxGenerator()
         {

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -25,6 +25,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
     [ExportLanguageService(typeof(SyntaxGenerator), LanguageNames.CSharp), Shared]
     internal class CSharpSyntaxGenerator : SyntaxGenerator
     {
+        // A bit hacky, but we need to actually run ParseToken on the "nameof" text as there's no
+        // other way to get a token back that has the appropriate internal bit set that indicates
+        // this has the .ContextualKind of SyntaxKind.NameOfKeyword.
+        private static readonly IdentifierNameSyntax s_nameOfIdentifier =
+            SyntaxFactory.IdentifierName(SyntaxFactory.ParseToken("nameof"));
+
+
         [ImportingConstructor]
         public CSharpSyntaxGenerator()
         {
@@ -3200,13 +3207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode NameOfExpression(SyntaxNode expression)
-        {
-            // A bit hacky, but we need to actually run ParseToken on the "nameof" text as there's
-            // no other way to get a token back that has the appropriate internal bit set that indicates
-            // this has the .ContextualKind of SyntaxKind.NameOfKeyword.
-            var nameofToken = SyntaxFactory.ParseToken("nameof");
-            return this.InvocationExpression(this.IdentifierName(nameofToken), expression);
-        }
+            => this.InvocationExpression(s_nameOfIdentifier, expression);
 
         public override SyntaxNode ReturnStatement(SyntaxNode expressionOpt = null)
             => SyntaxFactory.ReturnStatement((ExpressionSyntax)expressionOpt);

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3201,9 +3201,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode NameOfExpression(SyntaxNode expression)
         {
-            return this.InvocationExpression(
-                this.IdentifierName(CSharp.SyntaxFacts.GetText(SyntaxKind.NameOfKeyword)),
-                expression);
+            // A bit hacky, but we need to actually run ParseToken on the "nameof" text as there's
+            // no other way to get a token back that has the appropriate internal bit set that indicates
+            // this has the .ContextualKind of SyntaxKind.NameOfKeyword.
+            var nameofToken = SyntaxFactory.ParseToken("nameof");
+            return this.InvocationExpression(this.IdentifierName(nameofToken), expression);
         }
 
         public override SyntaxNode ReturnStatement(SyntaxNode expressionOpt = null)


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn/issues/24212