### PR TITLE
Convert ReferenceCountedDisposable<T> to a value type

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcConnection.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcConnection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         private readonly RemoteEndPoint _serviceEndPoint;
 
         // communication channel related to snapshot information
-        private readonly ReferenceCountedDisposable<RemotableDataProvider> _remotableDataProvider;
+        private ReferenceCountedDisposable<RemotableDataProvider> _remotableDataProvider;
 
         public JsonRpcConnection(
             Workspace workspace,
@@ -33,10 +33,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             Stream serviceStream,
             ReferenceCountedDisposable<RemotableDataProvider> remotableDataProvider)
         {
-            Contract.ThrowIfNull(remotableDataProvider);
+            Contract.ThrowIfTrue(remotableDataProvider.IsDefault);
 
             _workspace = workspace;
-            _remotableDataProvider = remotableDataProvider;
+            _remotableDataProvider = remotableDataProvider.Move();
             _serviceEndPoint = new RemoteEndPoint(serviceStream, logger, callbackTarget);
             _serviceEndPoint.UnexpectedExceptionThrown += UnexpectedExceptionThrown;
             _serviceEndPoint.StartListening();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposableCache.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposableCache.cs
@@ -23,7 +23,7 @@ namespace Roslyn.Utilities
         {
             lock (_gate)
             {
-                ReferenceCountedDisposable<Entry> disposable = null;
+                ReferenceCountedDisposable<Entry>/*??*/ disposable = default;
 
                 // If we already have one in the map to hand out, great
                 if (_cache.TryGetValue(key, out var weakReference))
@@ -31,7 +31,7 @@ namespace Roslyn.Utilities
                     disposable = weakReference.TryAddReference();
                 }
 
-                if (disposable == null)
+                if (disposable.IsDefault)
                 {
                     // We didn't easily get a disposable, so one of two things is the case:
                     //
@@ -45,7 +45,7 @@ namespace Roslyn.Utilities
                     _cache[key] = new ReferenceCountedDisposable<Entry>.WeakReference(disposable);
                 }
 
-                return disposable;
+                return disposable.Move();
             }
         }
 


### PR DESCRIPTION
Relies on non-copyable value types (dotnet/roslyn-analyzers#3420) and non-defaultable value types (dotnet/csharplang#99) for correctness. _All_ changes made in this pull request were the direct result of diagnostics produced by the compiler and/or analyzers covering the previous cases.

* No changes to the semantics of `ReferenceCountedDisposable<T>` or `ReferenceCountedDisposable<T>.WeakReference`
* Allocations in `ReferenceCountedDisposable<T>.TryAddReference` have been eliminated (use of the type is now a one-time allocation when the resource is wrapped, unless used through the interface)