### PR TITLE
Track changed option keys in global option service so the serializabl…

### DIFF
--- a/src/EditorFeatures/TestUtilities/Extensions/SolutionExtensions.cs
+++ b/src/EditorFeatures/TestUtilities/Extensions/SolutionExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+{
+    public static class SolutionExtensions
+    {
+        public static Solution WithChangedOptionsFrom(this Solution solution, OptionSet optionSet)
+        {
+            var newOptions = solution.Options;
+            foreach (var option in optionSet.GetChangedOptions(solution.Options))
+            {
+                newOptions = newOptions.WithChangedOption(option, optionSet.GetOption(option));
+            }
+
+            return solution.WithOptions(newOptions);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -276,7 +276,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 var languages = ImmutableHashSet.Create(LanguageNames.CSharp);
                 var remoteWorkspace = new RemoteWorkspace(workspaceKind: "test");
                 var optionService = remoteWorkspace.Services.GetRequiredService<IOptionService>();
-                var options = new SerializableOptionSet(languages, optionService, ImmutableHashSet<IOption>.Empty, ImmutableDictionary<OptionKey, object>.Empty);
+                var options = new SerializableOptionSet(languages, optionService, ImmutableHashSet<IOption>.Empty, ImmutableDictionary<OptionKey, object>.Empty, ImmutableHashSet<OptionKey>.Empty);
 
                 // this shouldn't throw exception
                 remoteWorkspace.TryAddSolutionIfPossible(solutionInfo, workspaceVersion: 1, options, out var solution);

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.DesignerAttributes;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
@@ -39,6 +40,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 return (RemoteWorkspace)primaryWorkspace.Workspace;
             }
         }
+
+        private static Solution WithChangedOptionsFromRemoteWorkspace(Solution solution)
+            => solution.WithChangedOptionsFrom(RemoteWorkspace.Options);
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public void TestRemoteHostCreation()
@@ -74,6 +78,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
                 await UpdatePrimaryWorkspace(client, solution);
                 await VerifyAssetStorageAsync(client, solution);
+
+                solution = WithChangedOptionsFromRemoteWorkspace(solution);
 
                 Assert.Equal(
                     await solution.State.GetChecksumAsync(CancellationToken.None),
@@ -207,11 +213,15 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             // See "RemoteSupportedLanguages.IsSupported"
             Assert.Empty(RemoteWorkspace.CurrentSolution.Projects);
 
+            solution = WithChangedOptionsFromRemoteWorkspace(solution);
+
             Assert.NotEqual(
                 await solution.State.GetChecksumAsync(CancellationToken.None),
                 await RemoteWorkspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None));
 
             solution = solution.RemoveProject(solution.ProjectIds.Single());
+            solution = WithChangedOptionsFromRemoteWorkspace(solution);
+
             Assert.Equal(
                 await solution.State.GetChecksumAsync(CancellationToken.None),
                 await RemoteWorkspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None));
@@ -229,6 +239,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 // verify initial setup
                 await UpdatePrimaryWorkspace(client, solution);
                 await VerifyAssetStorageAsync(client, solution);
+
+                solution = WithChangedOptionsFromRemoteWorkspace(solution);
 
                 Assert.Equal(
                     await solution.State.GetChecksumAsync(CancellationToken.None),

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -513,7 +513,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var sessionId = 0;
             var storage = new AssetStorage();
             _ = new SimpleAssetSource(storage, map);
-            var remoteWorkspace = new RemoteWorkspace();
+            var remoteWorkspace = new RemoteWorkspace(applyStartupOptions: false);
 
             return new SolutionService(new AssetProvider(sessionId, storage, remoteWorkspace.Services.GetService<ISerializerService>()));
         }

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -211,7 +211,8 @@ namespace Microsoft.CodeAnalysis.Options
         {
             var serializableOptionKeys = GetRegisteredSerializableOptions(languages);
             var serializableOptionValues = GetSerializableOptionValues(serializableOptionKeys, languages);
-            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues, _changedOptionKeys);
+            var changedOptionsKeys = _changedOptionKeys.Where(key => serializableOptionKeys.Contains(key.Option)).ToImmutableHashSet();
+            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues, changedOptionsKeys);
         }
 
         private ImmutableDictionary<OptionKey, object?> GetSerializableOptionValues(ImmutableHashSet<IOption> optionKeys, ImmutableHashSet<string> languages)

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Options
         private ImmutableDictionary<string, (IOption? option, IEditorConfigStorageLocation2? storageLocation)> _visualBasicEditorConfigKeysToOptions = s_emptyEditorConfigKeysToOptions;
 
         private ImmutableDictionary<OptionKey, object?> _currentValues;
+        private ImmutableHashSet<OptionKey> _changedOptionKeys;
         private ImmutableArray<Workspace> _registeredWorkspaces;
 
         [ImportingConstructor]
@@ -51,6 +52,7 @@ namespace Microsoft.CodeAnalysis.Options
             _registeredWorkspaces = ImmutableArray<Workspace>.Empty;
 
             _currentValues = ImmutableDictionary.Create<OptionKey, object?>();
+            _changedOptionKeys = ImmutableHashSet<OptionKey>.Empty;
         }
 
         private static ImmutableDictionary<string, Lazy<ImmutableHashSet<IOption>>> CreateLazySerializableOptionsByLanguage(IEnumerable<Lazy<IOptionProvider, LanguageMetadata>> optionProviders)
