### PR TITLE
Support executing generate-compiler-code.ps1 on Linux using Powershell Core

### DIFF
--- a/eng/build-utils-win.ps1
+++ b/eng/build-utils-win.ps1
@@ -1,0 +1,32 @@
+
+# Collection of powershell build utility functions that we use across our scripts.
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+Add-Type -AssemblyName 'System.Drawing'
+Add-Type -AssemblyName 'System.Windows.Forms'
+function Capture-Screenshot($path) {
+  $width = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
+  $height = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
+
+  $bitmap = New-Object System.Drawing.Bitmap $width, $height
+  try {
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+      $graphics.CopyFromScreen( `
+        [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.X, `
+        [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Y, `
+        0, `
+        0, `
+        $bitmap.Size, `
+        [System.Drawing.CopyPixelOperation]::SourceCopy)
+    } finally {
+      $graphics.Dispose()
+    }
+
+    $bitmap.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
+  } finally {
+    $bitmap.Dispose()
+  }
+}

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -159,7 +159,20 @@ function Exec-Script([string]$script, [string]$scriptArgs = "") {
 
 # Ensure the proper .NET Core SDK is available. Returns the location to the dotnet.exe.
 function Ensure-DotnetSdk() {
-  return Join-Path (InitializeDotNetCli -install:$true) "dotnet.exe"
+  $dotnetInstallDir = (InitializeDotNetCli -install:$true)
+  $dotnetTestPath = Join-Path $dotnetInstallDir "dotnet.exe"
+  if (Test-Path -Path $dotnetTestPath)
+  {
+    return $dotnetTestPath
+  }
+
+  $dotnetTestPath = Join-Path $dotnetInstallDir "dotnet"
+  if (Test-Path -Path $dotnetTestPath)
+  {
+    return $dotnetTestPath
+  }
+
+  throw "Could not find dotnet executable in $dotnetInstallDir"
 }
 
 function Get-VersionCore([string]$name, [string]$versionFile) {
@@ -287,31 +300,4 @@ function Make-BootstrapBuild([switch]$force32 = $false) {
   Run-MSBuild $projectPath "/t:Clean" -logFileName "BootstrapClean"
 
   return $dir
-}
-
-Add-Type -AssemblyName 'System.Drawing'
-Add-Type -AssemblyName 'System.Windows.Forms'
-function Capture-Screenshot($path) {
-  $width = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
-  $height = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
-
-  $bitmap = New-Object System.Drawing.Bitmap $width, $height
-  try {
-    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
-    try {
-      $graphics.CopyFromScreen( `
-        [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.X, `
-        [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Y, `
-        0, `
-        0, `
-        $bitmap.Size, `
-        [System.Drawing.CopyPixelOperation]::SourceCopy)
-    } finally {
-      $graphics.Dispose()
-    }
-
-    $bitmap.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
-  } finally {
-    $bitmap.Dispose()
-  }
 }

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -161,14 +161,12 @@ function Exec-Script([string]$script, [string]$scriptArgs = "") {
 function Ensure-DotnetSdk() {
   $dotnetInstallDir = (InitializeDotNetCli -install:$true)
   $dotnetTestPath = Join-Path $dotnetInstallDir "dotnet.exe"
-  if (Test-Path -Path $dotnetTestPath)
-  {
+  if (Test-Path -Path $dotnetTestPath) {
     return $dotnetTestPath
   }
 
   $dotnetTestPath = Join-Path $dotnetInstallDir "dotnet"
-  if (Test-Path -Path $dotnetTestPath)
-  {
+  if (Test-Path -Path $dotnetTestPath) {
     return $dotnetTestPath
   }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -605,6 +605,11 @@ try {
 
   . (Join-Path $PSScriptRoot "build-utils.ps1")
 
+  if ($testVsi)
+  {
+    . (Join-Path $PSScriptRoot "build-utils-win.ps1")
+  }
+
   Push-Location $RepoRoot
 
   if ($ci) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -605,8 +605,7 @@ try {
 
   . (Join-Path $PSScriptRoot "build-utils.ps1")
 
-  if ($testVsi)
-  {
+  if ($testVsi) {
     . (Join-Path $PSScriptRoot "build-utils-win.ps1")
   }
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Program.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Program.cs
@@ -204,7 +204,7 @@ namespace CSharpSyntaxGenerator
             do
             {
                 length = text.Length;
-                text = text.Replace("{\r\n\r\n", "{\r\n");
+                text = text.Replace($"{{{Environment.NewLine}{Environment.NewLine}", $"{{{Environment.NewLine}");
             } while (text.Length != length);
 
             try


### PR DESCRIPTION
This requires ensuring that we find the correct `dotnet` executable, and not importing WinForms-specific dlls unless we're running integration tests.