### PR TITLE
bug fix for https://github.com/dotnet/roslyn/pull/41371

### DIFF
--- a/src/Features/CSharp/Portable/CodeFixes/AddExplicitCast/AddExplicitCastCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddExplicitCast/AddExplicitCastCodeFixProvider.cs
@@ -332,7 +332,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddExplicitCast
                 }
             }
 
-            return IsInvocationExpressionWithNewArgumentsApplicable(semanticModel, root, argumentList, newArguments, targetArgument);
+            return targetArgumentConversionType != null
+                && IsInvocationExpressionWithNewArgumentsApplicable(semanticModel, root, argumentList, newArguments, targetArgument);
         }
 
         private static bool FindCorrespondingParameterByName(

--- a/src/Features/CSharp/Portable/CodeFixes/AddExplicitCast/AddExplicitCastCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddExplicitCast/AddExplicitCastCodeFixProvider.cs
@@ -269,12 +269,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddExplicitCast
             CancellationToken cancellationToken, [NotNullWhen(true)] out ITypeSymbol? targetArgumentConversionType)
         {
             targetArgumentConversionType = null;
+            var arguments = argumentList.Arguments;
 
             // No conversion happens under this case
-            if (parameters.Length == 0)
+            if (arguments.Count == 0 || parameters.Length == 0)
                 return false;
 
-            var arguments = argumentList.Arguments;
             var newArguments = new List<ArgumentSyntax>();
 
             for (var i = 0; i < arguments.Count; i++)

--- a/src/Features/CSharp/Portable/CodeFixes/AddExplicitCast/AddExplicitCastCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddExplicitCast/AddExplicitCastCodeFixProvider.cs
@@ -269,12 +269,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddExplicitCast
             CancellationToken cancellationToken, [NotNullWhen(true)] out ITypeSymbol? targetArgumentConversionType)
         {
             targetArgumentConversionType = null;
-            var arguments = argumentList.Arguments;
 
             // No conversion happens under this case
-            if (arguments.Count == 0 || parameters.Length == 0)
+            if (parameters.Length == 0)
                 return false;
 
+            var arguments = argumentList.Arguments;
             var newArguments = new List<ArgumentSyntax>();
 
             for (var i = 0; i < arguments.Count; i++)


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/41371 failed CI tests with error `CS8762: Parameter 'targetArgumentConversionType' may not have a null value when exiting with 'true'.` on file `AddExplicitCastCodeFixProvider.cs` line 335