### PR TITLE
Vary async iterator test names

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,6 +34,19 @@
         ],
         "problemMatcher": "$msCompile",
         "group": "build"
+    },
+    {
+        "label": "build directory skip analyzers",
+        "command": "dotnet",
+        "type": "shell",
+        "args": [
+          "msbuild",
+          "-p:UseRoslynAnalyzers=false",
+          "-p:GenerateFullPaths=true",
+          "${fileDirname}"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "build"
     }
   ]
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -30,11 +31,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         /// <summary>
         /// Enumerates `C.M()` a given number of iterations.
         /// </summary>
-        private static string Run(int iterations)
+        private static string Run(int iterations, [CallerMemberName] string testMethodName = null)
         {
-            string _runner = @"
+            string runner = $@"
 using static System.Console;
-class D
+class {testMethodName}
+";
+            runner += @"
 {
     static async System.Threading.Tasks.Task Main()
     {
@@ -73,7 +76,7 @@ class D
     }
 }
 ";
-            return _runner.Replace("ITERATIONS", iterations.ToString());
+            return runner.Replace("ITERATIONS", iterations.ToString());
         }
 
         private const string _enumerable = @"


### PR DESCRIPTION
This will help us identify which of the tests is the cause of #42590

The failing test is hard to track down now because the only information we have is the stack trace and every async iterator test here is using the same pair of class names. This change will add the test name into the traces and better help identify the failing test. 

```
System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()
   at D.<Main>d__0.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.MoveNextRunner.InvokeMoveNext(Object stateMachine)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.MoveNextRunner.Run()
   at System.Runtime.CompilerServices.ValueTaskAwaiter.<>c.<.cctor>b__9_0(Object state)
   at System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1.InvokeContinuation()
   at System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1.SignalCompletion()
   at System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1.SetResult(TResult result)
   at C.<M>d__0.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.MoveNextRunner.InvokeMoveNext(Object stateMachine)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.MoveNextRunner.Run()
   at System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.RunAction(Object state)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```