### PR TITLE
Rename should be a no-op if the name is unchanged

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -690,6 +690,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             VerifyNotDismissed();
 
             // If the identifier was deleted (or didn't change at all) then cancel the operation.
+            // Note: an alternative approach would be for the work we're doing (like detecting
+            // conflicts) to quickly bail in the case of no change.  However, that involves deeper
+            // changes to the system and is less easy to validate that nothing happens.
+            //
+            // The only potential downside here would be if there was a language that wanted to
+            // still 'rename' even if the identifier went away (or was unchanged).  But that  isn't
+            // a case we're aware of, so it's fine to be opinionated here that we can quickly bail
+            // in these cases.
             if (this.ReplacementText == string.Empty ||
                 this.ReplacementText == _initialRenameText)
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -695,7 +695,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             // changes to the system and is less easy to validate that nothing happens.
             //
             // The only potential downside here would be if there was a language that wanted to
-            // still 'rename' even if the identifier went away (or was unchanged).  But that  isn't
+            // still 'rename' even if the identifier went away (or was unchanged).  But that isn't
             // a case we're aware of, so it's fine to be opinionated here that we can quickly bail
             // in these cases.
             if (this.ReplacementText == string.Empty ||

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -103,6 +103,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private readonly IInlineRenameInfo _renameInfo;
 
+        /// <summary>
+        /// The initial text being renamed.
+        /// </summary>
+        private readonly string _initialRenameText;
+
         public InlineRenameSession(
             IThreadingContext threadingContext,
             InlineRenameService renameService,
@@ -150,7 +155,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 ? workspace.Options.WithChangedOption(RenameOptions.RenameOverloads, true)
                 : workspace.Options;
 
-            this.ReplacementText = triggerSpan.GetText();
+            _initialRenameText = triggerSpan.GetText();
+            this.ReplacementText = _initialRenameText;
 
             _baseSolution = _triggerDocument.Project.Solution;
             this.UndoManager = workspace.Services.GetService<IInlineRenameUndoManager>();
@@ -674,14 +680,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         }
 
         public void Commit(bool previewChanges = false)
+            => CommitWorker(previewChanges);
+
+        /// <returns><see langword="true"/> if the rename operation was commited, <see
+        /// langword="false"/> otherwise</returns>
+        private bool CommitWorker(bool previewChanges)
         {
             AssertIsForeground();
             VerifyNotDismissed();
 
-            if (this.ReplacementText == string.Empty)
+            // If the identifier was deleted (or didn't change at all) then cancel the operation.
+            if (this.ReplacementText == string.Empty ||
+                this.ReplacementText == _initialRenameText)
             {
                 Cancel();
-                return;
+                return false;
             }
 
             previewChanges = previewChanges || OptionSet.GetOption(RenameOptions.PreviewChanges);
@@ -697,7 +710,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 LogRenameSession(RenameLogMessage.UserActionOutcome.Canceled | RenameLogMessage.UserActionOutcome.Committed, previewChanges);
                 Dismiss(rollbackTemporaryEdits: true);
                 EndRenameSession();
+
+                return false;
             }
+
+            return true;
         }
 
         private void EndRenameSession()
@@ -842,6 +859,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             return false;
+        }
+
+        internal TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
+
+        public struct TestAccessor
+        {
+            private readonly InlineRenameSession _inlineRenameSession;
+
+            public TestAccessor(InlineRenameSession inlineRenameSession)
+                => _inlineRenameSession = inlineRenameSession;
+
+            public bool CommitWorker(bool previewChanges)
+                => _inlineRenameSession.CommitWorker(previewChanges);
         }
     }
 }

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1869,7 +1869,7 @@ class [|$$Test1|]
             End Using
         End Sub
 
-        <WpfFact>
+        <WpfFact, WorkItem(36063, "https://github.com/dotnet/roslyn/issues/36063")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Async Function EditBackToOriginalNameThenCommit() As Task
             Using workspace = CreateWorkspaceWithWaiter(

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1896,8 +1896,8 @@ class [|$$Test1|]
                 textBuffer.Insert(caretPosition, "Bar")
                 textBuffer.Delete(New Span(caretPosition, "Bar".Length))
 
-                Dim comitted = session.GetTestAccessor().CommitWorker(previewChanges:=False)
-                Assert.False(comitted)
+                Dim committed = session.GetTestAccessor().CommitWorker(previewChanges:=False)
+                Assert.False(committed)
 
                 Await VerifyTagsAreCorrect(workspace, "Test1")
             End Using

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1868,5 +1868,39 @@ class [|$$Test1|]
                 VerifyFileName(workspace, "test1")
             End Using
         End Sub
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function EditBackToOriginalNameThenCommit() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                class [|$$Test1|]
+                                {
+                                    void Blah()
+                                    {
+                                        [|Test1|] f = new [|Test1|]();
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                ' Type a bit in the file
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "Bar")
+                textBuffer.Delete(New Span(caretPosition, "Bar".Length))
+
+                Dim comitted = session.GetTestAccessor().CommitWorker(previewChanges:=False)
+                Assert.False(comitted)
+
+                Await VerifyTagsAreCorrect(workspace, "Test1")
+            End Using
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36063