### PR TITLE
Make more of the incremental analyzer async

### DIFF
--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
@@ -195,11 +195,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             }
         }
 
-        public void RemoveDocument(DocumentId documentId)
+        public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
             _state.Remove(documentId);
-
             RaiseTaskListUpdated(_workspace, null, documentId, ImmutableArray<TodoItem>.Empty);
+
+            return Task.CompletedTask;
         }
 
         public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
@@ -247,8 +248,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             return Task.CompletedTask;
         }
 
-        public void RemoveProject(ProjectId projectId)
+        public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
+            return Task.CompletedTask;
         }
         #endregion
     }

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1514,14 +1514,16 @@ End Class";
                 return Task.CompletedTask;
             }
 
-            public void RemoveDocument(DocumentId documentId)
+            public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
             {
                 InvalidateDocumentIds.Add(documentId);
+                return Task.CompletedTask;
             }
 
-            public void RemoveProject(ProjectId projectId)
+            public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
             {
                 InvalidateProjectIds.Add(projectId);
+                return Task.CompletedTask;
             }
 
             private void Process(DocumentId documentId, CancellationToken cancellationToken)
@@ -1589,8 +1591,8 @@ End Class";
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken) => Task.CompletedTask;
-            public void RemoveDocument(DocumentId documentId) { }
-            public void RemoveProject(ProjectId projectId) { }
+            public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken) => Task.CompletedTask;
             #endregion
         }
 

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return hostAnalyzers.CreateDiagnosticAnalyzersPerReference(project).Values.SelectMany(v => v);
             }
 
-            public void RemoveDocument(DocumentId documentId)
+            public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
             {
                 // a file is removed from a solution
                 //
@@ -194,13 +194,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // both of them at the end generates semantic errors
                 RaiseEmptyDiagnosticUpdated(AnalysisKind.Syntax, documentId);
                 RaiseEmptyDiagnosticUpdated(AnalysisKind.Semantic, documentId);
+                return Task.CompletedTask;
             }
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 // no closed file diagnostic and file is not opened, remove any existing diagnostics
-                RemoveDocument(document.Id);
-                return Task.CompletedTask;
+                return RemoveDocumentAsync(document.Id, cancellationToken);
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
@@ -229,8 +229,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return Task.CompletedTask;
             }
 
-            public void RemoveProject(ProjectId projectId)
+            public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
             {
+                return Task.CompletedTask;
             }
 
             private class DefaultUpdateArgsId : BuildToolId.Base<int, DocumentId>, ISupportLiveUpdate

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             RaiseDiagnosticsRemovedForDocument(document.Id, stateSets);
         }
 
-        public void RemoveDocument(DocumentId documentId)
+        public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Diagnostics_RemoveDocument, GetRemoveLogMessage, documentId, CancellationToken.None))
             {
@@ -208,14 +208,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var changed = _stateManager.OnDocumentRemoved(stateSets, documentId);
 
                 // if there was no diagnostic reported for this document, nothing to clean up
-                if (!changed)
+                // this is Perf to reduce raising events unnecessarily.
+                if (changed)
                 {
-                    // this is Perf to reduce raising events unnecessarily.
-                    return;
+                    RaiseDiagnosticsRemovedForDocument(documentId, stateSets);
                 }
-
-                RaiseDiagnosticsRemovedForDocument(documentId, stateSets);
             }
+
+            return Task.CompletedTask;
         }
 
         private void RaiseDiagnosticsRemovedForDocument(DocumentId documentId, IEnumerable<StateSet> stateSets)
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             });
         }
 
-        public void RemoveProject(ProjectId projectId)
+        public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellation)
         {
             using (Logger.LogBlock(FunctionId.Diagnostics_RemoveProject, GetRemoveLogMessage, projectId, CancellationToken.None))
             {
@@ -244,22 +244,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var changed = _stateManager.OnProjectRemoved(stateSets, projectId);
 
                 // if there was no diagnostic reported for this project, nothing to clean up
-                if (!changed)
+                // this is Perf to reduce raising events unnecessarily.
+                if (changed)
                 {
-                    // this is Perf to reduce raising events unnecessarily.
-                    return;
-                }
-
-                // remove all diagnostics for the project
-                AnalyzerService.RaiseBulkDiagnosticsUpdated(raiseEvents =>
-                {
-                    foreach (var stateSet in stateSets)
+                    // remove all diagnostics for the project
+                    AnalyzerService.RaiseBulkDiagnosticsUpdated(raiseEvents =>
                     {
-                        // clear all project diagnostics
-                        RaiseDiagnosticsRemoved(projectId, solution: null, stateSet, raiseEvents);
-                    }
-                });
+                        foreach (var stateSet in stateSets)
+                        {
+                            // clear all project diagnostics
+                            RaiseDiagnosticsRemoved(projectId, solution: null, stateSet, raiseEvents);
+                        }
+                    });
+                }
             }
