### PR TITLE
Update docs to make lifetimes clear

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -161,7 +161,10 @@ namespace Microsoft.CodeAnalysis
         /// Gets the <see cref="SyntaxTree" /> for this document asynchronously.
         /// </summary>
         /// <returns>
-        /// The returned syntax tree can be null if the <see cref="SupportsSyntaxTree"/> returns false.</returns>
+        /// The returned syntax tree can be <see langword="null"/> if the <see
+        /// cref="SupportsSyntaxTree"/> returns <see langword="false"/>. This function will return
+        /// the same value if called multiple times.
+        /// </returns>
         public Task<SyntaxTree?> GetSyntaxTreeAsync(CancellationToken cancellationToken = default)
         {
             // If the language doesn't support getting syntax trees for a document, then bail out immediately.
@@ -221,7 +224,9 @@ namespace Microsoft.CodeAnalysis
         /// Gets the root node of the syntax tree asynchronously.
         /// </summary>
         /// <returns>
-        /// The returned <see cref="SyntaxNode"/> will be null if <see cref="SupportsSyntaxTree"/> returns false.
+        /// The returned <see cref="SyntaxNode"/> will be <see langword="null"/> if <see
+        /// cref="SupportsSyntaxTree"/> returns <see langword="false"/>.  This function will return
+        /// the same value if called multiple times.
         /// </returns>
         public async Task<SyntaxNode?> GetSyntaxRootAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -265,7 +265,9 @@ namespace Microsoft.CodeAnalysis
         /// Gets the semantic model for this document asynchronously.
         /// </summary>
         /// <returns>
-        /// The returned <see cref="SemanticModel"/> may be null if <see cref="SupportsSemanticModel"/> returns false.
+        /// The returned <see cref="SemanticModel"/> may be <see langword="null"/> if <see
+        /// cref="SupportsSemanticModel"/> returns <see langword="false"/>. This function will
+        /// return the same value if called multiple times.
         /// </returns>
         public async Task<SemanticModel?> GetSemanticModelAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -331,7 +331,9 @@ namespace Microsoft.CodeAnalysis
         /// Get the <see cref="Compilation"/> for this project asynchronously.
         /// </summary>
         /// <returns>
-        /// Returns the produced <see cref="Compilation"/>, or <see langword="null"/> if the project language of this project doesn't support producing compilations.
+        /// Returns the produced <see cref="Compilation"/>, or <see langword="null"/> if <see
+        /// cref="SupportsCompilation"/> returns <see langword="false"/>. This function will
+        /// return the same value if called multiple times.
         /// </returns>
         public Task<Compilation?> GetCompilationAsync(CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/34562

That issue/discussion made it clear that we don't  doc our invariants about returning the same instances when calling these functions multiple times.  I thought about trying to describe the 'observably identical' semantics of the system we use.  But i felt  it was simpler to just tell people theycan depend on multiple callers getting the same instance. 