### PR TITLE
Refactor to support initialization

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 class C { }
 ";
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
@@ -49,7 +49,7 @@ class C { }
 class C { }
 ";
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
@@ -71,7 +71,7 @@ class C { }
 class C { }
 ";
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
@@ -92,16 +92,15 @@ class C { }
 class C { }
 ";
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
 
             int initCount = 0, executeCount = 0;
-            var generator = new CallbackGenerator((ic) => initCount++, (sgc) => executeCount++);
-            var generator2 = new SingleFileTestGenerator("public class C { }");
+            var generator = new CallbackGenerator((ic) => initCount++, (sgc) => executeCount++, sourceOpt: "public class C { }");
 
-            GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(generator, generator2), ImmutableArray<AdditionalText>.Empty);
+            GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(generator), ImmutableArray<AdditionalText>.Empty);
             driver = driver.RunFullGeneration(compilation, out var outputCompilation);
             driver = driver.RunFullGeneration(outputCompilation, out outputCompilation);
             driver.RunFullGeneration(outputCompilation, out outputCompilation);
@@ -122,7 +121,7 @@ class GeneratedClass { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
@@ -148,7 +147,7 @@ class GeneratedClass { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
@@ -180,7 +179,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -202,7 +201,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -228,7 +227,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -258,7 +257,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -288,7 +287,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -333,7 +332,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -380,7 +379,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -412,7 +411,7 @@ class C { }
 ";
 
             var parseOptions = TestOptions.Regular;
-            Compilation compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
@@ -473,15 +472,23 @@ class C { }
     {
         private readonly Action<InitializationContext> _onInit;
         private readonly Action<SourceGeneratorContext> _onExecute;
+        private readonly string _sourceOpt;
 
-        public CallbackGenerator(Action<InitializationContext> onInit, Action<SourceGeneratorContext> onExecute)
+        public CallbackGenerator(Action<InitializationContext> onInit, Action<SourceGeneratorContext> onExecute, string sourceOpt = "")
         {
             _onInit = onInit;
             _onExecute = onExecute;
+            _sourceOpt = sourceOpt;
         }
 
-        public void Execute(SourceGeneratorContext context) => _onExecute(context);
-
+        public void Execute(SourceGeneratorContext context)
+        {
+            _onExecute(context);
+            if (!string.IsNullOrWhiteSpace(_sourceOpt))
+            {
+                context.AdditionalSources.Add("source.cs", SourceText.From(_sourceOpt, Encoding.UTF8));
+            }
+        }
         public void Initialize(InitializationContext context) => _onInit(context);
     }
 

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -345,7 +345,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
             Assert.Contains("Microsoft.CodeAnalysis.UnitTests.AnalyzerFileReferenceTests+TestGenerator", typeNames);
             Assert.Contains("Microsoft.CodeAnalysis.UnitTests.AnalyzerFileReferenceTests+SomeType+NestedGenerator", typeNames);
             Assert.Contains("Microsoft.CodeAnalysis.UnitTests.TestGenerator", typeNames);
-            Assert.Contains("Microsoft.CodeAnalysis.UnitTests.AdditionalGenerator", typeNames);
+            Assert.Contains("Microsoft.CodeAnalysis.UnitTests.BaseGenerator", typeNames);
             Assert.Contains("Microsoft.CodeAnalysis.UnitTests.SubClassedGenerator", typeNames);
             Assert.DoesNotContain("Microsoft.CodeAnalysis.UnitTests.TestGeneratorNoAttrib", typeNames);
             Assert.DoesNotContain("Microsoft.CodeAnalysis.UnitTests.Test.NotAGenerator", typeNames);
@@ -377,6 +377,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
         public class TestGenerator : ISourceGenerator
         {
             public void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
+            public void Initialize(InitializationContext context) => throw new NotImplementedException();
         }
 
         public class SomeType
@@ -392,6 +393,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
             public class NestedGenerator : ISourceGenerator
             {
                 public void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
+                public void Initialize(InitializationContext context) => throw new NotImplementedException();
             }
         }
     }
@@ -441,25 +443,26 @@ public class TestAnalyzer : DiagnosticAnalyzer
     public class TestGenerator : ISourceGenerator
     {
         public void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
+        public void Initialize(InitializationContext context) => throw new NotImplementedException();
     }
 
     public class TestGeneratorNoAttrib : ISourceGenerator
     {
         public void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
+        public void Initialize(InitializationContext context) => throw new NotImplementedException();
     }
 
     [Generator]
-    public class AdditionalGenerator : ITriggeredByAdditionalFileGenerator
+    public class BaseGenerator : ISourceGenerator
     {
-        public void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
-
-        public virtual bool UpdateContext(UpdateContext context, AdditionalFileEdit edit) => throw new NotImplementedException();
+        public virtual void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
+        public void Initialize(InitializationContext context) => throw new NotImplementedException();
     }
 
     [Generator]
