### PR TITLE
Fix indentation after hitting enter multiple times after a comment.

### DIFF
--- a/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
@@ -62,14 +62,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
             if (caretPosition == null)
                 return false;
 
-            var exteriorText = GetExteriorTextForCurrentLine(caretPosition.Value);
-            if (exteriorText == null)
+            var textToInsert = GetTextToInsert(caretPosition.Value);
+            if (textToInsert == null)
                 return false;
 
             using var transaction = _undoHistoryRegistry.GetHistory(textView.TextBuffer).CreateTransaction(EditorFeaturesResources.Insert_new_line);
 
             var editorOperations = _editorOperationsFactoryService.GetEditorOperations(textView);
-            editorOperations.ReplaceText(GetReplacementSpan(caretPosition.Value), exteriorText);
+            editorOperations.ReplaceText(GetReplacementSpan(caretPosition.Value), textToInsert);
 
             transaction.Complete();
             return true;
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
             return Span.FromBounds(start, end);
         }
 
-        private string GetExteriorTextForCurrentLine(SnapshotPoint caretPosition)
+        private string GetTextToInsert(SnapshotPoint caretPosition)
         {
             var currentLine = caretPosition.GetContainingLine();
             var firstNonWhitespacePosition = currentLine.GetFirstNonWhitespacePosition() ?? -1;

--- a/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
             var snapshot = caretPosition.Snapshot;
             var start = caretPosition.Position;
             var end = caretPosition;
-            while (end < snapshot.Length && char.IsWhiteSpace(end.GetChar()) && !SyntaxFacts.IsNewLine(end.GetChar()))
+            while (end < snapshot.Length && SyntaxFacts.IsWhitespace(end.GetChar()) && !SyntaxFacts.IsNewLine(end.GetChar()))
                 end = end + 1;
 
             return Span.FromBounds(start, end);

--- a/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
@@ -226,8 +226,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
 
             string GetPaddingAfterCommentCharacter()
             {
-                var currentChar = firstNonWhitespacePosition;
-                Debug.Assert(textSnapshot[currentChar] == '/' || textSnapshot[currentChar] == '*');
+                var currentChar = currentLine == textSnapshot.GetLineFromPosition(blockComment.FullSpan.Start)
+                    ? blockComment.FullSpan.Start
+                    : firstNonWhitespacePosition;
 
                 // Skip past the first comment char.
                 currentChar++;

--- a/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -88,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
             return Span.FromBounds(start, end);
         }
 
-        private string GetTextToInsert(SnapshotPoint caretPosition)
+        private string? GetTextToInsert(SnapshotPoint caretPosition)
         {
             var currentLine = caretPosition.GetContainingLine();
             var firstNonWhitespacePosition = currentLine.GetFirstNonWhitespacePosition() ?? -1;
@@ -128,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
             var newLine = options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
             return newLine + exteriorText;
 
-            string GetExteriorText()
+            string? GetExteriorText()
             {
                 if (startsWithBlockCommentStartString)
                 {
@@ -231,7 +234,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
         }
 
         public static bool IsCaretInsideBlockCommentSyntax(
-            SnapshotPoint caretPosition, out Document document, out SyntaxTrivia trivia)
+            SnapshotPoint caretPosition,
+            [NotNullWhen(true)] out Document? document, out SyntaxTrivia trivia)
         {
             trivia = default;
 
@@ -240,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
             if (document == null)
                 return false;
 
-            var syntaxTree = document.GetSyntaxTreeSynchronously(CancellationToken.None);
+            var syntaxTree = document.GetRequiredSyntaxTreeSynchronously(CancellationToken.None);
             trivia = syntaxTree.FindTriviaAndAdjustForEndOfFile(caretPosition, CancellationToken.None);
 
             var isBlockComment = trivia.IsKind(SyntaxKind.MultiLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);

--- a/src/EditorFeatures/CSharp/BlockCommentEditing/CloseBlockCommentCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/BlockCommentEditing/CloseBlockCommentCommandHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
                             line.IsEmptyOrWhitespace(0, line.Length - 2))
                         {
                             if (args.SubjectBuffer.GetFeatureOnOffOption(FeatureOnOffOptions.AutoInsertBlockCommentStartString) &&
-                                BlockCommentEditingCommandHandler.IsCaretInsideBlockCommentSyntax(caret.Value))
+                                BlockCommentEditingCommandHandler.IsCaretInsideBlockCommentSyntax(caret.Value, out _, out _))
                             {
                                 args.SubjectBuffer.Replace(new VisualStudio.Text.Span(position - 1, 1), "/");
                                 return true;

--- a/src/EditorFeatures/CSharpTest/BlockCommentEditing/BlockCommentEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/BlockCommentEditing/BlockCommentEditingTests.cs
@@ -682,6 +682,44 @@ $$*";
             VerifyTabs(code, expected);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.BlockCommentEditing)]
+        public void InLanguageConstructTrailingTrivia()
+        {
+            var code = @"
+class C
+{
+    int i; /*$$
+}
+";
+            var expected = @"
+class C
+{
+    int i; /*
+            * $$
+}
+";
+            Verify(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.BlockCommentEditing)]
+        public void InLanguageConstructTrailingTrivia_Tabs()
+        {
+            var code = @"
+class C
+{
+<tab>int i; /*$$
+}
+";
+            var expected = @"
+class C
+{
+<tab>int i; /*
+<tab>        * $$
+}
+";
+            VerifyTabs(code, expected);
+        }
+
         protected override TestWorkspace CreateTestWorkspace(string initialMarkup)
             => TestWorkspace.CreateCSharp(initialMarkup);
 

--- a/src/EditorFeatures/CSharpTest/BlockCommentEditing/BlockCommentEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/BlockCommentEditing/BlockCommentEditingTests.cs
@@ -144,7 +144,7 @@ $$";
 ";
             var expected = @"
     /*
-     *$$*/
+     * $$*/
 ";
             Verify(code, expected);
         }
@@ -243,7 +243,7 @@ $$*
             var expected = @"
     /*
      *
-     * $$
+     *$$
 ";
             Verify(code, expected);
         }
@@ -342,7 +342,7 @@ $$*
             var expected = @"
     /*
   
-     * $$*
+     $$*
      */
 ";
             Verify(code, expected);
@@ -359,7 +359,7 @@ $$*
             var expected = @"
     /*
      *************
-     * $$
+     *$$
      */
 ";
             Verify(code, expected);
@@ -376,7 +376,7 @@ $$*
             var expected = @"
     /**
      *
-     * $$
+     *$$
      */
 ";
             Verify(code, expected);
@@ -392,7 +392,7 @@ $$*
             var expected = @"
     /**
       *
-      * $$
+      *$$
 ";
             Verify(code, expected);
         }
@@ -454,7 +454,7 @@ $$*
             var expected = @"
     /*
   
-     * $$*/
+     $$*/
 ";
             Verify(code, expected);
         }
@@ -528,7 +528,7 @@ $$*";
     /*$$ ";
             var expected = @"
     /*
-     *$$";
+     * $$";
             Verify(code, expected);
         }
 
@@ -566,7 +566,7 @@ $$*";
 ";
             var expected = @"
     /*
-     *$$*/
+     * $$*/
 ";
             VerifyTabs(code, expected);
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             AssertSmartIndent(
                 code,
                 indentationLine: 4,
-                expectedIndentation: 4);
+                expectedIndentation: 0);
         }
 
         [WpfFact]
