### PR TITLE
🧹 Remove unnecessary suppressions

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Host
                 DiagnosticOptions = diagnosticOptions;
             }
 
-            internal bool TryGetText([MaybeNullWhen(false)]out SourceText text)
+            internal bool TryGetText([NotNullWhen(true)] out SourceText? text)
             {
                 if (TextSource.TryGetValue(out var textAndVersion))
                 {
@@ -55,8 +55,7 @@ namespace Microsoft.CodeAnalysis.Host
                     return true;
                 }
 
-                // Suppressing nullable warning due to https://github.com/dotnet/roslyn/issues/40266
-                text = null!;
+                text = null;
                 return false;
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -165,7 +165,7 @@ namespace Roslyn.Utilities
 
         #endregion
 
-        public override bool TryGetValue([MaybeNullWhen(false)]out T result)
+        public override bool TryGetValue([MaybeNullWhen(false)] out T result)
         {
             // No need to lock here since this is only a fast check to 
             // see if the result is already computed.
@@ -175,8 +175,7 @@ namespace Roslyn.Utilities
                 return true;
             }
 
-            // Suppressing nullable warning due to https://github.com/dotnet/roslyn/issues/40266
-            result = default!;
+            result = default;
             return false;
         }
 


### PR DESCRIPTION
Cleans up code from cases where we annotated code before current features were available in the compiler.