### PR TITLE
Limit top-level statements to a single compilation unit within a program.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -110,10 +110,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Binder result;
                     if (!binderCache.TryGetValue(key, out result))
                     {
-                        SynthesizedSimpleProgramEntryPointSymbol simpleProgram = SimpleProgramNamedTypeSymbol.GetSimpleProgramEntryPoint(compilation);
+                        SynthesizedSimpleProgramEntryPointSymbol simpleProgram = SimpleProgramNamedTypeSymbol.GetSimpleProgramEntryPoint(compilation, (CompilationUnitSyntax)node.Parent, fallbackToMainEntryPoint: false);
                         ExecutableCodeBinder bodyBinder = simpleProgram.GetBodyBinder();
                         result = bodyBinder.GetBinder(compilationUnit);
-                        result = (SimpleProgramUnitBinder)result.Next;
 
                         binderCache.TryAdd(key, result);
                     }
@@ -921,8 +920,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // 
                         result = new InContainerBinder(compilation.GlobalNamespace, result, compilationUnit, inUsing: inUsing);
 
-                        SynthesizedSimpleProgramEntryPointSymbol simpleProgram;
-                        if (!inUsing && (simpleProgram = SimpleProgramNamedTypeSymbol.GetSimpleProgramEntryPoint(compilation)) is object)
+                        if (!inUsing &&
+                            SimpleProgramNamedTypeSymbol.GetSimpleProgramEntryPoint(compilation, compilationUnit, fallbackToMainEntryPoint: true) is SynthesizedSimpleProgramEntryPointSymbol simpleProgram)
                         {
                             ExecutableCodeBinder bodyBinder = simpleProgram.GetBodyBinder();
                             result = new SimpleProgramUnitBinder(result, (SimpleProgramBinder)bodyBinder.GetBinder(simpleProgram.SyntaxNode));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1763,23 +1763,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return node.SpanStart < localSymbolLocation.SourceSpan.Start;
                 }
 
-                if (localSymbol.ContainingSymbol is SynthesizedSimpleProgramEntryPointSymbol entryPoint)
-                {
-                    // Primary tree "precedes" other trees in a simple program
-                    if (node.SyntaxTree == entryPoint.PrimarySyntaxTree)
-                    {
-                        return true;
-                    }
-                    else if (localSymbolLocation.SourceTree == entryPoint.PrimarySyntaxTree)
-                    {
-                        return false;
-                    }
-
-                    // None is a primary tree, just compare ordinals for the trees involved
-                    // PROTOTYPE(SimplePrograms): It feels like we are going to have a problem with this for a speculative code.
-                    return Compilation.CompareSyntaxTreeOrdering(node.SyntaxTree, localSymbolLocation.SourceTree) < 0;
-                }
-
                 return false;
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/SimpleProgramBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SimpleProgramBinder.cs
@@ -28,18 +28,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance();
 
-            // All compilation units contribute top level declarations to this scope
-            foreach (var unit in _entryPoint.GetUnits())
+            foreach (var statement in _entryPoint.CompilationUnit.Members)
             {
-                var enclosing = GetBinder(unit);
-                var scopeBinder = (SimpleProgramUnitBinder)enclosing!.Next!;
-
-                foreach (var statement in unit.Members)
+                if (statement is GlobalStatementSyntax topLevelStatement)
                 {
-                    if (statement is GlobalStatementSyntax topLevelStatement)
-                    {
-                        scopeBinder.BuildLocals(enclosing, topLevelStatement.Statement, locals);
-                    }
+                    this.BuildLocals(this, topLevelStatement.Statement, locals);
                 }
             }
 
