### PR TITLE
Syntax aware generators:

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -166,9 +166,6 @@ class GeneratedClass { }
             Assert.NotEqual(compilation, outputCompilation1);
             Assert.NotEqual(compilation, outputCompilation2);
             Assert.NotEqual(compilation, outputCompilation3);
-            Assert.Equal(outputCompilation1, outputCompilation2);
-            Assert.Equal(outputCompilation2, outputCompilation3);
-            Assert.Equal(outputCompilation3, outputCompilation1);
         }
 
         [Fact]
@@ -417,7 +414,6 @@ class C { }
 
             SingleFileTestGenerator testGenerator1 = new SingleFileTestGenerator("public class D { }");
             SingleFileTestGenerator testGenerator2 = new SingleFileTestGenerator("public class E { }");
-
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions,
                                                                generators: ImmutableArray.Create<ISourceGenerator>(testGenerator1),

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -81,8 +81,6 @@ class C { }
 
             Assert.Single(compilation.SyntaxTrees);
 
-            ISyntaxReceiver? receiver = null;
-
             var testGenerator = new CallbackGenerator(
                 onInit: Initialize,
                 onExecute: (e) => { }
@@ -94,14 +92,10 @@ class C { }
             void Initialize(InitializationContext initContext)
             {
                 initContext.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
-                try
+                Assert.Throws<InvalidOperationException>(() =>
                 {
                     initContext.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
-                    Assert.True(false, "Failed to throw");
-                }
-                catch
-                {
-                }
+                });
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+#nullable enable
+namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
+{
+    public class SyntaxAwareGeneratorTests
+         : CSharpTestBase
+    {
+
+        [Fact]
+        public void Syntax_Receiver_Is_Present_When_Registered()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver()),
+                onExecute: (e) => receiver = e.SyntaxReceiver
+                );
+
+            GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
+            driver.RunFullGeneration(compilation, out var outputCompilation);
+
+            Assert.NotNull(receiver);
+            Assert.IsType<TestSyntaxReceiver>(receiver);
+        }
+
+        [Fact]
+        public void Syntax_Receiver_Is_Null_WhenNot_Registered()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => { },
+                onExecute: (e) => receiver = e.SyntaxReceiver
+                );
+
+            GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
+            driver.RunFullGeneration(compilation, out var outputCompilation);
+
+            Assert.Null(receiver);
+        }
+
+        [Fact]
+        public void Syntax_Receiver_Visits_Syntax_In_Compilation()
+        {
+            var source = @"
+class C 
+{
+    int Property { get; set; }
+
+    void Function()
+    {
+        var x = 5;
+        x += 4;
+    }
+}
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver()),
+                onExecute: (e) => receiver = e.SyntaxReceiver
+                );
+
+            GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
+            driver.RunFullGeneration(compilation, out _);
+
+            Assert.NotNull(receiver);
+            Assert.IsType<TestSyntaxReceiver>(receiver);
+
+            TestSyntaxReceiver testReceiver = (TestSyntaxReceiver)receiver!;
+            Assert.Equal(21, testReceiver.VisitedNodes.Count);
+            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
+        }
+
+        [Fact]
+        public void Syntax_Receiver_Is_Not_Reused_Between_Invocations()
+        {
+            var source = @"
+class C 
+{
+    int Property { get; set; }
+
+    void Function()
+    {
+        var x = 5;
+        x += 4;
+    }
+}
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxReceiver? receiver = null;
+            int invocations = 0;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver(++invocations)),
+                onExecute: (e) => receiver = e.SyntaxReceiver
+                );
+
+            GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
+            driver = driver.RunFullGeneration(compilation, out _);
+
+            Assert.NotNull(receiver);
+            Assert.IsType<TestSyntaxReceiver>(receiver);
+
+            TestSyntaxReceiver testReceiver = (TestSyntaxReceiver)receiver!;
+            Assert.Equal(1, testReceiver.Tag);
+            Assert.Equal(21, testReceiver.VisitedNodes.Count);
+            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
+
+            var previousReceiver = receiver;
+            driver = driver.RunFullGeneration(compilation, out _);
+
+            Assert.NotNull(receiver);
+            Assert.NotEqual(receiver, previousReceiver);
+
+            testReceiver = (TestSyntaxReceiver)receiver!;
+            Assert.Equal(2, testReceiver.Tag);
+            Assert.Equal(21, testReceiver.VisitedNodes.Count);
+            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
+        }
+
+
+        class TestSyntaxReceiver : ISyntaxReceiver
+        {
+            public List<SyntaxNode> VisitedNodes { get; } = new List<SyntaxNode>();
+
+            public int Tag { get; }
+
+            public TestSyntaxReceiver(int tag = 0)
+            {
+                Tag = tag;
+            }
+
+            public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+            {
+                VisitedNodes.Add(syntaxNode);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -687,4 +687,7 @@
     <value>Suppress the following diagnostics to disable this analyzer: {0}</value>
     <comment>{0}: Comma-separated list of diagnostic IDs</comment>
   </data>
+  <data name="Single_type_per_generator_0" xml:space="preserve">
+    <value>Only a single {0} can be registered per generator.</value>
+  </data>
 </root>

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 stateBuilder.Add(generator, generatorState);
 
-                // create the syntax reciever if requested
+                // create the syntax receiver if requested
                 if (generatorState.Info.SyntaxReceiverCreator is object)
                 {
                     var rx = generatorState.Info.SyntaxReceiverCreator();

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -53,19 +53,11 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            // PERF: if the input compilation is the same as the last compilation we saw, and we have a final compilation
-            //       we know nothing can have changed and can just short circuit, returning the already processed final compilation 
-            if (compilation == _state.Compilation && _state.FinalCompilation is object)
-            {
-                outputCompilation = _state.FinalCompilation;
-                return this;
-            }
-
             // run the actual generation
             var state = StateWithPendingEditsApplied(_state);
             var stateBuilder = PooledDictionary<ISourceGenerator, GeneratorState>.GetInstance();
+            var receivers = PooledDictionary<ISourceGenerator, ISyntaxReceiver>.GetInstance();
 
-            //PROTOTYPE: should be possible to parallelize this
             foreach (var generator in state.Generators)
             {
                 // initialize the generator if needed
@@ -73,13 +65,36 @@ namespace Microsoft.CodeAnalysis
                 {
                     generatorState = InitializeGenerator(generator, cancellationToken);
                 }
+                stateBuilder.Add(generator, generatorState);
 
+                // create the syntax reciever if requested
+                if (generatorState.Info.SyntaxReceiverCreator is object)
+                {
+                    var rx = generatorState.Info.SyntaxReceiverCreator();
+                    receivers.Add(generator, rx);
+                }
+            }
+
+            // Run a syntax walk if any of the generators requested it
+            if (receivers.Count > 0)
+            {
+                GeneratorSyntaxWalker walker = new GeneratorSyntaxWalker(receivers.Values.ToImmutableArray());
+                foreach (var syntaxTree in compilation.SyntaxTrees)
+                {
+                    walker.Visit(syntaxTree.GetRoot());
+                }
+            }
+
+            //PROTOTYPE: should be possible to parallelize this
+            foreach (var (generator, generatorState) in stateBuilder.ToImmutableDictionary())
+            {
                 try
                 {
                     // we create a new context for each run of the generator. We'll never re-use existing state, only replace anything we have
-                    var context = new SourceGeneratorContext(state.Compilation, new AnalyzerOptions(state.AdditionalTexts.NullToEmpty(), CompilerAnalyzerConfigOptionsProvider.Empty));
+                    _ = receivers.TryGetValue(generator, out var syntaxReceiverOpt);
+                    var context = new SourceGeneratorContext(state.Compilation, new AnalyzerOptions(state.AdditionalTexts.NullToEmpty(), CompilerAnalyzerConfigOptionsProvider.Empty), syntaxReceiverOpt);
                     generator.Execute(context);
-                    stateBuilder.Add(generator, generatorState.WithSources(context.AdditionalSources.ToImmutableAndFree()));
+                    stateBuilder[generator] = generatorState.WithSources(ParseAdditionalSources(context.AdditionalSources.ToImmutableAndFree()));
                 }
                 catch
                 {
@@ -116,6 +131,9 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
+            // remove the previously generated syntax trees
+            compilation = RemoveGeneratedSyntaxTrees(_state, compilation);
+
             success = true;
             return BuildFinalCompilation(compilation, out outputCompilation, state, cancellationToken);
         }
@@ -146,7 +164,7 @@ namespace Microsoft.CodeAnalysis
             return FromState(newState);
         }
 
-        private static GeneratorDriverState ApplyPartialEdit(GeneratorDriverState state, PendingEdit edit, CancellationToken cancellationToken = default)
+        private GeneratorDriverState ApplyPartialEdit(GeneratorDriverState state, PendingEdit edit, CancellationToken cancellationToken = default)
         {
             var initialState = state;
 
@@ -157,7 +175,7 @@ namespace Microsoft.CodeAnalysis
                 if (edit.AcceptedBy(generatorState.Info))
                 {
                     // attempt to apply the edit
-                    var context = new EditContext(generatorState.Sources, cancellationToken);
+                    var context = new EditContext(generatorState.Sources.Keys.ToImmutableArray(), cancellationToken);
                     var succeeded = edit.TryApply(generatorState.Info, context);
                     if (!succeeded)
                     {
@@ -167,10 +185,10 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     // update the state with the new edits
-                    state = state.With(generatorStates: state.GeneratorStates.SetItem(generator, generatorState.WithSources(context.AdditionalSources.ToImmutableAndFree())));
+                    state = state.With(generatorStates: state.GeneratorStates.SetItem(generator, generatorState.WithSources(ParseAdditionalSources(context.AdditionalSources.ToImmutableAndFree()))));
                 }
             }
-
+            state = edit.Commit(state);
             return state;
         }
 
@@ -204,25 +222,41 @@ namespace Microsoft.CodeAnalysis
             return new GeneratorState(info);
         }
 
-        private GeneratorDriver BuildFinalCompilation(Compilation compilation, out Compilation outputCompilation, GeneratorDriverState state, CancellationToken cancellationToken)
+        private static Compilation RemoveGeneratedSyntaxTrees(GeneratorDriverState state, Compilation compilation)
         {
-            var finalCompilation = compilation;
+            ArrayBuilder<SyntaxTree> trees = ArrayBuilder<SyntaxTree>.GetInstance();
             foreach (var (_, generatorState) in state.GeneratorStates)
             {
-                foreach (var sourceText in generatorState.Sources)
+                foreach (var (_, tree) in generatorState.Sources)
                 {
-                    try
+                    if (tree is object && compilation.ContainsSyntaxTree(tree))
                     {
-                        //PROTOTYPE: should be possible to parallelize the parsing
-                        var tree = ParseGeneratedSourceText(sourceText, cancellationToken);
-                        finalCompilation = finalCompilation.AddSyntaxTrees(tree);
-                    }
-                    catch
-                    {
-                        //PROTOTYPE: should issue a diagnostic that the generator produced unparseable source
+                        trees.Add(tree);
                     }
                 }
             }
+
+            return compilation.RemoveSyntaxTrees(trees.ToImmutableAndFree());
+        }
+
+        private ImmutableDictionary<GeneratedSourceText, SyntaxTree> ParseAdditionalSources(ImmutableArray<GeneratedSourceText> generatedSources)
+        {
+            var trees = PooledDictionary<GeneratedSourceText, SyntaxTree>.GetInstance();
+            foreach (var source in generatedSources)
+            {
+                trees.Add(source, ParseGeneratedSourceText(source, default)); //PROTOTYPE
+            }
+            return trees.ToImmutableDictionaryAndFree();
+        }
+
+        private GeneratorDriver BuildFinalCompilation(Compilation compilation, out Compilation outputCompilation, GeneratorDriverState state, CancellationToken cancellationToken)
+        {
+            var finalCompilation = compilation;
+            foreach (var (generator, generatorState) in state.GeneratorStates)
+            {
+                finalCompilation = finalCompilation.AddSyntaxTrees(generatorState.Sources.Values.ToImmutableArray());
+            }
+
             outputCompilation = finalCompilation;
             state = state.With(compilation: compilation,
                                finalCompilation: finalCompilation,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -9,16 +9,21 @@ namespace Microsoft.CodeAnalysis
     {
         internal EditCallback<AdditionalFileEdit>? EditCallback { get; }
 
-        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback)
+        internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; }
+
+        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxReceiverCreator? receiverCreator)
         {
             EditCallback = editCallback;
+            SyntaxReceiverCreator = receiverCreator;
         }
 
         internal class Builder
         {
             internal EditCallback<AdditionalFileEdit>? EditCallback { get; set; }
 
-            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback);
+            internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; set; }
+
+            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxReceiverCreator);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -10,21 +10,21 @@ namespace Microsoft.CodeAnalysis
     internal readonly struct GeneratorState
     {
         public GeneratorState(GeneratorInfo info)
-            : this(info, ImmutableArray<GeneratedSourceText>.Empty)
+            : this(info, ImmutableDictionary<GeneratedSourceText, SyntaxTree>.Empty)
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sources)
+        private GeneratorState(GeneratorInfo info, ImmutableDictionary<GeneratedSourceText, SyntaxTree> sources)
         {
             this.Sources = sources;
             this.Info = info;
         }
 
