### PR TITLE
Source Generators: Diagnostics + Remove Prototypes

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6016,4 +6016,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExpressionTreeContainsRangeExpression" xml:space="preserve">
     <value>An expression tree may not contain a range ('..') expression.</value>
   </data>
+  <data name="WRN_GeneratorFailedDuringGeneration" xml:space="preserve">
+    <value>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</value>
+  </data>
+  <data name="WRN_GeneratorFailedDuringInitialization" xml:space="preserve">
+    <value>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6022,4 +6022,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_GeneratorFailedDuringInitialization" xml:space="preserve">
     <value>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</value>
   </data>
+  <data name="WRN_GeneratorFailedDuringExecution_Title" xml:space="preserve">
+    <value>A Generator failed to generate source.</value>
+  </data>
+  <data name="WRN_GeneratorFailedDuringGeneration_Title" xml:space="preserve">
+    <value>A Generator failed to initialize.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6022,10 +6022,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_GeneratorFailedDuringInitialization" xml:space="preserve">
     <value>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</value>
   </data>
-  <data name="WRN_GeneratorFailedDuringExecution_Title" xml:space="preserve">
-    <value>A Generator failed to generate source.</value>
-  </data>
   <data name="WRN_GeneratorFailedDuringGeneration_Title" xml:space="preserve">
-    <value>A Generator failed to initialize.</value>
+    <value>Generator failed to generate source.</value>
+  </data>
+  <data name="WRN_GeneratorFailedDuringInitialization_Title" xml:space="preserve">
+    <value>Generator failed to initialize.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -399,16 +399,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private protected override Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts)
+        private protected override Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts, DiagnosticBag diagnostics)
         {
-            // PROTOTYPE: for now we gate behind langver == preview. We'll remove this before final shipping, as the feature is langver agnostic
+            // SG_ISSUE #42565: for now we gate behind langver == preview. We'll remove this before final shipping, as the feature is langver agnostic
             if (((CSharpParseOptions)parseOptions).LanguageVersion != LanguageVersion.Preview)
             {
                 return input;
             }
 
             var driver = new CSharpGeneratorDriver(input, parseOptions, generators, additionalTexts);
-            driver.RunFullGeneration(input, out var compilationOut);
+            driver.RunFullGeneration(input, out var compilationOut, out var generatorDiagnostics);
+            diagnostics.AddRange(generatorDiagnostics);
             return compilationOut;
         }
     }

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private protected override Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts, DiagnosticBag diagnostics)
         {
-            // SG_ISSUE #42565: for now we gate behind langver == preview. We'll remove this before final shipping, as the feature is langver agnostic
+            // https://github.com/dotnet/roslyn/issues/42565: for now we gate behind langver == preview. We'll remove this before final shipping, as the feature is langver agnostic
             if (((CSharpParseOptions)parseOptions).LanguageVersion != LanguageVersion.Preview)
             {
                 return input;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1761,6 +1761,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_ConditionalOnLocalFunction = 8783,
 
+        WRN_GeneratorFailedDuringInitialization = 8784,
+        WRN_GeneratorFailedDuringGeneration = 8785,
+
         ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer = 8790,
         ERR_ExpressionTreeContainsFromEndIndexExpression = 8791,
         ERR_ExpressionTreeContainsRangeExpression = 8792,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -444,6 +444,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnImplicitImplementationBecauseOfAttributes:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementationBecauseOfAttributes:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementationBecauseOfAttributes:
+                case ErrorCode.WRN_GeneratorFailedDuringInitialization:
+                case ErrorCode.WRN_GeneratorFailedDuringGeneration:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -227,6 +227,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override int ERR_EncUpdateFailedMissingAttribute => (int)ErrorCode.ERR_EncUpdateFailedMissingAttribute;
         public override int ERR_InvalidDebugInfo => (int)ErrorCode.ERR_InvalidDebugInfo;
 
+        // Generators:
+        public override int WRN_GeneratorFailedDuringInitialization => (int)ErrorCode.WRN_GeneratorFailedDuringInitialization;
+        public override int WRN_GeneratorFailedDuringGeneration => (int)ErrorCode.WRN_GeneratorFailedDuringGeneration;
+
         public override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -235,6 +235,8 @@
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementationBecauseOfAttributes:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementationBecauseOfAttributes:
                 case ErrorCode.WRN_DoesNotReturnMismatch:
+                case ErrorCode.WRN_GeneratorFailedDuringInitialization:
+                case ErrorCode.WRN_GeneratorFailedDuringGeneration:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
@@ -34,5 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, input.HintName, cancellationToken); //PROTOTYPE: hint path/ filename uniqueness
 
         internal override GeneratorDriver FromState(GeneratorDriverState state) => new CSharpGeneratorDriver(state);
+
+        internal override CommonMessageProvider MessageProvider => CSharp.MessageProvider.Instance;
     }
 }

--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override SyntaxTree ParseGeneratedSourceText(GeneratedSourceText input, CancellationToken cancellationToken)
-            => SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, input.HintName, cancellationToken); //PROTOTYPE: hint path/ filename uniqueness
+            => SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, input.HintName, cancellationToken); //SG_ISSUE #42628: hint path/ filename uniqueness
 
         internal override GeneratorDriver FromState(GeneratorDriverState state) => new CSharpGeneratorDriver(state);
 

