### PR TITLE
Fix using declaration crash with constants:

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1105,7 +1105,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     hasErrors = true;
                 }
             }
-            else if (kind == LocalDeclarationKind.Constant && initializerOpt != null && !localDiagnostics.HasAnyResolvedErrors())
+
+            if ((kind == LocalDeclarationKind.Constant || kind == LocalDeclarationKind.UsingVariable) && initializerOpt != null && !localDiagnostics.HasAnyResolvedErrors())
             {
                 var constantValueDiagnostics = localSymbol.GetConstantValueDiagnostics(initializerOpt);
                 foreach (var diagnostic in constantValueDiagnostics)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -216,7 +216,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (boundLocal.ConstantValue == ConstantValue.Null)
             {
                 //localSymbol will be declared by an enclosing block
-                return BoundBlock.SynthesizedNoLocals(usingSyntax, rewrittenDeclaration, tryBlock);
+
+                if (rewrittenDeclaration is null)
+                {
+                    // when the local declaration is constant, we end up with a null rewrittenDeclaration
+                    // (as it will be emitted at the use site rather than being declared here). As such
+                    // we can just emit the try block without any declaration.
+                    return BoundBlock.SynthesizedNoLocals(usingSyntax, tryBlock);
+                }
+                else
+                {
+                    return BoundBlock.SynthesizedNoLocals(usingSyntax, rewrittenDeclaration, tryBlock);
+                }
             }
 
             if (localType.IsDynamic())


### PR DESCRIPTION
- Correctly emit error when RHS is not constant for const declarations
- Don't try and emit the null declaration when it's constant valued
- Add tests to cover both cases

Fixes #42362