### PR TITLE
Fix the list of allowed modifiers in the C# syntax generator.

### DIFF
--- a/src/CodeStyle/Core/Analyzers/PublicAPI.Unshipped.txt
+++ b/src/CodeStyle/Core/Analyzers/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Equals(Microsoft.Co
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsAbstract.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsAsync.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsConst.get -> bool
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsExtern.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsNew.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsOverride.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsPartial.get -> bool
@@ -12,11 +13,13 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsSealed.get -> boo
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsStatic.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsUnsafe.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsVirtual.get -> bool
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsVolatile.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsWithEvents.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsWriteOnly.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithAsync(bool isAsync) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsAbstract(bool isAbstract) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsConst(bool isConst) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsExtern(bool isExtern) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsNew(bool isNew) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsOverride(bool isOverride) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsReadOnly(bool isReadOnly) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
@@ -25,6 +28,7 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsSealed(bool i
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsStatic(bool isStatic) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsUnsafe(bool isUnsafe) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsVirtual(bool isVirtual) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsWriteOnly(bool isWriteOnly) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithPartial(bool isPartial) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithWithEvents(bool withEvents) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
@@ -43,6 +47,7 @@ override Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.ToString()
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Abstract.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Async.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Const.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Extern.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.From(Microsoft.CodeAnalysis.ISymbol symbol) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.New.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.None.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
@@ -55,6 +60,7 @@ static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Static.get -
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers modifiers) -> bool
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Unsafe.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Virtual.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Volatile.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithEvents.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WriteOnly.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.operator !=(Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers left, Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers right) -> bool

--- a/src/EditorFeatures/CSharpTest/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
@@ -374,5 +374,47 @@ class C1 { }",
                 },
             }.RunAsync();
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)]
+        public async Task TestExternMethod()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+using System;
+using System.Runtime.InteropServices;
+
+internal class Program
+{
+    [DllImport(""User32.dll"", CharSet = CharSet.Unicode)]
+    static extern int [|MessageBox|](IntPtr h, string m, string c, int type);
+}
+",
+@"
+using System;
+using System.Runtime.InteropServices;
+
+internal class Program
+{
+    [DllImport(""User32.dll"", CharSet = CharSet.Unicode)]
+    private static extern int [|MessageBox|](IntPtr h, string m, string c, int type);
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)]
+        public async Task TestVolatile()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+internal class Program
+{
+    volatile int [|x|];
+}
+",
+@"
+internal class Program
+{
+    private volatile int x;
+}
+");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1404,16 +1404,87 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             });
         }
 
-        private static readonly DeclarationModifiers s_fieldModifiers = DeclarationModifiers.Const | DeclarationModifiers.New | DeclarationModifiers.ReadOnly | DeclarationModifiers.Static | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_methodModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.Async | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_constructorModifiers = DeclarationModifiers.Static | DeclarationModifiers.Unsafe;
+        private static readonly DeclarationModifiers s_fieldModifiers =
+            DeclarationModifiers.Const |
+            DeclarationModifiers.New |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Unsafe |
+            DeclarationModifiers.Volatile;
+
+        private static readonly DeclarationModifiers s_methodModifiers =
+            DeclarationModifiers.Abstract |
+            DeclarationModifiers.Async |
+            DeclarationModifiers.Extern |
+            DeclarationModifiers.New |
+            DeclarationModifiers.Override |
+            DeclarationModifiers.Partial |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Sealed |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Virtual |
+            DeclarationModifiers.Unsafe;
+
+        private static readonly DeclarationModifiers s_constructorModifiers =
+            DeclarationModifiers.Extern |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Unsafe;
+
         private static readonly DeclarationModifiers s_destructorModifiers = DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_propertyModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.ReadOnly | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_eventModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_eventFieldModifiers = DeclarationModifiers.New | DeclarationModifiers.Static | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_indexerModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.ReadOnly | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_classModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Unsafe;