--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override SyntaxTree ParseGeneratedSourceText(GeneratedSourceText input, CancellationToken cancellationToken)
-            => SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, input.HintName, cancellationToken); //SG_ISSUE #42628: hint path/ filename uniqueness
+            => SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, input.HintName, cancellationToken); // https://github.com/dotnet/roslyn/issues/42628: hint path/ filename uniqueness
 
         internal override GeneratorDriver FromState(GeneratorDriverState state) => new CSharpGeneratorDriver(state);
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">Rozhraní je už uvedené v seznamu rozhraní s různou možností použití hodnoty null u typů odkazů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">Daný výraz vždy odpovídá zadané konstantě.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">Rozhraní je už uvedené v seznamu rozhraní s různou možností použití hodnoty null u typů odkazů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">Rozhraní je už uvedené v seznamu rozhraní s různou možností použití hodnoty null u typů odkazů.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">Die Schnittstelle wird bereits mit einer anderen NULL-Zulässigkeit oder abweichenden Verweistypen in der Schnittstellenliste aufgeführt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">Der angegebene Ausdruck stimmt immer mit der angegebenen Konstante überein.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">Die Schnittstelle wird bereits mit einer anderen NULL-Zulässigkeit oder abweichenden Verweistypen in der Schnittstellenliste aufgeführt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">Die Schnittstelle wird bereits mit einer anderen NULL-Zulässigkeit oder abweichenden Verweistypen in der Schnittstellenliste aufgeführt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">La interfaz ya está en la lista de interfaces con una nulabilidad diferente de los tipos de referencia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">La expresión dada coincide siempre con la constante proporcionada.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">La interfaz ya está en la lista de interfaces con una nulabilidad diferente de los tipos de referencia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">La interfaz ya está en la lista de interfaces con una nulabilidad diferente de los tipos de referencia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">L'interface figure déjà dans la liste des interfaces avec différentes possibilités de valeur null des types référence.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">L'expression donnée correspond toujours à la constante fournie.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">L'interface figure déjà dans la liste des interfaces avec différentes possibilités de valeur null des types référence.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">L'interface figure déjà dans la liste des interfaces avec différentes possibilités de valeur null des types référence.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">L'interfaccia è già inclusa nell'elenco di interfacce con diverso supporto dei valori Null per i tipi riferimento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">L'espressione specificata corrisponde sempre alla costante fornita.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">L'interfaccia è già inclusa nell'elenco di interfacce con diverso supporto dei valori Null per i tipi riferimento.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">L'interfaccia è già inclusa nell'elenco di interfacce con diverso supporto dei valori Null per i tipi riferimento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">インターフェイスは既にインターフェイス リストに存在しますが、参照型の Null 許容性が異なっています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">指定された式は指定された定数と必ず一致します。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">インターフェイスは既にインターフェイス リストに存在しますが、参照型の Null 許容性が異なっています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">インターフェイスは既にインターフェイス リストに存在しますが、参照型の Null 許容性が異なっています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">인터페이스가 다른 참조 형식 Null 허용 여부를 사용하는 인터페이스 목록에 이미 나열되어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">지정한 식은 항상 제공한 상수와 일치합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">인터페이스가 다른 참조 형식 Null 허용 여부를 사용하는 인터페이스 목록에 이미 나열되어 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">인터페이스가 다른 참조 형식 Null 허용 여부를 사용하는 인터페이스 목록에 이미 나열되어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">Interfejs występuje już na liście interfejsów z inną obsługą wartości null typów referencyjnych.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">Dane wyrażenie jest zawsze zgodne z podaną stałą.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">Interfejs występuje już na liście interfejsów z inną obsługą wartości null typów referencyjnych.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">Interfejs występuje już na liście interfejsów z inną obsługą wartości null typów referencyjnych.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1452,6 +1452,16 @@
         <target state="translated">A interface já está listada na lista de interfaces com uma nulidade diferente de tipos de referência.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">A expressão fornecida sempre corresponde à constante fornecida.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1452,9 +1452,19 @@
         <target state="translated">A interface já está listada na lista de interfaces com uma nulidade diferente de tipos de referência.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1452,24 +1452,24 @@
         <target state="translated">A interface já está listada na lista de interfaces com uma nulidade diferente de tipos de referência.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">Интерфейс уже указан в списке интерфейсов с другой допустимостью значений NULL ссылочных типов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">Указанное выражение всегда соответствует предоставленной константе.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">Интерфейс уже указан в списке интерфейсов с другой допустимостью значений NULL ссылочных типов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">Интерфейс уже указан в списке интерфейсов с другой допустимостью значений NULL ссылочных типов.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">Arabirim, arabirim listesinde farklı başvuru türleri boş değer atanabilirliği ile zaten listelenmiş</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">Belirtilen ifade her zaman sağlanan sabitle eşleşir.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">Arabirim, arabirim listesinde farklı başvuru türleri boş değer atanabilirliği ile zaten listelenmiş</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">Arabirim, arabirim listesinde farklı başvuru türleri boş değer atanabilirliği ile zaten listelenmiş</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">接口已在接口列表中列出，引用类型具有不同的 Null 性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">给定的表达式始终与提供的常量匹配。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">接口已在接口列表中列出，引用类型具有不同的 Null 性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">接口已在接口列表中列出，引用类型具有不同的 Null 性。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1454,6 +1454,16 @@
         <target state="translated">介面已列在介面清單中，並具有不同的參考類型可 NULL 性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration">
+        <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization">
+        <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
+        <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">
         <source>The given expression always matches the provided constant.</source>
         <target state="translated">指定的運算式永遠符合提供的常數。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1454,9 +1454,19 @@
         <target state="translated">介面已列在介面清單中，並具有不同的參考類型可 NULL 性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
+        <source>A Generator failed to generate source.</source>
+        <target state="new">A Generator failed to generate source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
+        <source>A Generator failed to initialize.</source>
+        <target state="new">A Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1454,24 +1454,24 @@
         <target state="translated">介面已列在介面清單中，並具有不同的參考類型可 NULL 性。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_GeneratorFailedDuringExecution_Title">
-        <source>A Generator failed to generate source.</source>
-        <target state="new">A Generator failed to generate source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration">
         <source>Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringGeneration_Title">
