### PR TITLE
Ensure that all the NamingStyles applicable symbol kinds have an edit…

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Roslyn.Test.Utilities;
@@ -472,6 +473,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
             Assert.Equal("", namingStyle.Suffix);
             Assert.Equal("", namingStyle.WordSeparator);
             Assert.Equal(Capitalization.PascalCase, namingStyle.CapitalizationScheme);
+        }
+
+        [Fact]
+        public static void TestEditorConfigParseForApplicableSymbolKinds()
+        {
+            var symbolSpecifications = CreateDefaultSymbolSpecification();
+            foreach (var applicableSymbolKind in symbolSpecifications.ApplicableSymbolKindList)
+            {
+                var editorConfigString = EditorConfigNamingStyleParser.ToEditorConfigString(ImmutableArray.Create(applicableSymbolKind));
+                Assert.True(!string.IsNullOrEmpty(editorConfigString));
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
@@ -333,6 +333,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 case TypeKind.Delegate:
                     return "delegate";
 
+                case TypeKind.TypeParameter:
+                    return "type_parameter";
+
                 case null:
                     break;
 

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
@@ -333,6 +333,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 case TypeKind.Delegate:
                     return "delegate";
 
+                case TypeKind.Module:
+                    return "module";
+
+                case TypeKind.Pointer:
+                    return "pointer";
+
                 case TypeKind.TypeParameter:
                     return "type_parameter";
 

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
@@ -54,6 +54,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                     new SymbolKindOrTypeKind(TypeKind.Interface),
                     new SymbolKindOrTypeKind(TypeKind.Delegate),
                     new SymbolKindOrTypeKind(TypeKind.Enum),
+                    new SymbolKindOrTypeKind(TypeKind.Module),
+                    new SymbolKindOrTypeKind(TypeKind.Pointer),
                     new SymbolKindOrTypeKind(SymbolKind.Property),
                     new SymbolKindOrTypeKind(MethodKind.Ordinary),
                     new SymbolKindOrTypeKind(MethodKind.LocalFunction),

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
@@ -54,8 +54,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                     new SymbolKindOrTypeKind(TypeKind.Interface),
                     new SymbolKindOrTypeKind(TypeKind.Delegate),
                     new SymbolKindOrTypeKind(TypeKind.Enum),
-                    new SymbolKindOrTypeKind(TypeKind.Module),
-                    new SymbolKindOrTypeKind(TypeKind.Pointer),
                     new SymbolKindOrTypeKind(SymbolKind.Property),
                     new SymbolKindOrTypeKind(MethodKind.Ordinary),
                     new SymbolKindOrTypeKind(MethodKind.LocalFunction),


### PR DESCRIPTION
…orconfig string representation

Extracted from https://github.com/dotnet/roslyn/pull/42238/commits/efe41448bd9320d08cd38e6589e9e720bd67b391#r389220216