-        private static readonly DeclarationModifiers s_structModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial | DeclarationModifiers.ReadOnly | DeclarationModifiers.Ref | DeclarationModifiers.Unsafe;
+        private static readonly DeclarationModifiers s_propertyModifiers =
+            DeclarationModifiers.Abstract |
+            DeclarationModifiers.Extern |
+            DeclarationModifiers.New |
+            DeclarationModifiers.Override |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Sealed |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Virtual |
+            DeclarationModifiers.Unsafe;
+
+        private static readonly DeclarationModifiers s_eventModifiers =
+            DeclarationModifiers.Abstract |
+            DeclarationModifiers.Extern |
+            DeclarationModifiers.New |
+            DeclarationModifiers.Override |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Sealed |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Virtual |
+            DeclarationModifiers.Unsafe;
+
+        private static readonly DeclarationModifiers s_eventFieldModifiers =
+            DeclarationModifiers.New |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Unsafe;
+
+        private static readonly DeclarationModifiers s_indexerModifiers =
+            DeclarationModifiers.Abstract |
+            DeclarationModifiers.Extern |
+            DeclarationModifiers.New |
+            DeclarationModifiers.Override |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Sealed |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Virtual |
+            DeclarationModifiers.Unsafe;
+
+        private static readonly DeclarationModifiers s_classModifiers =
+            DeclarationModifiers.Abstract |
+            DeclarationModifiers.New |
+            DeclarationModifiers.Partial |
+            DeclarationModifiers.Sealed |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Unsafe;
+
+        private static readonly DeclarationModifiers s_structModifiers =
+            DeclarationModifiers.New |
+            DeclarationModifiers.Partial |
+            DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Ref |
+            DeclarationModifiers.Unsafe;
+
         private static readonly DeclarationModifiers s_interfaceModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial | DeclarationModifiers.Unsafe;
         private static readonly DeclarationModifiers s_accessorModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Virtual;
         private static readonly DeclarationModifiers s_localFunctionModifiers = DeclarationModifiers.Async | DeclarationModifiers.Static;
@@ -1545,96 +1616,78 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private static SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers)
         {
-            var list = SyntaxFactory.TokenList();
+            using var _ = ArrayBuilder<SyntaxToken>.GetInstance(out var list);
 
             switch (accessibility)
             {
                 case Accessibility.Internal:
-                    list = list.Add(SyntaxFactory.Token(SyntaxKind.InternalKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.InternalKeyword));
                     break;
                 case Accessibility.Public:
-                    list = list.Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
                     break;
                 case Accessibility.Private:
-                    list = list.Add(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
                     break;
                 case Accessibility.Protected:
-                    list = list.Add(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
                     break;
                 case Accessibility.ProtectedOrInternal:
-                    list = list.Add(SyntaxFactory.Token(SyntaxKind.InternalKeyword))
-                               .Add(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.InternalKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
                     break;
                 case Accessibility.ProtectedAndInternal:
-                    list = list.Add(SyntaxFactory.Token(SyntaxKind.PrivateKeyword))
-                               .Add(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+                    list.Add(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
                     break;
                 case Accessibility.NotApplicable:
                     break;
             }
 
             if (modifiers.IsAbstract)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
 
             if (modifiers.IsNew)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.NewKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.NewKeyword));
 
             if (modifiers.IsSealed)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.SealedKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.SealedKeyword));
 
             if (modifiers.IsOverride)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword));
 
             if (modifiers.IsVirtual)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.VirtualKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.VirtualKeyword));
 
             if (modifiers.IsStatic)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
 
             if (modifiers.IsAsync)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.AsyncKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.AsyncKeyword));
 
             if (modifiers.IsConst)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.ConstKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.ConstKeyword));
 
             if (modifiers.IsReadOnly)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
 
             if (modifiers.IsUnsafe)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.UnsafeKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.UnsafeKeyword));
+
+            if (modifiers.IsVolatile)
+                list.Add(SyntaxFactory.Token(SyntaxKind.VolatileKeyword));
+
+            if (modifiers.IsExtern)
+                list.Add(SyntaxFactory.Token(SyntaxKind.ExternKeyword));
 
             // partial and ref must be last
             if (modifiers.IsRef)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.RefKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.RefKeyword));
 
             if (modifiers.IsPartial)
-            {
-                list = list.Add(SyntaxFactory.Token(SyntaxKind.PartialKeyword));
-            }
+                list.Add(SyntaxFactory.Token(SyntaxKind.PartialKeyword));
 
-            return list;
+            return SyntaxFactory.TokenList(list);
         }
 
         private static void GetAccessibilityAndModifiers(SyntaxTokenList modifierList, out Accessibility accessibility, out DeclarationModifiers modifiers)
@@ -1675,6 +1728,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     SyntaxKind.UnsafeKeyword => DeclarationModifiers.Unsafe,
                     SyntaxKind.PartialKeyword => DeclarationModifiers.Partial,
                     SyntaxKind.RefKeyword => DeclarationModifiers.Ref,
