### PR TITLE
Fix official build YAML

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -49,7 +49,9 @@ stages:
       displayName: Tag PR validation build
       inputs:
         type: 'Build'
-        tags: 'PRValidationBuild'
+        tags: |
+          'PRValidationBuild'
+          'PRNumber:$(PRNumber)'
       condition: and(succeeded(), ne(variables['PRNumber'], 'default'))
 
     - task: PowerShell@2

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -43,7 +43,7 @@ stages:
       inputs:
         type: 'Build'
         tags: 'OfficialBuild'
-      condition: and(succeeded(), eq(variables['PRNumber'], 'default'))
+      condition: and(succeeded(), endsWith(variables['SourceBranchName'], '-vs-deps'), eq(variables['PRNumber'], 'default'))
           
     - task: tagBuildOrRelease@0
       displayName: Tag PR validation build


### PR DESCRIPTION
1. Add PRNumber as tag (so we can show which PR an insertion is validating https://github.com/dotnet/roslyn-tools/pull/743)
2. Don't tag build from non vs-deps branch as 'OfficialBuild'.

@JoeRobich 