### PR TITLE
Collapse empty lines between elements of the same kind

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/AccessorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/AccessorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -149,6 +150,98 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertyGetter3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        $${|hint:get{|textspan:
+        {
+        }|}
+|}
+        set
+        {
+        }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(56, 80),
+                    hintSpan: TextSpan.FromBounds(53, 78),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertyGetterWithSingleLineComments3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        {|span1:// My
+        // Getter|}
+        $${|hint2:get{|textspan2:
+        {
+        }|}
+|}
+        set
+        {
+        }
+    }
+}
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span1", "// My ...", autoCollapse: true),
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(90, 114),
+                    hintSpan: TextSpan.FromBounds(87, 112),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertyGetterWithMultiLineComments3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        {|span1:/* My
+           Getter */|}
+        $${|hint2:get{|textspan2:
+        {
+        }|}
+|}
+        set
+        {
+        }
+    }
+}
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span1", "/* My ...", autoCollapse: true),
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(93, 117),
+                    hintSpan: TextSpan.FromBounds(90, 115),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task TestPropertySetter1()
         {
             const string code = @"
@@ -264,6 +357,78 @@ class C
         get
         {
         }
+        {|span1:/* My
+           Setter */|}
+        $${|hint2:set{|textspan2:
+        {
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span1", "/* My ...", autoCollapse: true),
+                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertySetter3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        get
+        {
+        }
+
+        $${|hint:set{|textspan:
+        {
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertySetterWithSingleLineComments3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        get
+        {
+        }
+
+        {|span1:// My
+        // Setter|}
+        $${|hint2:set{|textspan2:
+        {
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span1", "// My ...", autoCollapse: true),
+                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertySetterWithMultiLineComments3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        get
+        {
+        }
+
         {|span1:/* My
            Setter */|}
         $${|hint2:set{|textspan2:

--- a/src/EditorFeatures/CSharpTest/Structure/ArrowExpressionClauseStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/ArrowExpressionClauseStructureTests.cs
@@ -32,6 +32,72 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Method2()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:void M(){|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+    void N() => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Method3()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:void M(){|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+
+    void N() => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Method4()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:void M(){|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+    int N => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Method5()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:void M(){|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+
+    int N => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task TestArrowExpressionClause_Property1()
         {
             await VerifyBlockSpansAsync(
@@ -41,6 +107,72 @@ class C
     {|hintspan:int M{|textspan: $$=> expression
         ? trueCase
         : falseCase;|}|};
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Property2()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:int M{|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+    int N => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Property3()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:int M{|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+
+    int N => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Property4()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:int M{|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+    int N() => 0;
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Property5()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:int M{|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|}
+
+    int N() => 0;
 }
 ",
                 Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));

--- a/src/EditorFeatures/CSharpTest/Structure/ConstructorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/ConstructorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -135,6 +136,49 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestConstructor9()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public C(){|textspan:
+    {
+    }|}|}
+    public C()
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestConstructor10()
+        {
+            const string code = @"
+class C
+{
+    $$public C()
+    {
+    }
+
+    public C(int x)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(28, 44),
+                    hintSpan: TextSpan.FromBounds(18, 42),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/ConversionOperatorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/ConversionOperatorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new ConversionOperatorDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestOperator()
+        public async Task TestOperator1()
         {
             const string code = @"
 class C
@@ -28,6 +29,49 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator2()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public static explicit operator C(byte i){|textspan:
+    {
+    }|}|}
+    public static explicit operator C(short i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator3()
+        {
+            const string code = @"
+class C
+{
+    $$public static explicit operator C(byte i)
+    {
+    }
+
+    public static explicit operator C(short i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(59, 75),
+                    hintSpan: TextSpan.FromBounds(18, 73),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
 
         [Fact,

--- a/src/EditorFeatures/CSharpTest/Structure/EnumDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/EnumDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new EnumDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestEnum()
+        public async Task TestEnum1()
         {
             const string code = @"
 {|hint:$$enum E{|textspan:
@@ -25,6 +26,51 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("struct")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        public async Task TestEnum2(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$enum E{{|textspan:
+{{
+}}|}}|}}
+{typeKind} Following
+{{
+}}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("struct")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        public async Task TestEnum3(string typeKind)
+        {
+            var code = $@"
+$$enum E
+{{
+}}
+
+{typeKind} Following
+{{
+}}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(8, 16),
+                    hintSpan: TextSpan.FromBounds(2, 14),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: false));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/EventDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/EventDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new EventDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestEvent()
+        public async Task TestEvent1()
         {
             const string code = @"
 class C
@@ -26,6 +27,103 @@ class C
         add { }
         remove { }
     }|}|}
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestEvent2()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$event EventHandler E{|textspan:
+    {
+        add { }
+        remove { }
+    }|}|}
+    event EventHandler E2
+    {
+        add { }
+        remove { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestEvent3()
+        {
+            const string code = @"
+class C
+{
+    $$event EventHandler E
+    {
+        add { }
+        remove { }
+    }
+
+    event EventHandler E2
+    {
+        add { }
+        remove { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(38, 91),
+                    hintSpan: TextSpan.FromBounds(18, 89),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestEvent4()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$event EventHandler E{|textspan:
+    {
+        add { }
+        remove { }
+    }|}|}
+
+    EventHandler E2
+    {
+        get;
+        set;
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestEvent5()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$event EventHandler E{|textspan:
+    {
+        add { }
+        remove { }
+    }|}|}
+
+    EventHandler this[int index]
+    {
+        get => throw null;
+        set => throw null;
+    }
 }";
 
             await VerifyBlockSpansAsync(code,

--- a/src/EditorFeatures/CSharpTest/Structure/IndexerDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/IndexerDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new IndexerDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestIndexer()
+        public async Task TestIndexer1()
         {
             const string code = @"
 class C
@@ -29,6 +30,47 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestIndexer2()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public string this[int index]{|textspan:
+    {
+        get { }
+    }|}|}
+    int Value => 0;
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestIndexer3()
+        {
+            const string code = @"
+class C
+{
+    $$public string this[int index]
+    {
+        get { }
+    }
+
+    int Value => 0;
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(47, 80),
+                    hintSpan: TextSpan.FromBounds(18, 78),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/OperatorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/OperatorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new OperatorDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestOperator()
+        public async Task TestOperator1()
         {
             const string code = @"
 class C
@@ -24,6 +25,85 @@ class C
     {|hint:$$public static int operator +(int i){|textspan:
     {
     }|}|}
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator2()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public static int operator +(int i){|textspan:
+    {
+    }|}|}
+    public static int operator -(int i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator3()
+        {
+            const string code = @"
+class C
+{
+    $$public static int operator +(int i)
+    {
+    }
+
+    public static int operator -(int i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(53, 69),
+                    hintSpan: TextSpan.FromBounds(18, 67),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator4()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public static int operator +(int i){|textspan:
+    {
+    }|}|}
+    public static explicit operator C(int i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator5()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public static int operator +(int i){|textspan:
+    {
+    }|}|}
+    public static explicit operator C(int i)
+    {
+    }
 }";
 
             await VerifyBlockSpansAsync(code,

--- a/src/EditorFeatures/CSharpTest/Structure/PropertyDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/PropertyDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new PropertyDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestProperty()
+        public async Task TestProperty1()
         {
             const string code = @"
 class C
@@ -26,6 +27,128 @@ class C
         get { }
         set { }
     }|}|}
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty2()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public int Goo{|textspan:
+    {
+        get { }
+        set { }
+    }|}|}
+    public int Goo2
+    {
+        get { }
+        set { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty3()
+        {
+            const string code = @"
+class C
+{
+    $$public int Goo
+    {
+        get { }
+        set { }
+    }
+
+    public int Goo2
+    {
+        get { }
+        set { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(32, 82),
+                    hintSpan: TextSpan.FromBounds(18, 80),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty4()
+        {
+            const string code = @"
+class C
+{
+    $$public int Goo
+    {
+        get { }
+        set { }
+    }
+
+    public int this[int value]
+    {
+        get { }
+        set { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(32, 82),
+                    hintSpan: TextSpan.FromBounds(18, 80),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty5()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public int Goo{|textspan:
+    {
+        get { }
+        set { }
+    }|}|}
+
+    public event EventHandler Event;
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty6()
+        {
+            const string code = @"
+class C
+{
+    {|hint:$$public int Goo{|textspan:
+    {
+        get { }
+        set { }
+    }|}|}
+
+    public event EventHandler Event
+    {
+        add { }
+        remove { }
+    }
 }";
 
             await VerifyBlockSpansAsync(code,

--- a/src/EditorFeatures/CSharpTest/Structure/TypeDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/TypeDeclarationStructureTests.cs
@@ -16,12 +16,51 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         internal override AbstractSyntaxStructureProvider CreateProvider() => new TypeDeclarationStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestClass()
+        public async Task TestClass1()
         {
             const string code = @"
 {|hint:$$class C{|textspan:
 {
 }|}|}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestClass2(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$class C{{|textspan:
+{{
+}}|}}|}}
+{typeKind}D
+{{
+}}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestClass3(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$class C{{|textspan:
+{{
+}}|}}|}}
+
+{typeKind}D
+{{
+}}";
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
@@ -58,12 +97,51 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestInterface()
+        public async Task TestInterface1()
         {
             const string code = @"
 {|hint:$$interface I{|textspan:
 {
 }|}|}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestInterface2(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$interface I{{|textspan:
+{{
+}}|}}|}}
+{typeKind}D
+{{
+}}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestInterface3(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$interface I{{|textspan:
+{{
+}}|}}|}}
+
+{typeKind}D
+{{
+}}";
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
@@ -100,12 +178,51 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestStruct()
+        public async Task TestStruct1()
         {
             const string code = @"
 {|hint:$$struct S{|textspan:
 {
 }|}|}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestStruct2(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$struct C{{|textspan:
+{{
+}}|}}|}}
+{typeKind}D
+{{
+}}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestStruct3(string typeKind)
+        {
+            var code = $@"
+{{|hint:$$struct C{{|textspan:
+{{
+}}|}}|}}
+
+{typeKind}D
+{{
+}}";
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));

--- a/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = accessorDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 accessorDeclaration,
                 accessorDeclaration.Keyword,
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.AsNode() is AccessorDeclarationSyntax,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
@@ -32,10 +32,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = accessorDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            //
+            // All accessor kinds are grouped together.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.AsNode() is AccessorDeclarationSyntax;
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 accessorDeclaration,
                 accessorDeclaration.Keyword,
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.AsNode() is AccessorDeclarationSyntax,
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/AnonymousMethodExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AnonymousMethodExpressionStructureProvider.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 anonymousMethod,
                 startToken,
                 lastToken,
+                compressEmptyLines: false,
                 autoCollapse: false,
                 type: BlockTypes.Expression,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/CompilationUnitStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/CompilationUnitStructureProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             externsAndUsings.Sort((node1, node2) => node1.SpanStart.CompareTo(node2.SpanStart));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
-                externsAndUsings, autoCollapse: true,
+                externsAndUsings, compressEmptyLines: false, autoCollapse: true,
                 type: BlockTypes.Imports, isCollapsible: true));
 
             if (compilationUnit.Usings.Count > 0 ||

--- a/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
@@ -32,10 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = constructorDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConstructorDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 constructorDeclaration,
                 constructorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConstructorDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = constructorDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 constructorDeclaration,
                 constructorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConstructorDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
@@ -32,10 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = operatorDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConversionOperatorDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 operatorDeclaration,
                 operatorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConversionOperatorDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = operatorDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 operatorDeclaration,
                 operatorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConversionOperatorDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/DestructorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DestructorDeclarationStructureProvider.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 destructorDeclaration,
                 destructorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
+                compressEmptyLines: false,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
@@ -24,9 +24,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             if (!enumDeclaration.OpenBraceToken.IsMissing &&
                 !enumDeclaration.CloseBraceToken.IsMissing)
             {
+                SyntaxNodeOrToken current = enumDeclaration;
+                var nextSibling = current.GetNextSibling();
+
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     enumDeclaration,
                     enumDeclaration.Identifier,
+                    compressEmptyLines: !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax,
                     autoCollapse: false,
                     type: BlockTypes.Member,
                     isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
@@ -27,10 +27,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 SyntaxNodeOrToken current = enumDeclaration;
                 var nextSibling = current.GetNextSibling();
 
+                // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+                var compressEmptyLines = !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax;
+
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     enumDeclaration,
                     enumDeclaration.Identifier,
-                    compressEmptyLines: !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax,
+                    compressEmptyLines: compressEmptyLines,
                     autoCollapse: false,
                     type: BlockTypes.Member,
                     isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
@@ -33,10 +33,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = eventDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            //
+            // Full events are grouped together with event field definitions.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.EventDeclaration) || nextSibling.IsKind(SyntaxKind.EventFieldDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 eventDeclaration,
                 eventDeclaration.Identifier,
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.EventDeclaration) || nextSibling.IsKind(SyntaxKind.EventFieldDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
@@ -30,9 +30,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = eventDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 eventDeclaration,
                 eventDeclaration.Identifier,
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.EventDeclaration) || nextSibling.IsKind(SyntaxKind.EventFieldDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
@@ -30,9 +30,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = indexerDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 indexerDeclaration,
                 indexerDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.IndexerDeclaration) || nextSibling.IsKind(SyntaxKind.PropertyDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
@@ -33,10 +33,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = indexerDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            //
+            // Indexers are grouped together with properties.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.IndexerDeclaration) || nextSibling.IsKind(SyntaxKind.PropertyDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 indexerDeclaration,
                 indexerDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.IndexerDeclaration) || nextSibling.IsKind(SyntaxKind.PropertyDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = methodDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 methodDeclaration,
                 methodDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.MethodDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
@@ -32,10 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = methodDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.MethodDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 methodDeclaration,
                 methodDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.MethodDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
@@ -26,13 +26,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             if (!namespaceDeclaration.OpenBraceToken.IsMissing &&
                 !namespaceDeclaration.CloseBraceToken.IsMissing)
             {
-                SyntaxNodeOrToken current = namespaceDeclaration;
-                var nextSibling = current.GetNextSibling();
-
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     namespaceDeclaration,
                     namespaceDeclaration.Name.GetLastToken(includeZeroWidth: true),
-                    compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.NamespaceDeclaration),
+                    compressEmptyLines: false,
                     autoCollapse: false,
                     type: BlockTypes.Namespace,
                     isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
@@ -26,9 +26,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             if (!namespaceDeclaration.OpenBraceToken.IsMissing &&
                 !namespaceDeclaration.CloseBraceToken.IsMissing)
             {
+                SyntaxNodeOrToken current = namespaceDeclaration;
+                var nextSibling = current.GetNextSibling();
+
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     namespaceDeclaration,
                     namespaceDeclaration.Name.GetLastToken(includeZeroWidth: true),
+                    compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.NamespaceDeclaration),
                     autoCollapse: false,
                     type: BlockTypes.Namespace,
                     isCollapsible: true));
@@ -46,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             }
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
-                externsAndUsings, autoCollapse: true,
+                externsAndUsings, compressEmptyLines: true, autoCollapse: true,
                 type: BlockTypes.Imports, isCollapsible: true));
 
             // finally, add any leading comments before the end of the namespace block

--- a/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = operatorDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 operatorDeclaration,
                 operatorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.OperatorDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
@@ -32,10 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = operatorDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.OperatorDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 operatorDeclaration,
                 operatorDeclaration.ParameterList.GetLastToken(includeZeroWidth: true),
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.OperatorDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/ParenthesizedLambdaExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ParenthesizedLambdaExpressionStructureProvider.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 lambdaExpression,
                 lambdaExpression.ArrowToken,
                 lastToken,
+                compressEmptyLines: false,
                 autoCollapse: false,
                 type: BlockTypes.Expression,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 return;
             }
 
+            SyntaxNodeOrToken current = propertyDeclaration;
+            var nextSibling = current.GetNextSibling();
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 propertyDeclaration,
                 propertyDeclaration.Identifier,
+                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.PropertyDeclaration) || nextSibling.IsKind(SyntaxKind.IndexerDeclaration),
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
@@ -32,10 +32,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             SyntaxNodeOrToken current = propertyDeclaration;
             var nextSibling = current.GetNextSibling();
 
+            // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+            //
+            // Properties are grouped together with indexers.
+            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.PropertyDeclaration) || nextSibling.IsKind(SyntaxKind.IndexerDeclaration);
+
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 propertyDeclaration,
                 propertyDeclaration.Identifier,
-                compressEmptyLines: !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.PropertyDeclaration) || nextSibling.IsKind(SyntaxKind.IndexerDeclaration),
+                compressEmptyLines: compressEmptyLines,
                 autoCollapse: true,
                 type: BlockTypes.Member,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/SimpleLambdaExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/SimpleLambdaExpressionStructureProvider.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 lambdaExpression,
                 lambdaExpression.ArrowToken,
                 lastToken,
+                compressEmptyLines: false,
                 autoCollapse: false,
                 type: BlockTypes.Expression,
                 isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
@@ -28,9 +28,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                     ? typeDeclaration.Identifier
                     : typeDeclaration.TypeParameterList.GetLastToken(includeZeroWidth: true);
 
+                SyntaxNodeOrToken current = typeDeclaration;
+                var nextSibling = current.GetNextSibling();
+
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     typeDeclaration,
                     lastToken,
+                    compressEmptyLines: !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax,
                     autoCollapse: false,
                     type: BlockTypes.Type,
                     isCollapsible: true));

--- a/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
@@ -31,10 +31,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 SyntaxNodeOrToken current = typeDeclaration;
                 var nextSibling = current.GetNextSibling();
 
+                // Check IsNode to compress blank lines after this node if it is the last child of the parent.
+                //
+                // Collapse to Definitions doesn't collapse type nodes, but a Toggle All Outlining would collapse groups
+                // of types to the compressed form of not showing blank lines. All kinds of types are grouped together.
+                var compressEmptyLines = !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax;
+
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     typeDeclaration,
                     lastToken,
-                    compressEmptyLines: !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax,
+                    compressEmptyLines: compressEmptyLines,
                     autoCollapse: false,
                     type: BlockTypes.Type,
                     isCollapsible: true));

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOutlining.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOutlining.cs
@@ -59,8 +59,8 @@ namespace ClassLibrary1[|
 #if DEBUG
 {|Release:        void Goo(){|Debug:
         {
-        }|}
-        
+        }
+        |}
         void Goo2(){|Debug:
         {
         }|}|}


### PR DESCRIPTION
This change updates **Collapse to Definitions** to produce a view closer to **Metadata As Source**, where empty lines are omitted between collapsed elements of the same kind. Since the blank lines are included in the folding region, this feature works without removing the blank lines from the original source.

Supersedes #42809

## Go To Decompiled Source

### Before

### After

![image](https://user-images.githubusercontent.com/1408396/77811157-dff30c00-7055-11ea-88bc-867a0ef5643a.png)

## Collapse to Definitions

### Before

![image](https://user-images.githubusercontent.com/1408396/77811178-ff8a3480-7055-11ea-9f20-702f0e8209dd.png)

### After

![image](https://user-images.githubusercontent.com/1408396/77811182-044ee880-7056-11ea-8dbd-3fc209eea4ba.png)
