### PR TITLE
Diagnostics for FailFast

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis
             {
                 exception = aggregate.InnerExceptions[0];
             }
-#endif
 
+#endif
             DumpStackTrace(exception);
 
             Environment.FailFast(exception.ToString(), exception);
@@ -57,10 +57,12 @@ namespace Microsoft.CodeAnalysis
                 current = current.InnerException;
             } while (current is object);
 
+#if !NET20 && !NETSTANDARD1_3
             Console.WriteLine("Stack trace of handler");
             var stackTrace = new StackTrace();
             Console.WriteLine(stackTrace.ToString());
             Console.Out.Flush();
+#endif
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -34,8 +34,33 @@ namespace Microsoft.CodeAnalysis
             }
 #endif
 
+            DumpStackTrace(exception);
+
             Environment.FailFast(exception.ToString(), exception);
             throw ExceptionUtilities.Unreachable; // to satisfy [DoesNotReturn]
+        }
+
+        /// <summary>
+        /// Dumps the stack trace of the exception and the handler to the console. This is useful
+        /// for debugging unit tests that hit a fatal exception
+        /// </summary>
+        [Conditional("DEBUG")]
+        private static void DumpStackTrace(Exception exception)
+        {
+            Console.WriteLine("Dumping info before call to failfast");
+            Console.WriteLine("Exception info");
+            Exception? current = exception;
+            do
+            {
+                Console.WriteLine(current.Message);
+                Console.WriteLine(current.StackTrace);
+                current = current.InnerException;
+            } while (current is object);
+
+            Console.WriteLine("Stack trace of handler");
+            var stackTrace = new StackTrace();
+            Console.WriteLine(stackTrace.ToString());
+            Console.Out.Flush();
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -49,20 +49,21 @@ namespace Microsoft.CodeAnalysis
         {
             Console.WriteLine("Dumping info before call to failfast");
             Console.WriteLine("Exception info");
-            Exception? current = exception;
-            do
+
+            for (Exception? current = exception; current is object; current = current.InnerException)
             {
                 Console.WriteLine(current.Message);
                 Console.WriteLine(current.StackTrace);
                 current = current.InnerException;
-            } while (current is object);
+            }
 
 #if !NET20 && !NETSTANDARD1_3
             Console.WriteLine("Stack trace of handler");
             var stackTrace = new StackTrace();
             Console.WriteLine(stackTrace.ToString());
-            Console.Out.Flush();
 #endif
+
+            Console.Out.Flush();
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
             Console.WriteLine("Dumping info before call to failfast");
             Console.WriteLine("Exception info");
 
-            for (Exception? current = exception; current is object; current = current.InnerException)
+            for (Exception? current = exception; current is object; current = current!.InnerException)
             {
                 Console.WriteLine(current.Message);
                 Console.WriteLine(current.StackTrace);


### PR DESCRIPTION
Add console diagnostics when we hit a fatal exception in debug mode.
This should help us track down test failures like #42586.