### PR TITLE
Add string ctor to MemberNotNull/When

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -256,25 +256,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         static internal void DecodeMemberNotNullAttribute<T>(TypeSymbol type, ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
             where T : WellKnownAttributeData, IMemberNotNullAttributeTarget, new()
         {
-            var membersArray = arguments.Attribute.CommonConstructorArguments[0];
-            if (membersArray.IsNull)
+            var value = arguments.Attribute.CommonConstructorArguments[0];
+            if (value.IsNull)
             {
                 return;
             }
 
-            var builder = ArrayBuilder<string>.GetInstance();
-            foreach (var member in membersArray.Values)
+            if (value.Kind != TypedConstantKind.Array)
             {
-                var memberName = member.DecodeValue<string>(SpecialType.System_String);
+                string? memberName = value.DecodeValue<string>(SpecialType.System_String);
                 if (memberName is object)
                 {
-                    builder.Add(memberName);
+                    arguments.GetOrCreateData<T>().AddNotNullMember(memberName);
                     ReportBadNotNullMemberIfNeeded(type, arguments, memberName);
                 }
             }
+            else
+            {
+                var builder = ArrayBuilder<string>.GetInstance();
+                foreach (var member in value.Values)
+                {
+                    var memberName = member.DecodeValue<string>(SpecialType.System_String);
+                    if (memberName is object)
+                    {
+                        builder.Add(memberName);
+                        ReportBadNotNullMemberIfNeeded(type, arguments, memberName);
+                    }
+                }
 
-            arguments.GetOrCreateData<T>().AddNotNullMember(builder);
-            builder.Free();
+                arguments.GetOrCreateData<T>().AddNotNullMember(builder);
+                builder.Free();
+            }
         }
 
         private static void ReportBadNotNullMemberIfNeeded(TypeSymbol type, DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, string memberName)
@@ -294,26 +306,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         static internal void DecodeMemberNotNullWhenAttribute<T>(TypeSymbol type, ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
             where T : WellKnownAttributeData, IMemberNotNullAttributeTarget, new()
         {
-            var membersArray = arguments.Attribute.CommonConstructorArguments[1];
-            if (membersArray.IsNull)
+            var value = arguments.Attribute.CommonConstructorArguments[1];
+            if (value.IsNull)
             {
                 return;
             }
 
-            var builder = ArrayBuilder<string>.GetInstance();
-            foreach (var member in membersArray.Values)
+            var sense = arguments.Attribute.CommonConstructorArguments[0].DecodeValue<bool>(SpecialType.System_Boolean);
+            if (value.Kind != TypedConstantKind.Array)
             {
-                var memberName = member.DecodeValue<string>(SpecialType.System_String);
+                var memberName = value.DecodeValue<string>(SpecialType.System_String);
                 if (memberName is object)
                 {
-                    builder.Add(memberName);
+                    arguments.GetOrCreateData<T>().AddNotNullWhenMember(sense, memberName);
                     ReportBadNotNullMemberIfNeeded(type, arguments, memberName);
                 }
             }
+            else
+            {
+                var builder = ArrayBuilder<string>.GetInstance();
+                foreach (var member in value.Values)
+                {
+                    var memberName = member.DecodeValue<string>(SpecialType.System_String);
+                    if (memberName is object)
+                    {
+                        builder.Add(memberName);
+                        ReportBadNotNullMemberIfNeeded(type, arguments, memberName);
+                    }
+                }
 
-            var sense = arguments.Attribute.CommonConstructorArguments[0].DecodeValue<bool>(SpecialType.System_Boolean);
-            arguments.GetOrCreateData<T>().AddNotNullWhenMember(sense, builder);
-            builder.Free();
+                arguments.GetOrCreateData<T>().AddNotNullWhenMember(sense, builder);
+                builder.Free();
+            }
         }
 
         private DeclarativeSecurityAction DecodeSecurityAttributeAction(Symbol targetSymbol, CSharpCompilation compilation, AttributeSyntax? nodeOpt, out bool hasErrors, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
@@ -206,60 +206,67 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbol? lazySystemType = null;
 
             ImmutableArray<ParameterSymbol> parameters = ctor.Parameters;
-            bool foundMatch = false;
 
-            for (int i = 0; i < description.Signatures.Length; i++)
+            for (int signatureIndex = 0; signatureIndex < description.Signatures.Length; signatureIndex++)
             {
-                byte[] targetSignature = description.Signatures[i];
+                byte[] targetSignature = description.Signatures[signatureIndex];
+
+                if (matches(targetSignature, parameters, ref lazySystemType))
+                {
+                    return signatureIndex;
+                }
+            }
+
+            return -1;
+
+            bool matches(byte[] targetSignature, ImmutableArray<ParameterSymbol> parameters, ref TypeSymbol? lazySystemType)
+            {
                 if (targetSignature[0] != (byte)SignatureAttributes.Instance)
                 {
-                    continue;
+                    return false;
                 }
 
                 byte parameterCount = targetSignature[1];
                 if (parameterCount != parameters.Length)
                 {
-                    continue;
+                    return false;
                 }
 
                 if ((SignatureTypeCode)targetSignature[2] != SignatureTypeCode.Void)
                 {
-                    continue;
+                    return false;
                 }
 
-                foundMatch = (targetSignature.Length == 3);
-                int k = 0;
-                for (int j = 3; j < targetSignature.Length; j++)
+                int parameterIndex = 0;
+                for (int signatureByteIndex = 3; signatureByteIndex < targetSignature.Length; signatureByteIndex++)
                 {
-                    if (k >= parameters.Length)
+                    if (parameterIndex >= parameters.Length)
                     {
-                        break;
+                        return false;
                     }
 
-                    TypeSymbol parameterType = parameters[k].Type;
+                    TypeSymbol parameterType = parameters[parameterIndex].Type;
                     SpecialType specType = parameterType.SpecialType;
-                    byte targetType = targetSignature[j];
+                    byte targetType = targetSignature[signatureByteIndex];
 
                     if (targetType == (byte)SignatureTypeCode.TypeHandle)
                     {
-                        j++;
+                        signatureByteIndex++;
 
                         if (parameterType.Kind != SymbolKind.NamedType && parameterType.Kind != SymbolKind.ErrorType)
                         {
-                            foundMatch = false;
-                            break;
+                            return false;
                         }
 
                         var namedType = (NamedTypeSymbol)parameterType;
-                        AttributeDescription.TypeHandleTargetInfo targetInfo = AttributeDescription.TypeHandleTargets[targetSignature[j]];
+                        AttributeDescription.TypeHandleTargetInfo targetInfo = AttributeDescription.TypeHandleTargets[targetSignature[signatureByteIndex]];
 
                         // Compare name and containing symbol name. Uses HasNameQualifier
                         // extension method to avoid string allocations.
                         if (!string.Equals(namedType.MetadataName, targetInfo.Name, System.StringComparison.Ordinal) ||
                             !namedType.HasNameQualifier(targetInfo.Namespace))
                         {
-                            foundMatch = false;
-                            break;
+                            return false;
                         }
 
                         targetType = (byte)targetInfo.Underlying;
@@ -269,116 +276,155 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             specType = parameterType.GetEnumUnderlyingType()!.SpecialType;
                         }
                     }
-                    else if (parameterType.IsArray())
+                    else if (targetType != (byte)SignatureTypeCode.SZArray && parameterType.IsArray())
                     {
+                        if (targetSignature[signatureByteIndex - 1] != (byte)SignatureTypeCode.SZArray)
+                        {
+                            return false;
+                        }
+
                         specType = ((ArrayTypeSymbol)parameterType).ElementType.SpecialType;
                     }
 
                     switch (targetType)
                     {
                         case (byte)SignatureTypeCode.Boolean:
-                            foundMatch = specType == SpecialType.System_Boolean;
-                            k += 1;
+                            if (specType != SpecialType.System_Boolean)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Char:
-                            foundMatch = specType == SpecialType.System_Char;
-                            k += 1;
+                            if (specType != SpecialType.System_Char)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.SByte:
-                            foundMatch = specType == SpecialType.System_SByte;
-                            k += 1;
+                            if (specType != SpecialType.System_SByte)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Byte:
-                            foundMatch = specType == SpecialType.System_Byte;
-                            k += 1;
+                            if (specType != SpecialType.System_Byte)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Int16:
-                            foundMatch = specType == SpecialType.System_Int16;
-                            k += 1;
+                            if (specType != SpecialType.System_Int16)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.UInt16:
-                            foundMatch = specType == SpecialType.System_UInt16;
-                            k += 1;
+                            if (specType != SpecialType.System_UInt16)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Int32:
-                            foundMatch = specType == SpecialType.System_Int32;
-                            k += 1;
+                            if (specType != SpecialType.System_Int32)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.UInt32:
-                            foundMatch = specType == SpecialType.System_UInt32;
-                            k += 1;
+                            if (specType != SpecialType.System_UInt32)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Int64:
-                            foundMatch = specType == SpecialType.System_Int64;
-                            k += 1;
+                            if (specType != SpecialType.System_Int64)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.UInt64:
-                            foundMatch = specType == SpecialType.System_UInt64;
-                            k += 1;
+                            if (specType != SpecialType.System_UInt64)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Single:
-                            foundMatch = specType == SpecialType.System_Single;
-                            k += 1;
+                            if (specType != SpecialType.System_Single)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Double:
-                            foundMatch = specType == SpecialType.System_Double;
-                            k += 1;
+                            if (specType != SpecialType.System_Double)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.String:
-                            foundMatch = specType == SpecialType.System_String;
-                            k += 1;
+                            if (specType != SpecialType.System_String)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.Object:
-                            foundMatch = specType == SpecialType.System_Object;
-                            k += 1;
+                            if (specType != SpecialType.System_Object)
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SerializationTypeCode.Type:
-                            if (lazySystemType is null)
-                            {
-                                lazySystemType = GetSystemType(targetSymbol);
-                            }
+                            lazySystemType ??= GetSystemType(targetSymbol);
 
-                            foundMatch = TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything2);
-                            k += 1;
+                            if (!TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything))
+                            {
+                                return false;
+                            }
+                            parameterIndex += 1;
                             break;
 
                         case (byte)SignatureTypeCode.SZArray:
                             // Skip over and check the next byte
-                            foundMatch = parameterType.IsArray();
+                            if (!parameterType.IsArray())
+                            {
+                                return false;
+                            }
                             break;
 
                         default:
-                            return -1;
-                    }
-
-                    if (!foundMatch)
-                    {
-                        break;
+                            return false;
                     }
                 }
 
-                if (foundMatch)
-                {
-                    return i;
-                }
+                return true;
             }
