### PR TITLE
Restore explicit tests for IEnumerable<byte> and byte[]

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyMetadataTests.cs
@@ -16,7 +16,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void Ctor_Errors()
         {
             Assert.Throws<ArgumentNullException>(() => AssemblyMetadata.CreateFromImage(default(ImmutableArray<byte>)));
-            Assert.Throws<ArgumentNullException>(() => AssemblyMetadata.CreateFromImage(null));
+
+            IEnumerable<byte> enumerableImage = null;
+            Assert.Throws<ArgumentNullException>(() => AssemblyMetadata.CreateFromImage(enumerableImage));
+
+            byte[] arrayImage = null;
+            Assert.Throws<ArgumentNullException>(() => AssemblyMetadata.CreateFromImage(arrayImage));
+
             Assert.Throws<ArgumentNullException>(() => AssemblyMetadata.Create((ModuleMetadata)null));
             Assert.Throws<ArgumentException>(() => AssemblyMetadata.Create(default(ImmutableArray<ModuleMetadata>)));
             Assert.Throws<ArgumentException>(() => AssemblyMetadata.Create(ImmutableArray.Create<ModuleMetadata>()));

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
@@ -61,7 +61,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentOutOfRangeException>(() => { fixed (byte* ptr = new byte[] { 1, 2, 3 }) ModuleMetadata.CreateFromImage((IntPtr)ptr, -1); });
 
             Assert.Throws<ArgumentNullException>(() => ModuleMetadata.CreateFromImage(default(ImmutableArray<byte>)));
-            Assert.Throws<ArgumentNullException>(() => ModuleMetadata.CreateFromImage(null));
+
+            IEnumerable<byte> enumerableImage = null;
+            Assert.Throws<ArgumentNullException>(() => ModuleMetadata.CreateFromImage(enumerableImage));
+
+            byte[] arrayImage = null;
+            Assert.Throws<ArgumentNullException>(() => ModuleMetadata.CreateFromImage(arrayImage));
 
             // It's not particularly important that this not throw. The parsing of the metadata is now lazy, and the result is that an exception
             // will be thrown when something tugs on the metadata later.


### PR DESCRIPTION
These tests call the same API, but provided value in clarity regarding behavior in two known user scenarios.