@@ -49,17 +42,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<LocalFunctionSymbol> BuildLocalFunctions()
         {
             ArrayBuilder<LocalFunctionSymbol>? locals = null;
-            // All compilation units contribute top level declarations to this scope
-            foreach (var unit in _entryPoint.GetUnits())
-            {
-                var enclosing = (SimpleProgramUnitBinder)GetBinder(unit)!.Next!;
 
-                foreach (var statement in unit.Members)
+            foreach (var statement in _entryPoint.CompilationUnit.Members)
+            {
+                if (statement is GlobalStatementSyntax topLevelStatement)
                 {
-                    if (statement is GlobalStatementSyntax topLevelStatement)
-                    {
-                        enclosing.BuildLocalFunctions(topLevelStatement.Statement, ref locals);
-                    }
+                    this.BuildLocalFunctions(topLevelStatement.Statement, ref locals);
                 }
             }
 
@@ -78,15 +66,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ArrayBuilder<LabelSymbol>? labels = null;
 
-            // All compilation units contribute top level declarations to this scope
-            foreach (var unit in _entryPoint.GetUnits())
+            foreach (var statement in _entryPoint.CompilationUnit.Members)
             {
-                foreach (var statement in unit.Members)
+                if (statement is GlobalStatementSyntax topLevelStatement)
                 {
-                    if (statement is GlobalStatementSyntax topLevelStatement)
-                    {
-                        BuildLabels(_entryPoint, topLevelStatement.Statement, ref labels);
-                    }
+                    BuildLabels(_entryPoint, topLevelStatement.Statement, ref labels);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/SimpleProgramUnitBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SimpleProgramUnitBinder.cs
@@ -5,15 +5,12 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
-    /// This binder provides a context for binding Simple Program top-level statements within a specific
-    /// compilation unit. It ensures that locals and labels are in scope, however it is not responsible
+    /// This binder provides a context for binding within a specific compilation unit, but outside of top-level statements.
+    /// It ensures that locals and labels are in scope, however it is not responsible
     /// for creating the symbols. That task is actually owned by <see cref="SimpleProgramBinder"/> and
     /// this binder simply delegates to it when appropriate. That ensures that the same set of symbols is 
     /// shared across all compilation units.
@@ -74,15 +71,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
         {
             return _scope.GetDeclaredLocalFunctionsForScope(scopeDesignator);
-        }
-
-        internal override Binder? GetBinder(SyntaxNode node)
-        {
-            // Delegating to the _scope first allows to get to a binder for another compilation unit
-            // with top level statements. That avoids adding any special cases for situations when 
-            // a SemanticModel binds an entire simple program body by calling Binder.BindMethodBody method
-            // on its root binder, which is specific to the compilation unit the model is associated with.
-            return _scope.GetBinder(node) ?? base.GetBinder(node);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6043,8 +6043,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_SimpleProgramLocalIsReferencedOutsideOfTopLevelStatement" xml:space="preserve">
     <value>Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</value>
   </data>
-  <data name="ERR_SimpleProgramMultipleUnitsWithExecutableStatements" xml:space="preserve">
-    <value>In all but one compilation unit the top-level statements must all be local function declarations.</value>
+  <data name="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements" xml:space="preserve">
+    <value>Only one compilation unit can have top-level statements.</value>
   </data>
   <data name="ERR_TopLevelStatementAfterNamespaceOrType" xml:space="preserve">
     <value>Top-level statements must precede namespace and type declarations.</value>

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #nullable restore
 
-        internal readonly SimpleProgramBodySemanticModelMergedBoundNodeCache MergedBoundNodeCache;
-
         private MethodBodySemanticModel(
             Symbol owner,
             Binder rootBinder,
@@ -57,16 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(owner.Kind == SymbolKind.Method);
             Debug.Assert(syntax != null);
             Debug.Assert(parentRemappedSymbolsOpt is null || IsSpeculativeSemanticModel);
-
-            if (!IsSpeculativeSemanticModel && owner is SynthesizedSimpleProgramEntryPointSymbol entryPoint)
-            {
-                Debug.Assert(syntax.Kind() == SyntaxKind.CompilationUnit);
-                MergedBoundNodeCache = entryPoint.GetSemanticModelMergedBoundNodeCache(rootBinder);
-            }
-            else
-            {
-                Debug.Assert(syntax.Kind() != SyntaxKind.CompilationUnit);
-            }
+            Debug.Assert((syntax.Kind() == SyntaxKind.CompilationUnit) == (!IsSpeculativeSemanticModel && owner is SynthesizedSimpleProgramEntryPointSymbol));
         }
 
         /// <summary>
@@ -79,11 +68,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (initialState.Body != null)
             {
-                // PROTOTYPE(SimplePrograms): At the moment this code path is not reachable for Simple Programs.
-                //                            However, once/if we adjust MethodCompiler.CompileMethod to change that, we should also make sure we adjust
-                //                            content of SimpleProgramBodySemanticModelMergedBoundNodeCache as appropriate. See what
-                //                            MemberSemanticModel.EnsureNullabilityAnalysisPerformedIfNecessary and IncrementalBinder are doing.
-                Debug.Assert(!(owner is SynthesizedSimpleProgramEntryPointSymbol));
                 result.UnguardedAddBoundTreeForStandaloneSyntax(initialState.Syntax, initialState.Body, initialState.SnapshotManager, initialState.RemappedSymbols);
             }
 

--- a/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
@@ -128,34 +128,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public bool HasAwaitExpressions
-        {
-            get
-            {
-                foreach (var decl in this.Declarations)
-                {
-                    if (decl.HasAwaitExpressions)
-                        return true;
-                }
-
-                return false;
-            }
-        }
-
-        public bool IsIterator
-        {
-            get
-            {
-                foreach (var decl in this.Declarations)
-                {
-                    if (decl.IsIterator)
-                        return true;
-                }
-
-                return false;
-            }
-        }
-
         public LexicalSortKey GetLexicalSortKey(CSharpCompilation compilation)
         {
             LexicalSortKey sortKey = new LexicalSortKey(Declarations[0].NameLocation, compilation);

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -35,12 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// Set only for <see cref="DeclarationKind.SimpleProgram"/>
             /// </summary>
-            AllTopLevelStatementsLocalFunctions = 1 << 7,
-
-            /// <summary>
-            /// Set only for <see cref="DeclarationKind.SimpleProgram"/>
-            /// </summary>
-            IsIterator = 1 << 8,
+            IsIterator = 1 << 7,
         }
 
         internal SingleTypeDeclaration(
@@ -145,14 +140,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return (_flags & TypeDeclarationFlags.HasAwaitExpressions) != 0;
-            }
-        }
-
-        public bool AllTopLevelStatementsLocalFunctions
-        {
-            get
-            {
-                return (_flags & TypeDeclarationFlags.AllTopLevelStatementsLocalFunctions) != 0;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1770,7 +1770,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExpressionTreeContainsRangeExpression = 8792,
 
         ERR_SimpleProgramLocalIsReferencedOutsideOfTopLevelStatement = 9000,
-        ERR_SimpleProgramMultipleUnitsWithExecutableStatements = 9001,
+        ERR_SimpleProgramMultipleUnitsWithTopLevelStatements = 9001,
         ERR_TopLevelStatementAfterNamespaceOrType = 9002,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -722,7 +722,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
             var binder = method is SynthesizedSimpleProgramEntryPointSymbol entryPoint ?
-                             entryPoint.GetBodyBinder() : // PROTOTYPE(SimplePrograms): Is this a good enough binder? It is not for any specific compilation unit. See if we can eliminate the need for a binder altogether.
+                             entryPoint.GetBodyBinder() :
                              compilation.GetBinderFactory(node.SyntaxTree).GetBinder(node.Syntax);
             var conversions = binder.Conversions;
             Analyze(compilation,

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (method is SynthesizedSimpleProgramEntryPointSymbol synthesized)
             {
-                return (CSharpSyntaxNode)method.ContainingSymbol.DeclaringSyntaxReferences.First().GetSyntax(); // PROTOTYPE(SimplePrograms): return first statement
+                return (CSharpSyntaxNode)synthesized.SyntaxRef.GetSyntax();
             }
 
             method = method.PartialDefinitionPart ?? method;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1339,7 +1339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         //       we often need to get members just to do a lookup.
         //       All additional checks and diagnostics may be not
         //       needed yet or at all.
-        private MembersAndInitializers GetMembersAndInitializers()
+        protected MembersAndInitializers GetMembersAndInitializers()
         {
             var membersAndInitializers = _lazyMembersAndInitializers;
             if (membersAndInitializers != null)
@@ -1672,7 +1672,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void ReportMethodSignatureCollision(DiagnosticBag diagnostics, SourceMemberMethodSymbol method1, SourceMemberMethodSymbol method2)
         {
             // Partial methods are allowed to collide by signature.
-            if (method1.IsPartial && method2.IsPartial)
+            if ((method1.IsPartial && method2.IsPartial) ||
+                (method1 is SynthesizedSimpleProgramEntryPointSymbol && method2 is SynthesizedSimpleProgramEntryPointSymbol))
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -47,6 +47,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return arrowExpression;
                 case LocalFunctionStatementSyntax localFunction:
                     return (CSharpSyntaxNode?)localFunction.Body ?? localFunction.ExpressionBody;
+                case CompilationUnitSyntax _ when this is SynthesizedSimpleProgramEntryPointSymbol entryPoint:
+                    return (CSharpSyntaxNode)entryPoint.SyntaxRef.GetSyntax();
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -505,19 +505,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool HasAwaitOperations(SyntaxNode node)
         {
             // Do not descend into functions
-            return node.DescendantNodesAndSelf(child => !IsNestedFunction(child)).Any(node =>
-                                                                                      {
-                                                                                          switch (node)
-                                                                                          {
-                                                                                              case AwaitExpressionSyntax _:
-                                                                                              case LocalDeclarationStatementSyntax local when local.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword):
-                                                                                              case CommonForEachStatementSyntax @foreach when @foreach.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword):
-                                                                                              case UsingStatementSyntax @using when @using.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword):
-                                                                                                  return true;
-                                                                                              default:
-                                                                                                  return false;
-                                                                                          }
-                                                                                      });
+            return node.DescendantNodesAndSelf(child => !IsNestedFunction(child)).Any(
+                            node =>
+                            {
+                                switch (node)
+                                {
+                                    case AwaitExpressionSyntax _:
+                                    case LocalDeclarationStatementSyntax local when local.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword):
+                                    case CommonForEachStatementSyntax @foreach when @foreach.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword):
+                                    case UsingStatementSyntax @using when @using.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword):
+                                        return true;
+                                    default:
+                                        return false;
+                                }
+                            });
         }
 
         internal static bool IsNestedFunction(SyntaxNode child)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -442,9 +442,9 @@
         <target state="new">Cannot use local variable or local function '{0}' declared in a top-level statement in this context.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithExecutableStatements">
-        <source>In all but one compilation unit the top-level statements must all be local function declarations.</source>
-        <target state="new">In all but one compilation unit the top-level statements must all be local function declarations.</target>
+      <trans-unit id="ERR_SimpleProgramMultipleUnitsWithTopLevelStatements">
+        <source>Only one compilation unit can have top-level statements.</source>
+        <target state="new">Only one compilation unit can have top-level statements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SingleElementPositionalPatternRequiresDisambiguation">


### PR DESCRIPTION
Related to #41704.
Reflects design changes outlined in https://github.com/dotnet/csharplang/pull/3292.