### PR TITLE
Avoid using Workspace.GetRelatedDocumentIds

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
@@ -308,18 +308,21 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             // We're switching between the target language and the Interactive Command "language".
             // First, remove the current submission from the solution.
 
+            var documentId = _workspace.GetDocumentIdInCurrentContext(buffer.AsTextContainer());
             var oldSolution = _workspace.CurrentSolution;
+            var relatedDocumentIds = oldSolution.GetRelatedDocumentIds(documentId);
+
             var newSolution = oldSolution;
 
-            foreach (var documentId in _workspace.GetRelatedDocumentIds(buffer.AsTextContainer()))
+            foreach (var relatedDocumentId in relatedDocumentIds)
             {
-                Debug.Assert(documentId != null);
+                Debug.Assert(relatedDocumentId != null);
 
-                newSolution = newSolution.RemoveDocument(documentId);
+                newSolution = newSolution.RemoveDocument(relatedDocumentId);
 
                 // TODO (tomat): Is there a better way to remove mapping between buffer and document in REPL? 
                 // Perhaps TrackingWorkspace should implement RemoveDocumentAsync?
-                _workspace.ClearOpenDocument(documentId);
+                _workspace.ClearOpenDocument(relatedDocumentId);
             }
 
             // Next, remove the previous submission project and update the workspace.

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -34,11 +34,15 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
                     if (!object.Equals(oldProject.ParseOptions, newProject.ParseOptions))
                     {
                         var workspace = e.NewSolution.Workspace;
-                        var documentIds = workspace.GetRelatedDocumentIds(SubjectBuffer.AsTextContainer());
-
-                        if (documentIds.Any(d => d.ProjectId == e.ProjectId))
+                        var documentId = workspace.GetDocumentIdInCurrentContext(SubjectBuffer.AsTextContainer());
+                        if (documentId != null)
                         {
-                            this.RaiseChanged();
+                            var relatedDocumentIds = e.NewSolution.GetRelatedDocumentIds(documentId);
+
+                            if (relatedDocumentIds.Any(d => d.ProjectId == e.ProjectId))
+                            {
+                                RaiseChanged();
+                            }
                         }
                     }
                 }

--- a/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
@@ -39,7 +39,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SuggestionServi
                 var sourceTextContainer = textBuffer.AsTextContainer();
                 if (Workspace.TryGetWorkspace(sourceTextContainer, out var workspace))
                 {
-                    return SupportsRenameWorker(workspace.GetRelatedDocumentIds(sourceTextContainer).ToImmutableArray());
+                    var documentId = workspace.GetDocumentIdInCurrentContext(sourceTextContainer);
+                    return SupportsRenameWorker(workspace.CurrentSolution.GetRelatedDocumentIds(documentId));
                 }
 
                 return false;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
@@ -63,16 +63,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
         }
 
-        public static IEnumerable<DocumentId> FilterDocumentIdsByLanguage(this Solution solution, ImmutableArray<DocumentId> documentIds, string language)
-        {
-            foreach (var documentId in documentIds)
-            {
-                var document = solution.GetDocument(documentId);
-                if (document != null && document.Project.Language == language)
-                {
-                    yield return documentId;
-                }
-            }
-        }
+        public static ImmutableArray<DocumentId> FilterDocumentIdsByLanguage(this Solution solution, ImmutableArray<DocumentId> documentIds, string language)
+            => documentIds.WhereAsArray(
+                (documentId, args) => args.solution.GetDocument(documentId)?.Project.Language == args.language,
+                (solution, language));
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis
         public ImmutableArray<DocumentId> GetLinkedDocumentIds()
         {
             var documentIdsWithPath = this.Project.Solution.GetDocumentIdsWithFilePath(this.FilePath);
-            var filteredDocumentIds = this.Project.Solution.FilterDocumentIdsByLanguage(documentIdsWithPath, this.Project.Language).ToImmutableArray();
+            var filteredDocumentIds = this.Project.Solution.FilterDocumentIdsByLanguage(documentIdsWithPath, this.Project.Language);
             return filteredDocumentIds.Remove(this.Id);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1540,11 +1540,11 @@ namespace Microsoft.CodeAnalysis
             if (string.IsNullOrEmpty(filePath))
             {
                 // this document can't have any related document. only related document is itself.
-                return ImmutableArray.Create<DocumentId>(documentId);
+                return ImmutableArray.Create(documentId);
             }
 
-            var documentIds = this.GetDocumentIdsWithFilePath(filePath);
-            return this.FilterDocumentIdsByLanguage(documentIds, projectState.ProjectInfo.Language).ToImmutableArray();
+            var documentIds = GetDocumentIdsWithFilePath(filePath);
+            return this.FilterDocumentIdsByLanguage(documentIds, projectState.ProjectInfo.Language);
         }
 
         internal Solution WithNewWorkspace(Workspace workspace, int workspaceVersion)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1445,12 +1445,12 @@ namespace Microsoft.CodeAnalysis
         {
             if (string.IsNullOrEmpty(filePath))
             {
-                return ImmutableArray.Create<DocumentId>();
+                return ImmutableArray<DocumentId>.Empty;
             }
 
             return _filePathToDocumentIdsMap.TryGetValue(filePath!, out var documentIds)
                 ? documentIds
-                : ImmutableArray.Create<DocumentId>();
+                : ImmutableArray<DocumentId>.Empty;
         }
 
         private static ProjectDependencyGraph CreateDependencyGraph(

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis
 #nullable enable
 
         /// <summary>
-        /// Gets the ids for documents associated with a text container using the <see cref="CurrentSolution"/> snapshot.
+        /// Gets the ids for documents in the <see cref="CurrentSolution"/> snapshot associated with the given <paramref name="container"/>.
         /// Documents are normally associated with a text container when the documents are opened.
         /// </summary>
         public virtual IEnumerable<DocumentId> GetRelatedDocumentIds(SourceTextContainer container)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -204,9 +204,10 @@ namespace Microsoft.CodeAnalysis
                 return _projectToOpenDocumentsMap.SelectMany(kvp => kvp.Value).ToImmutableArray();
             }
         }