-        <source>A Generator failed to initialize.</source>
-        <target state="new">A Generator failed to initialize.</target>
+        <source>Generator failed to generate source.</source>
+        <target state="new">Generator failed to generate source.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GeneratorFailedDuringInitialization">
         <source>Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</source>
         <target state="new">Generator '{0}' failed to initialize. It will not contribute to the output and compilation errors may occur as a result.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_GeneratorFailedDuringInitialization_Title">
+        <source>Generator failed to initialize.</source>
+        <target state="new">Generator failed to initialize.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_GivenExpressionAlwaysMatchesConstant">

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -690,7 +690,7 @@ class C { }
 
         public void Execute(SourceGeneratorContext context)
         {
-            foreach (var file in context.AnalyzerOptions.AdditionalFiles)
+            foreach (var file in context.AdditionalFiles)
             {
                 AddSourceForAdditionalFile(context.AdditionalSources, file);
             }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -64,7 +64,7 @@ class C { }
                 );
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
-            driver.RunFullGeneration(compilation, out var outputCompilation);
+            driver.RunFullGeneration(compilation, out var outputCompilation, out _);
 
             Assert.Null(receiver);
         }
@@ -87,7 +87,7 @@ class C { }
                 );
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
-            driver.RunFullGeneration(compilation, out _);
+            driver.RunFullGeneration(compilation, out _, out _);
 
             void Initialize(InitializationContext initContext)
             {

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -38,7 +38,7 @@ class C { }
                 );
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
-            driver.RunFullGeneration(compilation, out _);
+            driver.RunFullGeneration(compilation, out _, out _);
 
             Assert.NotNull(receiver);
             Assert.IsType<TestSyntaxReceiver>(receiver);
@@ -64,7 +64,7 @@ class C { }
                 );
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
-            driver.RunFullGeneration(compilation, out _);
+            driver.RunFullGeneration(compilation, out var outputCompilation);
 
             Assert.Null(receiver);
         }
@@ -128,7 +128,7 @@ class C
                 );
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
-            driver.RunFullGeneration(compilation, out _);
+            driver.RunFullGeneration(compilation, out _, out _);
 
             Assert.NotNull(receiver);
             Assert.IsType<TestSyntaxReceiver>(receiver);
@@ -168,7 +168,7 @@ class C
                 );
 
             GeneratorDriver driver = new CSharpGeneratorDriver(compilation, parseOptions, ImmutableArray.Create<ISourceGenerator>(testGenerator), ImmutableArray<AdditionalText>.Empty);
-            driver = driver.RunFullGeneration(compilation, out _);
+            driver = driver.RunFullGeneration(compilation, out _, out _);
 
             Assert.NotNull(receiver);
             Assert.IsType<TestSyntaxReceiver>(receiver);
@@ -179,7 +179,7 @@ class C
             Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
 
             var previousReceiver = receiver;
-            driver = driver.RunFullGeneration(compilation, out _);
+            driver = driver.RunFullGeneration(compilation, out _, out _);
 
             Assert.NotNull(receiver);
             Assert.NotEqual(receiver, previousReceiver);

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -316,6 +316,8 @@ class X
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementationBecauseOfAttributes:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverrideBecauseOfAttributes:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverrideBecauseOfAttributes:
+                        case ErrorCode.WRN_GeneratorFailedDuringInitialization:
+                        case ErrorCode.WRN_GeneratorFailedDuringGeneration:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:
@@ -358,6 +360,8 @@ class X
                     ErrorCode.WRN_MissingNonNullTypesContextForAnnotation,
                     ErrorCode.WRN_MissingNonNullTypesContextForAnnotationInGeneratedCode,
                     ErrorCode.WRN_ImplicitCopyInReadOnlyMember,
+                    ErrorCode.WRN_GeneratorFailedDuringInitialization,
+                    ErrorCode.WRN_GeneratorFailedDuringGeneration
                 };
 
                 Assert.Contains(error, nullableUnrelatedWarnings);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -693,8 +693,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        //PROTOTYPE: hook to do generation, by default does nothing
-
         /// <summary>
         /// Peform source generation, if the compiler supports it.
         /// </summary>
@@ -702,8 +700,9 @@ namespace Microsoft.CodeAnalysis
         /// <param name="parseOptions">The <see cref="ParseOptions"/> to use when parsing any generated sources.</param>
         /// <param name="generators">The generators to run</param>
         /// <param name="additionalTexts">Any additional texts that should be passed to the generators when run.</param>
+        /// <param name="generatorDiagnostics">Any diagnostics that were produced during generation</param>
         /// <returns>A compilation that represents the original compilation with any additional, generated texts added to it.</returns>
