### PR TITLE
Propagate isSpecialNameAndRuntimeSpecial.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
@@ -1,4 +1,4 @@
-' Licensed to the .NET Foundation under one or more agreements.	' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Licensed to the .NET Foundation under one or more agreements.
 ' The .NET Foundation licenses this file to you under the MIT license.	
 ' See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
@@ -1,4 +1,6 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Licensed to the .NET Foundation under one or more agreements.	' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' The .NET Foundation licenses this file to you under the MIT license.	
+' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Symbols

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
@@ -1,5 +1,5 @@
 ' Licensed to the .NET Foundation under one or more agreements.
-' The .NET Foundation licenses this file to you under the MIT license.	
+' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.CodeGen

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.vb
@@ -1,6 +1,4 @@
-﻿' Licensed to the .NET Foundation under one or more agreements.
-' The .NET Foundation licenses this file to you under the MIT license.
-' See the LICENSE file in the project root for more information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Symbols
@@ -36,7 +34,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                    slotIndex:=-1,
                    accessibility:=accessibility,
                    isReadOnly:=isReadOnly,
-                   isShared:=isShared)
+                   isShared:=isShared,
+                   isSpecialNameAndRuntimeSpecial:=isSpecialNameAndRuntimeSpecial)
         End Sub
 
         Public Sub New(stateMachineType As NamedTypeSymbol,
@@ -57,7 +56,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                    slotIndex:=slotindex,
                    accessibility:=accessibility,
                    isReadOnly:=isReadOnly,
-                   isShared:=isShared)
+                   isShared:=isShared,
+                   isSpecialNameAndRuntimeSpecial:=isSpecialNameAndRuntimeSpecial)
         End Sub
 
         Public Sub New(stateMachineType As NamedTypeSymbol,


### PR DESCRIPTION
Constructor parameter `isSpecialNameAndRuntimeSpecial` wasn't be propagated down to the base constructors.