@@ -2794,6 +2794,62 @@ class C
                 code: code,
                 indentationLine: 5,
                 expectedIndentation: 12);
+        }
+
+        [WorkItem(28752, "https://github.com/dotnet/roslyn/issues/28752")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void EnterAfterBlankLineAfterCommentedOutCode1()
+        {
+            var code = @"class Test
+{
+    public void Test()
+    {
+        // comment
+
+
+    }
+}";
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 5,
+                expectedIndentation: 8);
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 6,
+                expectedIndentation: 8);
+        }
+
+        [WorkItem(28752, "https://github.com/dotnet/roslyn/issues/28752")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void EnterAfterBlankLineAfterCommentedOutCode2()
+        {
+            var code = @"
+class T
+{
+    // comment
+
+
+
+    // comment
+    int i = 1;
+}";
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 4,
+                expectedIndentation: 4);
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 5,
+                expectedIndentation: 4);
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 6,
+                expectedIndentation: 4);
         }
 
         [WorkItem(38819, "https://github.com/dotnet/roslyn/issues/38819")]

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests_Performance.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests_Performance.cs
@@ -2211,7 +2211,7 @@ class Program
 
             AssertSmartIndent(
                 code,
-                expectedIndentation: 4);
+                expectedIndentation: 12);
         }
     }
 }

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotLineExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotLineExtensions.cs
@@ -144,9 +144,7 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         {
             var snapshot = line.Snapshot;
             if (index + value.Length > snapshot.Length)
-            {
                 return false;
-            }
 
             for (var i = 0; i < value.Length; i++)
             {
@@ -161,12 +159,25 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
                 }
 
                 if (actualCharacter != expectedCharacter)
-                {
                     return false;
-                }
             }
 
             return true;
+        }
+
+        public static bool Contains(this ITextSnapshotLine line, int index, string value, bool ignoreCase)
+        {
+            var snapshot = line.Snapshot;
+            for (var i = index; i < line.End; i++)
+            {
+                if (i + value.Length > snapshot.Length)
+                    return false;
+
+                if (line.StartsWith(i, value, ignoreCase))
+                    return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -179,7 +179,7 @@ End Module
             AssertSmartIndent(
                 code,
                 indentationLine:=1,
-                expectedIndentation:=0)
+                expectedIndentation:=8)
         End Sub
 
         <WpfFact>

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -167,7 +167,7 @@ End Module
             AssertSmartIndent(
                 code,
                 indentationLine:=1,
-                expectedIndentation:=0)
+                expectedIndentation:=8)
         End Sub
 
         <WpfFact>

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -167,7 +167,7 @@ End Module
             AssertSmartIndent(
                 code,
                 indentationLine:=1,
-                expectedIndentation:=12)
+                expectedIndentation:=0)
         End Sub
 
         <WpfFact>
@@ -179,7 +179,7 @@ End Module
             AssertSmartIndent(
                 code,
                 indentationLine:=1,
-                expectedIndentation:=8)
+                expectedIndentation:=0)
         End Sub
 
         <WpfFact>

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Indentation
@@ -31,75 +30,42 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
             return new CSharpSmartTokenFormatter(indenter.OptionSet, rules, indenter.Root);
         }
 