-        internal ImmutableArray<GeneratedSourceText> Sources { get; }
+        internal ImmutableDictionary<GeneratedSourceText, SyntaxTree> Sources { get; }
 
         internal GeneratorInfo Info { get; }
 
-        internal GeneratorState WithSources(ImmutableArray<GeneratedSourceText> sources)
+        internal GeneratorState WithSources(ImmutableDictionary<GeneratedSourceText, SyntaxTree> sources)
         {
             return new GeneratorState(this.Info, sources);
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
-    internal class GeneratorSyntaxWalker : SyntaxWalker
+    internal sealed class GeneratorSyntaxWalker : SyntaxWalker
     {
         private readonly ImmutableArray<ISyntaxReceiver> _syntaxReceivers;
 
@@ -21,9 +18,9 @@ namespace Microsoft.CodeAnalysis
 
         public override void Visit(SyntaxNode node)
         {
-            foreach (var recevier in _syntaxReceivers)
+            foreach (var receivier in _syntaxReceivers)
             {
-                recevier.OnVisitSyntaxNode(node);
+                receivier.OnVisitSyntaxNode(node);
             }
             base.Visit(node);
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+#nullable enable
+namespace Microsoft.CodeAnalysis
+{
+    internal class GeneratorSyntaxWalker : SyntaxWalker
+    {
+        private readonly ImmutableArray<ISyntaxReceiver> _syntaxReceivers;
+
+        public GeneratorSyntaxWalker(ImmutableArray<ISyntaxReceiver> syntaxReceivers)
+        {
+            _syntaxReceivers = syntaxReceivers;
+        }
+
+        public override void Visit(SyntaxNode node)
+        {
+            foreach (var recevier in _syntaxReceivers)
+            {
+                recevier.OnVisitSyntaxNode(node);
+            }
+            base.Visit(node);
+        }
+    }
+
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis
 
         public override void Visit(SyntaxNode node)
         {
-            foreach (var receivier in _syntaxReceivers)
+            foreach (var receiver in _syntaxReceivers)
             {
-                receivier.OnVisitSyntaxNode(node);
+                receiver.OnVisitSyntaxNode(node);
             }
             base.Visit(node);
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -6,11 +6,38 @@
 namespace Microsoft.CodeAnalysis
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    /// <summary>
+    /// Receives notifications of each syntax node in the compilation before generation runs
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
+    /// via a <see cref="SyntaxReceiverCreator"/>.
+    /// 
+    /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
+    /// obtain an instance of <see cref="ISyntaxReceiver"/>. This instance will have its 
+    /// <see cref="OnVisitSyntaxNode(SyntaxNode)"/> called for every syntax node in the compilation.
+    /// 
+    /// The <see cref="ISyntaxReceiver"/> can record any information about the nodes visited. During
+    /// <see cref="ISourceGenerator.Execute(SourceGeneratorContext)"/> the generator can obtain the 
+    /// created instance via the <see cref="SourceGeneratorContext.SyntaxReceiver"/> property. The
+    /// information contained can be used to perform final generation.
+    /// 
+    /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
+    /// is free to store state without worrying about lifetime or reuse.
+    /// </remarks>
     public interface ISyntaxReceiver
     {
+        /// <summary>
+        /// Called for each <see cref="SyntaxNode"/> in the compilation
+        /// </summary>
+        /// <param name="syntaxNode">The current <see cref="SyntaxNode"/> being visited</param>
         void OnVisitSyntaxNode(SyntaxNode syntaxNode);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    /// <summary>
+    /// Allows a generator to provide instances of an <see cref="ISyntaxReceiver"/>
+    /// </summary>
+    /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
     public delegate ISyntaxReceiver SyntaxReceiverCreator();
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+#nullable enable
+namespace Microsoft.CodeAnalysis
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    public interface ISyntaxReceiver
+    {
+        void OnVisitSyntaxNode(SyntaxNode syntaxNode);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    public delegate ISyntaxReceiver SyntaxReceiverCreator();
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -5,7 +5,6 @@
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     /// <summary>
     /// Receives notifications of each syntax node in the compilation before generation runs
     /// </summary>
@@ -25,6 +24,7 @@ namespace Microsoft.CodeAnalysis
     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
     /// is free to store state without worrying about lifetime or reuse.
     /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public interface ISyntaxReceiver
     {
         /// <summary>
@@ -34,10 +34,10 @@ namespace Microsoft.CodeAnalysis
         void OnVisitSyntaxNode(SyntaxNode syntaxNode);
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     /// <summary>
     /// Allows a generator to provide instances of an <see cref="ISyntaxReceiver"/>
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public delegate ISyntaxReceiver SyntaxReceiverCreator();
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -57,6 +57,22 @@ namespace Microsoft.CodeAnalysis
 
         public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback) => InfoBuilder.EditCallback = callback;
 
+        /// <summary>
+        /// Register a <see cref="SyntaxReceiverCreator"/> for this generator, which can be used to create an instance of an <see cref="ISyntaxReceiver"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method allows generators to be 'syntax aware'. Before each generation the <paramref name="receiverCreator"/> will be invoked to create
+        /// an instance of <see cref="ISyntaxReceiver"/>. This receiver will have its <see cref="ISyntaxReceiver.OnVisitSyntaxNode(SyntaxNode)"/> 
+        /// invoked for each syntax node in the compilation, allowing the receiver to build up information about the compilation before generation occurs.
+        /// 
+        /// During <see cref="ISourceGenerator.Execute(SourceGeneratorContext)"/> the generator can obtain the generator instance that was created 
+        /// by accessing the <see cref="SourceGeneratorContext.SyntaxReceiver"/> property. Any information that was collected by the receiver can be
+        /// used to generate the final output.
+        /// 
+        /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning there is no need to manage the lifetime of the 
+        /// receiver or its contents.
+        /// </remarks>
+        /// <param name="receiverCreator">A <see cref="SyntaxReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxReceiver"/></param>
         public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator) => InfoBuilder.SyntaxReceiverCreator = receiverCreator;
     }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -57,10 +57,7 @@ namespace Microsoft.CodeAnalysis
 
         public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback)
         {
-            if (InfoBuilder.EditCallback is object)
-            {
-                throw new InvalidOperationException($"Only a single {nameof(EditCallback<AdditionalFileEdit>)} can be registered per generator.");
-            }
+            CheckIsEmpty(InfoBuilder.EditCallback);
             InfoBuilder.EditCallback = callback;
         }
 
@@ -82,11 +79,16 @@ namespace Microsoft.CodeAnalysis
         /// <param name="receiverCreator">A <see cref="SyntaxReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxReceiver"/></param>
         public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator)
         {
-            if (InfoBuilder.SyntaxReceiverCreator is object)
-            {
-                throw new InvalidOperationException($"Only a single {nameof(SyntaxReceiverCreator)} can be registered per generator.");
-            }
+            CheckIsEmpty(InfoBuilder.SyntaxReceiverCreator);
             InfoBuilder.SyntaxReceiverCreator = receiverCreator;
+        }
+
+        private void CheckIsEmpty<T>(T x)
+        {
+            if (x is object)
+            {
+                throw new InvalidOperationException(string.Format(CodeAnalysisResources.Single_type_per_generator_0, typeof(T).Name));
+            }
         }
     }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis
             InfoBuilder.SyntaxReceiverCreator = receiverCreator;
         }
 
-        private void CheckIsEmpty<T>(T x)
+        private static void CheckIsEmpty<T>(T x)
         {
             if (x is object)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -55,7 +55,14 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo.Builder InfoBuilder { get; }
 
-        public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback) => InfoBuilder.EditCallback = callback;
+        public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback)
+        {
+            if (InfoBuilder.EditCallback is object)
+            {
+                throw new InvalidOperationException($"Only a single {nameof(EditCallback<AdditionalFileEdit>)} can be registered per generator.");
+            }
+            InfoBuilder.EditCallback = callback;
+        }
 
         /// <summary>
         /// Register a <see cref="SyntaxReceiverCreator"/> for this generator, which can be used to create an instance of an <see cref="ISyntaxReceiver"/>.