+                    SyntaxKind.VolatileKeyword => DeclarationModifiers.Volatile,
+                    SyntaxKind.ExternKeyword => DeclarationModifiers.Extern,
                     _ => DeclarationModifiers.None,
                 };
             }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1487,7 +1487,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private static readonly DeclarationModifiers s_interfaceModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial | DeclarationModifiers.Unsafe;
         private static readonly DeclarationModifiers s_accessorModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Virtual;
-        private static readonly DeclarationModifiers s_localFunctionModifiers = DeclarationModifiers.Async | DeclarationModifiers.Static;
+
+        private static readonly DeclarationModifiers s_localFunctionModifiers =
+            DeclarationModifiers.Async |
+            DeclarationModifiers.Static |
+            DeclarationModifiers.Extern;
 
         private static DeclarationModifiers GetAllowedModifiers(SyntaxKind kind)
         {

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2219,7 +2219,7 @@ public class C
                 Generator.GetModifiers(Generator.WithModifiers(SyntaxFactory.DestructorDeclaration("c"), allModifiers)));
 
             Assert.Equal(
-                DeclarationModifiers.Abstract | DeclarationModifiers.Async | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe,
+                DeclarationModifiers.Abstract | DeclarationModifiers.Async | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe | DeclarationModifiers.ReadOnly,
                 Generator.GetModifiers(Generator.WithModifiers(Generator.MethodDeclaration("m"), allModifiers)));
 
             Assert.Equal(
@@ -2231,11 +2231,11 @@ public class C
                 Generator.GetModifiers(Generator.WithModifiers(Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("i") }, Generator.IdentifierName("t")), allModifiers)));
 
             Assert.Equal(
-                DeclarationModifiers.New | DeclarationModifiers.Static | DeclarationModifiers.Unsafe,
+                DeclarationModifiers.New | DeclarationModifiers.Static | DeclarationModifiers.Unsafe | DeclarationModifiers.ReadOnly,
                 Generator.GetModifiers(Generator.WithModifiers(Generator.EventDeclaration("ef", Generator.IdentifierName("t")), allModifiers)));
 
             Assert.Equal(
-                DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe,
+                DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe | DeclarationModifiers.ReadOnly,
                 Generator.GetModifiers(Generator.WithModifiers(Generator.CustomEventDeclaration("ep", Generator.IdentifierName("t")), allModifiers)));
 
             Assert.Equal(

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -65,14 +65,14 @@ namespace Microsoft.CodeAnalysis.Editing
             return new DeclarationModifiers(
                 isStatic: symbol.IsStatic,
                 isAbstract: symbol.IsAbstract,
-                ////isNew: (property != null && property.OverriddenProperty == null) || (method != null && method.OverriddenMethod == null),
-                isReadOnly: (field != null && field.IsReadOnly) || (property != null && property.IsReadOnly),
+                isReadOnly: field?.IsReadOnly == true || property?.IsReadOnly == true,
                 isVirtual: symbol.IsVirtual,
                 isOverride: symbol.IsOverride,
                 isSealed: symbol.IsSealed,
                 isConst: field != null && field.IsConst,
                 isUnsafe: symbol.IsUnsafe(),
-                isVolatile: field != null && field.IsVolatile);
+                isVolatile: field != null && field.IsVolatile,
+                isExtern: symbol.IsExtern);
         }
 
         public bool IsStatic => (_modifiers & Modifiers.Static) != 0;

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -35,7 +35,9 @@ namespace Microsoft.CodeAnalysis.Editing
             bool isPartial = false,
             bool isAsync = false,
             bool isWriteOnly = false,
-            bool isRef = false)
+            bool isRef = false,
+            bool isVolatile = false,
+            bool isExtern = false)
             : this(
                   (isStatic ? Modifiers.Static : Modifiers.None) |
                   (isAbstract ? Modifiers.Abstract : Modifiers.None) |
@@ -49,7 +51,9 @@ namespace Microsoft.CodeAnalysis.Editing
                   (isWithEvents ? Modifiers.WithEvents : Modifiers.None) |
                   (isPartial ? Modifiers.Partial : Modifiers.None) |
                   (isAsync ? Modifiers.Async : Modifiers.None) |
-                  (isRef ? Modifiers.Ref : Modifiers.None))
+                  (isRef ? Modifiers.Ref : Modifiers.None) |
+                  (isVolatile ? Modifiers.Volatile : Modifiers.None) |
+                  (isExtern ? Modifiers.Extern : Modifiers.None))
         {
         }
 
