### PR TITLE
Use FailFast with diagnostics

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -34,9 +34,18 @@ namespace Microsoft.CodeAnalysis
             }
 
 #endif
-            DumpStackTrace(exception);
+            DumpStackTrace(exception: exception);
 
             Environment.FailFast(exception.ToString(), exception);
+            throw ExceptionUtilities.Unreachable; // to satisfy [DoesNotReturn]
+        }
+
+        [DebuggerHidden]
+        [DoesNotReturn]
+        internal static void Fail(string message)
+        {
+            DumpStackTrace(message: message);
+            Environment.FailFast(message);
             throw ExceptionUtilities.Unreachable; // to satisfy [DoesNotReturn]
         }
 
@@ -45,16 +54,23 @@ namespace Microsoft.CodeAnalysis
         /// for debugging unit tests that hit a fatal exception
         /// </summary>
         [Conditional("DEBUG")]
-        private static void DumpStackTrace(Exception exception)
+        internal static void DumpStackTrace(Exception? exception = null, string? message = null)
         {
             Console.WriteLine("Dumping info before call to failfast");
-            Console.WriteLine("Exception info");
-
-            for (Exception? current = exception; current is object; current = current!.InnerException)
+            if (message is object)
             {
-                Console.WriteLine(current.Message);
-                Console.WriteLine(current.StackTrace);
-                current = current.InnerException;
+                Console.WriteLine(message);
+            }
+
+            if (exception is object)
+            {
+                Console.WriteLine("Exception info");
+                for (Exception? current = exception; current is object; current = current!.InnerException)
+                {
+                    Console.WriteLine(current.Message);
+                    Console.WriteLine(current.StackTrace);
+                    current = current.InnerException;
+                }
             }
 
 #if !NET20 && !NETSTANDARD1_3
@@ -88,6 +104,7 @@ namespace Microsoft.CodeAnalysis
                 Debugger.Break();
             }
 
+            DumpStackTrace(message: message);
             Environment.FailFast("ASSERT FAILED" + Environment.NewLine + message);
         }
     }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     textBuffer = text.Container.TryGetTextBuffer();
                     if (textBuffer == null)
                     {
-                        Environment.FailFast(string.Format("document with name {0} is open but textBuffer is null. Textcontainer is of type {1}. SourceText is: {2}",
+                        FailFast.Fail(string.Format("document with name {0} is open but textBuffer is null. Textcontainer is of type {1}. SourceText is: {2}",
                                                             document.Name, text.Container.GetType().FullName, text.ToString()));
                     }
 

--- a/src/EditorFeatures/TestUtilities/Async/AsynchronousOperationBlocker.cs
+++ b/src/EditorFeatures/TestUtilities/Async/AsynchronousOperationBlocker.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Test.Utilities
 {
@@ -70,7 +71,7 @@ namespace Roslyn.Test.Utilities
         {
             if (_disposed)
             {
-                Environment.FailFast("Badness");
+                FailFast.Fail("Badness");
             }
 
             return _waitHandle.WaitOne(timeout);

--- a/src/EditorFeatures/TestUtilities/ExceptionUtilities.cs
+++ b/src/EditorFeatures/TestUtilities/ExceptionUtilities.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         [DebuggerHidden]
         public static void FailFast(Exception exception)
         {
+            Microsoft.CodeAnalysis.FailFast.DumpStackTrace(exception);
+
             RaiseFailFastException(IntPtr.Zero, IntPtr.Zero, 0);
 
             // the RaiseFailFastException above may have not actually killed the process if a

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // this shouldn't happen. would like to get some diagnostic
                         while (_workItemQueue.HasAnyWork)
                         {
-                            Environment.FailFast("How?");
+                            FailFast.Fail("How?");
                         }
                     }
                 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // this shouldn't happen. would like to get some diagnostic
                         while (_workItemQueue.HasAnyWork)
                         {
-                            Environment.FailFast("How?");
+                            FailFast.Fail("How?");
                         }
                     }
                 }

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 
@@ -80,7 +81,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
         Protected Overridable Sub Dispose(disposing As Boolean)
             If Not disposing Then
-                Environment.FailFast("TestWorkspaceAndFileModelCodel GC'd without call to Dispose()!")
+                FailFast.Fail("TestWorkspaceAndFileModelCodel GC'd without call to Dispose()!")
             End If
 
             If Not Me._disposedValue Then


### PR DESCRIPTION
Change all the direct uses of `Environment.FailFast` to instead use
`FailFast.Fail`. The latter has diagnostics which are useful for determining why
unit tests are failing.