### PR TITLE
Fix race in VBCSCompiler test

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/Extensions.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/Extensions.cs
@@ -14,16 +14,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     internal static class Extensions
     {
-        public static Task<bool> ToTask(this WaitHandle handle, int? timeoutMilliseconds)
+        public static Task ToTask(this WaitHandle handle, int? timeoutMilliseconds)
         {
             RegisteredWaitHandle registeredHandle = null;
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             registeredHandle = ThreadPool.RegisterWaitForSingleObject(
                 handle,
-                (_, timedOut) =>
+                (_, timeout) =>
                 {
-                    tcs.TrySetResult(!timedOut);
-                    if (!timedOut)
+                    tcs.TrySetResult(null);
+                    if (registeredHandle is object)
                     {
                         registeredHandle.Unregister(waitObject: null);
                     }
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             return tcs.Task;
         }
 
-        public static async Task<bool> WaitOneAsync(this WaitHandle handle, int? timeoutMilliseconds = null) => await handle.ToTask(timeoutMilliseconds);
+        public static async Task WaitOneAsync(this WaitHandle handle, int? timeoutMilliseconds = null) => await handle.ToTask(timeoutMilliseconds);
 
         public static async ValueTask<T> TakeAsync<T>(this BlockingCollection<T> collection, TimeSpan? pollTimeSpan = null, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Need to account for the case that the callback executes before the handle is assigned. Or that the handle is visible in the call back.

closes #41788