+
+            return Task.CompletedTask;
         }
 
         public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -291,11 +291,12 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 metadataInfo.ReferencingProjects.Add(project.Id);
             }
 
-            public override void RemoveProject(ProjectId projectId)
+            public override Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
             {
                 _projectToInfo.TryRemove(projectId, out var info);
-
                 RemoveMetadataReferences(projectId);
+
+                return Task.CompletedTask;
             }
 
             private void RemoveMetadataReferences(ProjectId projectId)

--- a/src/Features/Core/Portable/Notification/SemanticChangeNotificationService.cs
+++ b/src/Features/Core/Portable/Notification/SemanticChangeNotificationService.cs
@@ -45,19 +45,20 @@ namespace Microsoft.CodeAnalysis.Notification
                 _owner = owner;
             }
 
-            public void RemoveDocument(DocumentId documentId)
+            public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
             {
                 // now it runs for all workspace, make sure we get rid of entry from the map
                 // as soon as it is not needed.
                 // this whole thing will go away when workspace disable itself from solution crawler.
                 _map.TryRemove(documentId, out var unused);
+                return Task.CompletedTask;
             }
 
-            public void RemoveProject(ProjectId projectId)
+            public async Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
             {
                 foreach (var documentId in _map.Keys.Where(id => id.ProjectId == projectId).ToArray())
                 {
-                    RemoveDocument(documentId);
+                    await RemoveDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -68,8 +69,7 @@ namespace Microsoft.CodeAnalysis.Notification
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
-                RemoveDocument(document.Id);
-                return Task.CompletedTask;
+                return RemoveDocumentAsync(document.Id, cancellationToken);
             }
 
             public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)

--- a/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
@@ -99,24 +99,24 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             return true;
         }
 
-        public void RemoveDocument(DocumentId documentId)
+        public async Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
             foreach (var (_, analyzer) in Analyzers)
             {
                 if (analyzer.IsValueCreated)
                 {
-                    analyzer.Value.RemoveDocument(documentId);
+                    await analyzer.Value.RemoveDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
 
-        public void RemoveProject(ProjectId projectId)
+        public async Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
             foreach (var (_, analyzer) in Analyzers)
             {
                 if (analyzer.IsValueCreated)
                 {
-                    analyzer.Value.RemoveProject(projectId);
+                    await analyzer.Value.RemoveProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
@@ -54,12 +54,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             return Task.CompletedTask;
         }
 
-        public virtual void RemoveDocument(DocumentId documentId)
+        public virtual Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
+            return Task.CompletedTask;
         }
 
-        public virtual void RemoveProject(ProjectId projectId)
+        public virtual Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellation)
         {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 {
                                     SolutionCrawlerLogger.LogProcessProjectNotExist(Processor._logAggregator);
 
-                                    RemoveProject(projectId);
+                                    await RemoveProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
                                 }
 
                                 if (!cancellationToken.IsCancellationRequested)
@@ -183,11 +183,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
                     }
 
-                    private void RemoveProject(ProjectId projectId)
+                    private async Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
                     {
                         foreach (var analyzer in Analyzers)
                         {
-                            analyzer.RemoveProject(projectId);
+                            await analyzer.RemoveProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
                         }
                     }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 {
                                     SolutionCrawlerLogger.LogProcessDocumentNotExist(Processor._logAggregator);
 
-                                    RemoveDocument(documentId);
+                                    await RemoveDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                                 }
 
                                 if (!cancellationToken.IsCancellationRequested)
@@ -451,16 +451,16 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
                     }
 
-                    private void RemoveDocument(DocumentId documentId)
+                    private Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
                     {
-                        RemoveDocument(Analyzers, documentId);
+                        return RemoveDocumentAsync(Analyzers, documentId, cancellationToken);
                     }
 
