### PR TITLE
Implement binding and lowering for the with expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -684,6 +684,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SuppressNullableWarningExpression:
                     return BindSuppressNullableWarningExpression((PostfixUnaryExpressionSyntax)node, diagnostics);
 
+                case SyntaxKind.WithExpression:
+                    return BindWithExpression((WithExpressionSyntax)node, diagnostics);
+
                 default:
                     // NOTE: We could probably throw an exception here, but it's conceivable
                     // that a non-parser syntax tree could reach this point with an unexpected

--- a/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
@@ -78,6 +78,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var expr = BindValue(initializer.Expression, diagnostics, BindValueKind.RValue);
+                if (!(member is null))
+                {
+                    expr = GenerateConversionForAssignment(
+                        member.GetTypeOrReturnType().Type,
+                        expr,
+                        diagnostics);
+                }
                 lookupResult.Clear();
                 args.Add((member, expr));
             }
@@ -233,22 +240,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ErrorCode.ERR_WithMemberArgumentDoesntMatchParameter,
                             syntax.Initializers[i].NameEquals!.Name.Location,
                             member.Name);
-                    }
-
-                    var memberType = member.GetTypeOrReturnType().Type;
-                    var conversion = Conversions.ClassifyImplicitConversionFromExpression(
-                        expr,
-                        memberType,
-                        ref useSiteDiagnostics);
-
-                    if (!conversion.IsImplicit || !conversion.IsValid)
-                    {
-                        GenerateImplicitConversionError(
-                            diagnostics,
-                            expr.Syntax,
-                            conversion,
-                            expr,
-                            memberType);
                     }
                 }
                 useSiteDiagnostics = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // look for a single remaining one
                 foreach (var member in members)
                 {
-                    if (member is MethodSymbol { IsOverride: false} method)
+                    if (member is MethodSymbol { IsOverride: false } method)
                     {
                         if (withMethod is null)
                         {
@@ -86,7 +86,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         withMethod.ReturnType);
                 }
 
-
                 // Build WithMethod member list
                 var matchingMembers = ArrayBuilder<Symbol?>.GetInstance(withMethod.ParameterCount); 
                 foreach (var p in withMethod.Parameters)
@@ -112,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             p.Name);
                         member = null;
                     }
