### PR TITLE
Enable brace matchers on client side.

### DIFF
--- a/src/EditorFeatures/CSharp/Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj
@@ -35,6 +35,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.DiagnosticsTests.Utilities" />
     <InternalsVisibleTo Include="Roslyn.Services.Test.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.LiveShare" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/EditorFeatures/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj
+++ b/src/EditorFeatures/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj
@@ -47,6 +47,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.UnitTests" />
     <InternalsVisibleTo Include="Roslyn.Services.Test.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.LiveShare" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="VBEditorResources.resx" GenerateSource="true" Namespace="Microsoft.CodeAnalysis.Editor.VisualBasic" />

--- a/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/CSharpRemoteBraceMatchers.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/CSharpRemoteBraceMatchers.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.LocalForwarders
+{
+    [ExportBraceMatcher(StringConstants.CSharpLspLanguageName)]
+    internal class CSharpRemoteOpenCloseBraceBraceMatcher : OpenCloseBraceBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public CSharpRemoteOpenCloseBraceBraceMatcher() : base()
+        {
+        }
+    }
+
+    [ExportBraceMatcher(StringConstants.CSharpLspLanguageName)]
+    internal class CSharpRemoteOpenCloseBracketBraceMatcher : OpenCloseBracketBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public CSharpRemoteOpenCloseBracketBraceMatcher() : base()
+        {
+        }
+    }
+
+    [ExportBraceMatcher(StringConstants.CSharpLspLanguageName)]
+    internal class CSharpRemoteOpenCloseParenBraceMatcher : OpenCloseParenBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public CSharpRemoteOpenCloseParenBraceMatcher() : base()
+        {
+        }
+    }
+
+    [ExportBraceMatcher(StringConstants.CSharpLspLanguageName)]
+    internal class CSharpRemoteLessThanGreaterThanBraceMatcher : LessThanGreaterThanBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public CSharpRemoteLessThanGreaterThanBraceMatcher() : base()
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/VBRemoteBraceMatchers.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/VBRemoteBraceMatchers.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.VisualBasic.BraceMatching;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.LocalForwarders
+{
+    [ExportBraceMatcher(StringConstants.VBLspLanguageName)]
+    internal class VBRemoteOpenCloseBraceBraceMatcher : OpenCloseBraceBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public VBRemoteOpenCloseBraceBraceMatcher() : base()
+        {
+        }
+    }
+
+    [ExportBraceMatcher(StringConstants.VBLspLanguageName)]
+    internal class VBRemoteOpenCloseParenBraceMatcher : OpenCloseParenBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public VBRemoteOpenCloseParenBraceMatcher() : base()
+        {
+        }
+    }
+
+    [ExportBraceMatcher(StringConstants.VBLspLanguageName)]
+    internal class VBRemoteLessThanGreaterThanBraceMatcher : LessThanGreaterThanBraceMatcher
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
+        public VBRemoteLessThanGreaterThanBraceMatcher() : base()
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/Microsoft.VisualStudio.LanguageServices.LiveShare.csproj
+++ b/src/VisualStudio/LiveShare/Impl/Microsoft.VisualStudio.LanguageServices.LiveShare.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
   
   <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\..\EditorFeatures\CSharp\Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj" />
     <ProjectReference Include="..\..\..\Features\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
     <ProjectReference Include="..\..\Core\Def\Microsoft.VisualStudio.LanguageServices.csproj" />
   </ItemGroup>


### PR DESCRIPTION
export brace matchers on the client.  these can be removed as soon as we switch from C#_LSP.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1073275/