### PR TITLE
Remove capturing of log content during NFW reporting, filter logs

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
             catch
             {
+                // ignore any exceptions (e.g. OOM)
             }
 
             FailFast.OnFatalException(exception);

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.VisualStudio.LanguageServices.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
 
@@ -57,7 +58,14 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
         public static void ReportFatal(Exception exception)
         {
-            _ = CaptureLogFiles();
+            try
+            {
+                CaptureFilesInMemory(CollectServiceHubLogFilePaths());
+            }
+            catch
+            {
+            }
+
             FailFast.OnFatalException(exception);
         }
 
@@ -89,8 +97,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 return;
             }
 
-            var logFilePaths = CaptureLogFiles();
-
             var faultEvent = new FaultEvent(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: "Roslyn NonFatal Watson",
@@ -102,7 +108,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                     faultUtility.AddProcessDump(currentProcess.Id);
 
                     // add ServiceHub log files:
-                    foreach (var path in logFilePaths)
+                    foreach (var path in CollectServiceHubLogFilePaths())
                     {
                         faultUtility.AddFile(path);
                     }
@@ -119,39 +125,48 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             session.PostEvent(faultEvent);
         }
 
-        private static List<string> CaptureLogFiles()
+        private static List<string> CollectServiceHubLogFilePaths()
         {
-            var result = new List<string>();
-            CollectServiceHubLogFiles(result);
-            CaptureFilesInMemory(result);
-            return result;
-        }
+            var paths = new List<string>();
 
-        private static void CollectServiceHubLogFiles(List<string> paths)
-        {
             try
             {
                 var logPath = Path.Combine(Path.GetTempPath(), "servicehub", "logs");
                 if (!Directory.Exists(logPath))
                 {
-                    return;
+                    return paths;
                 }
 
                 // attach all log files that are modified less than 1 day before.
                 var now = DateTime.UtcNow;
                 var oneDay = TimeSpan.FromDays(1);
 
-                foreach (var file in Directory.EnumerateFiles(logPath, "*.log"))
+                foreach (var path in Directory.EnumerateFiles(logPath, "*.log"))
                 {
                     try
                     {
-                        var lastWrite = File.GetLastWriteTimeUtc(file);
+                        var name = Path.GetFileNameWithoutExtension(path);
+
+                        // TODO: https://github.com/dotnet/roslyn/issues/42582 
+                        // name our services more consistently to simplify filtering
+
+                        // filter logs that are not relevant to Roslyn investigation
+                        if (!name.Contains("-" + WellKnownServiceHubServices.NamePrefix) &&
+                            !name.Contains("-CodeLens") &&
+                            !name.Contains("-pythia") &&
+                            !name.Contains("-ManagedLanguage.IDE.RemoteHostClient") &&
+                            !name.Contains("-hub"))
+                        {
+                            continue;
+                        }
+
+                        var lastWrite = File.GetLastWriteTimeUtc(path);
                         if (now - lastWrite > oneDay)
                         {
                             continue;
                         }
 
-                        paths.Add(file);
+                        paths.Add(path);
                     }
                     catch
                     {
@@ -163,6 +178,8 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             {
                 // ignore failures
             }
+
+            return paths;
         }
 
         private static void CaptureFilesInMemory(IEnumerable<string> paths)

--- a/src/Workspaces/Core/Portable/Remote/WellKnownServiceHubServices.cs
+++ b/src/Workspaces/Core/Portable/Remote/WellKnownServiceHubServices.cs
@@ -6,24 +6,26 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal static class WellKnownServiceHubServices
     {
+        public const string NamePrefix = "roslyn";
+
         public static void Set64bit(bool x64)
         {
             var bit = x64 ? "64" : "";
 
-            SnapshotService = "roslynSnapshot" + bit;
-            CodeAnalysisService = "roslynCodeAnalysis" + bit;
-            RemoteDesignerAttributeService = "roslynRemoteDesignerAttributeService" + bit;
-            RemoteProjectTelemetryService = "roslynRemoteProjectTelemetryService" + bit;
-            RemoteSymbolSearchUpdateEngine = "roslynRemoteSymbolSearchUpdateEngine" + bit;
-            LanguageServer = "roslynLanguageServer" + bit;
+            SnapshotService = NamePrefix + "Snapshot" + bit;
+            CodeAnalysisService = NamePrefix + "CodeAnalysis" + bit;
+            RemoteDesignerAttributeService = NamePrefix + "RemoteDesignerAttributeService" + bit;
+            RemoteProjectTelemetryService = NamePrefix + "RemoteProjectTelemetryService" + bit;
+            RemoteSymbolSearchUpdateEngine = NamePrefix + "RemoteSymbolSearchUpdateEngine" + bit;
+            LanguageServer = NamePrefix + "LanguageServer" + bit;
         }
 
-        public static string SnapshotService { get; private set; } = "roslynSnapshot";
-        public static string CodeAnalysisService { get; private set; } = "roslynCodeAnalysis";
-        public static string RemoteSymbolSearchUpdateEngine { get; private set; } = "roslynRemoteSymbolSearchUpdateEngine";
-        public static string RemoteDesignerAttributeService { get; private set; } = "roslynRemoteDesignerAttributeService";
-        public static string RemoteProjectTelemetryService { get; private set; } = "roslynRemoteProjectTelemetryService";
-        public static string LanguageServer { get; private set; } = "roslynLanguageServer";
+        public static string SnapshotService { get; private set; } = NamePrefix + "Snapshot";
+        public static string CodeAnalysisService { get; private set; } = NamePrefix + "CodeAnalysis";
+        public static string RemoteSymbolSearchUpdateEngine { get; private set; } = NamePrefix + "RemoteSymbolSearchUpdateEngine";
+        public static string RemoteDesignerAttributeService { get; private set; } = NamePrefix + "RemoteDesignerAttributeService";
+        public static string RemoteProjectTelemetryService { get; private set; } = NamePrefix + "RemoteProjectTelemetryService";
+        public static string LanguageServer { get; private set; } = NamePrefix + "LanguageServer";
 
         // these are OOP implementation itself should care. not features that consume OOP care
         public const string ServiceHubServiceBase_Initialize = "Initialize";


### PR DESCRIPTION
Avoid loading content of log files into memory during non-fatal Watson reporting. 
Loading the file content increases the time it takes to capture the process memory dump, making UI delays longer if we are reporting NFW from UI thread.
This is not a concert for fatal error reporting since we are going to crash the process anyways.

Also filters out log files we are not interested in.