-                    else 
+                    else
                     {
                         member = lookupResult.SingleSymbolOrDefault;
                         Debug.Assert(member.Kind == SymbolKind.Field || member.Kind == SymbolKind.Property);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
@@ -227,8 +227,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Verify that the member name exists in the 'With' method parameter list
-            // and that there is an implicit conversion from the expression to the
-            // property type
             for (int i = 0; i < args.Count; i++)
             {
                 var (member, expr) = args[i];

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2052,4 +2052,19 @@
     <Field Name="Type" Type="TypeSymbol?" Override="true"/> <!-- We use null Type for placeholders representing out vars -->
     <Field Name="NullableAnnotation" Type="NullableAnnotation"/>
   </Node>
+
+  <Node Name="BoundWithExpression" Base="BoundExpression">
+    <!-- Non-null type is required for this node kind -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Receiver" Type="BoundExpression" />
+    <!-- WithMethod may be null in error scenarios-->
+    <Field Name="WithMethod" Type="MethodSymbol?" />
+    <!-- The set of fields/properties that are used for the WithMethod. There are exactly as many WithMembers as 
+         there are parameters to the With method. If there was no matching field/property for the With parameter,
+         that index should contain null. -->
+    <Field Name="WithMembers" Type="ImmutableArray&lt;Symbol?&gt;" Null="allow" />
+    <!-- Members and expressions passed as arguments to the With expression. -->
+    <Field Name="Arguments" Type="ImmutableArray&lt;(Symbol? Member, BoundExpression Expression)&gt;" />
+  </Node>
+
 </Tree>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6046,4 +6046,19 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_DuplicateRecordConstructor" xml:space="preserve">
     <value>There cannot be a primary constructor and a member constructor with the same parameter types.</value>
   </data>
+  <data name="ERR_InvalidWithReceiverType" xml:space="preserve">
+    <value>The receiver of a `with` expression must have a valid non-void type.</value>
+  </data>
+  <data name="ERR_NoSingleWithMethod" xml:space="preserve">
+    <value>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</value>
+  </data>
+  <data name="ERR_ContainingTypeMustDeriveFromWithReturnType" xml:space="preserve">
+    <value>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</value>
+  </data>
+  <data name="ERR_WithParameterWithoutMatchingMember" xml:space="preserve">
+    <value>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</value>
+  </data>
+  <data name="ERR_WithParameterTypeDoesntMatchMemberType" xml:space="preserve">
+    <value>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6056,9 +6056,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</value>
   </data>
   <data name="ERR_WithParameterWithoutMatchingMember" xml:space="preserve">
-    <value>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</value>
+    <value>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</value>
   </data>
   <data name="ERR_WithParameterTypeDoesntMatchMemberType" xml:space="preserve">
     <value>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</value>
+  </data>
+  <data name="ERR_WithMemberArgumentDoesntMatchParameter" xml:space="preserve">
+    <value>There is no `With` method parameter which matches property '{0}'.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6064,4 +6064,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_WithMemberArgumentDoesntMatchParameter" xml:space="preserve">
     <value>There is no `With` method parameter which matches property '{0}'.</value>
   </data>
+  <data name="ERR_WithMemberIsNotInstancePropertyOrField" xml:space="preserve">
+    <value>All arguments to a `with` expression must be instance properties or fields.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1771,6 +1771,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_BadRecordDeclaration = 8800,
         ERR_DuplicateRecordConstructor = 8801,
+        ERR_InvalidWithReceiverType = 8802,
+        ERR_NoSingleWithMethod = 8803,
+        ERR_ContainingTypeMustDeriveFromWithReturnType = 8804,
+        ERR_WithParameterWithoutMatchingMember = 8805,
+        ERR_WithParameterTypeDoesntMatchMemberType = 8806,
+
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1776,7 +1776,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ContainingTypeMustDeriveFromWithReturnType = 8804,
         ERR_WithParameterWithoutMatchingMember = 8805,
         ERR_WithParameterTypeDoesntMatchMemberType = 8806,
-
+        ERR_WithMemberArgumentDoesntMatchParameter = 8807,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1777,6 +1777,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_WithParameterWithoutMatchingMember = 8805,
         ERR_WithParameterTypeDoesntMatchMemberType = 8806,
         ERR_WithMemberArgumentDoesntMatchParameter = 8807,
+        ERR_WithMemberIsNotInstancePropertyOrField = 8808,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2026,6 +2026,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitWithExpression(BoundWithExpression node)
         {
+            // PROTOTYPE: This is wrong
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2024,6 +2024,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitWithExpression(BoundWithExpression node)
+        {
+            return null;
+        }
+
         public override BoundNode VisitArrayAccess(BoundArrayAccess node)
         {
             VisitRvalue(node.Expression);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2190,8 +2190,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitWithExpression(BoundWithExpression expr)
         {
-            SetResultType(expr, 
-                expr.WithMethod?.ReturnTypeWithAnnotations.ToTypeWithState() 
+            SetResultType(expr,
+                expr.WithMethod?.ReturnTypeWithAnnotations.ToTypeWithState()
                     ?? TypeWithState.Create(expr.Type, NullableFlowState.NotNull));
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2190,6 +2190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitWithExpression(BoundWithExpression expr)
         {
+            // PROTOTYPE: This is wrong
             SetResultType(expr,
                 expr.WithMethod?.ReturnTypeWithAnnotations.ToTypeWithState()
                     ?? TypeWithState.Create(expr.Type, NullableFlowState.NotNull));

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2188,6 +2188,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitWhileStatement(node);
         }
 
+        public override BoundNode VisitWithExpression(BoundWithExpression expr)
+        {
+            SetResultType(expr, 
+                expr.WithMethod?.ReturnTypeWithAnnotations.ToTypeWithState() 
+                    ?? TypeWithState.Create(expr.Type, NullableFlowState.NotNull));
+            return null;
+        }
+
         public override BoundNode VisitForStatement(BoundForStatement node)
         {
             DeclareLocals(node.OuterLocals);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -208,6 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         NonConstructorMethodBody,
         ConstructorMethodBody,
         ExpressionWithNullability,
+        WithExpression,
     }
 
 
@@ -7397,6 +7398,47 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal sealed partial class BoundWithExpression : BoundExpression
+    {
+        public BoundWithExpression(SyntaxNode syntax, BoundExpression receiver, MethodSymbol? withMethod, ImmutableArray<Symbol?> withMembers, ImmutableArray<(Symbol? Member, BoundExpression Expression)> arguments, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.WithExpression, syntax, type, hasErrors || receiver.HasErrors())
+        {
+
+            RoslynDebug.Assert(receiver is object, "Field 'receiver' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(!arguments.IsDefault, "Field 'arguments' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.Receiver = receiver;
+            this.WithMethod = withMethod;
+            this.WithMembers = withMembers;
+            this.Arguments = arguments;
+        }
+
+
+        public new TypeSymbol Type => base.Type!;
+
+        public BoundExpression Receiver { get; }
+
+        public MethodSymbol? WithMethod { get; }
+
+        public ImmutableArray<Symbol?> WithMembers { get; }
+
+        public ImmutableArray<(Symbol? Member, BoundExpression Expression)> Arguments { get; }
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitWithExpression(this);
+
+        public BoundWithExpression Update(BoundExpression receiver, MethodSymbol? withMethod, ImmutableArray<Symbol?> withMembers, ImmutableArray<(Symbol? Member, BoundExpression Expression)> arguments, TypeSymbol type)
+        {
+            if (receiver != this.Receiver || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(withMethod, this.WithMethod) || withMembers != this.WithMembers || arguments != this.Arguments || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            {
+                var result = new BoundWithExpression(this.Syntax, receiver, withMethod, withMembers, arguments, type, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
     internal abstract partial class BoundTreeVisitor<A,R>
     {
 
@@ -7779,6 +7821,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitConstructorMethodBody((BoundConstructorMethodBody)node, arg);
                 case BoundKind.ExpressionWithNullability: 
                     return VisitExpressionWithNullability((BoundExpressionWithNullability)node, arg);
+                case BoundKind.WithExpression: 
+                    return VisitWithExpression((BoundWithExpression)node, arg);
             }
 
             return default(R)!;
@@ -7974,6 +8018,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitNonConstructorMethodBody(BoundNonConstructorMethodBody node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitConstructorMethodBody(BoundConstructorMethodBody node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitExpressionWithNullability(BoundExpressionWithNullability node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitWithExpression(BoundWithExpression node, A arg) => this.DefaultVisit(node, arg);
     }
 
     internal abstract partial class BoundTreeVisitor
@@ -8165,6 +8210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitNonConstructorMethodBody(BoundNonConstructorMethodBody node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitConstructorMethodBody(BoundConstructorMethodBody node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitExpressionWithNullability(BoundExpressionWithNullability node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitWithExpression(BoundWithExpression node) => this.DefaultVisit(node);
     }
 
     internal abstract partial class BoundTreeWalker: BoundTreeVisitor
@@ -9017,6 +9063,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitExpressionWithNullability(BoundExpressionWithNullability node)
         {
             this.Visit(node.Expression);
+            return null;
+        }
+        public override BoundNode? VisitWithExpression(BoundWithExpression node)
+        {
+            this.Visit(node.Receiver);
             return null;
         }
     }
@@ -10126,6 +10177,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(expression, node.NullableAnnotation, type);
+        }
+        public override BoundNode? VisitWithExpression(BoundWithExpression node)
+        {
+            BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(receiver, node.WithMethod, node.WithMembers, node.Arguments, type);
         }
     }
 
@@ -12356,6 +12413,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             return updatedNode;
         }
+
+        public override BoundNode? VisitWithExpression(BoundWithExpression node)
+        {
+            MethodSymbol? withMethod = GetUpdatedSymbol(node, node.WithMethod);
+            ImmutableArray<Symbol?> withMembers = GetUpdatedArray(node, node.WithMembers);
+            BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
+            BoundWithExpression updatedNode;
+
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(receiver, withMethod, withMembers, node.Arguments, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(receiver, withMethod, withMembers, node.Arguments, node.Type);
+            }
+            return updatedNode;
+        }
     }
 
     internal sealed class BoundTreeDumperNodeProducer : BoundTreeVisitor<object?, TreeDumperNode>
@@ -14070,6 +14146,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
             new TreeDumperNode("nullableAnnotation", node.NullableAnnotation, null),
+            new TreeDumperNode("type", node.Type, null),
+            new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
+        public override TreeDumperNode VisitWithExpression(BoundWithExpression node, object? arg) => new TreeDumperNode("withExpression", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("receiver", null, new TreeDumperNode[] { Visit(node.Receiver, null) }),
+            new TreeDumperNode("withMethod", node.WithMethod, null),
+            new TreeDumperNode("withMembers", node.WithMembers, null),
+            new TreeDumperNode("arguments", node.Arguments, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_WithExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_WithExpression.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed partial class LocalRewriter
+    {
+        public override BoundNode VisitWithExpression(BoundWithExpression withExpr)
+        {
+            RoslynDebug.AssertNotNull(withExpr.WithMethod);
+            Debug.Assert(withExpr.WithMembers.Length == withExpr.WithMethod.ParameterCount);
+
+            // for a with expression of the form
+            //
+            //      receiver with { P1 = e1, P2 = e2 }
+            //
+            // we want to lower it to a call to the receiver's `With` method, filling
+            // in any "missing" parameters with a call to a matching field/property on
+            // the receiver
+            var F = _factory;
+            var tempsCount = withExpr.Arguments.Length + 1;
+            var locals = ArrayBuilder<LocalSymbol>.GetInstance(tempsCount);
+            var stores = ArrayBuilder<BoundExpression>.GetInstance(tempsCount);
+
+            // First lower the receiver and arguments to temps. This preserves lexical evaluation order
+            var receiverLocal = F.StoreToTemp(
+                VisitExpression(withExpr.Receiver),
+                out var receiverStore);
+            locals.Add(receiverLocal.LocalSymbol);
+            stores.Add(receiverStore);
+
+            var nameToLocal = PooledDictionary<string, BoundLocal>.GetInstance();
+            foreach (var arg in withExpr.Arguments)
+            {
+                RoslynDebug.AssertNotNull(arg.Member);
+                var local = F.StoreToTemp(VisitExpression(arg.Expression), out var store);
+                locals.Add(local.LocalSymbol);
+                stores.Add(store);
+                nameToLocal.Add(arg.Member.Name, local);
+            }
+
+            // Now construct call to the WithMethod
+            var methodArgs = ArrayBuilder<BoundExpression>.GetInstance(withExpr.WithMembers.Length);
+            foreach (var m in withExpr.WithMembers)
+            {
+                RoslynDebug.AssertNotNull(m);
+                if (nameToLocal.TryGetValue(m.Name, out var local))
+                {
+                    methodArgs.Add(local);
+                }
+                else
+                {
+                    // receiver.With(..., receiver.P_n);
+                    BoundExpression access;
+                    if (m is PropertySymbol p)
+                    {
+                        access = F.Property(receiverLocal, p);
+                    }
+                    else
+                    {
+                        var field = (FieldSymbol)m; 
+                        access = F.Field(receiverLocal, field);
+                    }
+                    methodArgs.Add(access);
+                }
+            }
+            nameToLocal.Free();
+
+            return new BoundSequence(
+                withExpr.Syntax,
+                locals.ToImmutableAndFree(),
+                stores.ToImmutableAndFree(),
+                F.Call(receiverLocal, withExpr.WithMethod, methodArgs.ToImmutableAndFree()),
+                withExpr.Type);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_WithExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_WithExpression.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        var field = (FieldSymbol)m; 
+                        var field = (FieldSymbol)m;
                         access = F.Field(receiverLocal, field);
                     }
                     methodArgs.Add(access);

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Výčty, třídy a struktury není možné deklarovat v rozhraní, které má parametr typu in/out.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Výraz typu {0} nelze zpracovat vzorem typu {1}. Použijte prosím verzi jazyka {2} nebo vyšší, aby odpovídala otevřenému typu se vzorem konstanty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Název {0} neodpovídá příslušnému parametru Deconstruct {1}.</target>
@@ -307,6 +312,11 @@
         <target state="translated">Specifikátor rozsahu je neplatný. Očekávala se pravá hranatá závorka ].</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Ve výrazu is-type se nepovoluje použití typu odkazu s možnou hodnotou null {0}?; místo toho použijte základní typ {0}.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Výčty, třídy a struktury není možné deklarovat v rozhraní, které má parametr typu in/out.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Ein Ausdruck vom Typ "{0}" kann nicht von einem Muster vom Typ "{1}" behandelt werden. Verwenden Sie Sprachversion {2} oder höher, um einen offenen Typ mit einem konstanten Muster abzugleichen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Der Name "{0}" stimmt nicht mit dem entsprechenden Deconstruct-Parameter "{1}" überein.</target>
@@ -307,6 +312,11 @@
         <target state="translated">"Ungültiger Rangspezifizierer: Erwartet wurde ]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Es ist unzulässig, den Nullable-Verweistyp "{0}?" in einem is-Ausdruck zu verwenden. Verwenden Sie stattdessen den zugrunde liegenden Typ "{0}".</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Enumerationen, Klassen und Strukturen können nicht in Schnittstellen mit Parametern vom Typ "in" oder "out" deklariert werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Enumerationen, Klassen und Strukturen können nicht in Schnittstellen mit Parametern vom Typ "in" oder "out" deklariert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Las enumeraciones, las clases y las estructuras no se pueden declarar en una interfaz que tenga un parámetro de tipo "in" o "out".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Un patrón de tipo "{0}" no se puede controlar por un patrón de tipo "{1}". Use la versión de lenguaje "{2}" o superior para buscar un tipo abierto con un patrón constante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">El nombre "{0}" no coincide con el parámetro de "Deconstruct" correspondiente, "{1}".</target>
@@ -307,6 +312,11 @@
         <target state="translated">"Especificador de rango no válido: se esperaba "]""</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">No se puede usar el tipo "{0}?" que acepta valores NULL en una expresión is-type; use en su lugar el tipo "{0}" subyacente.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Las enumeraciones, las clases y las estructuras no se pueden declarar en una interfaz que tenga un parámetro de tipo "in" o "out".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Une expression de type '{0}' ne peut pas être prise en charge par un modèle de type '{1}'. Utilisez la version de langage '{2}' ou une version ultérieure pour faire correspondre un type ouvert à un modèle de constante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Le nom '{0}' ne correspond pas au paramètre 'Deconstruct' correspondant '{1}'.</target>
@@ -307,6 +312,11 @@
         <target state="translated">"Spécificateur de rang non valide : ']' attendu</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Il n'est pas correct d'utiliser le type de référence Nullable '{0}?' dans une expression is-type. Utilisez le type sous-jacent '{0}' à la place.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Les enums, les classes et les structures ne peuvent pas être déclarés dans une interface contenant un paramètre de type 'in' ou 'out'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Les enums, les classes et les structures ne peuvent pas être déclarés dans une interface contenant un paramètre de type 'in' ou 'out'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Un'espressione di tipo '{0}' non può essere gestita da un criterio di tipo '{1}'. Usare la versione '{2}' o versioni successive del linguaggio per abbinare un tipo aperto a un criterio costante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Il nome '{0}' non corrisponde al parametro '{1}' di 'Deconstruct' corrispondente.</target>
@@ -307,6 +312,11 @@
         <target state="translated">"L'identificatore del numero di dimensioni non è valido: è previsto ']'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Non è consentito usare il tipo riferimento nullable '{0}?' in un'espressione is-type. Usare il tipo sottostante '{0}'.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Non è possibile dichiarare enumerazioni, classi e strutture in un'interfaccia che contiene un parametro di tipo 'in' o 'out'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Non è possibile dichiarare enumerazioni, classi e strutture in un'interfaccia che contiene un parametro di tipo 'in' o 'out'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -552,14 +552,19 @@
         <target state="translated">'in' または 'out' の型パラメーターを持つインターフェイス内では、列挙体、クラス、および構造体を宣言することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -117,6 +117,11 @@
         <target state="translated">型 '{0}' の式を型 '{1}' のパターンで処理することはできません。オープン型と定数パターンを一致させるには、言語バージョン '{2}' 以上をご使用ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">名前 '{0}' は対応する 'Deconstruct' パラメーター '{1}' と一致しません。</target>
@@ -307,6 +312,11 @@
         <target state="translated">"無効な次元指定子です: ']' を指定してください</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">is-type 式で Null 許容参照型 '{0}?' を使用することはできません。代わりに基になる型 '{0}' をご使用ください。</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">'in' または 'out' の型パラメーターを持つインターフェイス内では、列挙体、クラス、および構造体を宣言することはできません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -117,6 +117,11 @@
         <target state="translated">'{0}' 형식의 식은 '{1}' 형식의 패턴으로 처리할 수 없습니다. 언어 버전 '{2}' 이상을 사용하여 개방형 형식과 상수 패턴을 일치시키세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">'{0}' 이름이 해당 'Deconstruct' 매개 변수 '{1}'과(와) 일치하지 않습니다.</target>
@@ -307,6 +312,11 @@
         <target state="translated">잘못된 차수 지정자입니다. ']'가 필요합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">is-type 식에 nullable 참조 형식 '{0}?'을(를) 사용하는 것은 올바르지 않습니다. 대신 기본 형식 '{0}'을(를) 사용하세요.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">'in' 또는 'out' 형식 매개 변수가 있는 인터페이스에서 열거형, 클래스, 구조체를 선언할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -552,14 +552,19 @@
         <target state="translated">'in' 또는 'out' 형식 매개 변수가 있는 인터페이스에서 열거형, 클래스, 구조체를 선언할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Wyrażenie typu „{0}” nie może być obsługiwane przez wzorzec typu „{1}”. Użyj wersji języka „{2}” lub nowszej, aby dopasować typ otwarty za pomocą wzorca stałej.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Nazwa „{0}” nie jest zgodna z odpowiednim parametrem „Deconstruct” „{1}”.</target>
@@ -307,6 +312,11 @@
         <target state="translated">Nieprawidłowy specyfikator rangi: oczekiwano „]”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Użycie typu odwołania dopuszczającego wartość null „{0}?” w wyrażeniu „is-type” jest niedozwolone. Zamiast tego użyj bazowego typu „{0}”.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Wyliczenia, klasy i struktury nie mogą być deklarowane w interfejsie mającym parametr typu „in” lub „out”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Wyliczenia, klasy i struktury nie mogą być deklarowane w interfejsie mającym parametr typu „in” lub „out”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Uma expressão do tipo '{0}' não pode ser manipulada por um padrão do tipo '{1}'. Use a versão de linguagem '{2}' ou superior para corresponder a um tipo aberto com um padrão constante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">O nome '{0}' não corresponde ao parâmetro 'Deconstruct' '{1}'.</target>
@@ -307,6 +312,11 @@
         <target state="translated">"Especificador de classificação inválido: era esperado ']'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">É ilegal usar o tipo de referência anulável '{0}?' em uma expressão is-type; use o tipo subjacente '{0}' em seu lugar.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Não é possível declarar enumerações, classes e estruturas em uma interface que tenha um parâmetro de tipo 'in' ou 'out'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Não é possível declarar enumerações, classes e estruturas em uma interface que tenha um parâmetro de tipo 'in' ou 'out'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Перечисления, классы и структуры не могут быть объявлены в интерфейсе, имеющем параметр типа "In" или "Out".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Выражение типа "{0}" не может быть обработано шаблоном типа "{1}". Используйте версию языка "{2}" или более позднюю, чтобы сопоставить открытый тип с постоянным шаблоном.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Имя "{0}" не соответствует указанному параметру "Deconstruct" "{1}".</target>
@@ -307,6 +312,11 @@
         <target state="translated">"Недопустимый описатель ранга: ожидается "]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Недопустимо использовать ссылочный тип "{0}", допускающий значения NULL, в выражении "is-type". Используйте вместо него базовый тип "{0}".</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Перечисления, классы и структуры не могут быть объявлены в интерфейсе, имеющем параметр типа "In" или "Out".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -552,14 +552,19 @@
         <target state="translated">Sabit listeleri, sınıflar ve yapılar 'in' veya 'out' tür parametresine sahip bir arabirimde bildirilemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">'{0}' türünde bir ifade, '{1}' türünde bir desen tarafından işlenemez. Lütfen açık bir türü sabit bir desenle eşleştirmek için '{2}' veya daha yüksek bir dil sürümü kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">'{0}' adı ilgili '{1}' 'Deconstruct' parametresiyle eşleşmiyor.</target>
@@ -307,6 +312,11 @@
         <target state="translated">"IGeçersiz sıra belirticisi: ']' bekleniyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">Boş değer atanabilir '{0}?' başvuru türünün bir is-type ifadesinde kullanılması yasaktır; bunun yerine temel alınan '{0}' türünü kullanın.</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Sabit listeleri, sınıflar ve yapılar 'in' veya 'out' tür parametresine sahip bir arabirimde bildirilemez.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -552,14 +552,19 @@
         <target state="translated">无法在含有 "in" 或 "out" 类型参数的接口中声明枚举、类和结构。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -117,6 +117,11 @@
         <target state="translated">"{0}" 类型的表达式不能由 "{1}" 类型的模式进行处理。请使用语言版本 "{2}" 或更高版本，将开放类型与常数模式进行匹配。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">名称“{0}”与相应 "Deconstruct" 参数“{1}”不匹配。</target>
@@ -307,6 +312,11 @@
         <target state="translated">“无效的秩说明符: 应为“]”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">在 is-type 表达式中使用可以为 null 的引用类型“{0}?”是非法的；请改用基础类型“{0}”。</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">无法在含有 "in" 或 "out" 类型参数的接口中声明枚举、类和结构。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -552,14 +552,19 @@
         <target state="translated">無法在有 'in' 或 'out' 型別參數的介面中宣告列舉、類別和結構。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberArgumentDoesntMatchParameter">
+        <source>There is no `With` method parameter which matches property '{0}'.</source>
+        <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WithParameterWithoutMatchingMember">
-        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
-        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
+        <source>The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a matching field or property to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -557,6 +557,11 @@
         <target state="new">There is no `With` method parameter which matches property '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_WithMemberIsNotInstancePropertyOrField">
+        <source>All arguments to a `with` expression must be instance properties or fields.</source>
+        <target state="new">All arguments to a `with` expression must be instance properties or fields.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
         <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
         <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -117,6 +117,11 @@
         <target state="translated">類型 '{0}' 的運算式無法由類型 '{1}' 的模式處理。請使用語言 '{2}' 版或更新版本，以比對開放式類型與常數模式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
+        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</source>
+        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'With' method, '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">名稱 '{0}' 與對應的 'Deconstruct' 參數 '{1}' 不相符。</target>
@@ -307,6 +312,11 @@
         <target state="translated">"陣序規範無效: 必須是 ']'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InvalidWithReceiverType">
+        <source>The receiver of a `with` expression must have a valid non-void type.</source>
+        <target state="new">The receiver of a `with` expression must have a valid non-void type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_IsNullableType">
         <source>It is not legal to use nullable reference type '{0}?' in an is-type expression; use the underlying type '{0}' instead.</source>
         <target state="translated">在 is-type 運算式中使用可為 Null 的參考型別 '{0}' 不合法嗎? 請改用基礎類型 '{0}'。</target>
@@ -355,6 +365,11 @@
       <trans-unit id="ERR_NoOutputDirectory">
         <source>Output directory could not be determined</source>
         <target state="new">Output directory could not be determined</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoSingleWithMethod">
+        <source>The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</source>
+        <target state="new">The 'with' expression requires the receiver type '{0}' to have a single accessible non-inherited instance method named "With".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -535,6 +550,16 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">無法在有 'in' 或 'out' 型別參數的介面中宣告列舉、類別和結構。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterTypeDoesntMatchMemberType">
+        <source>The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</source>
+        <target state="new">The 'With' method parameter named '{0}' has type '{1}' which doesn't match member type '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_WithParameterWithoutMatchingMember">
+        <source>The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</source>
+        <target state="new">The receiver type '{0}' does not have a corresponding member to the 'With' method parameter named '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -1356,7 +1356,7 @@ data class C(long X)
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "s").WithArguments("S", "long").WithLocation(19, 41)
             );
         }
- 
+
         [Fact]
         public void WithExprConversions5()
         {
@@ -1372,6 +1372,6 @@ data class C(object X)
     }
 }";
             var verifier = CompileAndVerify(src, expectedOutput: "abc");
-        }   
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -869,5 +869,51 @@ data class C(int X, int Y)
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(8, 26)
             );
         }
+
+        [Fact]
+        public void WithExpr17()
+        {
+            var src = @"
+class B
+{
+    public int X { get; }
+    private B With(int X) => null;
+}
+class C : B
+{
+    public static void Main()
+    {
+        var b = new B();
+        b = b with { };
+    }
+}";
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics(
+                // (12,13): error CS8803: The 'with' expression requires the receiver type 'B' to have a single accessible non-inherited instance method named "With".
+                //         b = b with { };
+                Diagnostic(ErrorCode.ERR_NoSingleWithMethod, "b").WithArguments("B").WithLocation(12, 13)
+            );
+        }
+
+        [Fact]
+        public void WithExpr18()
+        {
+            var src = @"
+class B
+{
+    public int X { get; }
+    protected B With(int X) => null;
+}
+class C : B
+{
+    public static void Main()
+    {
+        var b = new B();
+        b = b with { };
+    }
+}";
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
A with expression binds to a method called With on the receiver
type. It is an error if there are multiple With methods where more than
one is not an override.

All parameters to the With method must have corresponding fields or
properties on the receiver type, and the With call is constructed by
substituting the expressions assigned to the properties in the `with`
expression arguments. Any "missing" arguments are substituted with
a property or field access to the corresponding member of the same
name on the receiver type.