### PR TITLE
Apply color scheme when in high contrast

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ColorSchemes/ColorSchemeApplier.cs
@@ -110,8 +110,8 @@ namespace Microsoft.VisualStudio.LanguageServices.ColorSchemes
         {
             AssertIsForeground();
 
-            // Simply return if we were queued to run during shutdown or the user is in High Contrast mode.
-            if (_isDisposed || SystemParameters.HighContrast)
+            // Simply return if we were queued to run during shutdown.
+            if (_isDisposed)
             {
                 return;
             }


### PR DESCRIPTION
We were not applying color schemes when in high contrast mode. Causing accessibility issues with Dark Contast modes.