-        protected override IndentationResult GetDesiredIndentationWorker(
-            Indenter indenter, SyntaxToken token, TextLine previousLine, int lastNonWhitespacePosition)
+        protected override IndentationResult GetDesiredIndentationWorker(Indenter indenter, SyntaxToken? tokenOpt, SyntaxTrivia? triviaOpt)
+            => TryGetDesiredIndentation(indenter, triviaOpt) ??
+               TryGetDesiredIndentation(indenter, tokenOpt) ?? default;
+
+        private IndentationResult? TryGetDesiredIndentation(Indenter indenter, SyntaxTrivia? triviaOpt)
         {
-            //// okay, now check whether the text we found is trivia or actual token.
-            //if (token.Span.Contains(lastNonWhitespacePosition))
-            //{
-                // okay, it is a token case, do special work based on type of last token on previous line
-                return GetIndentationBasedOnToken(indenter, token);
-            //}
-            //else
-            //{
-            //    // there must be trivia that contains or touch this position
-            //    Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition));
+            // If we have a // comment, and it's the only thing on the line, then if we hit enter, we should align to
+            // that.  This helps for cases like:
+            //
+            //          int goo; // this comment
+            //                   // continues
+            //                   // onwards
+            //
+            // The user will have to manually indent `// continues`, but we'll respect that indentation from that point on.
 
-            //    // okay, now check whether the trivia is at the beginning of the line
-            //    var firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition();
-            //    if (!firstNonWhitespacePosition.HasValue)
-            //    {
-            //        return indenter.IndentFromStartOfLine(0);
-            //    }
+            if (triviaOpt == null)
+                return null;
 
-            //    var trivia = indenter.Root.FindTrivia(firstNonWhitespacePosition.Value, findInsideTrivia: true);
-            //    if (trivia.Kind() == SyntaxKind.None || indenter.LineToBeIndented.LineNumber > previousLine.LineNumber + 1)
-            //    {
-            //        // If the token belongs to the next statement and is also the first token of the statement, then it means the user wants
-            //        // to start type a new statement. So get indentation from the start of the line but not based on the token.
-            //        // Case:
-            //        // static void Main(string[] args)
-            //        // {
-            //        //     // A
-            //        //     // B
-            //        //     
-            //        //     $$
-            //        //     return;
-            //        // }
+            var trivia = triviaOpt.Value;
+            if (!trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
+                return null;
 
-            //        var containingStatement = token.GetAncestor<StatementSyntax>();
-            //        if (containingStatement != null && containingStatement.GetFirstToken() == token)
-            //        {
-            //            var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
-            //            return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
-            //        }
+            var line = indenter.Text.Lines.GetLineFromPosition(trivia.SpanStart);
+            if (line.GetFirstNonWhitespacePosition() != trivia.SpanStart)
+                return null;
 
-            //        // If the token previous of the base token happens to be a Comma from a separation list then we need to handle it different
-            //        // Case:
-            //        // var s = new List<string>
-            //        //                 {
-            //        //                     """",
-            //        //                             """",/*sdfsdfsdfsdf*/
-            //        //                                  // dfsdfsdfsdfsdf
-            //        //                                  
-            //        //                             $$
-            //        //                 };
-            //        var previousToken = token.GetPreviousToken();
-            //        if (previousToken.IsKind(SyntaxKind.CommaToken))
-            //        {
-            //            return GetIndentationFromCommaSeparatedList(indenter, previousToken);
-            //        }
-            //        else if (!previousToken.IsKind(SyntaxKind.None))
-            //        {
-            //            // okay, beginning of the line is not trivia, use the last token on the line as base token
-            //            return GetIndentationBasedOnToken(indenter, token);
-            //        }
-            //    }
+            // Previous line just contained this single line comment.  Align us with it.
+            return new IndentationResult(trivia.SpanStart, 0);
+        }
 
-            //    // this case we will keep the indentation of this trivia line
-            //    // this trivia can't be preprocessor by the way.
-            //    return indenter.GetIndentationOfLine(previousLine);
-            //}
+        private IndentationResult? TryGetDesiredIndentation(Indenter indenter, SyntaxToken? tokenOpt)
+        {
+            if (tokenOpt == null)
+                return null;
+
+            return GetIndentationBasedOnToken(indenter, tokenOpt.Value);
         }
 
         private IndentationResult GetIndentationBasedOnToken(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
@@ -31,9 +31,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
             return new CSharpSmartTokenFormatter(indenter.OptionSet, rules, indenter.Root);
         }
 
-        protected override IndentationResult GetDesiredIndentationWorker(Indenter indenter, SyntaxToken? tokenOpt, SyntaxTrivia? triviaOpt)
+        protected override IndentationResult? GetDesiredIndentationWorker(Indenter indenter, SyntaxToken? tokenOpt, SyntaxTrivia? triviaOpt)
             => TryGetDesiredIndentation(indenter, triviaOpt) ??
-               TryGetDesiredIndentation(indenter, tokenOpt) ?? default;
+               TryGetDesiredIndentation(indenter, tokenOpt);
 
         private IndentationResult? TryGetDesiredIndentation(Indenter indenter, SyntaxTrivia? triviaOpt)
         {

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -49,15 +50,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 return null;
 
             var trivia = triviaOpt.Value;
-            if (!trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
+            if (!trivia.IsSingleOrMultiLineComment() && !trivia.IsDocComment())
                 return null;
 
-            var line = indenter.Text.Lines.GetLineFromPosition(trivia.SpanStart);
-            if (line.GetFirstNonWhitespacePosition() != trivia.SpanStart)
+            var line = indenter.Text.Lines.GetLineFromPosition(trivia.FullSpan.Start);
+            if (line.GetFirstNonWhitespacePosition() != trivia.FullSpan.Start)
                 return null;
 
             // Previous line just contained this single line comment.  Align us with it.
-            return new IndentationResult(trivia.SpanStart, 0);
+            return new IndentationResult(trivia.FullSpan.Start, 0);
         }
 
         private IndentationResult? TryGetDesiredIndentation(Indenter indenter, SyntaxToken? tokenOpt)

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
@@ -34,72 +34,72 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
         protected override IndentationResult GetDesiredIndentationWorker(
             Indenter indenter, SyntaxToken token, TextLine previousLine, int lastNonWhitespacePosition)
         {
-            // okay, now check whether the text we found is trivia or actual token.
-            if (token.Span.Contains(lastNonWhitespacePosition))
-            {
+            //// okay, now check whether the text we found is trivia or actual token.
+            //if (token.Span.Contains(lastNonWhitespacePosition))
+            //{
                 // okay, it is a token case, do special work based on type of last token on previous line
                 return GetIndentationBasedOnToken(indenter, token);
-            }
-            else
-            {
-                // there must be trivia that contains or touch this position
-                Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition));
+            //}
+            //else
+            //{
+            //    // there must be trivia that contains or touch this position
+            //    Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition));
 
-                // okay, now check whether the trivia is at the beginning of the line
-                var firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition();
-                if (!firstNonWhitespacePosition.HasValue)
-                {
-                    return indenter.IndentFromStartOfLine(0);
-                }
+            //    // okay, now check whether the trivia is at the beginning of the line
+            //    var firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition();
+            //    if (!firstNonWhitespacePosition.HasValue)
+            //    {
+            //        return indenter.IndentFromStartOfLine(0);
+            //    }
 
-                var trivia = indenter.Root.FindTrivia(firstNonWhitespacePosition.Value, findInsideTrivia: true);
-                if (trivia.Kind() == SyntaxKind.None || indenter.LineToBeIndented.LineNumber > previousLine.LineNumber + 1)
-                {
-                    // If the token belongs to the next statement and is also the first token of the statement, then it means the user wants
-                    // to start type a new statement. So get indentation from the start of the line but not based on the token.
-                    // Case:
-                    // static void Main(string[] args)
-                    // {
-                    //     // A
-                    //     // B
-                    //     
-                    //     $$
-                    //     return;
-                    // }
+            //    var trivia = indenter.Root.FindTrivia(firstNonWhitespacePosition.Value, findInsideTrivia: true);
+            //    if (trivia.Kind() == SyntaxKind.None || indenter.LineToBeIndented.LineNumber > previousLine.LineNumber + 1)
+            //    {
+            //        // If the token belongs to the next statement and is also the first token of the statement, then it means the user wants
+            //        // to start type a new statement. So get indentation from the start of the line but not based on the token.
+            //        // Case:
+            //        // static void Main(string[] args)
+            //        // {
+            //        //     // A
+            //        //     // B
+            //        //     
+            //        //     $$
+            //        //     return;
+            //        // }
 
-                    var containingStatement = token.GetAncestor<StatementSyntax>();
-                    if (containingStatement != null && containingStatement.GetFirstToken() == token)
-                    {
-                        var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
-                        return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
-                    }
+            //        var containingStatement = token.GetAncestor<StatementSyntax>();
+            //        if (containingStatement != null && containingStatement.GetFirstToken() == token)
+            //        {
+            //            var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
+            //            return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
+            //        }
 
-                    // If the token previous of the base token happens to be a Comma from a separation list then we need to handle it different
-                    // Case:
-                    // var s = new List<string>
-                    //                 {
-                    //                     """",
-                    //                             """",/*sdfsdfsdfsdf*/
-                    //                                  // dfsdfsdfsdfsdf
-                    //                                  
-                    //                             $$
-                    //                 };
-                    var previousToken = token.GetPreviousToken();
-                    if (previousToken.IsKind(SyntaxKind.CommaToken))
-                    {
-                        return GetIndentationFromCommaSeparatedList(indenter, previousToken);
-                    }
-                    else if (!previousToken.IsKind(SyntaxKind.None))
-                    {
-                        // okay, beginning of the line is not trivia, use the last token on the line as base token
-                        return GetIndentationBasedOnToken(indenter, token);
-                    }
-                }
+            //        // If the token previous of the base token happens to be a Comma from a separation list then we need to handle it different
+            //        // Case:
+            //        // var s = new List<string>
+            //        //                 {
+            //        //                     """",
+            //        //                             """",/*sdfsdfsdfsdf*/
+            //        //                                  // dfsdfsdfsdfsdf
+            //        //                                  
+            //        //                             $$
+            //        //                 };
+            //        var previousToken = token.GetPreviousToken();
+            //        if (previousToken.IsKind(SyntaxKind.CommaToken))
+            //        {
+            //            return GetIndentationFromCommaSeparatedList(indenter, previousToken);
+            //        }
+            //        else if (!previousToken.IsKind(SyntaxKind.None))
+            //        {
+            //            // okay, beginning of the line is not trivia, use the last token on the line as base token
+            //            return GetIndentationBasedOnToken(indenter, token);
+            //        }
+            //    }
 
-                // this case we will keep the indentation of this trivia line
-                // this trivia can't be preprocessor by the way.
-                return indenter.GetIndentationOfLine(previousLine);
-            }
+            //    // this case we will keep the indentation of this trivia line
+            //    // this trivia can't be preprocessor by the way.
+            //    return indenter.GetIndentationOfLine(previousLine);
+            //}
         }
 
         private IndentationResult GetIndentationBasedOnToken(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -50,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Indentation
                 Document = document;
 
                 _service = service;
-                _syntaxFacts = document.Document.GetLanguageService<ISyntaxFactsService>();
+                _syntaxFacts = document.Document.GetRequiredLanguageService<ISyntaxFactsService>();
                 OptionSet = optionSet;
                 OptionService = document.Document.Project.Solution.Workspace.Services.GetRequiredService<IOptionService>();
                 Root = (TSyntaxRoot)document.Root;
@@ -66,11 +68,11 @@ namespace Microsoft.CodeAnalysis.Indentation
                     tokenStream: null);
             }
 
