### PR TITLE
Keep parens around conditional exprs as they effect semantics.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3561,7 +3561,7 @@ class C
     {
         foreach (var t in types)
         {
-            var identity = t?.Something().First()?.ToArray();
+            var identity = (t?.Something().First())?.ToArray();
         }
 
         return null;
@@ -3627,7 +3627,7 @@ class C
     {
         foreach (var t in types)
         {
-            var identity = (t?.Something2())()?.Something().First()?.ToArray();
+            var identity = ((t?.Something2())()?.Something().First())?.ToArray();
         }
 
         return null;

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
-        public async Task TestMissingForConditionalAccess()
+        public async Task TestMissingForConditionalAccess1()
         {
             await TestMissingAsync(
 @"class C
@@ -521,6 +521,41 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
         var v = $$(s?.Length).ToString();
     }
 }", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(37046, "https://github.com/dotnet/roslyn/issues/37046")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForConditionalAccess2()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M(string s)
+    {
+        var v = $$(s?.Length)?.ToString();
+    }
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestForConditionalAccessNotInExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(string s)
+    {
+        var v = $$(s?.Length);
+    }
+}",
+
+@"class C
+{
+    void M(string s)
+    {
+        var v = s?.Length;
+    }
+}", options: RemoveAllUnnecessaryParentheses);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -84,12 +84,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
-            // Don't change (x?.Count).GetValueOrDefault() to x?.Count.GetValueOrDefault()
-            if (expression.IsKind(SyntaxKind.ConditionalAccessExpression) && parentExpression is MemberAccessExpressionSyntax)
-            {
-                return false;
-            }
-
             // Easy statement-level cases:
             //   var y = (x);           -> var y = x;
             //   var (y, z) = (x);      -> var (y, z) = x;
@@ -274,6 +268,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             // This syntax is only allowed since C# 7.2
             if (expression.IsKind(SyntaxKind.ConditionalExpression) &&
                 node.IsLeftSideOfAnyAssignExpression())
+            {
+                return false;
+            }
+
+            // Don't change (x?.Count)... to x?.Count...
+            //
+            // It very much changes the semantics to have code that always executed (outside the
+            // parenthesized expression) now only conditionally run depending on if 'x' is null or
+            // not.
+            if (expression.IsKind(SyntaxKind.ConditionalAccessExpression))
             {
                 return false;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/37046
Fixes https://github.com/dotnet/roslyn/issues/31585