### PR TITLE
Support parenthesized expressions in use-compound-operator.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseCompoundAssignment/UseCompoundAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCompoundAssignment/UseCompoundAssignmentTests.cs
@@ -770,15 +770,36 @@ public class C
 @"
 struct InsertionPoint
 {
-	int level;
-	
-	InsertionPoint Up()
-	{
-		return new InsertionPoint
+    int level;
+    
+    InsertionPoint Up()
+    {
+        return new InsertionPoint
         {
-			level [||]= level - 1,
-		};
-	}
+            level [||]= level - 1,
+        };
+    }
+}");
+        }
+
+        [WorkItem(38137, "https://github.com/dotnet/roslyn/issues/38137")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestParenthesizedExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M(int a)
+    {
+        a [||]= (a + 10);
+    }
+}",
+@"public class C
+{
+    void M(int a)
+    {
+        a += 10;
+    }
 }");
         }
     }

--- a/src/EditorFeatures/VisualBasicTest/UseCompoundAssignment/UseCompoundAssignmentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCompoundAssignment/UseCompoundAssignmentTests.vb
@@ -364,5 +364,37 @@ end class",
     end sub
 end class")
         End Function
+
+        <WorkItem(38137, "https://github.com/dotnet/roslyn/issues/38137")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)>
+        Public Async Function TestParenthesizedExpression() As Task
+            Await TestInRegularAndScriptAsync(
+"public class C
+    sub M(a as integer)
+        a [||]= (a + 10)
+    end sub
+end class",
+"public class C
+    sub M(a as integer)
+        a += 10
+    end sub
+end class")
+        End Function
+
+        <WorkItem(38137, "https://github.com/dotnet/roslyn/issues/38137")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)>
+        Public Async Function TestParenthesizedExpressionTrailingTrivia() As Task
+            Await TestInRegularAndScriptAsync(
+"public class C
+    sub M(a as integer)
+        a [||]= (a + 10) ' trailing
+    end sub
+end class",
+"public class C
+    sub M(a as integer)
+        a += 10 ' trailing
+    end sub
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentCodeFixProvider.cs
@@ -73,8 +73,11 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
                         syntaxFacts.GetPartsOfAssignmentExpressionOrStatement(currentAssignment,
                             out var leftOfAssign, out var equalsToken, out var rightOfAssign);
 
+                        while (syntaxFacts.IsParenthesizedExpression(rightOfAssign))
+                            rightOfAssign = syntaxFacts.Unparenthesize(rightOfAssign);
+
                         syntaxFacts.GetPartsOfBinaryExpression(rightOfAssign,
-                           out _, out var opToken, out var rightExpr);
+                            out _, out var opToken, out var rightExpr);
 
                         var assignmentOpKind = _binaryToAssignmentMap[syntaxKinds.Convert<TSyntaxKind>(rightOfAssign.RawKind)];
                         var compoundOperator = Token(_assignmentToTokenMap[assignmentOpKind]);

--- a/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -71,6 +71,8 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
             _syntaxFacts.GetPartsOfAssignmentExpressionOrStatement(assignment,
                 out var assignmentLeft, out var assignmentToken, out var assignmentRight);
 
+            assignmentRight = _syntaxFacts.WalkDownParentheses(assignmentRight);
+
             // has to be of the form:  a = b op c
             // op has to be a form we could convert into op=
             if (!(assignmentRight is TBinaryExpressionSyntax binaryExpression))


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38137