-            public IndentationResult GetDesiredIndentation(FormattingOptions.IndentStyle indentStyle)
+            public IndentationResult? GetDesiredIndentation(FormattingOptions.IndentStyle indentStyle)
             {
                 // If the caller wants no indent, then we'll return an effective '0' indent.
                 if (indentStyle == FormattingOptions.IndentStyle.None)
-                    return default;
+                    return null;
 
                 // If the user has explicitly set 'block' indentation, or they're in an inactive preprocessor region,
                 // then just do simple block indentation.
@@ -84,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Indentation
                 return GetDesiredSmartIndentation();
             }
 
-            private readonly IndentationResult GetDesiredSmartIndentation()
+            private readonly IndentationResult? GetDesiredSmartIndentation()
             {
                 // For smart indent, we generally will be computing from either the previous token in the code, or in a
                 // few special cases, the previous trivia.
@@ -97,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Indentation
                 var trivia = TryGetImmediatelyPrecedingVisibleTrivia();
 
                 if (token == null && trivia == null)
-                    return default;
+                    return null;
 
                 return _service.GetDesiredIndentationWorker(this, token, trivia);
             }
@@ -143,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Indentation
                 return token;
             }
 
-            private IndentationResult GetDesiredBlockIndentation()
+            private IndentationResult? GetDesiredBlockIndentation()
             {
                 // Block indentation is simple, we keep walking back lines until we find a line with any sort of
                 // text on it.  We then set our indentation to whatever the indentation of that line was.
@@ -158,8 +160,8 @@ namespace Microsoft.CodeAnalysis.Indentation
                     return new IndentationResult(basePosition: line.Start + offset.Value, offset: 0);
                 }
 
