### PR TITLE
Add f1 support for 'nameof' keyword

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -244,6 +244,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         private bool TryGetTextForContextualKeyword(SyntaxToken token, out string text)
         {
+            if (token.Text == "nameof")
+            {
+                text = Keyword("nameof");
+                return true;
+            }
+
             if (token.IsContextualKeyword())
             {
                 switch (token.Kind())

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -562,5 +562,19 @@ class Program
     }
 }", "System.String");
         }
+
+        [WorkItem(36001, "https://github.com/dotnet/roslyn/issues/36001")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestNameof()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void goo()
+    {
+        var v = [||]nameof(goo);
+    }
+}", "nameof");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36001

I smoke tested this as well to make sure this goes to the right page.