### PR TITLE
fix ref returns in expression bodied local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3163,9 +3163,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder bodyBinder = this.GetBinder(expressionBody);
             Debug.Assert(bodyBinder != null);
 
-            RefKind refKind = RefKind.None;
-            ExpressionSyntax expressionSyntax = expressionBody.Expression.CheckAndUnwrapRefExpression(diagnostics, out refKind);
-            BindValueKind requiredValueKind = GetRequiredReturnValueKind(refKind);
+            ExpressionSyntax expressionSyntax = expressionBody.Expression.CheckAndUnwrapRefExpression(diagnostics, out var refKind);
+            BindValueKind requiredValueKind = bodyBinder.GetRequiredReturnValueKind(refKind);
             BoundExpression expression = bodyBinder.BindValue(expressionSyntax, diagnostics, requiredValueKind);
             expression = ValidateEscape(expression, Binder.ExternalScope, refKind != RefKind.None, diagnostics);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -327,12 +327,13 @@ class C {
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                    // (5,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
-                    //         ref int M1(in int i) => ref i;
-                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 37),
-                    // (6,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
-                    //         ref int M2(in int i) { return ref i; }
-                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(6, 43));
+                // (5,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                //         ref int M1(in int i) => ref i;
+                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 37),
+                // (6,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                //         ref int M2(in int i) { return ref i; }
+                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(6, 43)
+            );
         }
 
         [Fact, WorkItem(42259, "https://github.com/dotnet/roslyn/issues/42259")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -327,23 +327,23 @@ class C {
 }";
             CreateCompilation(source).VerifyDiagnostics(
                 // (4,17): warning CS8321: The local function 'M1' is declared but never used
-                    //         ref int M1(in int i) => ref i;
-                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M1").WithArguments("M1").WithLocation(4, 17),
-                    // (4,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
-                    //         ref int M1(in int i) => ref i;
-                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(4, 37),
-                    // (5,17): warning CS8321: The local function 'M2' is declared but never used
-                    //         ref int M2(in int i) { return ref i; }
-                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M2").WithArguments("M2").WithLocation(5, 17),
-                    // (5,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
-                    //         ref int M2(in int i) { return ref i; }
-                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 43),
-                    // (6,26): warning CS8321: The local function 'M3' is declared but never used
-                    //         ref readonly int M3(in int i) => ref i;
-                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M3").WithArguments("M3").WithLocation(6, 26),
-                    // (7,26): warning CS8321: The local function 'M4' is declared but never used
-                    //         ref readonly int M4(in int i) { return ref i; }
-                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M4").WithArguments("M4").WithLocation(7, 26)
+                //         ref int M1(in int i) => ref i;
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M1").WithArguments("M1").WithLocation(4, 17),
+                // (4,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                //         ref int M1(in int i) => ref i;
+                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(4, 37),
+                // (5,17): warning CS8321: The local function 'M2' is declared but never used
+                //         ref int M2(in int i) { return ref i; }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M2").WithArguments("M2").WithLocation(5, 17),
+                // (5,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                //         ref int M2(in int i) { return ref i; }
+                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 43),
+                // (6,26): warning CS8321: The local function 'M3' is declared but never used
+                //         ref readonly int M3(in int i) => ref i;
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M3").WithArguments("M3").WithLocation(6, 26),
+                // (7,26): warning CS8321: The local function 'M4' is declared but never used
+                //         ref readonly int M4(in int i) { return ref i; }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M4").WithArguments("M4").WithLocation(7, 26)
 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -313,6 +313,60 @@ class C
                 Diagnostic(ErrorCode.ERR_AssgReadonly, "_ro").WithLocation(15, 47));
         }
 
