### PR TITLE
Add back in a legacy todo-comment entrypoint for TypeScript.

### DIFF
--- a/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 using System.Threading;
@@ -29,12 +31,14 @@ namespace Microsoft.CodeAnalysis.TodoComments
         }
 
         internal TodoCommentData CreateSerializableData(
-            Document document, SourceText text, SyntaxTree tree)
+            Document document, SourceText text, SyntaxTree? tree)
         {
             // make sure given position is within valid text range.
             var textSpan = new TextSpan(Math.Min(text.Length, Math.Max(0, Position)), 0);
 
-            var location = tree.GetLocation(textSpan);
+            var location = tree == null
+                ? Location.Create(document.FilePath!, textSpan, text.Lines.GetLinePositionSpan(textSpan))
+                : tree.GetLocation(textSpan);
             var originalLineInfo = location.GetLineSpan();
             var mappedLineInfo = location.GetMappedLineSpan();
 

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/IVsTypeScriptTodoCommentService.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/IVsTypeScriptTodoCommentService.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.TodoComments;
+
+namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api
+{
+    internal interface IVsTypeScriptTodoCommentService
+    {
+        /// <summary>
+        /// Legacy entry-point to allow existing in-process TypeScript language service to report todo comments.
+        /// TypeScript is responsible for determining when to compute todo comments (for example, on <see
+        /// cref="Workspace.WorkspaceChanged"/>).  This can be called on any thread.
+        /// </summary>
+        Task ReportTodoCommentsAsync(Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken);
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
@@ -23,13 +23,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
         /// analysis of the workspace to find todo comments
         /// </summary>
         void Start(CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Legacy entry-point to allow existing in-process languages to report todo comments.  These languages are
-        /// responsible for determining when to compute todo comments (for example, on <see
-        /// cref="Workspace.WorkspaceChanged"/>).  This can be called on any thread.
-        /// </summary>
-        [Obsolete("Only for legacy access", error: false)]
-        Task ReportTodoCommentsAsync(Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
@@ -4,12 +4,7 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Immutable;
 using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.TodoComments;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
 {

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
@@ -4,8 +4,11 @@
 
 #nullable enable
 
+using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.Host;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.TodoComments;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
 {
@@ -19,5 +22,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
         /// analysis of the workspace to find todo comments
         /// </summary>
         void Start(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Legacy entry-point to allow existing in-process languages to report todo comments.  These languages are
+        /// responsible for determining when to compute todo comments (for example, on <see
+        /// cref="Workspace.WorkspaceChanged"/>).  This can be called on any thread.
+        /// </summary>
+        Task ReportTodoCommentsAsync(Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/IVisualStudioTodoCommentsService.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,6 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
         /// responsible for determining when to compute todo comments (for example, on <see
         /// cref="Workspace.WorkspaceChanged"/>).  This can be called on any thread.
         /// </summary>
+        [Obsolete("Only for legacy access", error: false)]
         Task ReportTodoCommentsAsync(Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.TodoComments;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -25,8 +26,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
 {
-    using Microsoft.CodeAnalysis.PooledObjects;
-
     [Export(typeof(IVisualStudioTodoCommentsService))]
     internal class VisualStudioTodoCommentsService
         : ForegroundThreadAffinitizedObject, IVisualStudioTodoCommentsService, ITodoCommentsListener, ITodoListProvider

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -21,14 +21,20 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.TodoComments;
+using Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
 {
     [Export(typeof(IVisualStudioTodoCommentsService))]
+    [Export(typeof(IVsTypeScriptTodoCommentService))]
     internal class VisualStudioTodoCommentsService
-        : ForegroundThreadAffinitizedObject, IVisualStudioTodoCommentsService, ITodoCommentsListener, ITodoListProvider
+        : ForegroundThreadAffinitizedObject,
+          IVisualStudioTodoCommentsService,
+          ITodoCommentsListener,
+          ITodoListProvider,
+          IVsTypeScriptTodoCommentService
     {
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly EventListenerTracker<ITodoListProvider> _eventListenerTracker;
@@ -197,8 +203,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
             return Task.CompletedTask;
         }
 
-        /// <inheritdoc cref="IVisualStudioTodoCommentsService.ReportTodoCommentsAsync(Document, ImmutableArray{TodoComment}, CancellationToken)"/>
-        public async Task ReportTodoCommentsAsync(
+        /// <inheritdoc cref="IVsTypeScriptTodoCommentService.ReportTodoCommentsAsync(Document, ImmutableArray{TodoComment}, CancellationToken)"/>
+        async Task IVsTypeScriptTodoCommentService.ReportTodoCommentsAsync(
             Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<TodoCommentData>.GetInstance(out var converted);

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -18,11 +18,9 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.TodoComments;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments


### PR DESCRIPTION
TypeScript would like to still leverage our Todo functionality.  However, as we've moved the core logic for scanning out of proc they cannot.  Until we move entirely over to LSP, we have a simple way for them to still benefit from teh majority of code in roslyn, and their existing assets by allowing them to directly dump comments into our todo-comment-sink.

TS will now responsible for still kicking off the work compute the results.  But that's much simpler than having to both do that, and tie into the VS UI.