### PR TITLE
Spread out code inside decompiled methods to make things look better.

### DIFF
--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceFormattingRule.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceFormattingRule.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
+{
+    internal class CSharpDecompiledSourceFormattingRule : AbstractFormattingRule
+    {
+        public static readonly AbstractFormattingRule Instance = new CSharpDecompiledSourceFormattingRule();
+
+        private CSharpDecompiledSourceFormattingRule()
+        {
+        }
+
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
+            SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options, in NextGetAdjustNewLinesOperation nextOperation)
+        {
+            var operation = GetAdjustNewLinesOperation(previousToken, currentToken);
+            return operation ?? nextOperation.Invoke();
+        }
+
+        private AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
+        {
+            // To help code not look too tightly packed, we place a blank line after every statement that ends with a
+            // `}` (unless it's also followed by another `}`).
+            if (previousToken.Kind() != SyntaxKind.CloseBraceToken)
+                return null;
+
+            if (currentToken.Kind() == SyntaxKind.CloseBraceToken)
+                return null;
+
+            var previousStatement = previousToken.Parent.FirstAncestorOrSelf<StatementSyntax>();
+            var nextStatement = currentToken.Parent.FirstAncestorOrSelf<StatementSyntax>();
+
+            if (previousStatement == null || nextStatement == null || previousStatement == nextStatement)
+                return null;
+
+            // Ensure that we're only updating the whitespace between statements.
+            if (previousStatement.GetLastToken() != previousToken || nextStatement.GetFirstToken() != currentToken)
+                return null;
+
+            // Ensure a blank line between these two.
+            return FormattingOperations.CreateAdjustNewLinesOperation(2, AdjustNewLinesOption.ForceLines);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceFormattingRule.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceFormattingRule.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -24,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             return operation ?? nextOperation.Invoke();
         }
 
-        private AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
+        private AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
         {
             // To help code not look too tightly packed, we place a blank line after every statement that ends with a
             // `}` (unless it's also followed by another `}`).
@@ -32,6 +34,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
                 return null;
 
             if (currentToken.Kind() == SyntaxKind.CloseBraceToken)
+                return null;
+
+            if (previousToken.Parent == null || currentToken.Parent == null)
                 return null;
 
             var previousStatement = previousToken.Parent.FirstAncestorOrSelf<StatementSyntax>();

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -81,6 +81,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             var docCommentFormattingService = document.GetLanguageService<IDocumentationCommentFormattingService>();
             document = await ConvertDocCommentsToRegularCommentsAsync(document, docCommentFormattingService, cancellationToken).ConfigureAwait(false);
 
+            return await FormatDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+        }
+
+        public static async Task<Document> FormatDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
             var node = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             // Apply formatting rules

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -84,11 +84,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             var node = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             // Apply formatting rules
-            document = await Formatter.FormatAsync(
-                  document, SpecializedCollections.SingletonEnumerable(node.FullSpan),
-                  options: null, Formatter.GetDefaultFormattingRules(document), cancellationToken).ConfigureAwait(false);
+            var formattedDoc = await Formatter.FormatAsync(
+                 document, SpecializedCollections.SingletonEnumerable(node.FullSpan),
+                 options: null,
+                 CSharpDecompiledSourceFormattingRule.Instance.Concat(Formatter.GetDefaultFormattingRules(document)),
+                 cancellationToken).ConfigureAwait(false);
 
-            return document;
+            return formattedDoc;
         }
 
         private Document PerformDecompilation(Document document, string fullName, Compilation compilation, string assemblyLocation)