@@ -57,7 +61,6 @@ namespace Microsoft.CodeAnalysis.Editing
         {
             var field = symbol as IFieldSymbol;
             var property = symbol as IPropertySymbol;
-            var method = symbol as IMethodSymbol;
 
             return new DeclarationModifiers(
                 isStatic: symbol.IsStatic,
@@ -68,7 +71,8 @@ namespace Microsoft.CodeAnalysis.Editing
                 isOverride: symbol.IsOverride,
                 isSealed: symbol.IsSealed,
                 isConst: field != null && field.IsConst,
-                isUnsafe: symbol.IsUnsafe());
+                isUnsafe: symbol.IsUnsafe(),
+                isVolatile: field.IsVolatile);
         }
 
         public bool IsStatic => (_modifiers & Modifiers.Static) != 0;
@@ -99,100 +103,84 @@ namespace Microsoft.CodeAnalysis.Editing
 
         public bool IsRef => (_modifiers & Modifiers.Ref) != 0;
 
+        public bool IsVolatile => (_modifiers & Modifiers.Volatile) != 0;
+
+        public bool IsExtern => (_modifiers & Modifiers.Extern) != 0;
+
         public DeclarationModifiers WithIsStatic(bool isStatic)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Static, isStatic));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Static, isStatic));
 
         public DeclarationModifiers WithIsAbstract(bool isAbstract)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Abstract, isAbstract));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Abstract, isAbstract));
 
         public DeclarationModifiers WithIsNew(bool isNew)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.New, isNew));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.New, isNew));
 
         public DeclarationModifiers WithIsUnsafe(bool isUnsafe)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Unsafe, isUnsafe));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Unsafe, isUnsafe));
 
         public DeclarationModifiers WithIsReadOnly(bool isReadOnly)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.ReadOnly, isReadOnly));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.ReadOnly, isReadOnly));
 
         public DeclarationModifiers WithIsVirtual(bool isVirtual)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Virtual, isVirtual));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Virtual, isVirtual));
 
         public DeclarationModifiers WithIsOverride(bool isOverride)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Override, isOverride));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Override, isOverride));
 
         public DeclarationModifiers WithIsSealed(bool isSealed)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Sealed, isSealed));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Sealed, isSealed));
 
         public DeclarationModifiers WithIsConst(bool isConst)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Const, isConst));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Const, isConst));
 
         public DeclarationModifiers WithWithEvents(bool withEvents)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.WithEvents, withEvents));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.WithEvents, withEvents));
 
         public DeclarationModifiers WithPartial(bool isPartial)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Partial, isPartial));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Partial, isPartial));
 
         [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Public API.")]
         public DeclarationModifiers WithAsync(bool isAsync)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Async, isAsync));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Async, isAsync));
 
         public DeclarationModifiers WithIsWriteOnly(bool isWriteOnly)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.WriteOnly, isWriteOnly));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.WriteOnly, isWriteOnly));
 
         public DeclarationModifiers WithIsRef(bool isRef)
-        {
-            return new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Ref, isRef));
-        }
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Ref, isRef));
+
+        public DeclarationModifiers WithIsVolatile(bool isVolatile)
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Volatile, isVolatile));
+
+        public DeclarationModifiers WithIsExtern(bool isExtern)
+            => new DeclarationModifiers(SetFlag(_modifiers, Modifiers.Extern, isExtern));
 
         private static Modifiers SetFlag(Modifiers existing, Modifiers modifier, bool isSet)
-        {
-            return isSet ? (existing | modifier) : (existing & ~modifier);
-        }
+            => isSet ? (existing | modifier) : (existing & ~modifier);
 
         [Flags]
         private enum Modifiers
         {
-            None = 0x0000,
-            Static = 0x0001,
-            Abstract = 0x0002,
-            New = 0x0004,
-            Unsafe = 0x0008,
-            ReadOnly = 0x0010,
-            Virtual = 0x0020,
-            Override = 0x0040,
-            Sealed = 0x0080,
-            Const = 0x0100,
-            WithEvents = 0x0200,
-            Partial = 0x0400,
-            Async = 0x0800,
-            WriteOnly = 0x1000,
-            Ref = 0x2000,
+#pragma warning disable format
+            None        = 0,
+            Static      = 1 << 0,
+            Abstract    = 1 << 1,
+            New         = 1 << 2,
+            Unsafe      = 1 << 3,
+            ReadOnly    = 1 << 4,
+            Virtual     = 1 << 5,
+            Override    = 1 << 6,
+            Sealed      = 1 << 7,
+            Const       = 1 << 8,
+            WithEvents  = 1 << 9,
+            Partial     = 1 << 10,
+            Async       = 1 << 11,
+            WriteOnly   = 1 << 12,
+            Ref         = 1 << 13,
+            Volatile    = 1 << 14,
+            Extern      = 1 << 15,
+#pragma warning restore format
         }
 
         public static DeclarationModifiers None => default;