+#nullable enable
 
         /// <summary>
-        /// Gets the ids for documents associated with a text container.
+        /// Gets the ids for documents associated with a text container using the <see cref="CurrentSolution"/> snapshot.
         /// Documents are normally associated with a text container when the documents are opened.
         /// </summary>
         public virtual IEnumerable<DocumentId> GetRelatedDocumentIds(SourceTextContainer container)
@@ -216,28 +217,20 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(container));
             }
 
-            using (_stateLock.DisposableWait())
+            var documentId = GetDocumentIdInCurrentContext(container);
+            if (documentId == null)
             {
-                return GetRelatedDocumentIds_NoLock(container);
-            }
-        }
-
-        private ImmutableArray<DocumentId> GetRelatedDocumentIds_NoLock(SourceTextContainer container)
-        {
-            if (!_bufferToDocumentInCurrentContextMap.TryGetValue(container, out var documentId))
-            {
-                // it is not an opened file
                 return ImmutableArray<DocumentId>.Empty;
             }
 
-            return this.CurrentSolution.GetRelatedDocumentIds(documentId);
+            return CurrentSolution.GetRelatedDocumentIds(documentId);
         }
 
         /// <summary>
         /// Gets the id for the document associated with the given text container in its current context.
         /// Documents are normally associated with a text container when the documents are opened.
         /// </summary>
-        public virtual DocumentId GetDocumentIdInCurrentContext(SourceTextContainer container)
+        public virtual DocumentId? GetDocumentIdInCurrentContext(SourceTextContainer container)
         {
             if (container == null)
             {
@@ -249,6 +242,11 @@ namespace Microsoft.CodeAnalysis
                 return GetDocumentIdInCurrentContext_NoLock(container);
             }
         }
+
+        private DocumentId? GetDocumentIdInCurrentContext_NoLock(SourceTextContainer container)
+            => _bufferToDocumentInCurrentContextMap.TryGetValue(container, out var documentId) ? documentId : null;
+
+#nullable restore
 
         /// <summary>
         /// Finds the <see cref="DocumentId"/> related to the given <see cref="DocumentId"/> that
@@ -275,20 +273,6 @@ namespace Microsoft.CodeAnalysis
         {
             // TODO: remove linear search
             return _bufferToAssociatedDocumentsMap.Where(kvp => kvp.Value.Contains(documentId)).Select(kvp => kvp.Key).FirstOrDefault();
-        }
-
-        private DocumentId GetDocumentIdInCurrentContext_NoLock(SourceTextContainer container)
-        {
-            var foundValue = _bufferToDocumentInCurrentContextMap.TryGetValue(container, out var docId);
-
-            if (foundValue)
-            {
-                return docId;
-            }
-            else
-            {
-                return null;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
We have code paths that start with a solution snapshot and call to `Workspace.GetRelatedDocumentIds` to get document ids. 

`Workspace.GetRelatedDocumentIds` however fetches the current solution snapshot, which might be different than the solution snapshot the caller started with.

This may or may not matter, but the possible discrepancy makes it harder to reason about correctness of the code.