### PR TITLE
'Simplify interpolation' should not suggest removing .ToString() from base

### DIFF
--- a/src/EditorFeatures/CSharpTest/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SimplifyInterpolation
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    void M(string someValue)
+    void M(System.DateTime someValue)
     {
         const string someConst = ""some format code"";
         _ = $""prefix {someValue[||].ToString(someConst)} suffix"";
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SimplifyInterpolation
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    void M(string someValue)
+    void M(System.DateTime someValue)
     {
         _ = $""prefix {someValue[||].ToString(""some format code"", System.Globalization.CultureInfo.CurrentCulture)} suffix"";
     }

--- a/src/EditorFeatures/CSharpTest/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -752,5 +752,54 @@ public static class Sample
     }
 }");
         }
+
+        [Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")]
+        public async Task MissingOnBaseToString()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    public override string ToString() => $""Test: {base[||].ToString()}"";
+}");
+        }
+
+        [Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")]
+        public async Task MissingOnBaseToStringEvenWhenNotOverridden()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    string M() => $""Test: {base[||].ToString()}"";
+}");
+        }
+
+        [Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")]
+        public async Task MissingOnBaseToStringWithArgument()
+        {
+            await TestMissingAsync(
+@"class Base
+{
+    public string ToString(string format) => format;
+}
+
+class Derived : Base
+{
+    public override string ToString() => $""Test: {base[||].ToString(""a"")}"";
+}");
+        }
+
+        [Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")]
+        public async Task PadLeftSimplificationIsStillOfferedOnBaseToString()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public override string ToString() => $""Test: {base.ToString()[||].PadLeft(10)}"";
+}",
+@"class C
+{
+    public override string ToString() => $""Test: {base.ToString(),10}"";
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/SimplifyInterpolation/SimplifyInterpolationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SimplifyInterpolation/SimplifyInterpolationTests.vb
@@ -1,0 +1,516 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.SimplifyInterpolation
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SimplifyInterpolation
+    <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyInterpolation)>
+    Public Class SimplifyInterpolationTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
+            Return (New VisualBasicSimplifyInterpolationDiagnosticAnalyzer(),
+                    New VisualBasicSimplifyInterpolationCodeFixProvider())
+        End Function
+
+        <Fact>
+        Public Async Function SubsequentUnnecessarySpansDoNotRepeatTheSmartTag() As Task
+            Dim parameters = New TestParameters(retainNonFixableDiagnostics:=True, includeDiagnosticsOutsideSelection:=True)
+
+            Using workspace = CreateWorkspaceFromOptions("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].ToString()|}{|Unnecessary:.PadLeft(|}{|Unnecessary:3|})} suffix""
+    End Sub
+End Class", parameters)
+
+                Dim diagnostics = Await GetDiagnosticsWorkerAsync(workspace, parameters)
+
+                Assert.Equal(
+                    {
+                        ("IDE0071", DiagnosticSeverity.Info),
+                        ("IDE0071WithoutSuggestion", DiagnosticSeverity.Hidden),
+                        ("IDE0071WithoutSuggestion", DiagnosticSeverity.Hidden)
+                    },
+                    diagnostics.Select(Function(d) (d.Descriptor.Id, d.Severity)))
+            End Using
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithNoParameter() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].ToString()|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithParameter() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].ToString(""|}g{|Unnecessary:"")|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue:g} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithEscapeSequences() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].ToString(""|}""""d""""{|Unnecessary:"")|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue:""""d""""} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithStringConstantParameter() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Const someConst As String = ""some format code""
+        Dim v = $""prefix {someValue[||].ToString(someConst)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithCharacterLiteralParameter() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As C)
+        Dim v = $""prefix {someValue[||].ToString(""f""c)} suffix""
+    End Sub
+
+    Function ToString(_ As Object) As String
+        Return ""Goobar""
+    End Function
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithFormatProvider() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].ToString(""some format code"", System.Globalization.CultureInfo.CurrentCulture)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWithIntegerLiteral() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].PadLeft(|}3{|Unnecessary:)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWithIntegerLiteral() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].PadRight(|}3{|Unnecessary:)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,-3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWithComplexConstantExpression() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Const someConstant As Integer = 1
+        Dim v = $""prefix {someValue{|Unnecessary:[||].PadLeft(|}CByte(3.3) + someConstant{|Unnecessary:)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Const someConstant As Integer = 1
+        Dim v = $""prefix {someValue,CByte(3.3) + someConstant} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWithSpaceChar() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].PadLeft(|}3{|Unnecessary:, "" ""c)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWithSpaceChar() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].PadRight(|}3{|Unnecessary:, "" ""c)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,-3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWithNonSpaceChar() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadLeft(3, ""x""c)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWithNonSpaceChar() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadRight(3, ""x""c)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWithComplexConstantExpressionRequiringParentheses() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Const someConstant As Integer = 1
+        Dim v = $""prefix {someValue{|Unnecessary:[||].PadRight(|}CByte(3.3) + someConstant{|Unnecessary:)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Const someConstant As Integer = 1
+        Dim v = $""prefix {someValue,-(CByte(3.3) + someConstant)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithNoParameterWhenFormattingComponentIsSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].ToString():goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithStringLiteralParameterWhenFormattingComponentIsSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].ToString(""bar""):goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithNoParameterWhenAlignmentComponentIsSpecified() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].ToString()|},3} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithNoParameterWhenBothComponentsAreSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].ToString(),3:goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithStringLiteralParameterWhenBothComponentsAreSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].ToString(""some format code""),3:goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWhenFormattingComponentIsSpecified() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadLeft(3):goo} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,3:goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWhenFormattingComponentIsSpecified() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadRight(3):goo} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,-3:goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWhenAlignmentComponentIsSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadLeft(3),3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWhenAlignmentComponentIsSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadRight(3),3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftWhenBothComponentsAreSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadLeft(3),3:goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadRightWhenBothComponentsAreSpecified() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue[||].PadRight(3),3:goo} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function ToStringWithoutFormatThenPadLeft() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue{|Unnecessary:[||].ToString()|}{|Unnecessary:.PadLeft(|}3{|Unnecessary:)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue,3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftThenToStringWithoutFormat() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3){|Unnecessary:[||].ToString()|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftThenToStringWithoutFormatWhenAlignmentComponentIsSpecified() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3){|Unnecessary:[||].ToString()|},3} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3),3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftThenPadRight_WithoutAlignment() As Task
+            Await TestInRegularAndScriptAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3){|Unnecessary:[||].PadRight(|}3{|Unnecessary:)|}} suffix""
+    End Sub
+End Class", "
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3),-3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function PadLeftThenPadRight_WithAlignment() As Task
+            Await TestMissingAsync("
+Class C
+    Sub M(someValue As String)
+        Dim v = $""prefix {someValue.PadLeft(3)[||].PadRight(3),3} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact, WorkItem(41381, "https://github.com/dotnet/roslyn/issues/41381")>
+        Public Async Function MissingOnImplicitToStringReceiver() As Task
+            Await TestMissingAsync("
+Class C
+    Public Overrides Function ToString() As String
+        Return ""Goobar""
+    End Function
+
+    Function GetViaInterpolation() As String
+        Return $""Hello {ToString[||]()}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(41381, "https://github.com/dotnet/roslyn/issues/41381")>
+        Public Async Function MissingOnImplicitToStringReceiverWithArg() As Task
+            Await TestMissingAsync("
+Class C
+    Function ToString(arg As String) As String
+        Return ""Goobar""
+    End Function
+
+    Function GetViaInterpolation() As String
+        Return $""Hello {ToString[||](""g"")}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(41381, "https://github.com/dotnet/roslyn/issues/41381")>
+        Public Async Function MissingOnStaticToStringReceiver() As Task
+            Await TestMissingAsync("
+Class C
+    Shared Function ToString() As String
+        Return ""Goobar""
+    End Function
+
+    Function GetViaInterpolation() As String
+        Return $""Hello {ToString[||]()}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(41381, "https://github.com/dotnet/roslyn/issues/41381")>
+        Public Async Function MissingOnStaticToStringReceiverWithArg() As Task
+            Await TestMissingAsync("
+Class C
+    Shared Function ToString(arg As String) As String
+        Return ""Goobar""
+    End Function
+
+    Function GetViaInterpolation() As String
+        Return $""Hello {ToString[||](""g"")}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(41381, "https://github.com/dotnet/roslyn/issues/41381")>
+        Public Async Function MissingOnImplicitPadLeft() As Task
+            Await TestMissingAsync("
+Class C
+    Function PadLeft(ByVal val As Integer) As String
+        Return """"
+    End Function
+
+    Sub M(someValue As String)
+        Dim v = $""prefix {[||]PadLeft(3)} suffix""
+    End Sub
+End Class")
+        End Function
+
+        <Fact, WorkItem(41381, "https://github.com/dotnet/roslyn/issues/41381")>
+        Public Async Function MissingOnStaticPadLeft() As Task
+            Await TestMissingAsync("
+Class C
+    Shared Function PadLeft(ByVal val As Integer) As String
+        Return """"
+    End Function
+
+    Sub M(someValue As String)
+        Dim v = $""prefix {[||]PadLeft(3)} suffix""
+    End Sub
+End Class")
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/SimplifyInterpolation/SimplifyInterpolationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SimplifyInterpolation/SimplifyInterpolationTests.vb
@@ -512,5 +512,58 @@ Class C
     End Sub
 End Class")
         End Function
+
+        <Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")>
+        Public Async Function MissingOnBaseToString() As Task
+            Await TestMissingAsync(
+"Class C
+    Public Overrides Function ToString() As String
+        Return $""Test: {MyBase[||].ToString()}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")>
+        Public Async Function MissingOnBaseToStringEvenWhenNotOverridden() As Task
+            Await TestMissingAsync(
+"Class C
+    Function M() As String
+        Return $""Test: {MyBase[||].ToString()}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")>
+        Public Async Function MissingOnBaseToStringWithArgument() As Task
+            Await TestMissingAsync(
+"Class Base
+    Public Function ToString(format As String) As String
+        Return format
+    End Function
+End Class
+
+Class Derived
+    Inherits Base
+
+    Public Overrides Function ToString() As String
+        Return $""Test: {MyBase[||].ToString(""a"")}""
+    End Function
+End Class")
+        End Function
+
+        <Fact, WorkItem(42669, "https://github.com/dotnet/roslyn/issues/42669")>
+        Public Async Function PadLeftSimplificationIsStillOfferedOnBaseToString() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Public Overrides Function ToString() As String
+        Return $""Test: {MyBase.ToString()[||].PadLeft(10)}""
+    End Function
+End Class",
+"Class C
+    Public Overrides Function ToString() As String
+        Return $""Test: {MyBase.ToString(),10}""
+    End Function
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/SimplifyInterpolation/SimplifyInterpolationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SimplifyInterpolation/SimplifyInterpolationTests.vb
@@ -44,12 +44,12 @@ End Class", parameters)
         Public Async Function ToStringWithNoParameter() As Task
             Await TestInRegularAndScriptAsync("
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue{|Unnecessary:[||].ToString()|}} suffix""
     End Sub
 End Class", "
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue} suffix""
     End Sub
 End Class")
@@ -59,12 +59,12 @@ End Class")
         Public Async Function ToStringWithParameter() As Task
             Await TestInRegularAndScriptAsync("
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue{|Unnecessary:[||].ToString(""|}g{|Unnecessary:"")|}} suffix""
     End Sub
 End Class", "
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue:g} suffix""
     End Sub
 End Class")
@@ -74,12 +74,12 @@ End Class")
         Public Async Function ToStringWithEscapeSequences() As Task
             Await TestInRegularAndScriptAsync("
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue{|Unnecessary:[||].ToString(""|}""""d""""{|Unnecessary:"")|}} suffix""
     End Sub
 End Class", "
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue:""""d""""} suffix""
     End Sub
 End Class")
@@ -89,7 +89,7 @@ End Class")
         Public Async Function ToStringWithStringConstantParameter() As Task
             Await TestMissingInRegularAndScriptAsync("
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Const someConst As String = ""some format code""
         Dim v = $""prefix {someValue[||].ToString(someConst)} suffix""
     End Sub
@@ -114,7 +114,7 @@ End Class")
         Public Async Function ToStringWithFormatProvider() As Task
             Await TestMissingInRegularAndScriptAsync("
 Class C
-    Sub M(someValue As String)
+    Sub M(someValue As System.DateTime)
         Dim v = $""prefix {someValue[||].ToString(""some format code"", System.Globalization.CultureInfo.CurrentCulture)} suffix""
     End Sub
 End Class")

--- a/src/Features/CSharp/Portable/SimplifyInterpolation/CSharpSimplifyInterpolationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/SimplifyInterpolation/CSharpSimplifyInterpolationDiagnosticAnalyzer.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.SimplifyInterpolation;
 
 namespace Microsoft.CodeAnalysis.CSharp.SimplifyInterpolation
@@ -16,5 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.SimplifyInterpolation
     {
         protected override IVirtualCharService GetVirtualCharService()
             => CSharpVirtualCharService.Instance;
+
+        protected override ISyntaxFacts GetSyntaxFacts()
+            => CSharpSyntaxFacts.Instance;
     }
 }

--- a/src/Features/Core/Portable/SimplifyInterpolation/AbstractSimplifyInterpolationCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SimplifyInterpolation/AbstractSimplifyInterpolationCodeFixProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -63,7 +64,8 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                     interpolationSyntax.Parent is TInterpolatedStringExpressionSyntax interpolatedString)
                 {
                     Helpers.UnwrapInterpolation<TInterpolationSyntax, TExpressionSyntax>(
-                        document.GetRequiredLanguageService<IVirtualCharService>(), interpolation, out var unwrapped,
+                        document.GetRequiredLanguageService<IVirtualCharService>(),
+                        document.GetRequiredLanguageService<ISyntaxFactsService>(), interpolation, out var unwrapped,
                         out var alignment, out var negate, out var formatString, out _);
 
                     if (unwrapped == null)

--- a/src/Features/Core/Portable/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.SimplifyInterpolation
@@ -26,6 +27,8 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
         }
 
         protected abstract IVirtualCharService GetVirtualCharService();
+
+        protected abstract ISyntaxFacts GetSyntaxFacts();
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
@@ -56,8 +59,8 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
             }
 
             Helpers.UnwrapInterpolation<TInterpolationSyntax, TExpressionSyntax>(
-                GetVirtualCharService(), interpolation, out _, out var alignment, out _, out var formatString,
-                out var unnecessaryLocations);
+                GetVirtualCharService(), GetSyntaxFacts(), interpolation, out _, out var alignment, out _,
+                out var formatString, out var unnecessaryLocations);
 
             if (alignment == null && formatString == null)
             {

--- a/src/Features/Core/Portable/SimplifyInterpolation/Helpers.cs
+++ b/src/Features/Core/Portable/SimplifyInterpolation/Helpers.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
     internal static class Helpers
     {
         public static void UnwrapInterpolation<TInterpolationSyntax, TExpressionSyntax>(
-            IVirtualCharService virtualCharService, IInterpolationOperation interpolation,
+            IVirtualCharService virtualCharService, ISyntaxFacts syntaxFacts, IInterpolationOperation interpolation,
             out TExpressionSyntax? unwrapped, out TExpressionSyntax? alignment, out bool negate,
             out string? formatString, out ImmutableArray<Location> unnecessaryLocations)
                 where TInterpolationSyntax : SyntaxNode
@@ -38,7 +39,7 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
 
             if (interpolation.FormatString == null)
             {
-                UnwrapFormatString(virtualCharService, expression, out expression, out formatString, unnecessarySpans);
+                UnwrapFormatString(virtualCharService, syntaxFacts, expression, out expression, out formatString, unnecessarySpans);
             }
 
             unwrapped = expression.Syntax as TExpressionSyntax;
@@ -67,11 +68,12 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
         }
 
         private static void UnwrapFormatString(
-            IVirtualCharService virtualCharService, IOperation expression, out IOperation unwrapped,
+            IVirtualCharService virtualCharService, ISyntaxFacts syntaxFacts, IOperation expression, out IOperation unwrapped,
             out string? formatString, List<TextSpan> unnecessarySpans)
         {
             if (expression is IInvocationOperation { TargetMethod: { Name: nameof(ToString) } } invocation &&
-                HasNonImplicitInstance(invocation))
+                HasNonImplicitInstance(invocation) &&
+                !syntaxFacts.IsBaseExpression(invocation.Instance.Syntax))
             {
                 if (invocation.Arguments.Length == 1 &&
                     invocation.Arguments[0].Value is ILiteralOperation { ConstantValue: { HasValue: true, Value: string value } } literal)

--- a/src/Features/VisualBasic/Portable/SimplifyInterpolation/VisualBasicSimplifyInterpolationDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/SimplifyInterpolation/VisualBasicSimplifyInterpolationDiagnosticAnalyzer.vb
@@ -4,8 +4,10 @@
 
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.SimplifyInterpolation
 Imports Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.VirtualChars
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SimplifyInterpolation
@@ -15,6 +17,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SimplifyInterpolation
 
         Protected Overrides Function GetVirtualCharService() As IVirtualCharService
             Return VisualBasicVirtualCharService.Instance
+        End Function
+
+        Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts
+            Return VisualBasicSyntaxFacts.Instance
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #42669

The first two commits were moved from https://github.com/dotnet/roslyn/pull/42250 in order to add more VB tests.