-
-            Debug.Assert(!foundMatch);
-            return -1;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -46,6 +46,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<string> _memberNotNullAttributeData = ImmutableArray<string>.Empty;
 
+        public void AddNotNullMember(string memberName)
+        {
+            VerifySealed(expected: false);
+            _memberNotNullAttributeData = _memberNotNullAttributeData.Add(memberName);
+            SetDataStored();
+        }
+
         public void AddNotNullMember(ArrayBuilder<string> memberNames)
         {
             VerifySealed(expected: false);
@@ -64,6 +71,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<string> _memberNotNullWhenTrueAttributeData = ImmutableArray<string>.Empty;
         private ImmutableArray<string> _memberNotNullWhenFalseAttributeData = ImmutableArray<string>.Empty;
+
+        public void AddNotNullWhenMember(bool sense, string memberName)
+        {
+            VerifySealed(expected: false);
+            if (sense)
+            {
+                _memberNotNullWhenTrueAttributeData = _memberNotNullWhenTrueAttributeData.Add(memberName);
+            }
+            else
+            {
+                _memberNotNullWhenFalseAttributeData = _memberNotNullWhenFalseAttributeData.Add(memberName);
+            }
+            SetDataStored();
+        }
 
         public void AddNotNullWhenMember(bool sense, ArrayBuilder<string> memberNames)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
@@ -94,6 +94,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<string> _memberNotNullAttributeData = ImmutableArray<string>.Empty;
 
+        public void AddNotNullMember(string memberName)
+        {
+            VerifySealed(expected: false);
+            _memberNotNullAttributeData = _memberNotNullAttributeData.Add(memberName);
+            SetDataStored();
+        }
+
         public void AddNotNullMember(ArrayBuilder<string> memberNames)
         {
             VerifySealed(expected: false);
@@ -112,6 +119,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<string> _memberNotNullWhenTrueAttributeData = ImmutableArray<string>.Empty;
         private ImmutableArray<string> _memberNotNullWhenFalseAttributeData = ImmutableArray<string>.Empty;
+
+        public void AddNotNullWhenMember(bool sense, string memberName)
+        {
+            VerifySealed(expected: false);
+            if (sense)
+            {
+                _memberNotNullWhenTrueAttributeData = _memberNotNullWhenTrueAttributeData.Add(memberName);
+            }
+            else
+            {
+                _memberNotNullWhenFalseAttributeData = _memberNotNullWhenFalseAttributeData.Add(memberName);
+            }
+            SetDataStored();
+        }
 
         public void AddNotNullWhenMember(bool sense, ArrayBuilder<string> memberNames)
         {

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1244,7 +1244,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (ai.SignatureIndex == 0)
                 {
-                    if (TryExtractStringValueFromAttribute(ai.Handle, out var extracted))
+                    if (TryExtractStringValueFromAttribute(ai.Handle, out string extracted))
                     {
                         if (extracted is object)
                         {
@@ -1252,7 +1252,7 @@ namespace Microsoft.CodeAnalysis
                         }
                     }
                 }
-                else if (TryExtractStringArrayValueFromAttribute(ai.Handle, out var extracted2))
+                else if (TryExtractStringArrayValueFromAttribute(ai.Handle, out ImmutableArray<string> extracted2))
                 {
                     foreach (var value in extracted2)
                     {
@@ -1285,7 +1285,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (ai.SignatureIndex == 0)
                 {
-                    if (TryExtractValueFromAttribute(ai.Handle, out var extracted, s_attributeBoolAndStringValueExtractor))
+                    if (TryExtractValueFromAttribute(ai.Handle, out BoolAndStringData extracted, s_attributeBoolAndStringValueExtractor))
                     {
                         if (extracted.String is object)
                         {
@@ -1294,7 +1294,7 @@ namespace Microsoft.CodeAnalysis
                         }
                     }
                 }
-                else if (TryExtractValueFromAttribute(ai.Handle, out var extracted2, s_attributeBoolAndStringArrayValueExtractor))
+                else if (TryExtractValueFromAttribute(ai.Handle, out BoolAndStringArrayData extracted2, s_attributeBoolAndStringArrayValueExtractor))
                 {
                     var whenResult = extracted2.Sense ? whenTrue : whenFalse;
                     foreach (var value in extracted2.Strings)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -193,6 +193,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[] s_signature_HasThis_Void_SzArray_Byte = new byte[] { (byte)SignatureAttributes.Instance, 1, Void, SzArray, Byte };
         private static readonly byte[] s_signature_HasThis_Void_SzArray_String = new byte[] { (byte)SignatureAttributes.Instance, 1, Void, SzArray, String };
         private static readonly byte[] s_signature_HasThis_Void_Boolean_SzArray_String = new byte[] { (byte)SignatureAttributes.Instance, 2, Void, Boolean, SzArray, String };
+        private static readonly byte[] s_signature_HasThis_Void_Boolean_String = new byte[] { (byte)SignatureAttributes.Instance, 2, Void, Boolean, String };
 
         private static readonly byte[] s_signature_HasThis_Void_String_DeprecationType_UInt32 = new byte[] { (byte)SignatureAttributes.Instance, 3, Void, String, TypeHandle, (byte)TypeHandleTarget.DeprecationType, UInt32 };
         private static readonly byte[] s_signature_HasThis_Void_String_DeprecationType_UInt32_Platform = new byte[] { (byte)SignatureAttributes.Instance, 4, Void, String, TypeHandle, (byte)TypeHandleTarget.DeprecationType, UInt32, TypeHandle, (byte)TypeHandleTarget.Platform };
@@ -271,8 +272,8 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfMaybeNullAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfMaybeNullWhenAttribute = { s_signature_HasThis_Void_Boolean };
         private static readonly byte[][] s_signaturesOfNotNullAttribute = { s_signature_HasThis_Void };
-        private static readonly byte[][] s_signaturesOfMemberNotNullAttribute = { s_signature_HasThis_Void_SzArray_String };
-        private static readonly byte[][] s_signaturesOfMemberNotNullWhenAttribute = { s_signature_HasThis_Void_Boolean_SzArray_String };
+        private static readonly byte[][] s_signaturesOfMemberNotNullAttribute = { s_signature_HasThis_Void_String, s_signature_HasThis_Void_SzArray_String };
+        private static readonly byte[][] s_signaturesOfMemberNotNullWhenAttribute = { s_signature_HasThis_Void_Boolean_String, s_signature_HasThis_Void_Boolean_SzArray_String };
         private static readonly byte[][] s_signaturesOfNotNullIfNotNullAttribute = { s_signature_HasThis_Void_String };
         private static readonly byte[][] s_signaturesOfNotNullWhenAttribute = { s_signature_HasThis_Void_Boolean };
         private static readonly byte[][] s_signaturesOfDoesNotReturnIfAttribute = { s_signature_HasThis_Void_Boolean };

--- a/src/Compilers/Core/Portable/Symbols/Attributes/IMemberNotNullAttributeTarget.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/IMemberNotNullAttributeTarget.cs
@@ -9,9 +9,13 @@ namespace Microsoft.CodeAnalysis
 {
     interface IMemberNotNullAttributeTarget
     {
+        void AddNotNullMember(string memberName);
+
         void AddNotNullMember(ArrayBuilder<string> memberNames);
 
         ImmutableArray<string> NotNullMembers { get; }
+
+        void AddNotNullWhenMember(bool sense, string memberName);
 
         void AddNotNullWhenMember(bool sense, ArrayBuilder<string> memberNames);
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -154,10 +154,11 @@ namespace System.Diagnostics.CodeAnalysis
         protected const string MemberNotNullAttributeDefinition = @"
 namespace System.Diagnostics.CodeAnalysis
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true)]
     public sealed class MemberNotNullAttribute : Attribute
     {
         public MemberNotNullAttribute(params string[] members) { }
+        public MemberNotNullAttribute(string member) { }
     }
 }
 ";
@@ -165,10 +166,11 @@ namespace System.Diagnostics.CodeAnalysis
         protected const string MemberNotNullWhenAttributeDefinition = @"
 namespace System.Diagnostics.CodeAnalysis
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true)]
     public sealed class MemberNotNullWhenAttribute : Attribute
     {
         public MemberNotNullWhenAttribute(bool when, params string[] members) { }
+        public MemberNotNullWhenAttribute(bool when, string member) { }
     }
 }
 ";

--- a/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
+++ b/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         {
             var hasParent = TryGetParent(node, out var parent);
             Debug.Assert(hasParent);
-            return parent;
+            return parent!;
         }
 
         internal TNode GetAncestor(TNode node, int level)


### PR DESCRIPTION
Follow-up on PR https://github.com/dotnet/roslyn/pull/41675 (Add support for MemberNotNull/When attributes)

The constructors with `string[]` are not CLS-compliant and that causes problems for the BCL team. From email discussion with LDM, we'll add simple constructors that take a single member name at a time, and we'll allow the attributes to be instantiated multiple times.

Relates to https://github.com/dotnet/roslyn/issues/41438 (Implement `MemberNotNull` nullability attribute)
Corresponding BCL change: https://github.com/dotnet/runtime/pull/33864