-                // Couldn't find a previous non-blank line.  Don't indent at all.
-                return default;
+                // Couldn't find a previous non-blank line.
+                return null;
             }
 
             public bool TryGetSmartTokenIndentation(out IndentationResult indentationResult)

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Indentation
         private IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document, int position, FormattingOptions.IndentStyle indentStyle)
         {
             var workspace = document.Project.Solution.Workspace;
-            var formattingRuleFactory = workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>();
+            var formattingRuleFactory = workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
             var baseIndentationRule = formattingRuleFactory.CreateRule(document, position);
 
             var formattingRules = new[] { baseIndentationRule, this.GetSpecializedIndentationFormattingRule(indentStyle) }.Concat(Formatter.GetDefaultFormattingRules(document));

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.cs
@@ -71,6 +71,6 @@ namespace Microsoft.CodeAnalysis.Indentation
         protected abstract ISmartTokenFormatter CreateSmartTokenFormatter(Indenter indenter);
 
         protected abstract IndentationResult GetDesiredIndentationWorker(
-            Indenter indenter, SyntaxToken token, TextLine previousLine, int lastNonWhitespacePosition);
+            Indenter indenter, SyntaxToken? token, SyntaxTrivia? trivia);
     }
 }

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Indentation
@@ -45,7 +46,8 @@ namespace Microsoft.CodeAnalysis.Indentation
                 return indentationResult;
             }
 
-            return indenter.GetDesiredIndentation(indentStyle);
+            // If the indenter can't produce a valid result, just default to 0 as our indentation.
+            return indenter.GetDesiredIndentation(indentStyle) ?? default;
         }
 
         private Indenter GetIndenter(Document document, int lineNumber, FormattingOptions.IndentStyle indentStyle, CancellationToken cancellationToken)
@@ -70,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Indentation
         protected abstract bool ShouldUseTokenIndenter(Indenter indenter, out SyntaxToken token);
         protected abstract ISmartTokenFormatter CreateSmartTokenFormatter(Indenter indenter);
 
-        protected abstract IndentationResult GetDesiredIndentationWorker(
+        protected abstract IndentationResult? GetDesiredIndentationWorker(
             Indenter indenter, SyntaxToken? token, SyntaxTrivia? trivia);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -41,11 +41,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return syntaxTree ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
         }
 
+#if !CODE_STYLE
         public static SyntaxTree GetRequiredSyntaxTreeSynchronously(this Document document, CancellationToken cancellationToken)
         {
             var syntaxTree = document.GetSyntaxTreeSynchronously(cancellationToken);
             return syntaxTree ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
         }
+#endif
 
         public static async Task<SyntaxNode> GetRequiredSyntaxRootAsync(this Document document, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -41,6 +41,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return syntaxTree ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
         }
 
+        public static SyntaxTree GetRequiredSyntaxTreeSynchronously(this Document document, CancellationToken cancellationToken)
+        {
+            var syntaxTree = document.GetSyntaxTreeSynchronously(cancellationToken);
+            return syntaxTree ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
+        }
+
         public static async Task<SyntaxNode> GetRequiredSyntaxRootAsync(this Document document, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -30,53 +30,53 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
                 previousLine As TextLine,
                 lastNonWhitespacePosition As Integer) As IndentationResult
 
-            If token.Span.End = lastNonWhitespacePosition + 1 Then
-                Return GetIndentationBasedOnToken(indenter, token)
-            Else
-                Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition))
+            'If token.Span.End = lastNonWhitespacePosition + 1 Then
+            Return GetIndentationBasedOnToken(indenter, token)
+            'Else
+            '    Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition))
 
-                Dim trivia = indenter.Root.FindTrivia(lastNonWhitespacePosition)
+            '    Dim trivia = indenter.Root.FindTrivia(lastNonWhitespacePosition)
 