-        private protected virtual Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts) { return input; }
+        private protected virtual Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts, DiagnosticBag generatorDiagnostics) { return input; }
 
         private int RunCore(TextWriter consoleOutput, ErrorLogger errorLogger, CancellationToken cancellationToken)
         {
@@ -785,12 +784,9 @@ namespace Microsoft.CodeAnalysis
 
             var additionalTexts = ImmutableArray<AdditionalText>.CastUp(additionalTextFiles);
 
-            // PROTOTYPE: at this point we have a compilation with nothing yet computed. 
+            // At this point we have a compilation with nothing yet computed. 
             // We pass it to the generators, which will realize any symbols they require. 
-
-            // PROTOTYPE: we'll need to handle diagnostics produced by the generators seperately too, so we
-            // can fail the build on a generator error
-            compilation = RunGenerators(compilation, Arguments.ParseOptions, generators, additionalTexts);
+            compilation = RunGenerators(compilation, Arguments.ParseOptions, generators, additionalTexts, diagnostics);
 
             CompileAndEmit(
                 touchedFilesLogger,

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -237,6 +237,10 @@ namespace Microsoft.CodeAnalysis
         public abstract int ERR_EncUpdateFailedMissingAttribute { get; }
         public abstract int ERR_InvalidDebugInfo { get; }
 
+        // Generators:
+        public abstract int WRN_GeneratorFailedDuringInitialization { get; }
+        public abstract int WRN_GeneratorFailedDuringGeneration { get; }
+
         /// <summary>
         /// Takes an exception produced while writing to a file stream and produces a diagnostic.
         /// </summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -76,7 +76,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _diagnosticAnalyzers.GetExtensions(language);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
         public override ImmutableArray<ISourceGenerator> GetGenerators()
         {
             return _generators.GetExtensionsForAllLanguages();

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerReference.cs
@@ -62,8 +62,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="language">Language name.</param>
         public abstract ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language);
 
-        //PROTOTYPE
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+        /// <summary>
+        /// Gets all the source generators defined in this assembly reference.
+        /// </summary>
         public virtual ImmutableArray<ISourceGenerator> GetGenerators() { return ImmutableArray<ISourceGenerator>.Empty; }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -17,8 +17,8 @@ Microsoft.CodeAnalysis.InitializationContext
 Microsoft.CodeAnalysis.InitializationContext.CancellationToken.get -> System.Threading.CancellationToken
 Microsoft.CodeAnalysis.InitializationContext.RegisterForSyntaxNotifications(Microsoft.CodeAnalysis.SyntaxReceiverCreator receiverCreator) -> void
 Microsoft.CodeAnalysis.SourceGeneratorContext
-Microsoft.CodeAnalysis.SourceGeneratorContext.AdditionalSources.get -> Microsoft.CodeAnalysis.AdditionalSourcesCollection
-Microsoft.CodeAnalysis.SourceGeneratorContext.AnalyzerOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
+Microsoft.CodeAnalysis.SourceGeneratorContext.AddSource(string hintName, Microsoft.CodeAnalysis.Text.SourceText sourceText) -> void
+Microsoft.CodeAnalysis.SourceGeneratorContext.AdditionalFiles.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AdditionalText>
 Microsoft.CodeAnalysis.SourceGeneratorContext.CancellationToken.get -> System.Threading.CancellationToken
 Microsoft.CodeAnalysis.SourceGeneratorContext.Compilation.get -> Microsoft.CodeAnalysis.Compilation
 Microsoft.CodeAnalysis.SourceGeneratorContext.ReportDiagnostic(Microsoft.CodeAnalysis.Diagnostic diagnostic) -> void

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,28 @@
 Microsoft.CodeAnalysis.CommandLineSourceFile.CommandLineSourceFile(string path, bool isScript, bool isInputRedirected) -> void
 Microsoft.CodeAnalysis.CommandLineSourceFile.IsInputRedirected.get -> bool
+Microsoft.CodeAnalysis.GeneratorAttribute
+Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute() -> void
+Microsoft.CodeAnalysis.GeneratorDriver
+Microsoft.CodeAnalysis.GeneratorDriver.AddAdditionalTexts(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AdditionalText> additionalTexts) -> Microsoft.CodeAnalysis.GeneratorDriver
+Microsoft.CodeAnalysis.GeneratorDriver.AddGenerators(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator> generators) -> Microsoft.CodeAnalysis.GeneratorDriver
+Microsoft.CodeAnalysis.GeneratorDriver.RemoveGenerators(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator> generators) -> Microsoft.CodeAnalysis.GeneratorDriver
+Microsoft.CodeAnalysis.GeneratorDriver.RunFullGeneration(Microsoft.CodeAnalysis.Compilation compilation, out Microsoft.CodeAnalysis.Compilation outputCompilation, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.GeneratorDriver
+Microsoft.CodeAnalysis.GeneratorDriver.TryApplyEdits(Microsoft.CodeAnalysis.Compilation compilation, out Microsoft.CodeAnalysis.Compilation outputCompilation, out bool success, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.GeneratorDriver
+Microsoft.CodeAnalysis.ISourceGenerator
+Microsoft.CodeAnalysis.ISourceGenerator.Execute(Microsoft.CodeAnalysis.SourceGeneratorContext context) -> void
+Microsoft.CodeAnalysis.ISourceGenerator.Initialize(Microsoft.CodeAnalysis.InitializationContext context) -> void
+Microsoft.CodeAnalysis.ISyntaxReceiver
+Microsoft.CodeAnalysis.ISyntaxReceiver.OnVisitSyntaxNode(Microsoft.CodeAnalysis.SyntaxNode syntaxNode) -> void
+Microsoft.CodeAnalysis.InitializationContext
+Microsoft.CodeAnalysis.InitializationContext.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.CodeAnalysis.InitializationContext.RegisterForSyntaxNotifications(Microsoft.CodeAnalysis.SyntaxReceiverCreator receiverCreator) -> void
+Microsoft.CodeAnalysis.SourceGeneratorContext
+Microsoft.CodeAnalysis.SourceGeneratorContext.AdditionalSources.get -> Microsoft.CodeAnalysis.AdditionalSourcesCollection
+Microsoft.CodeAnalysis.SourceGeneratorContext.AnalyzerOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
+Microsoft.CodeAnalysis.SourceGeneratorContext.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.CodeAnalysis.SourceGeneratorContext.Compilation.get -> Microsoft.CodeAnalysis.Compilation
+Microsoft.CodeAnalysis.SourceGeneratorContext.ReportDiagnostic(Microsoft.CodeAnalysis.Diagnostic diagnostic) -> void
+Microsoft.CodeAnalysis.SourceGeneratorContext.SyntaxReceiver.get -> Microsoft.CodeAnalysis.ISyntaxReceiver
+Microsoft.CodeAnalysis.SyntaxReceiverCreator
+override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGenerators() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>
+virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGenerators() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis
 
         internal ImmutableArray<GeneratedSourceText> ToImmutableAndFree()
         {
-            // SG_ISSUE #42627: This needs to be consistently ordered
+            // https://github.com/dotnet/roslyn/issues/42627: This needs to be consistently ordered
             ArrayBuilder<GeneratedSourceText> builder = ArrayBuilder<GeneratedSourceText>.GetInstance();
             foreach (var (hintName, sourceText) in _sourcesAdded)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -11,9 +11,7 @@ using Roslyn.Utilities;
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
-    // PROTOTYPE: should this implement ICollection?
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
-    public sealed class AdditionalSourcesCollection
+    internal sealed class AdditionalSourcesCollection
     {
         private readonly PooledDictionary<string, SourceText> _sourcesAdded;
 
@@ -45,7 +43,7 @@ namespace Microsoft.CodeAnalysis
 
         internal ImmutableArray<GeneratedSourceText> ToImmutableAndFree()
         {
-            // PROTOTYPE: This needs to be consistently ordered
+            // SG_ISSUE #42627: This needs to be consistently ordered
             ArrayBuilder<GeneratedSourceText> builder = ArrayBuilder<GeneratedSourceText>.GetInstance();
             foreach (var (hintName, sourceText) in _sourcesAdded)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAttribute.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAttribute.cs
@@ -11,9 +11,8 @@ namespace Microsoft.CodeAnalysis
     /// Place this attribute onto a type to cause it to be considered a source generator
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public sealed class GeneratorAttribute : Attribute
     {
-        // PROTOTYPE: we don't know if we'll keep this, but for now it lets us re-use the analyzer discovery mechansim
+        // SG_ISSUE #42566: we don't know if we'll keep this, but for now it lets us re-use the analyzer discovery mechansim
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAttribute.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAttribute.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class GeneratorAttribute : Attribute
     {
-        // SG_ISSUE #42566: we don't know if we'll keep this, but for now it lets us re-use the analyzer discovery mechansim
+        // https://github.com/dotnet/roslyn/issues/: we don't know if we'll keep this, but for now it lets us re-use the analyzer discovery mechanism
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     // we create a new context for each run of the generator. We'll never re-use existing state, only replace anything we have
                     _ = receivers.TryGetValue(generator, out var syntaxReceiverOpt);
-                    var context = new SourceGeneratorContext(state.Compilation, new AnalyzerOptions(state.AdditionalTexts.NullToEmpty(), CompilerAnalyzerConfigOptionsProvider.Empty), syntaxReceiverOpt);
+                    var context = new SourceGeneratorContext(state.Compilation, new AnalyzerOptions(state.AdditionalTexts.NullToEmpty(), CompilerAnalyzerConfigOptionsProvider.Empty), syntaxReceiverOpt, diagnosticsBag);
                     generator.Execute(context);
                     stateBuilder[generator] = generatorState.WithSources(ParseAdditionalSources(context.AdditionalSources.ToImmutableAndFree(), cancellationToken));
                 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -90,14 +90,14 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            //PROTOTYPE: should be possible to parallelize this
+            // SG_ISSUE #42629: should be possible to parallelize this
             foreach (var (generator, generatorState) in stateBuilder.ToImmutableArray())
             {
                 try
                 {
                     // we create a new context for each run of the generator. We'll never re-use existing state, only replace anything we have
                     _ = receivers.TryGetValue(generator, out var syntaxReceiverOpt);
-                    var context = new SourceGeneratorContext(state.Compilation, new AnalyzerOptions(state.AdditionalTexts.NullToEmpty(), CompilerAnalyzerConfigOptionsProvider.Empty), syntaxReceiverOpt, diagnosticsBag);
+                    var context = new SourceGeneratorContext(state.Compilation, state.AdditionalTexts.NullToEmpty(), syntaxReceiverOpt, diagnosticsBag);
                     generator.Execute(context);
                     stateBuilder[generator] = generatorState.WithSources(ParseAdditionalSources(context.AdditionalSources.ToImmutableAndFree(), cancellationToken));
                 }
@@ -127,7 +127,6 @@ namespace Microsoft.CodeAnalysis
             var state = _state;
             foreach (var edit in _state.Edits)
             {
-                // PROTOTYPE: we'll need to pass in the various compilation states too
                 state = ApplyPartialEdit(state, edit);
                 if (state.EditsFailed)
                 {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis
     ///     on generators that support it
     ///   - At any time a full generation pass can be re-run, resetting the pending edits
     /// </remarks>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public abstract class GeneratorDriver
     {
         internal readonly GeneratorDriverState _state;
@@ -164,8 +163,8 @@ namespace Microsoft.CodeAnalysis
             return FromState(newState);
         }
 
-        //PROTOTYPE: remove arbitrary edit adding and replace with dedicated edit types
-        public GeneratorDriver WithPendingEdits(ImmutableArray<PendingEdit> edits)
+        // When we expose this publically, remove arbitrary edit adding and replace with dedicated edit types
+        internal GeneratorDriver WithPendingEdits(ImmutableArray<PendingEdit> edits)
         {
             var newState = _state.With(edits: _state.Edits.AddRange(edits));
             return FromState(newState);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // SG_ISSUE #42629: should be possible to parallelize this
+            // https://github.com/dotnet/roslyn/issues/42629: should be possible to parallelize this
             foreach (var (generator, generatorState) in stateBuilder.ToImmutableArray())
             {
                 try
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis
             return FromState(newState);
         }
 
-        // When we expose this publically, remove arbitrary edit adding and replace with dedicated edit types
+        // When we expose this publicly, remove arbitrary edit adding and replace with dedicated edit types
         internal GeneratorDriver WithPendingEdits(ImmutableArray<PendingEdit> edits)
         {
             var newState = _state.With(edits: _state.Edits.AddRange(edits));

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -11,10 +11,13 @@ namespace Microsoft.CodeAnalysis
 
         internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; }
 
+        internal bool Initialized { get; }
+
         internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxReceiverCreator? receiverCreator)
         {
             EditCallback = editCallback;
             SyntaxReceiverCreator = receiverCreator;
+            Initialized = true;
         }
 
         internal class Builder

--- a/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
@@ -12,10 +12,38 @@ using Microsoft.CodeAnalysis.Text;
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
+    /// <summary>
+    /// The base interface required to implement a source generator
+    /// </summary>
+    /// <remarks>
+    /// The lifetime of a generator is controlled by the compiler.
+    /// State should not be stored directly on the generator, as there
+    /// is no guarantee that the same instance will be used on a 
+    /// subsequent generation pass.
+    /// </remarks>
     public interface ISourceGenerator
     {
+        /// <summary>
+        /// Called before generation occurs. A generator can use the <paramref name="context"/>
+        /// to register callbacks required to peform generation.
+        /// </summary>
+        /// <param name="context">The <see cref="InitializationContext"/> to register callbacks on</param>
         void Initialize(InitializationContext context);
+
+        /// <summary>
+        /// Called to peform source generation. A generator can use the <paramref name="context"/>
+        /// to add source files via the the <see cref="SourceGeneratorContext.AdditionalSources"/>
+        /// collection.
+        /// </summary>
+        /// <param name="context">The <see cref="SourceGeneratorContext"/> to add source to</param>
+        /// <remarks>
+        /// This call represents the main generation step. It is called after a <see cref="Compilation"/> is 
+        /// created that contains the user written code. 
+        /// 
+        /// A generator can use the <see cref="SourceGeneratorContext.Compilation"/> property to
+        /// discover information about the users compilation and make decisions on what source to 
+        /// provide. 
+        /// </remarks>
         void Execute(SourceGeneratorContext context);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Called to peform source generation. A generator can use the <paramref name="context"/>
-        /// to add source files via the the <see cref="SourceGeneratorContext.AdditionalSources"/>
-        /// collection.
+        /// to add source files via the <see cref="SourceGeneratorContext.AddSource(string, SourceText)"/> 
+        /// method.
         /// </summary>
         /// <param name="context">The <see cref="SourceGeneratorContext"/> to add source to</param>
         /// <remarks>

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis
     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
     /// is free to store state without worrying about lifetime or reuse.
     /// </remarks>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public interface ISyntaxReceiver
     {
         /// <summary>
@@ -38,6 +37,5 @@ namespace Microsoft.CodeAnalysis
     /// Allows a generator to provide instances of an <see cref="ISyntaxReceiver"/>
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public delegate ISyntaxReceiver SyntaxReceiverCreator();
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/PendingEdit.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/PendingEdit.cs
@@ -13,11 +13,9 @@ using System.Text;
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
-    public delegate bool EditCallback<T>(EditContext context, T edit) where T : PendingEdit;
+    internal delegate bool EditCallback<T>(EditContext context, T edit) where T : PendingEdit;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
-    public abstract class PendingEdit
+    internal abstract class PendingEdit
     {
         internal abstract GeneratorDriverState Commit(GeneratorDriverState state);
 
@@ -26,13 +24,11 @@ namespace Microsoft.CodeAnalysis
         internal abstract bool TryApply(GeneratorInfo info, EditContext context);
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
-    public abstract class AdditionalFileEdit : PendingEdit
+    internal abstract class AdditionalFileEdit : PendingEdit
     {
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
-    public sealed class AdditionalFileAddedEdit : AdditionalFileEdit
+    internal sealed class AdditionalFileAddedEdit : AdditionalFileEdit
     {
         public AdditionalFileAddedEdit(AdditionalText addedText)
         {

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -15,7 +15,9 @@ using Roslyn.Utilities;
 #nullable enable
 namespace Microsoft.CodeAnalysis
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    /// <summary>
+    /// Context passed to a source generator when <see cref="ISourceGenerator.Execute(SourceGeneratorContext)"/> is called
+    /// </summary>
     public readonly struct SourceGeneratorContext
     {
         private readonly DiagnosticBag _diagnostics;
@@ -30,22 +32,41 @@ namespace Microsoft.CodeAnalysis
             _diagnostics = diagnostics;
         }
 
+        /// <summary>
+        /// Get the current <see cref="Compilation"/> at the time of execution.
+        /// </summary>
+        /// <remarks>
+        /// This compilation contains only the user supplied code; other generated code is not
+        /// available. As user code can depend on the results of generation, it is possible that
+        /// this compilation will contain errors.
+        /// </remarks>
         public Compilation Compilation { get; }
 
         // PROTOTYPE: replace AnalyzerOptions with an differently named type that is otherwise identical.
         // The concern being that something added to one isn't necessarily applicable to the other.
         public AnalyzerOptions AnalyzerOptions { get; }
 
+        /// <summary>
+        /// If the generator registered an <see cref="ISyntaxReceiver"/> during initialization, this will be the instance created for this generation pass.
+        /// </summary>
         public ISyntaxReceiver? SyntaxReceiver { get; }
 
+        /// <summary>
+        /// A <see cref="CancellationToken"/> that can be checked to see if the generation should be cancelled.
+        /// </summary>
         public CancellationToken CancellationToken { get; }
 
+        /// <summary>
+        /// PROTOTYPE:
+        /// </summary>
         public AdditionalSourcesCollection AdditionalSources { get; }
 
         public void ReportDiagnostic(Diagnostic diagnostic) => _diagnostics.Add(diagnostic);
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
+    /// <summary>
+    /// Context passed to a source generator when <see cref="ISourceGenerator.Initialize(InitializationContext)"/> is called
+    /// </summary>
     public struct InitializationContext
     {
         internal InitializationContext(CancellationToken cancellationToken = default)
@@ -54,6 +75,9 @@ namespace Microsoft.CodeAnalysis
             InfoBuilder = new GeneratorInfo.Builder();
         }
 
+        /// <summary>
+        /// A <see cref="CancellationToken"/> that can be checked to see if the initialization should be cancelled.
+        /// </summary>
         public CancellationToken CancellationToken { get; }
 
         internal GeneratorInfo.Builder InfoBuilder { get; }
@@ -95,9 +119,7 @@ namespace Microsoft.CodeAnalysis
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In progress")]
-    // PROTOTYPE: this is going to need to track the input and output compilations that occured
-    public readonly struct EditContext
+    internal readonly struct EditContext
     {
         internal EditContext(ImmutableArray<GeneratedSourceText> sources, CancellationToken cancellationToken = default)
         {

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly DiagnosticBag _diagnostics;
 
-        internal SourceGeneratorContext(Compilation compilation, AnalyzerOptions options, ISyntaxReceiver? syntaxReceiver, DiagnosticBag diagnostics, CancellationToken cancellationToken = default)
+        internal SourceGeneratorContext(Compilation compilation, ImmutableArray<AdditionalText> additionalTexts, ISyntaxReceiver? syntaxReceiver, DiagnosticBag diagnostics, CancellationToken cancellationToken = default)
         {
             Compilation = compilation;
-            AnalyzerOptions = options;
+            AdditionalFiles = additionalTexts;
             SyntaxReceiver = syntaxReceiver;
             CancellationToken = cancellationToken;
             AdditionalSources = new AdditionalSourcesCollection();
@@ -42,9 +42,10 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public Compilation Compilation { get; }
 
-        // PROTOTYPE: replace AnalyzerOptions with an differently named type that is otherwise identical.
-        // The concern being that something added to one isn't necessarily applicable to the other.
-        public AnalyzerOptions AnalyzerOptions { get; }
+        /// <summary>
+        /// A set of additional non-code text files that can be used by generators.
+        /// </summary>
+        public ImmutableArray<AdditionalText> AdditionalFiles { get; }
 
         /// <summary>
         /// If the generator registered an <see cref="ISyntaxReceiver"/> during initialization, this will be the instance created for this generation pass.
@@ -56,10 +57,9 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        /// <summary>
-        /// PROTOTYPE:
-        /// </summary>
-        public AdditionalSourcesCollection AdditionalSources { get; }
+        internal AdditionalSourcesCollection AdditionalSources { get; }
+
+        public void AddSource(string hintName, SourceText sourceText) => AdditionalSources.Add(hintName, sourceText);
 
         public void ReportDiagnostic(Diagnostic diagnostic) => _diagnostics.Add(diagnostic);
     }
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo.Builder InfoBuilder { get; }
 
-        public void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback)
+        internal void RegisterForAdditionalFileChanges(EditCallback<AdditionalFileEdit> callback)
         {
             CheckIsEmpty(InfoBuilder.EditCallback);
             InfoBuilder.EditCallback = callback;

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -18,13 +18,16 @@ namespace Microsoft.CodeAnalysis
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
     public readonly struct SourceGeneratorContext
     {
-        internal SourceGeneratorContext(Compilation compilation, AnalyzerOptions options, ISyntaxReceiver? syntaxReceiver, CancellationToken cancellationToken = default)
+        private readonly DiagnosticBag _diagnostics;
+
+        internal SourceGeneratorContext(Compilation compilation, AnalyzerOptions options, ISyntaxReceiver? syntaxReceiver, DiagnosticBag diagnostics, CancellationToken cancellationToken = default)
         {
             Compilation = compilation;
             AnalyzerOptions = options;
             SyntaxReceiver = syntaxReceiver;
             CancellationToken = cancellationToken;
             AdditionalSources = new AdditionalSourcesCollection();
+            _diagnostics = diagnostics;
         }
 
         public Compilation Compilation { get; }
@@ -39,7 +42,7 @@ namespace Microsoft.CodeAnalysis
 
         public AdditionalSourcesCollection AdditionalSources { get; }
 
-        public void ReportDiagnostic(Diagnostic diagnostic) { throw new NotImplementedException(); }
+        public void ReportDiagnostic(Diagnostic diagnostic) => _diagnostics.Add(diagnostic);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "In Progress")]
@@ -105,7 +108,5 @@ namespace Microsoft.CodeAnalysis
         public CancellationToken CancellationToken { get; }
 
         public AdditionalSourcesCollection AdditionalSources { get; }
-
-        public void ReportDiagnostic(Diagnostic diagnostic) { throw new NotImplementedException(); }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -571,6 +571,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return ERRID.ERR_InvalidDebugInfo
             End Get
         End Property
+
+        ' Generators
+        Public Overrides ReadOnly Property WRN_GeneratorFailedDuringInitialization As Integer
+            Get
+                Throw New NotImplementedException()
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property WRN_GeneratorFailedDuringGeneration As Integer
+            Get
+                Throw New NotImplementedException()
+            End Get
+        End Property
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -575,13 +575,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' Generators
         Public Overrides ReadOnly Property WRN_GeneratorFailedDuringInitialization As Integer
             Get
-                Throw New NotImplementedException()
+                Throw ExceptionUtilities.Unreachable
             End Get
         End Property
 
         Public Overrides ReadOnly Property WRN_GeneratorFailedDuringGeneration As Integer
             Get
-                Throw New NotImplementedException()
+                Throw ExceptionUtilities.Unreachable
             End Get
         End Property
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             Contract.ThrowIfFalse(project.SupportsCompilation);
-            //AssertCompilation(project, compilation); //PROTOTYPE: this assert no longer holds
+            AssertCompilation(project, compilation);
 
             // in IDE, we always set concurrentAnalysis == false otherwise, we can get into thread starvation due to
             // async being used with synchronous blocking concurrency.

--- a/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
@@ -455,5 +455,9 @@ namespace Roslyn.Test.Utilities
         }
 
         public override int ERR_InvalidHashAlgorithmName => throw new NotImplementedException();
+
+        public override int WRN_GeneratorFailedDuringGeneration => throw new NotImplementedException();
+
+        public override int WRN_GeneratorFailedDuringInitialization => throw new NotImplementedException();
     }
 }

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpCompilationFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpCompilationFactoryService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -51,18 +50,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         CompilationOptions ICompilationFactoryService.GetDefaultCompilationOptions()
         {
             return s_defaultOptions;
-        }
-
-        //PROTOTYPE
-#nullable enable
-        GeneratorDriver? ICompilationFactoryService.CreateGeneratorDriver(Compilation compilation, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts)
-        {
-            // PROTOTYPE: for now we gate behind langver == preview. We'll remove this before final shipping, as the feature is langver agnostic
-            if (((CSharpParseOptions)parseOptions).LanguageVersion != LanguageVersion.Preview)
-            {
-                return null;
-            }
-            return new CSharpGeneratorDriver(compilation, parseOptions, generators, additionalTexts);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/CompilationFactory/ICompilationFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/CompilationFactory/ICompilationFactoryService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Host
 {
@@ -14,8 +13,5 @@ namespace Microsoft.CodeAnalysis.Host
         Compilation GetCompilationFromCompilationReference(MetadataReference reference);
         bool IsCompilationReference(MetadataReference reference);
         CompilationOptions GetDefaultCompilationOptions();
-
-        // PROTOTYPE: an easy way to get a generator driver into the IDE layer
-        GeneratorDriver CreateGeneratorDriver(Compilation compilation, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, ImmutableArray<AdditionalText> additionalTexts);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -699,6 +699,14 @@ namespace Microsoft.CodeAnalysis
                 projectInfo: this.ProjectInfo.WithMetadataReferences(metadataReferences).WithVersion(this.Version.GetNewerVersion()));
         }
 
+        public ProjectState AddAnalyzerReference(AnalyzerReference analyzerReference)
+        {
+            Debug.Assert(!this.AnalyzerReferences.Contains(analyzerReference));
+
+            return this.With(
+                projectInfo: this.ProjectInfo.WithAnalyzerReferences(this.AnalyzerReferences.ToImmutableArray().Add(analyzerReference)).WithVersion(this.Version.GetNewerVersion()));
+        }
+
         public ProjectState RemoveAnalyzerReference(AnalyzerReference analyzerReference)
         {
             Debug.Assert(this.AnalyzerReferences.Contains(analyzerReference));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -592,7 +592,15 @@ namespace Microsoft.CodeAnalysis
         /// specified analyzer reference.
         /// </summary>
         public Solution AddAnalyzerReference(ProjectId projectId, AnalyzerReference analyzerReference)
-            => AddAnalyzerReferences(projectId, ImmutableArray.Create(analyzerReference));
+        {
+            var newState = _state.AddAnalyzerReference(projectId, analyzerReference);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
 
         /// <summary>
         /// Create a new solution instance with the project specified updated to include the

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1850,7 +1850,7 @@ namespace Microsoft.CodeAnalysis
                     // PROTOTYPE: obviously we don't want to run full generation everytime
                     //            we should instead periodically run full generation, and TryApplyEdits as needed.
                     //            For now this lets us imagine what the experience feels like in the IDE
-                    driver = driver.RunFullGeneration(comp, out comp);
+                    driver = driver.RunFullGeneration(comp, out comp, out _);
                     _projectIdToGeneratorDriverMap = _projectIdToGeneratorDriverMap.SetItem(project.Id, driver);
                 }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1213,15 +1213,6 @@ namespace Microsoft.CodeAnalysis
 
                 var (newProjectState, compilationTranslationAction) = addDocumentsToProjectState(oldProjectState, newDocumentStatesForProject);
 
-                // PROTOTYPE: we add the edit to the projects driver, if we have one
-                if (_projectIdToGeneratorDriverMap.TryGetValue(oldProjectState.Id, out var driver))
-                {
-                    var edits = newDocumentStatesForProject.SelectAsArray<T, PendingEdit>(s => new AdditionalFileAddedEdit(new AdditionalTextWithState(s)));
-                    driver = driver.WithPendingEdits(edits);
-
-                    _projectIdToGeneratorDriverMap = _projectIdToGeneratorDriverMap.SetItem(oldProjectState.Id, driver);
-                }
-
                 newSolutionState = newSolutionState.ForkProject(newProjectState,
                     compilationTranslationAction,
                     newFilePathToDocumentIdsMap: CreateFilePathToDocumentIdsMapWithAddedDocuments(newDocumentStatesForProject));

--- a/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicCompilationFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicCompilationFactoryService.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
@@ -63,11 +62,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function GetDefaultCompilationOptions() As CompilationOptions Implements ICompilationFactoryService.GetDefaultCompilationOptions
             Return s_defaultOptions
-        End Function
-
-        'PROTOTYPE
-        Public Function CreateGeneratorDriver(compilation As Compilation, parseOptions As ParseOptions, generators As ImmutableArray(Of ISourceGenerator), additionalTexts As ImmutableArray(Of AdditionalText)) As GeneratorDriver Implements ICompilationFactoryService.CreateGeneratorDriver
-            Return Nothing
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Note: this might be easier to go commit by commit.

This adds diagnostics to the generator driver so we can handle cases where they fail to init or execute. It also alows generators to report their own diagnostics when running.

The last two commits remove the remaining prototype comments, either by creating issues, or making things internal for this preview. We can add things back to the public API as we need them, rather than having to remove them at a later date.