### PR TITLE
Only simplify interpolations when the alignment value is constant.

### DIFF
--- a/src/EditorFeatures/CSharpTest/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -688,5 +688,69 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SimplifyInterpolation
     }
 }");
         }
+
+        [Fact, WorkItem(42247, "https://github.com/dotnet/roslyn/issues/42247")]
+        public async Task OnConstantAlignment1()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+using System.Linq;
+
+public static class Sample
+{
+    public static void PrintRightAligned ( String[] strings )
+    {
+        const int maxLength = 1;
+
+        for ( var i = 0; i < strings.Length; i++ )
+        {
+            var str = strings[i];
+            Console.WriteLine ($""{i}.{str[||].PadRight(maxLength, ' ')}"");
+        }
+    }
+}",
+
+@"
+using System;
+using System.Linq;
+
+public static class Sample
+{
+    public static void PrintRightAligned ( String[] strings )
+    {
+        const int maxLength = 1;
+
+        for ( var i = 0; i < strings.Length; i++ )
+        {
+            var str = strings[i];
+            Console.WriteLine ($""{i}.{str,-maxLength}"");
+        }
+    }
+}");
+        }
+
+        [Fact, WorkItem(42247, "https://github.com/dotnet/roslyn/issues/42247")]
+        public async Task MissingOnNonConstantAlignment()
+        {
+            await TestMissingAsync(
+@"
+using System;
+using System.Linq;
+
+public static class Sample
+{
+    public static void PrintRightAligned ( String[] strings )
+    {
+        var maxLength = strings.Max(str => str.Length);
+
+        for ( var i = 0; i < strings.Length; i++ )
+        {
+            var str = strings[i];
+            Console.WriteLine ($""{i}.{str[||].PadRight(maxLength, ' ')}"");
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/SimplifyInterpolation/Helpers.cs
+++ b/src/Features/Core/Portable/SimplifyInterpolation/Helpers.cs
@@ -127,16 +127,20 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                         if (argCount == 1 ||
                             IsSpaceChar(invocation.Arguments[1]))
                         {
-                            var alignmentSyntax = invocation.Arguments[0].Value.Syntax;
+                            var alignmentOp = invocation.Arguments[0].Value;
+                            if (alignmentOp != null && alignmentOp.ConstantValue.HasValue)
+                            {
+                                var alignmentSyntax = alignmentOp.Syntax;
 
-                            unwrapped = invocation.Instance;
-                            alignment = alignmentSyntax as TExpressionSyntax;
-                            negate = targetName == nameof(string.PadRight);
+                                unwrapped = invocation.Instance;
+                                alignment = alignmentSyntax as TExpressionSyntax;
+                                negate = targetName == nameof(string.PadRight);
 
-                            unnecessarySpans.AddRange(invocation.Syntax.Span
-                                .Subtract(invocation.Instance.Syntax.FullSpan)
-                                .Subtract(alignmentSyntax.FullSpan));
-                            return;
+                                unnecessarySpans.AddRange(invocation.Syntax.Span
+                                    .Subtract(invocation.Instance.Syntax.FullSpan)
+                                    .Subtract(alignmentSyntax.FullSpan));
+                                return;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/42247