-                ' preserve the indentation of the comment trivia before a case statement
-                If trivia.Kind = SyntaxKind.CommentTrivia AndAlso trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
-                    Return indenter.GetIndentationOfLine(previousLine)
-                End If
+            '    ' preserve the indentation of the comment trivia before a case statement
+            '    If trivia.Kind = SyntaxKind.CommentTrivia AndAlso trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
+            '        Return indenter.GetIndentationOfLine(previousLine)
+            '    End If
 
-                If trivia.Kind = SyntaxKind.LineContinuationTrivia Then
-                    Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-                End If
+            '    If trivia.Kind = SyntaxKind.LineContinuationTrivia Then
+            '        Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+            '    End If
 
-                ' Line ends in comment
-                If trivia.Kind = SyntaxKind.CommentTrivia Then ' Two cases a line ending comment or _ comment
-                    Dim firstTrivia As SyntaxTrivia = indenter.Tree.GetRoot(indenter.CancellationToken).FindTrivia(token.Span.End + 1)
-                    ' firstTrivia contains either an _ or a comment, this is the First trivia after the last Token on the line
-                    If firstTrivia.Kind = SyntaxKind.LineContinuationTrivia Then
-                        Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(firstTrivia), firstTrivia)
-                    Else
-                        ' This is we have just a comment
-                        Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-                    End If
-                End If
+            '    ' Line ends in comment
+            '    If trivia.Kind = SyntaxKind.CommentTrivia Then ' Two cases a line ending comment or _ comment
+            '        Dim firstTrivia As SyntaxTrivia = indenter.Tree.GetRoot(indenter.CancellationToken).FindTrivia(token.Span.End + 1)
+            '        ' firstTrivia contains either an _ or a comment, this is the First trivia after the last Token on the line
+            '        If firstTrivia.Kind = SyntaxKind.LineContinuationTrivia Then
+            '            Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(firstTrivia), firstTrivia)
+            '        Else
+            '            ' This is we have just a comment
+            '            Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+            '        End If
+            '    End If
 
-                ' if we are at invalid token (skipped token) at the end of statement, treat it like we are after line continuation
-                If trivia.Kind = SyntaxKind.SkippedTokensTrivia AndAlso trivia.Token.IsLastTokenOfStatement() Then
-                    Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-                End If
+            '    ' if we are at invalid token (skipped token) at the end of statement, treat it like we are after line continuation
+            '    If trivia.Kind = SyntaxKind.SkippedTokensTrivia AndAlso trivia.Token.IsLastTokenOfStatement() Then
+            '        Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+            '    End If
 
-                ' okay, now check whether the trivia is at the beginning of the line
-                Dim firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition()
-                If Not firstNonWhitespacePosition.HasValue Then
-                    Return indenter.IndentFromStartOfLine(0)
-                End If
+            '    ' okay, now check whether the trivia is at the beginning of the line
+            '    Dim firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition()
+            '    If Not firstNonWhitespacePosition.HasValue Then
+            '        Return indenter.IndentFromStartOfLine(0)
+            '    End If
 
-                Dim firstTokenOnLine = indenter.Root.FindToken(firstNonWhitespacePosition.Value, findInsideTrivia:=True)
-                If firstTokenOnLine.Kind <> SyntaxKind.None AndAlso firstTokenOnLine.Span.Contains(firstNonWhitespacePosition.Value) Then
-                    'okay, beginning of the line is not trivia, use this token as the base token
-                    Return GetIndentationBasedOnToken(indenter, firstTokenOnLine)
-                End If
+            '    Dim firstTokenOnLine = indenter.Root.FindToken(firstNonWhitespacePosition.Value, findInsideTrivia:=True)
+            '    If firstTokenOnLine.Kind <> SyntaxKind.None AndAlso firstTokenOnLine.Span.Contains(firstNonWhitespacePosition.Value) Then
+            '        'okay, beginning of the line is not trivia, use this token as the base token
+            '        Return GetIndentationBasedOnToken(indenter, firstTokenOnLine)
+            '    End If
 
-                Return indenter.GetIndentationOfLine(previousLine)
-            End If
+            '    Return indenter.GetIndentationOfLine(previousLine)
+            'End If
         End Function
 
         Private Function GetTokenOnLeft(trivia As SyntaxTrivia) As SyntaxToken

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -32,16 +32,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             If triviaOpt.HasValue Then
                 Dim trivia = triviaOpt.Value
 
+                If trivia.Kind = SyntaxKind.CommentTrivia OrElse
+                   trivia.Kind = SyntaxKind.DocumentationCommentTrivia Then
+
+                    ' if the comment is the only thing on a line, then preserve its indentation for the next line.
+                    Dim line = indenter.Text.Lines.GetLineFromPosition(trivia.FullSpan.Start)
+                    If line.GetFirstNonWhitespacePosition() = trivia.FullSpan.Start Then
+                        Return New IndentationResult(trivia.FullSpan.Start, 0)
+                    End If
+                End If
+
                 ' preserve the indentation of the comment trivia before a case statement
                 If trivia.Kind = SyntaxKind.CommentTrivia Then
                     If trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso
                        trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
-                        Return New IndentationResult(trivia.SpanStart, 0)
-                    End If
-
-                    ' if the comment is the only thing on a line, then preserve its indentation for the next line.
-                    Dim line = indenter.Text.Lines.GetLineFromPosition(trivia.SpanStart)
-                    If line.GetFirstNonWhitespacePosition() = trivia.SpanStart Then
                         Return New IndentationResult(trivia.SpanStart, 0)
                     End If
 

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -26,65 +26,48 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
 
         Protected Overrides Function GetDesiredIndentationWorker(
                 indenter As Indenter,
-                token As SyntaxToken,
-                previousLine1 As TextLine,
-                lastNonWhitespacePosition1 As Integer) As IndentationResult
+                tokenOpt As SyntaxToken?,
+                triviaOpt As SyntaxTrivia?) As IndentationResult
 
