### PR TITLE
Don't use System.HashCode if that type is not an accessible type.

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -2243,18 +2243,18 @@ namespace System { internal struct HashCode { } }
 struct S
 {
     int j;
-    
+
     public override bool Equals(object obj)
     {
         if (!(obj is S))
         {
             return false;
         }
-    
+
         var s = (S)obj;
         return j == s.j;
     }
-    
+
     public override int GetHashCode()
     {
         return 1424088837 + j.GetHashCode();

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -2227,6 +2227,43 @@ index: 1,
 parameters: CSharp6Implicit);
         }
 
+        [WorkItem(37297, "https://github.com/dotnet/roslyn/issues/37297")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestInternalSystemHashCode()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+namespace System { internal struct HashCode { } }
+struct S
+{
+    [|int j;|]
+}",
+@"using System.Collections.Generic;
+namespace System { internal struct HashCode { } }
+struct S
+{
+    int j;
+    
+    public override bool Equals(object obj)
+    {
+        if (!(obj is S))
+        {
+            return false;
+        }
+    
+        var s = (S)obj;
+        return j == s.j;
+    }
+    
+    public override int GetHashCode()
+    {
+        return 1424088837 + j.GetHashCode();
+    }
+}",
+index: 1,
+parameters: CSharp6Implicit);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public async Task TestGetHashCodeSystemHashCodeEightMembers()
         {

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -2229,37 +2229,111 @@ parameters: CSharp6Implicit);
 
         [WorkItem(37297, "https://github.com/dotnet/roslyn/issues/37297")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
-        public async Task TestInternalSystemHashCode()
+        public async Task TestPublicSystemHashCodeOtherProject()
         {
             await TestInRegularAndScript1Async(
-@"using System.Collections.Generic;
-namespace System { internal struct HashCode { } }
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P1"">
+        <Document>
+using System.Collections.Generic;
+namespace System { public struct HashCode { } }
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P2"">
+        <ProjectReference>P1</ProjectReference>
+        <Document>
 struct S
 {
     [|int j;|]
-}",
-@"using System.Collections.Generic;
-namespace System { internal struct HashCode { } }
+}
+        </Document>
+    </Project>
+</Workspace>",
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P1"">
+        <Document>
+using System.Collections.Generic;
+namespace System { public struct HashCode { } }
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P2"">
+        <ProjectReference>P1</ProjectReference>
+        <Document>
+using System;
+
 struct S
 {
     int j;
 
     public override bool Equals(object obj)
     {
-        if (!(obj is S))
-        {
-            return false;
+        return obj is S s &amp;&amp;
+               j == s.j;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(j);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>",
+index: 1,
+parameters: CSharp6Implicit);
         }
 
-        var s = (S)obj;
-        return j == s.j;
+        [WorkItem(37297, "https://github.com/dotnet/roslyn/issues/37297")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestInternalSystemHashCode()
+        {
+            await TestInRegularAndScript1Async(
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P1"">
+        <Document>
+using System.Collections.Generic;
+namespace System { internal struct HashCode { } }
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P2"">
+        <ProjectReference>P1</ProjectReference>
+        <Document>
+struct S
+{
+    [|int j;|]
+}
+        </Document>
+    </Project>
+</Workspace>",
+
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P1"">
+        <Document>
+using System.Collections.Generic;
+namespace System { internal struct HashCode { } }
+        </Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" Name=""P2"">
+        <ProjectReference>P1</ProjectReference>
+        <Document>
+struct S
+{
+    int j;
+
+    public override bool Equals(object obj)
+    {
+        return obj is S s &amp;&amp;
+               j == s.j;
     }
 
     public override int GetHashCode()
     {
         return 1424088837 + j.GetHashCode();
     }
-}",
+}
+        </Document>
+    </Project>
+</Workspace>",
 index: 1,
 parameters: CSharp6Implicit);
         }

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -147,6 +147,8 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         {
             // If we have access to System.HashCode, then just use that.
             var hashCodeType = compilation.GetTypeByMetadataName("System.HashCode");
+            if (hashCodeType != null && hashCodeType.DeclaredAccessibility != Accessibility.Public)
+                hashCodeType = null;
 
             var components = factory.GetGetHashCodeComponents(
                 compilation, namedType, members, justMemberReference: true);

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -145,9 +145,9 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             SyntaxGenerator factory, Compilation compilation,
             INamedTypeSymbol namedType, ImmutableArray<ISymbol> members)
         {
-            // If we have access to System.HashCode, then just use that.
+            // See if there's an accessible System.HashCode we can call into to do all the work.
             var hashCodeType = compilation.GetTypeByMetadataName("System.HashCode");
-            if (hashCodeType?.DeclaredAccessibility != Accessibility.Public)
+            if (hashCodeType != null && !hashCodeType.IsAccessibleWithin(namedType))
                 hashCodeType = null;
 
             var components = factory.GetGetHashCodeComponents(

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         {
             // If we have access to System.HashCode, then just use that.
             var hashCodeType = compilation.GetTypeByMetadataName("System.HashCode");
-            if (hashCodeType != null && hashCodeType.DeclaredAccessibility != Accessibility.Public)
+            if (hashCodeType?.DeclaredAccessibility != Accessibility.Public)
                 hashCodeType = null;
 
             var components = factory.GetGetHashCodeComponents(


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/37297