--- a/src/EditorFeatures/CSharpTest/DecompiledSource/DecompiledSourceFormattingTests.cs
+++ b/src/EditorFeatures/CSharpTest/DecompiledSource/DecompiledSourceFormattingTests.cs
@@ -1,0 +1,233 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DecompiledSource
+{
+    [UseExportProvider]
+    public class DecompiledSourceFormattingTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestIfFormatting1()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    if (true) {
+    }
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        if (true)
+        {
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestIfFormatting2()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    if (true) {
+    }
+    return;
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        if (true)
+        {
+        }
+
+        return;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestIfFormatting3()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    if (true) {
+    } else {
+    return;
+}
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        if (true)
+        {
+        }
+        else
+        {
+            return;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestTryCatchFinally()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    try {
+    } catch {
+    } finally {
+    }
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        try
+        {
+        }
+        catch
+        {
+        }
+        finally
+        {
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestDoWhile()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    do {
+    } while(true);
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        do
+        {
+        } while (true);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestNestedIf()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    if (true) {
+        if (true) {
+        }
+    }
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        if (true)
+        {
+            if (true)
+            {
+            }
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DecompiledSource)]
+        public async Task TestBraces()
+        {
+            await TestAsync(
+@"class C {
+  void M() {
+    if (true) {
+    }
+    while (true) {
+    }
+    switch (true) {
+    }
+    try {
+    } finally {
+    }
+    using (null) {
+    }
+    foreach (var x in y) {
+    }
+  }
+}",
+@"class C
+{
+    void M()
+    {
+        if (true)
+        {
+        }
+
+        while (true)
+        {
+        }
+
+        switch (true)
+        {
+        }
+
+        try
+        {
+        }
+        finally
+        {
+        }
+
+        using (null)
+        {
+        }
+
+        foreach (var x in y)
+        {
+        }
+    }
+}");
+        }
+
+        private async Task TestAsync(string input, string expected)
+        {
+            using var workspace = TestWorkspace.CreateCSharp(input);
+            var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+            var formatted = await CSharpDecompiledSourceService.FormatDocumentAsync(document, CancellationToken.None);
+            var test = await formatted.GetTextAsync();
+
+            AssertEx.Equal(expected, test.ToString());
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -77,7 +77,4 @@
   </ItemGroup>
   <Import Project="..\..\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems" Label="Shared" />
   <Import Project="$(RepositoryEngineeringDir)targets\ILTools.targets" />
-  <ItemGroup>
-    <ExpectedCompile Remove="DecompiledSource\DecompiledSourceFormattingTests.cs" />
-  </ItemGroup>
 </Project>

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -77,4 +77,7 @@
   </ItemGroup>
   <Import Project="..\..\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems" Label="Shared" />
   <Import Project="$(RepositoryEngineeringDir)targets\ILTools.targets" />
+  <ItemGroup>
+    <ExpectedCompile Remove="DecompiledSource\DecompiledSourceFormattingTests.cs" />
+  </ItemGroup>
 </Project>

--- a/src/EditorFeatures/Core/FindUsages/IFindSymbolMonikerUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/IFindSymbolMonikerUsagesService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -43,6 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
     internal class DefaultFindSymbolMonikerUsagesService : AbstractFindSymbolMonikerUsagesService
     {
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public DefaultFindSymbolMonikerUsagesService()
         {
         }

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -202,6 +202,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string DebuggingLocationName = "Debugging.LocationName";
             public const string DebuggingNameResolver = "Debugging.NameResolver";
             public const string DebuggingProximityExpressions = "Debugging.ProximityExpressions";
+            public const string DecompiledSource = nameof(DecompiledSource);
             public const string Diagnostics = nameof(Diagnostics);
             public const string DisposeAnalysis = nameof(DisposeAnalysis);
             public const string DocCommentFormatting = nameof(DocCommentFormatting);


### PR DESCRIPTION
Followup to: https://github.com/dotnet/roslyn/pull/42809

Before:

![image](https://user-images.githubusercontent.com/4564579/77718350-f50d6380-6f9f-11ea-9d55-d56a48137252.png)


After: 

![image](https://user-images.githubusercontent.com/4564579/77718059-2a658180-6f9f-11ea-974c-6d94d88d7da4.png)