-            ' in VB the trivia following the preceding token is relevant for determining what indentation we should be
-            ' at.  For example, it's very different to get indentation after
-            '
-            '       dim x _
-            '
-            ' versus
-            '
-            '       dim x
+            If triviaOpt.HasValue Then
+                Dim trivia = triviaOpt.Value
 
-            Dim trivia = token.TrailingTrivia().LastOrDefault(Function(t) Not t.IsWhitespaceOrEndOfLine())
-            If trivia = Nothing Then
-                Return GetIndentationBasedOnToken(indenter, token)
-            End If
+                ' preserve the indentation of the comment trivia before a case statement
+                If trivia.Kind = SyntaxKind.CommentTrivia Then
+                    If trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso
+                       trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
+                        Return New IndentationResult(trivia.SpanStart, 0)
+                    End If
 
-            ' preserve the indentation of the comment trivia before a case statement
-            'If trivia.Kind = SyntaxKind.CommentTrivia AndAlso
-            '   trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso
-            '   trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
-            '    Return indenter.GetIndentationOfLine(previousLine)
-            'End If
+                    ' Line ends in comment
+                    ' Two cases a line ending comment or _ comment
+                    If tokenOpt.HasValue Then
+                        Dim firstTrivia As SyntaxTrivia = indenter.Tree.GetRoot(indenter.CancellationToken).FindTrivia(tokenOpt.Value.Span.End + 1)
+                        ' firstTrivia contains either an _ or a comment, this is the First trivia after the last Token on the line
+                        If firstTrivia.Kind = SyntaxKind.LineContinuationTrivia Then
+                            Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(firstTrivia), firstTrivia)
+                        Else
+                            ' This is we have just a comment
+                            Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+                        End If
+                    End If
+                End If
 
-            If trivia.Kind = SyntaxKind.LineContinuationTrivia Then
-                Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-            End If
+                ' if we are at invalid token (skipped token) at the end of statement, treat it like we are after line continuation
+                If trivia.Kind = SyntaxKind.SkippedTokensTrivia AndAlso trivia.Token.IsLastTokenOfStatement() Then
+                    Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+                End If
 
-            ' Line ends in comment
-            If trivia.Kind = SyntaxKind.CommentTrivia Then ' Two cases a line ending comment or _ comment
-                Dim firstTrivia As SyntaxTrivia = indenter.Tree.GetRoot(indenter.CancellationToken).FindTrivia(token.Span.End + 1)
-                ' firstTrivia contains either an _ or a comment, this is the First trivia after the last Token on the line
-                If firstTrivia.Kind = SyntaxKind.LineContinuationTrivia Then
-                    Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(firstTrivia), firstTrivia)
-                Else
-                    ' This is we have just a comment
+                If trivia.Kind = SyntaxKind.LineContinuationTrivia Then
                     Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
                 End If
             End If
 
-            ' if we are at invalid token (skipped token) at the end of statement, treat it like we are after line continuation
-            If trivia.Kind = SyntaxKind.SkippedTokensTrivia AndAlso trivia.Token.IsLastTokenOfStatement() Then
-                Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+            If tokenOpt.HasValue Then
+                Return GetIndentationBasedOnToken(indenter, tokenOpt.Value)
             End If
 
-            ' okay, now check whether the trivia is at the beginning of the line
-            'Dim firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition()
-            'If Not firstNonWhitespacePosition.HasValue Then
-            '    Return indenter.IndentFromStartOfLine(0)
-            'End If
-
-            'Dim firstTokenOnLine = indenter.Root.FindToken(firstNonWhitespacePosition.Value, findInsideTrivia:=True)
-            'If firstTokenOnLine.Kind <> SyntaxKind.None AndAlso firstTokenOnLine.Span.Contains(firstNonWhitespacePosition.Value) Then
-            '    'okay, beginning of the line is not trivia, use this token as the base token
-            '    Return GetIndentationBasedOnToken(indenter, firstTokenOnLine)
-            'End If
-
-            Return GetIndentationBasedOnToken(indenter, token)
+            Return Nothing
         End Function
 
         Private Function GetTokenOnLeft(trivia As SyntaxTrivia) As SyntaxToken

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -39,6 +39,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
                         Return New IndentationResult(trivia.SpanStart, 0)
                     End If
 
+                    ' if the comment is the only thing on a line, then preserve its indentation for the next line.
+                    Dim line = indenter.Text.Lines.GetLineFromPosition(trivia.SpanStart)
+                    If line.GetFirstNonWhitespacePosition() = trivia.SpanStart Then
+                        Return New IndentationResult(trivia.SpanStart, 0)
+                    End If
+
                     ' Line ends in comment
                     ' Two cases a line ending comment or _ comment
                     If tokenOpt.HasValue Then

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -27,56 +27,64 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
         Protected Overrides Function GetDesiredIndentationWorker(
                 indenter As Indenter,
                 token As SyntaxToken,
-                previousLine As TextLine,
-                lastNonWhitespacePosition As Integer) As IndentationResult
+                previousLine1 As TextLine,
+                lastNonWhitespacePosition1 As Integer) As IndentationResult
 
-            'If token.Span.End = lastNonWhitespacePosition + 1 Then
-            Return GetIndentationBasedOnToken(indenter, token)
-            'Else
-            '    Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition))
+            ' in VB the trivia following the preceding token is relevant for determining what indentation we should be
+            ' at.  For example, it's very different to get indentation after
+            '
+            '       dim x _
+            '
+            ' versus
+            '
+            '       dim x
 