+        [Fact, WorkItem(42259, "https://github.com/dotnet/roslyn/issues/42259")]
+        public void RefReturnLocalFunction()
+        {
+            var source = @"
+class C {
+    static void M(){
+        ref int M1(in int i) => ref i;
+        ref int M2(in int i) { return ref i; }
+        ref readonly int M3(in int i) => ref i;
+        ref readonly int M4(in int i) { return ref i; }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (4,17): warning CS8321: The local function 'M1' is declared but never used
+                    //         ref int M1(in int i) => ref i;
+                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M1").WithArguments("M1").WithLocation(4, 17),
+                    // (4,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                    //         ref int M1(in int i) => ref i;
+                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(4, 37),
+                    // (5,17): warning CS8321: The local function 'M2' is declared but never used
+                    //         ref int M2(in int i) { return ref i; }
+                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M2").WithArguments("M2").WithLocation(5, 17),
+                    // (5,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                    //         ref int M2(in int i) { return ref i; }
+                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 43),
+                    // (6,26): warning CS8321: The local function 'M3' is declared but never used
+                    //         ref readonly int M3(in int i) => ref i;
+                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M3").WithArguments("M3").WithLocation(6, 26),
+                    // (7,26): warning CS8321: The local function 'M4' is declared but never used
+                    //         ref readonly int M4(in int i) { return ref i; }
+                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M4").WithArguments("M4").WithLocation(7, 26)
+);
+        }
+
+        [Fact, WorkItem(42259, "https://github.com/dotnet/roslyn/issues/42259")]
+        public void RefReadonlyReturnLocalFunction()
+        {
+            var source = @"
+class C {
+    ref int M(){
+        throw new System.Exception();
+        ref readonly int M1(in int i) => ref i;
+        ref readonly int M2(in int i) { return ref i; }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                    // (5,26): warning CS8321: The local function 'M1' is declared but never used
+                    //         ref readonly int M1(in int i) => ref i;
+                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M1").WithArguments("M1").WithLocation(5, 26),
+                    // (6,26): warning CS8321: The local function 'M2' is declared but never used
+                    //         ref readonly int M2(in int i) { return ref i; }
+                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M2").WithArguments("M2").WithLocation(6, 26));
+        }
+
         [Fact]
         public void ReadonlyFieldRefReassign()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -317,6 +317,7 @@ class C
         public void RefReturnLocalFunction()
         {
             var source = @"
+#pragma warning disable CS8321
 class C {
     static void M(){
         ref int M1(in int i) => ref i;
@@ -326,31 +327,19 @@ class C {
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (4,17): warning CS8321: The local function 'M1' is declared but never used
-                //         ref int M1(in int i) => ref i;
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M1").WithArguments("M1").WithLocation(4, 17),
-                // (4,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
-                //         ref int M1(in int i) => ref i;
-                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(4, 37),
-                // (5,17): warning CS8321: The local function 'M2' is declared but never used
-                //         ref int M2(in int i) { return ref i; }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M2").WithArguments("M2").WithLocation(5, 17),
-                // (5,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
-                //         ref int M2(in int i) { return ref i; }
-                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 43),
-                // (6,26): warning CS8321: The local function 'M3' is declared but never used
-                //         ref readonly int M3(in int i) => ref i;
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M3").WithArguments("M3").WithLocation(6, 26),
-                // (7,26): warning CS8321: The local function 'M4' is declared but never used
-                //         ref readonly int M4(in int i) { return ref i; }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M4").WithArguments("M4").WithLocation(7, 26)
-);
+                    // (5,37): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                    //         ref int M1(in int i) => ref i;
+                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(5, 37),
+                    // (6,43): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                    //         ref int M2(in int i) { return ref i; }
+                    Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "i").WithArguments("variable", "in int").WithLocation(6, 43));
         }
 
         [Fact, WorkItem(42259, "https://github.com/dotnet/roslyn/issues/42259")]
         public void RefReadonlyReturnLocalFunction()
         {
             var source = @"
+#pragma warning disable CS8321
 class C {
     ref int M(){
         throw new System.Exception();
@@ -358,13 +347,7 @@ class C {
         ref readonly int M2(in int i) { return ref i; }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics(
-                    // (5,26): warning CS8321: The local function 'M1' is declared but never used
-                    //         ref readonly int M1(in int i) => ref i;
-                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M1").WithArguments("M1").WithLocation(5, 26),
-                    // (6,26): warning CS8321: The local function 'M2' is declared but never used
-                    //         ref readonly int M2(in int i) { return ref i; }
-                    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M2").WithArguments("M2").WithLocation(6, 26));
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioManagedModuleUpdateProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioManagedModuleUpdateProvider.cs
@@ -17,6 +17,7 @@ using Roslyn.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 {
     [Export(typeof(IEditAndContinueManagedModuleUpdateProvider)), Shared]
+    [ExportMetadata("UIContext", Guids.EncCapableProjectExistsInWorkspaceUIContextString)]
     internal sealed class VisualStudioManagedModuleUpdateProvider : IEditAndContinueManagedModuleUpdateProvider
     {
         private readonly IEditAndContinueWorkspaceService _encService;


### PR DESCRIPTION
Fix #42259 caused by use of incorrect binder when checking ref return type.