@@ -209,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Options
         {
             var serializableOptionKeys = GetRegisteredSerializableOptions(languages);
             var serializableOptionValues = GetSerializableOptionValues(serializableOptionKeys, languages);
-            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues);
+            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues, _changedOptionKeys);
         }
 
         private ImmutableDictionary<OptionKey, object?> GetSerializableOptionValues(ImmutableHashSet<IOption> optionKeys, ImmutableHashSet<string> languages)
@@ -282,6 +284,12 @@ namespace Microsoft.CodeAnalysis.Options
             return value;
         }
 
+        private void SetOptionCore(OptionKey optionKey, object? newValue)
+        {
+            _currentValues = _currentValues.SetItem(optionKey, newValue);
+            _changedOptionKeys = _changedOptionKeys.Add(optionKey);
+        }
+
         public void SetOptions(OptionSet optionSet)
         {
             var changedOptionKeys = optionSet switch
@@ -309,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Options
                     // The value is actually changing, so update
                     changedOptions.Add(new OptionChangedEventArgs(optionKey, setValue));
 
-                    _currentValues = _currentValues.SetItem(optionKey, setValue);
+                    SetOptionCore(optionKey, setValue);
 
                     foreach (var serializer in _optionSerializers)
                     {
@@ -338,7 +346,7 @@ namespace Microsoft.CodeAnalysis.Options
                     }
                 }
 
-                _currentValues = _currentValues.SetItem(optionKey, newValue);
+                SetOptionCore(optionKey, newValue);
             }
 
             UpdateRegisteredWorkspacesAndRaiseEvents(new List<OptionChangedEventArgs> { new OptionChangedEventArgs(optionKey, newValue) });

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -70,8 +70,9 @@ namespace Microsoft.CodeAnalysis.Options
             ImmutableHashSet<string> languages,
             IOptionService optionService,
             ImmutableHashSet<IOption> serializableOptions,
-            ImmutableDictionary<OptionKey, object?> values)
-            : this(languages, new WorkspaceOptionSet(optionService), serializableOptions, values, changedOptionKeys: ImmutableHashSet<OptionKey>.Empty)
+            ImmutableDictionary<OptionKey, object?> values,
+            ImmutableHashSet<OptionKey> changedOptionKeys)
+            : this(languages, new WorkspaceOptionSet(optionService), serializableOptions, values, changedOptionKeys)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -87,7 +87,9 @@ namespace Microsoft.CodeAnalysis
 
             // initialize with empty solution
             var info = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Create());
-            var emptyOptions = new SerializableOptionSet(languages: ImmutableHashSet<string>.Empty, _optionService, serializableOptions: ImmutableHashSet<IOption>.Empty, values: ImmutableDictionary<OptionKey, object?>.Empty);
+            var emptyOptions = new SerializableOptionSet(languages: ImmutableHashSet<string>.Empty, _optionService,
+                serializableOptions: ImmutableHashSet<IOption>.Empty, values: ImmutableDictionary<OptionKey, object?>.Empty,
+                changedOptionKeys: ImmutableHashSet<OptionKey>.Empty);
             _latestSolution = CreateSolution(info, emptyOptions);
 
             _optionService.RegisterDocumentOptionsProvider(EditorConfigDocumentOptionsProviderFactory.Create(this));

--- a/src/Workspaces/CoreTest/Host/WorkspaceServices/TestOptionService.cs
+++ b/src/Workspaces/CoreTest/Host/WorkspaceServices/TestOptionService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -14,13 +16,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     internal static class TestOptionService
     {
-        public static OptionServiceFactory.OptionService GetService()
+        public static OptionServiceFactory.OptionService GetService(IOptionProvider? optionProvider = null)
         {
             var features = new Dictionary<string, object>();
             features.Add("Features", new List<string>(new[] { "Test Features" }));
             return new OptionServiceFactory.OptionService(new GlobalOptionService(new[]
                 {
-                    new Lazy<IOptionProvider, LanguageMetadata>(() => new TestOptionsProvider(), new LanguageMetadata(LanguageNames.CSharp))
+                    new Lazy<IOptionProvider, LanguageMetadata>(() => optionProvider ??= new TestOptionsProvider(), new LanguageMetadata(LanguageNames.CSharp))
                 },
                 Enumerable.Empty<Lazy<IOptionPersister>>()), workspaceServices: new AdhocWorkspace().Services);
         }

--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -29,6 +29,12 @@ namespace Microsoft.CodeAnalysis.Remote
         private int _currentRemoteWorkspaceVersion = -1;
 
         public RemoteWorkspace()
+            : this(applyStartupOptions: true)
+        {
+        }
+
+        // internal for testing purposes.
+        internal RemoteWorkspace(bool applyStartupOptions)
             : base(RoslynServices.HostServices, workspaceKind: WorkspaceKind.RemoteWorkspace)
         {
             var exportProvider = (IMefHostExportProvider)Services.HostServices;
@@ -37,7 +43,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
             RegisterDocumentOptionProviders(exportProvider.GetExports<IDocumentOptionsProviderFactory, OrderableMetadata>());
 
-            SetOptions(Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0));
+            if (applyStartupOptions)
+                SetOptions(Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0));
 
             _registrationService = Services.GetService<ISolutionCrawlerRegistrationService>();
             _registrationService?.Register(this);


### PR DESCRIPTION
…e option set in the solution snapshot always has up-to-date changed option keys. This ensures that subsequent attempts to apply this option set to a different workspace, say RemoteWorkspace, correctly apply the changed options.

Thanks @CyrusNajmabadi for finding this bug!