-            '    Dim trivia = indenter.Root.FindTrivia(lastNonWhitespacePosition)
+            Dim trivia = token.TrailingTrivia().LastOrDefault(Function(t) Not t.IsWhitespaceOrEndOfLine())
+            If trivia = Nothing Then
+                Return GetIndentationBasedOnToken(indenter, token)
+            End If
 
-            '    ' preserve the indentation of the comment trivia before a case statement
-            '    If trivia.Kind = SyntaxKind.CommentTrivia AndAlso trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
-            '        Return indenter.GetIndentationOfLine(previousLine)
-            '    End If
-
-            '    If trivia.Kind = SyntaxKind.LineContinuationTrivia Then
-            '        Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-            '    End If
-
-            '    ' Line ends in comment
-            '    If trivia.Kind = SyntaxKind.CommentTrivia Then ' Two cases a line ending comment or _ comment
-            '        Dim firstTrivia As SyntaxTrivia = indenter.Tree.GetRoot(indenter.CancellationToken).FindTrivia(token.Span.End + 1)
-            '        ' firstTrivia contains either an _ or a comment, this is the First trivia after the last Token on the line
-            '        If firstTrivia.Kind = SyntaxKind.LineContinuationTrivia Then
-            '            Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(firstTrivia), firstTrivia)
-            '        Else
-            '            ' This is we have just a comment
-            '            Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-            '        End If
-            '    End If
-
-            '    ' if we are at invalid token (skipped token) at the end of statement, treat it like we are after line continuation
-            '    If trivia.Kind = SyntaxKind.SkippedTokensTrivia AndAlso trivia.Token.IsLastTokenOfStatement() Then
-            '        Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
-            '    End If
-
-            '    ' okay, now check whether the trivia is at the beginning of the line
-            '    Dim firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition()
-            '    If Not firstNonWhitespacePosition.HasValue Then
-            '        Return indenter.IndentFromStartOfLine(0)
-            '    End If
-
-            '    Dim firstTokenOnLine = indenter.Root.FindToken(firstNonWhitespacePosition.Value, findInsideTrivia:=True)
-            '    If firstTokenOnLine.Kind <> SyntaxKind.None AndAlso firstTokenOnLine.Span.Contains(firstNonWhitespacePosition.Value) Then
-            '        'okay, beginning of the line is not trivia, use this token as the base token
-            '        Return GetIndentationBasedOnToken(indenter, firstTokenOnLine)
-            '    End If
-
+            ' preserve the indentation of the comment trivia before a case statement
+            'If trivia.Kind = SyntaxKind.CommentTrivia AndAlso
+            '   trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso
+            '   trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
             '    Return indenter.GetIndentationOfLine(previousLine)
             'End If
+
+            If trivia.Kind = SyntaxKind.LineContinuationTrivia Then
+                Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+            End If
+
+            ' Line ends in comment
+            If trivia.Kind = SyntaxKind.CommentTrivia Then ' Two cases a line ending comment or _ comment
+                Dim firstTrivia As SyntaxTrivia = indenter.Tree.GetRoot(indenter.CancellationToken).FindTrivia(token.Span.End + 1)
+                ' firstTrivia contains either an _ or a comment, this is the First trivia after the last Token on the line
+                If firstTrivia.Kind = SyntaxKind.LineContinuationTrivia Then
+                    Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(firstTrivia), firstTrivia)
+                Else
+                    ' This is we have just a comment
+                    Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+                End If
+            End If
+
+            ' if we are at invalid token (skipped token) at the end of statement, treat it like we are after line continuation
+            If trivia.Kind = SyntaxKind.SkippedTokensTrivia AndAlso trivia.Token.IsLastTokenOfStatement() Then
+                Return GetIndentationBasedOnToken(indenter, GetTokenOnLeft(trivia), trivia)
+            End If
+
+            ' okay, now check whether the trivia is at the beginning of the line
+            'Dim firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition()
+            'If Not firstNonWhitespacePosition.HasValue Then
+            '    Return indenter.IndentFromStartOfLine(0)
+            'End If
+
+            'Dim firstTokenOnLine = indenter.Root.FindToken(firstNonWhitespacePosition.Value, findInsideTrivia:=True)
+            'If firstTokenOnLine.Kind <> SyntaxKind.None AndAlso firstTokenOnLine.Span.Contains(firstNonWhitespacePosition.Value) Then
+            '    'okay, beginning of the line is not trivia, use this token as the base token
+            '    Return GetIndentationBasedOnToken(indenter, firstTokenOnLine)
+            'End If
+
+            Return GetIndentationBasedOnToken(indenter, token)
         End Function
 
         Private Function GetTokenOnLeft(trivia As SyntaxTrivia) As SyntaxToken

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -42,13 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
                     End If
                 End If
 
-                ' preserve the indentation of the comment trivia before a case statement
                 If trivia.Kind = SyntaxKind.CommentTrivia Then
-                    If trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso
-                       trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
-                        Return New IndentationResult(trivia.SpanStart, 0)
-                    End If
-
                     ' Line ends in comment
                     ' Two cases a line ending comment or _ comment
                     If tokenOpt.HasValue Then

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
         Protected Overrides Function GetDesiredIndentationWorker(
                 indenter As Indenter,
                 tokenOpt As SyntaxToken?,
-                triviaOpt As SyntaxTrivia?) As IndentationResult
+                triviaOpt As SyntaxTrivia?) As IndentationResult?
 
             If triviaOpt.HasValue Then
                 Dim trivia = triviaOpt.Value


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/28752

Should be viewed with whitespace changes off.  I recommend looking at the abstractindenter first, then the c# and vb impls.