@@ -65,15 +72,22 @@ namespace Microsoft.CodeAnalysis
         /// an instance of <see cref="ISyntaxReceiver"/>. This receiver will have its <see cref="ISyntaxReceiver.OnVisitSyntaxNode(SyntaxNode)"/> 
         /// invoked for each syntax node in the compilation, allowing the receiver to build up information about the compilation before generation occurs.
         /// 
-        /// During <see cref="ISourceGenerator.Execute(SourceGeneratorContext)"/> the generator can obtain the generator instance that was created 
-        /// by accessing the <see cref="SourceGeneratorContext.SyntaxReceiver"/> property. Any information that was collected by the receiver can be
+        /// During <see cref="ISourceGenerator.Execute(SourceGeneratorContext)"/> the generator can obtain the <see cref="ISyntaxReceiver"/> instance that was
+        /// created by accessing the <see cref="SourceGeneratorContext.SyntaxReceiver"/> property. Any information that was collected by the receiver can be
         /// used to generate the final output.
         /// 
         /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning there is no need to manage the lifetime of the 
         /// receiver or its contents.
         /// </remarks>
         /// <param name="receiverCreator">A <see cref="SyntaxReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxReceiver"/></param>
-        public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator) => InfoBuilder.SyntaxReceiverCreator = receiverCreator;
+        public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator)
+        {
+            if (InfoBuilder.SyntaxReceiverCreator is object)
+            {
+                throw new InvalidOperationException($"Only a single {nameof(SyntaxReceiverCreator)} can be registered per generator.");
+            }
+            InfoBuilder.SyntaxReceiverCreator = receiverCreator;
+        }
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -18,10 +18,11 @@ namespace Microsoft.CodeAnalysis
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public readonly struct SourceGeneratorContext
     {
-        internal SourceGeneratorContext(Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken = default)
+        internal SourceGeneratorContext(Compilation compilation, AnalyzerOptions options, ISyntaxReceiver? syntaxReceiver, CancellationToken cancellationToken = default)
         {
             Compilation = compilation;
             AnalyzerOptions = options;
+            SyntaxReceiver = syntaxReceiver;
             CancellationToken = cancellationToken;
             AdditionalSources = new AdditionalSourcesCollection();
         }
@@ -31,6 +32,8 @@ namespace Microsoft.CodeAnalysis
         // PROTOTYPE: replace AnalyzerOptions with an differently named type that is otherwise identical.
         // The concern being that something added to one isn't necessarily applicable to the other.
         public AnalyzerOptions AnalyzerOptions { get; }
+
+        public ISyntaxReceiver? SyntaxReceiver { get; }
 
         public CancellationToken CancellationToken { get; }
 
@@ -53,6 +56,8 @@ namespace Microsoft.CodeAnalysis
         internal GeneratorInfo.Builder InfoBuilder { get; }
 
         public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback) => InfoBuilder.EditCallback = callback;
