### PR TITLE
Avoid showing <remarks> documentation for items in System.*

### DIFF
--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
@@ -342,6 +342,13 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             }
             else if (documentedSymbol is object)
             {
+                if (documentedSymbol.IsInSystemNamespace())
+                {
+                    // Don't show <remarks> content for items in the System namespace (or any child namespace).
+                    // https://github.com/dotnet/roslyn/issues/42606
+                    return default;
+                }
+
                 var documentation = documentedSymbol.GetRemarksDocumentationParts(semanticModel, token.SpanStart, formatter, cancellationToken);
                 if (documentation != null)
                 {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -692,5 +692,20 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return symbols.FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, compilation)
                 .WhereAsArray(s => !s.IsUnsafe());
         }
+
+        public static bool IsInSystemNamespace(this ISymbol symbol)
+        {
+            for (var namespaceSymbol = symbol as INamespaceSymbol ?? symbol.ContainingNamespace;
+                namespaceSymbol is object;
+                namespaceSymbol = namespaceSymbol.ContainingNamespace)
+            {
+                if (namespaceSymbol is { Name: nameof(System), ContainingNamespace: { IsGlobalNamespace: true } })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This change mitigates the most pronounced problem observed for Mono/Xamarin users (and aligns with the original intent of the feature, since .NET Framework and .NET Core reference assemblies already did not include this content). While some comments are likely to still appear as very long, these cases are not expected to be a significant fraction of Quick Info operations. User feedback will help us determine if further design iterations are necessary.

See #42606