-                    private static void RemoveDocument(ImmutableArray<IIncrementalAnalyzer> analyzers, DocumentId documentId)
+                    private static async Task RemoveDocumentAsync(ImmutableArray<IIncrementalAnalyzer> analyzers, DocumentId documentId, CancellationToken cancellationToken)
                     {
                         foreach (var analyzer in analyzers)
                         {
-                            analyzer.RemoveDocument(documentId);
+                            await analyzer.RemoveDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                         }
                     }
 

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
@@ -67,10 +67,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 return Task.CompletedTask;
             }
 
-            public void RemoveDocument(DocumentId documentId)
+            public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
             {
                 // REVIEW: do we need to fire events when a document is removed from the solution?
                 FireEvents(documentId, CancellationToken.None);
+                return Task.CompletedTask;
             }
 
             public void FireEvents(DocumentId documentId, CancellationToken cancellationToken)
@@ -138,8 +139,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 return Task.CompletedTask;
             }
 
-            public void RemoveProject(ProjectId projectId)
+            public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
             {
+                return Task.CompletedTask;
             }
             #endregion
         }

--- a/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
@@ -183,10 +183,10 @@ class A
 
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
+
                 Await analyzer.AnalyzeSyntaxAsync(document, InvocationReasons.Empty, CancellationToken.None)
                 Await analyzer.AnalyzeDocumentAsync(document, Nothing, InvocationReasons.Empty, CancellationToken.None)
-
-                analyzer.RemoveDocument(document.Id)
+                Await analyzer.RemoveDocumentAsync(document.Id, CancellationToken.None)
 
                 Dim listenerProvider = workspace.ExportProvider.GetExportedValue(Of IAsynchronousOperationListenerProvider)
                 Await listenerProvider.GetWaiter(FeatureAttribute.DiagnosticService).ExpeditedWaitAsync()

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/UnitTestingIncrementalAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/UnitTestingIncrementalAnalyzer.cs
@@ -41,11 +41,17 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
         public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             => _implementation.NewSolutionSnapshotAsync(solution, cancellationToken);
 
-        public void RemoveDocument(DocumentId documentId)
-            => _implementation.RemoveDocument(documentId);
+        public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
+        {
+            _implementation.RemoveDocument(documentId);
+            return Task.CompletedTask;
+        }
 
-        public void RemoveProject(ProjectId projectId)
-            => _implementation.RemoveProject(projectId);
+        public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
+        {
+            _implementation.RemoveProject(projectId);
+            return Task.CompletedTask;
+        }
 
         // Unit testing incremental analyzer only supports full solution analysis scope.
         // In future, we should add a separate option to allow users to configure background analysis scope for unit testing.

--- a/src/Workspaces/Core/Portable/SolutionCrawler/IIncrementalAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/IIncrementalAnalyzer.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken);
         Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken);
 
-        void RemoveDocument(DocumentId documentId);
-        void RemoveProject(ProjectId projectId);
+        Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken);
+        Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken);
 
         bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e);
     }

--- a/src/Workspaces/Remote/Core/Telemetry/ApiUsageIncrementalAnalyzerProvider.cs
+++ b/src/Workspaces/Remote/Core/Telemetry/ApiUsageIncrementalAnalyzerProvider.cs
@@ -41,12 +41,14 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
 
             private readonly HashSet<ProjectId> _reported = new HashSet<ProjectId>();
 
-            public void RemoveProject(ProjectId projectId)
+            public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
             {
                 lock (_reported)
                 {
                     _reported.Remove(projectId);
                 }
+
+                return Task.CompletedTask;
             }
 
             public async Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
@@ -227,8 +229,9 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
                 return Task.CompletedTask;
             }
 
-            public void RemoveDocument(DocumentId documentId)
+            public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
             {
+                return Task.CompletedTask;
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/ProjectTelemetry/RemoteProjectTelemetryIncrementalAnalyzer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProjectTelemetry/RemoteProjectTelemetryIncrementalAnalyzer.cs
@@ -74,12 +74,14 @@ namespace Microsoft.CodeAnalysis.Remote
                 cancellationToken).ConfigureAwait(false);
         }
 
-        public override void RemoveProject(ProjectId projectId)
+        public override Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
             lock (_gate)
             {
                 _projectToInfo.Remove(projectId);
             }
+
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
We want this because we're moving SolutionCrawler OOP, and on some of these calls we'll be calling back into VSHost.  I would prefer that no calls that involve cross process communication need to be synchronous or fire-and-forget.