+
+        public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator) => InfoBuilder.SyntaxReceiverCreator = receiverCreator;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Kopie modulu se nedá použít k vytvoření metadat sestavení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">Analyzátor {0} má v SupportedDiagnostics deskriptor s hodnotou null.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Modulkopie kann nicht zum Erstellen von Assembly-Metadaten verwendet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">Der Analyzer "{0}" enthält einen NULL-Deskriptor in "SupportedDiagnostics".</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -94,6 +94,11 @@
         <target state="translated">No se puede usar una copia de módulo para crear metadatos de ensamblado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">El analizador de "{0}" contiene un descriptor nulo en "SupportedDiagnostics".</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Impossible d'utiliser le module de copie pour créer des métadonnées d'assembly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">L'analyseur '{0}' contient un descripteur null dans 'SupportedDiagnostics'.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Non è possibile usare la copia del modulo per creare i metadati di un assembly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">L'analizzatore '{0}' contiene un descrittore Null nel relativo elemento 'SupportedDiagnostics'.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -94,6 +94,11 @@
         <target state="translated">モジュールのコピーは、アセンブリ メタデータの作成には使用できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">アナライザー '{0}' の 'SupportedDiagnostics' に null 記述子が含まれています。</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -94,6 +94,11 @@
         <target state="translated">모듈 복사본은 어셈블리 메타데이터를 만드는 데 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">'{0}' 분석기의 'SupportedDiagnostics'에 null 설명자가 포함되어 있습니다.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Nie można użyć kopii modułu do utworzenia metadanych zestawu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">Analizator „{0}” zawiera deskryptor null we właściwości „SupportedDiagnostics”.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Cópia de módulo não pode ser usada para criar metadados do assembly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">O analisador '{0}' contém um descritor nulo em seu 'SupportedDiagnostics'.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Копию модуля нельзя использовать для создания метаданных сборки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">Анализатор "{0}" содержит дескриптор null в разделе "SupportedDiagnostics".</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -94,6 +94,11 @@
         <target state="translated">Derleme meta verileri oluşturmak için modül kopyası kullanılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">Çözümleyicisi '{0}', 'SupportedDiagnostics' boş bir tanımlayıcısı içerir.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -94,6 +94,11 @@
         <target state="translated">模块复制不能用于创建程序集元数据。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">分析器“{0}”在其 "SupportedDiagnostics" 中包含 null 描述符。</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -94,6 +94,11 @@
         <target state="translated">不可使用模組複本建立組件中繼資料。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Single_type_per_generator_0">
+        <source>Only a single {0} can be registered per generator.</source>
+        <target state="new">Only a single {0} can be registered per generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="translated">分析器 '{0}' 在其 'SupportedDiagnostics' 中包含一個 null 描述項。</target>


### PR DESCRIPTION
Syntax aware generators:
- Allow generators to register a 'syntax receiver' that is created per-generation to receive syntax
- Pass the populated syntax walker back to the generator when running generation
- Add tests

Bug fixes:
- Track the syntax trees so we can remove them as needed during partial generation