### PR TITLE
Reject object reference equality with new()

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -655,8 +655,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     resultSignature = signature;
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    bool leftDefault = left.IsLiteralDefaultOrTypelessNew();
-                    bool rightDefault = right.IsLiteralDefaultOrTypelessNew();
+                    bool leftDefault = left.IsLiteralDefault();
+                    bool rightDefault = right.IsLiteralDefault();
                     foundOperator = !isObjectEquality || BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, leftDefault, rightType, rightNull, rightDefault, ref useSiteDiagnostics);
                     diagnostics.Add(node, useSiteDiagnostics);
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedObjectCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedObjectCreationTests.cs
@@ -3548,9 +3548,20 @@ class C
 ";
 
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
-
-            CompileAndVerify(comp, expectedOutput: "0101");
+            comp.VerifyDiagnostics(
+                // (8,23): error CS0019: Operator '==' cannot be applied to operands of type 'C' and 'new()'
+                //         Console.Write(new C() == new() ? 1 : 0);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "new C() == new()").WithArguments("==", "C", "new()").WithLocation(8, 23),
+                // (9,23): error CS0019: Operator '!=' cannot be applied to operands of type 'C' and 'new()'
+                //         Console.Write(new C() != new() ? 1 : 0);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "new C() != new()").WithArguments("!=", "C", "new()").WithLocation(9, 23),
+                // (10,23): error CS0019: Operator '==' cannot be applied to operands of type 'new()' and 'C'
+                //         Console.Write(new() == new C() ? 1 : 0);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "new() == new C()").WithArguments("==", "new()", "C").WithLocation(10, 23),
+                // (11,23): error CS0019: Operator '!=' cannot be applied to operands of type 'new()' and 'C'
+                //         Console.Write(new() != new C() ? 1 : 0);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "new() != new C()").WithArguments("!=", "new()", "C").WithLocation(11, 23)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
Probably needs LDM sign-off, but the current behavior is most likely incorrect.

--

In `new C() == new()` where there's no user-defined implicit conversion for type `C`, we emit `new C() == new object()` due to object equality operator resolution.

The user might expect `new C()` to be inferred but we don't convert to the other operand's type, rather we infer `object` from object equality semantics.

In contrast, we do the same for `default` literals in a similar situation - inferring `object` - but since the resultant value would be `null` that's not much of an unexpected outcome.

I propose we reject such comparison to avoid this seemingly surprising behavior.

Note: In this PR, we still accept such code if there is a user-defined implicit conversion, it is possible that we want to reject it as well.