-    public class SubClassedGenerator : AdditionalGenerator
+    public class SubClassedGenerator : BaseGenerator
     {
-        public override bool UpdateContext(UpdateContext context, AdditionalFileEdit edit) => base.UpdateContext(context, edit);
+        public override void Execute(SourceGeneratorContext context) => throw new NotImplementedException();
     }
 
     [Generator]

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -68,15 +68,14 @@ namespace Microsoft.CodeAnalysis
             //PROTOTYPE: should be possible to parallelize this
             foreach (var generator in state.Generators)
             {
+                // initialize the generator if needed
+                if (!state.GeneratorStates.TryGetValue(generator, out GeneratorState generatorState))
+                {
+                    generatorState = InitializeGenerator(generator, cancellationToken);
+                }
+
                 try
                 {
-                    // initialize the generator if needed
-                    GeneratorState generatorState;
-                    if (!state.GeneratorStates.TryGetValue(generator, out generatorState))
-                    {
-                        generatorState = InitializeGenerator(generator, cancellationToken);
-                    }
-
                     // we create a new context for each run of the generator. We'll never re-use existing state, only replace anything we have
                     var context = new SourceGeneratorContext(state.Compilation, new AnalyzerOptions(state.AdditionalTexts.NullToEmpty(), CompilerAnalyzerConfigOptionsProvider.Empty));
                     generator.Execute(context);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+namespace Microsoft.CodeAnalysis
+{
+    internal readonly struct GeneratorInfo
+    {
+        internal EditCallback<AdditionalFileEdit>? EditCallback { get; }
+
+        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback)
+        {
+            EditCallback = editCallback;
+        }
+
+        internal class Builder
+        {
+            internal EditCallback<AdditionalFileEdit>? EditCallback { get; set; }
+
+            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 using System.Collections.Immutable;
 
 #nullable enable

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+#nullable enable
+namespace Microsoft.CodeAnalysis
+{
+    internal readonly struct GeneratorState
+    {
+        public GeneratorState(GeneratorInfo info)
+            : this(info, ImmutableArray<GeneratedSourceText>.Empty)
+        {
+        }
+
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sources)
+        {
+            this.Sources = sources;
+            this.Info = info;
+        }
+
+        internal ImmutableArray<GeneratedSourceText> Sources { get; }
+
+        internal GeneratorInfo Info { get; }
+
+        internal GeneratorState WithSources(ImmutableArray<GeneratedSourceText> sources)
+        {
+            return new GeneratorState(this.Info, sources);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
@@ -15,13 +15,8 @@ namespace Microsoft.CodeAnalysis
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
     public interface ISourceGenerator
     {
+        void Initialize(InitializationContext context);
         void Execute(SourceGeneratorContext context);
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
-    public interface ITriggeredByAdditionalFileGenerator : ISourceGenerator
-    {
-        bool UpdateContext(UpdateContext context, AdditionalFileEdit edit);
     }
 }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/PendingEdit.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/PendingEdit.cs
@@ -13,14 +13,17 @@ using System.Text;
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    public delegate bool EditCallback<T>(EditContext context, T edit) where T : PendingEdit;
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
     public abstract class PendingEdit
     {
         internal abstract GeneratorDriverState Commit(GeneratorDriverState state);
 
-        internal abstract bool AcceptedBy(ISourceGenerator generator);
+        internal abstract bool AcceptedBy(GeneratorInfo info);
 
-        internal abstract bool TryApply(ISourceGenerator generator, UpdateContext context);
+        internal abstract bool TryApply(GeneratorInfo info, EditContext context);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
@@ -40,8 +43,8 @@ namespace Microsoft.CodeAnalysis
 
         internal override GeneratorDriverState Commit(GeneratorDriverState state) => state.With(additionalTexts: state.AdditionalTexts.Add(this.AddedText));
 
-        internal override bool AcceptedBy(ISourceGenerator generator) => generator is ITriggeredByAdditionalFileGenerator;
+        internal override bool AcceptedBy(GeneratorInfo info) => info.EditCallback is object;
 
-        internal override bool TryApply(ISourceGenerator generator, UpdateContext context) => ((ITriggeredByAdditionalFileGenerator)generator).UpdateContext(context, this);
+        internal override bool TryApply(GeneratorInfo info, EditContext context) => info.EditCallback!.Invoke(context, this);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -39,11 +39,27 @@ namespace Microsoft.CodeAnalysis
         public void ReportDiagnostic(Diagnostic diagnostic) { throw new NotImplementedException(); }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    public struct InitializationContext
+    {
+        internal InitializationContext(CancellationToken cancellationToken = default)
+        {
+            CancellationToken = cancellationToken;
+            InfoBuilder = new GeneratorInfo.Builder();
+        }
+
+        public CancellationToken CancellationToken { get; }
+
+        internal GeneratorInfo.Builder InfoBuilder { get; }
+
+        public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback) => InfoBuilder.EditCallback = callback;
+    }
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
     // PROTOTYPE: this is going to need to track the input and output compilations that occured
-    public readonly struct UpdateContext
+    public readonly struct EditContext
     {
-        internal UpdateContext(ImmutableArray<GeneratedSourceText> sources, CancellationToken cancellationToken = default)
+        internal EditContext(ImmutableArray<GeneratedSourceText> sources, CancellationToken cancellationToken = default)
         {
             AdditionalSources = new AdditionalSourcesCollection(sources);
             CancellationToken = cancellationToken;


### PR DESCRIPTION
This PR refactors source generators to support an initialization pass.

During the syntax aware work, it became clear that relying on interfaces was becoming increasingly verbose. This change instead allows generators to implement a single interface and register callbacks during initialization to enable more advanced functionality.

I don't particularly like the `GeneratorInfo` builder pattern with mutators on the `InitializatonContext`. I started playing around with a generic way of having edits register callbacks, but it started getting complicated and I wanted to unblock progress on the syntax aware generators. I suspect once we get above 3 or 4 edits we'll want to devise something more elegant, but this is all internal so we can stick with it for now.

Changes:

- Make the default source generator have an Initialize method
- Use that to register callbacks for functionality, rather than based on interfaces
- Add GeneratorState and Info structs that can be used to retain info about the generators
- Update tests