@@ -211,56 +199,38 @@ namespace Microsoft.CodeAnalysis.Editing
         public static DeclarationModifiers Async => new DeclarationModifiers(Modifiers.Async);
         public static DeclarationModifiers WriteOnly => new DeclarationModifiers(Modifiers.WriteOnly);
         public static DeclarationModifiers Ref => new DeclarationModifiers(Modifiers.Ref);
+        public static DeclarationModifiers Volatile => new DeclarationModifiers(Modifiers.Volatile);
+        public static DeclarationModifiers Extern => new DeclarationModifiers(Modifiers.Extern);
 
         public static DeclarationModifiers operator |(DeclarationModifiers left, DeclarationModifiers right)
-        {
-            return new DeclarationModifiers(left._modifiers | right._modifiers);
-        }
+            => new DeclarationModifiers(left._modifiers | right._modifiers);
 
         public static DeclarationModifiers operator &(DeclarationModifiers left, DeclarationModifiers right)
-        {
-            return new DeclarationModifiers(left._modifiers & right._modifiers);
-        }
+            => new DeclarationModifiers(left._modifiers & right._modifiers);
 
         public static DeclarationModifiers operator +(DeclarationModifiers left, DeclarationModifiers right)
-        {
-            return new DeclarationModifiers(left._modifiers | right._modifiers);
-        }
+            => new DeclarationModifiers(left._modifiers | right._modifiers);
 
         public static DeclarationModifiers operator -(DeclarationModifiers left, DeclarationModifiers right)
-        {
-            return new DeclarationModifiers(left._modifiers & ~right._modifiers);
-        }
+            => new DeclarationModifiers(left._modifiers & ~right._modifiers);
 
         public bool Equals(DeclarationModifiers modifiers)
-        {
-            return _modifiers == modifiers._modifiers;
-        }
+            => _modifiers == modifiers._modifiers;
 
         public override bool Equals(object obj)
-        {
-            return obj is DeclarationModifiers && Equals((DeclarationModifiers)obj);
-        }
+            => obj is DeclarationModifiers mods && Equals(mods);
 
         public override int GetHashCode()
-        {
-            return (int)_modifiers;
-        }
+            => (int)_modifiers;
 
         public static bool operator ==(DeclarationModifiers left, DeclarationModifiers right)
-        {
-            return left._modifiers == right._modifiers;
-        }
+            => left._modifiers == right._modifiers;
 
         public static bool operator !=(DeclarationModifiers left, DeclarationModifiers right)
-        {
-            return left._modifiers != right._modifiers;
-        }
+            => left._modifiers != right._modifiers;
 
         public override string ToString()
-        {
-            return _modifiers.ToString();
-        }
+            => _modifiers.ToString();
 
         public static bool TryParse(string value, out DeclarationModifiers modifiers)
         {

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 isSealed: symbol.IsSealed,
                 isConst: field != null && field.IsConst,
                 isUnsafe: symbol.IsUnsafe(),
-                isVolatile: field.IsVolatile);
+                isVolatile: field != null && field.IsVolatile);
         }
 
         public bool IsStatic => (_modifiers & Modifiers.Static) != 0;

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsExtern.get -> bool
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsVolatile.get -> bool
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsExtern(bool isExtern) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ElementBindingExpression(params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Project.RemoveDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Project
 Microsoft.CodeAnalysis.Solution.RemoveAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution
@@ -6,3 +10,5 @@ Microsoft.CodeAnalysis.Solution.RemoveDocuments(System.Collections.Immutable.Imm
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ConditionalAccessExpression(Microsoft.CodeAnalysis.SyntaxNode expression, Microsoft.CodeAnalysis.SyntaxNode whenNotNull) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ElementBindingExpression(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.MemberBindingExpression(Microsoft.CodeAnalysis.SyntaxNode name) -> Microsoft.CodeAnalysis.SyntaxNode
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Extern.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Volatile.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/29561
Fixes https://github.com/dotnet/roslyn/issues/32423
Fixes https://github.com/dotnet/roslyn/issues/35881

Did an audit of the compiler and their calls to `MakeAndCheckXXXMemberModifiers` to see where we differed.