### PR TITLE
WIP: Theme the Roslyn dialogs

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -8,16 +8,21 @@
     xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
     xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
     xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+    xmlns:vs3="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
     xmlns:imagingPlatformUI="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
-    Height="420" Width="560"
-    MinHeight="420" MinWidth="560"
+    Height="425" Width="560"
+    MinHeight="425" MinWidth="560"
     Title="{Binding ElementName=dialog, Path=ChangeSignatureDialogTitle}"
     HasHelpButton="True"
     ResizeMode="CanResizeWithGrip"
     ShowInTaskbar="False"
     HasDialogFrame="True"
-    WindowStartupLocation="CenterOwner">
+    WindowStartupLocation="CenterOwner"
+    vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+    Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
     <Window.Resources>
+        <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
         <Style x:Key="DataGridStyle" TargetType="DataGrid">
             <Setter Property="CellStyle">
                 <Setter.Value>
@@ -58,7 +63,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Height="Auto" Width="Auto" Padding="0,4,0,0" Text="{Binding ElementName=dialog, Path=Parameters}"/>
+        <Label Grid.Row="0" Height="Auto" Width="Auto" Padding="0,4,0,0" Content="{Binding ElementName=dialog, Path=Parameters}"/>
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition MinHeight="180"/>
@@ -238,25 +243,27 @@
                               Background="{DynamicResource {x:Static vs:EnvironmentColors.DesignerBackgroundBrushKey}}"/>
             </Border>
             <StackPanel Name="ControlButtonsPanel" Grid.Column="1" Grid.Row="0" Height="Auto" Width="Auto" Margin="0, 3, 0, 0" >
-                <vs:DialogButton Name="UpButton" 
+                <Button Name="UpButton" 
                                  AutomationProperties.Name="{Binding MoveUpAutomationText}"
                                  Margin="9 0 0 0"
                                  IsEnabled="{Binding CanMoveUp, Mode=OneWay}" 
                                  AutomationProperties.AutomationId="UpButton"
                                  Height="Auto" Width="Auto"
+                                 vs2:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, RelativeSource={RelativeSource Self},Converter={StaticResource BrushToColorConverter}}"
                                  Command="{StaticResource MoveUp}">
                     <imaging:CrispImage Name="UpArrowImage" 
                                         Height="16" 
                                         Width="16" 
                                         Moniker="{x:Static imagecatalog:KnownMonikers.MoveUp}" 
                                         Grayscale="{Binding IsEnabled, ElementName=UpButton, Converter={StaticResource NegateBooleanConverter}}"/>
-                </vs:DialogButton>
-                <vs:DialogButton Name="DownButton" 
+                </Button>
+                <Button Name="DownButton" 
                                  AutomationProperties.Name="{Binding MoveDownAutomationText}"
                                  Margin="9 9 0 0"
                                  IsEnabled="{Binding CanMoveDown, Mode=OneWay}" 
                                  AutomationProperties.AutomationId="DownButton"
                                  Height="Auto" Width="Auto"
+                                 vs2:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, RelativeSource={RelativeSource Self},Converter={StaticResource BrushToColorConverter}}"
                                  Command="{StaticResource MoveDown}">
                     <imaging:CrispImage Name="DownArrowImage" 
                                         Height="16" 
@@ -264,8 +271,8 @@
                                         Moniker="{x:Static imagecatalog:KnownMonikers.MoveDown}" 
                                         Grayscale="{Binding IsEnabled, ElementName=DownButton, Converter={StaticResource NegateBooleanConverter}}"/>
 
-                </vs:DialogButton>
-                <vs:DialogButton
+                </Button>
+                <Button
                         Name="RemoveButton"
                         Margin="9 29 0 0"
                         IsEnabled="{Binding CanRemove, Mode=OneWay}" 
@@ -274,9 +281,9 @@
                         AutomationProperties.AutomationId="RemoveButton" 
                         Content="{Binding ElementName=dialog, Path=Remove}" 
                         Height="Auto" Width="Auto">
-                </vs:DialogButton>
+                </Button>
 
-                <vs:DialogButton
+                <Button
                         Name="RestoreButton"
                         Margin="9 9 0 0"
                         IsEnabled="{Binding CanRestore, Mode=OneWay}" 
@@ -300,7 +307,7 @@
                     HorizontalAlignment="Right" 
                     Margin="0, 11, 0, 0"
                     Orientation="Horizontal" Width="153">
-            <vs:DialogButton x:Uid="OKButton" 
+            <Button x:Uid="OKButton" 
                     Name="OKButton"
                     Content="{Binding ElementName=dialog, Path=OK}" 
                     Margin="0, 0, 0, 0" 
@@ -310,7 +317,7 @@
                     IsEnabled="{Binding IsOkButtonEnabled, Mode=OneWay}"
                     MinWidth="73"
                     MinHeight="21"/>
-            <vs:DialogButton x:Uid="CancelButton" 
+            <Button x:Uid="CancelButton" 
                     Name="CancelButton"
                     Content="{Binding ElementName=dialog, Path=Cancel}" 
                     Margin="7, 0, 0, 0" 

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -21,7 +21,7 @@
     WindowStartupLocation="CenterOwner"
     vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
     vs2:ImageThemingUtilities.ThemeScrollBars="True"
-    Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+    Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
     <Window.Resources>
         <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
         <Style x:Key="DataGridStyle" TargetType="DataGrid">

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -20,6 +20,7 @@
     HasDialogFrame="True"
     WindowStartupLocation="CenterOwner"
     vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+    vs2:ImageThemingUtilities.ThemeScrollBars="True"
     Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
     <Window.Resources>
         <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -220,17 +220,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 
             public DataGrid Members => _dialog.Members;
 
-            public DialogButton OKButton => _dialog.OKButton;
+            public Button OKButton => _dialog.OKButton;
 
-            public DialogButton CancelButton => _dialog.CancelButton;
+            public Button CancelButton => _dialog.CancelButton;
 
-            public DialogButton DownButton => _dialog.DownButton;
+            public Button DownButton => _dialog.DownButton;
 
-            public DialogButton UpButton => _dialog.UpButton;
+            public Button UpButton => _dialog.UpButton;
 
-            public DialogButton RemoveButton => _dialog.RemoveButton;
+            public Button RemoveButton => _dialog.RemoveButton;
 
-            public DialogButton RestoreButton => _dialog.RestoreButton;
+            public Button RestoreButton => _dialog.RestoreButton;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml
@@ -4,19 +4,23 @@
             x:ClassModifier="internal"
             x:Name="dialog"
             xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+            xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
             mc:Ignorable="d" d:DesignWidth="460"
             Height="353" Width="460"
-            MinHeight="370" MinWidth="460"
+            MinHeight="353" MinWidth="460"
             Title="{Binding ElementName=dialog, Path=GenerateTypeDialogTitle}"
             HasHelpButton="True"
             ResizeMode="CanResizeWithGrip"
             ShowInTaskbar="False"
             HasDialogFrame="True"
-            WindowStartupLocation="CenterOwner">
+            WindowStartupLocation="CenterOwner"
+            vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+            vs2:ImageThemingUtilities.ThemeScrollBars="True"
+            Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
     <StackPanel Margin="0,0,0,9" >
         <Label Content="{Binding ElementName=dialog, Path=TypeDetails}" FontWeight="Bold" Margin="20,10,0,0" VerticalAlignment="Top" RenderTransformOrigin="0.5,0.5"/>
         <Grid Margin="20,0,1,0" Height="49">

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml
@@ -20,7 +20,7 @@
             WindowStartupLocation="CenterOwner"
             vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
             vs2:ImageThemingUtilities.ThemeScrollBars="True"
-            Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+            Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
     <StackPanel Margin="0,0,0,9" >
         <Label Content="{Binding ElementName=dialog, Path=TypeDetails}" FontWeight="Bold" Margin="20,10,0,0" VerticalAlignment="Top" RenderTransformOrigin="0.5,0.5"/>
         <Grid Margin="20,0,1,0" Height="49">

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
@@ -18,6 +18,7 @@
              ShowInTaskbar="False"
              HasDialogFrame="True"
              WindowStartupLocation="CenterOwner"
+             vs2:ImageThemingUtilities.ThemeScrollBars="True"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
              Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
 

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
@@ -19,7 +19,7 @@
              HasDialogFrame="True"
              WindowStartupLocation="CenterOwner"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
-             Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+             Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
 
     <Window.Resources>
         <Thickness x:Key="verticalLabelMargin">0, 0, 0, 5</Thickness>

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
@@ -7,6 +7,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"
@@ -16,7 +17,9 @@
              ResizeMode="CanResizeWithGrip"
              ShowInTaskbar="False"
              HasDialogFrame="True"
-             WindowStartupLocation="CenterOwner">
+             WindowStartupLocation="CenterOwner"
+             vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+             Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
 
     <Window.Resources>
         <Thickness x:Key="verticalLabelMargin">0, 0, 0, 5</Thickness>
@@ -53,7 +56,9 @@
         <StackPanel Grid.Row="1">
             <StackPanel Orientation="Horizontal"  
                         Visibility="{Binding ShowMessage, Converter={StaticResource BooleanToVisibilityConverter}}"
-                        Margin="{StaticResource messageMargin}">
+                        Margin="{StaticResource messageMargin}"
+                        vs2:ImageThemingUtilities.ImageBackgroundColor="White">
+                        <!-- Set ImageBackgroundColor to White to prevent icon inversion -->
                 <imaging:CrispImage Name="MessageIcon"
                                     Moniker="{Binding Icon}" 
                                     Height="16"
@@ -61,6 +66,7 @@
                                     VerticalAlignment="Top" />
 
                 <vs:LiveTextBlock x:Name="MessageText"
+                           Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"
                            Text="{Binding Message}"
                            Margin="7, 0, 0, 0" />
             </StackPanel>

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -24,6 +24,7 @@
              HasDialogFrame="True"
              WindowStartupLocation="CenterOwner"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+             vs2:ImageThemingUtilities.ThemeScrollBars="True"
              Background="{DynamicResource {x:Static vs:EnvironmentColors.EnvironmentBackgroundBrushKey}}">
     <Window.Resources>
         <Style TargetType="ListBoxItem">
@@ -51,8 +52,7 @@
         <KeyBinding Key="Up" Modifiers="Alt" Command="{StaticResource MoveUp}" />
         <KeyBinding Key="Down" Modifiers="Alt" Command="{StaticResource MoveDown}" />
     </Window.InputBindings>
-    <Grid Margin="11,6,11,11"
-          vs2:ImageThemingUtilities.ThemeScrollBars="True">
+    <Grid Margin="11,6,11,11">
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -21,11 +21,16 @@
              ResizeMode="CanResizeWithGrip"
              ShowInTaskbar="False"
              HasDialogFrame="True"
-             WindowStartupLocation="CenterOwner">
+             WindowStartupLocation="CenterOwner"
+             vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+             Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
     <Window.Resources>
         <Style TargetType="ListBoxItem">
-            <Setter Property="IsTabStop" 
-                    Value="False" />
+            <Setter Property="IsTabStop" Value="False" />
+        </Style>
+        <Style TargetType="GroupBox">
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBorderBrushKey}}"/>
         </Style>
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
@@ -70,7 +75,10 @@
                           SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}"
                           PreviewKeyDown="OnListViewPreviewKeyDown"
                           MouseDoubleClick="OnListViewDoubleClick"
-                          ItemsSource="{Binding MemberContainers, Mode=TwoWay}">
+                          ItemsSource="{Binding MemberContainers, Mode=TwoWay}"
+                          Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+                                           <!-- TODO: Setting the AutomationDelegatingListView's Background should not be necessary.
+                                                The AutomationDelegatingListView should inherit styles from ListView -->
                     <u:AutomationDelegatingListView.ItemTemplate x:Uid="SelectableMemberListItem">
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
@@ -84,8 +92,11 @@
                                 <Image x:Uid="SelectableMemberGlyph" 
                                        Margin="8,0,0,0"
                                                Source="{Binding Glyph}"/>
-                                <TextBlock x:Uid="SelectableMemberName" 
-                                                   Text="{Binding SymbolName}"/>
+                                <TextBlock x:Uid="SelectableMemberName"
+                                           Text="{Binding SymbolName}"
+                                           Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                                           <!-- TODO: Setting the TextBlock's Foreground should not be necessary.
+                                                The AutomationDelegatingListView should inherit styles from ListView -->
                             </StackPanel>
                         </DataTemplate>
                     </u:AutomationDelegatingListView.ItemTemplate>
@@ -93,7 +104,7 @@
 
                 <StackPanel Grid.Column="1">
 
-                    <vs:DialogButton Name="UpButton" 
+                    <Button Name="UpButton" 
                                  AutomationProperties.Name="{Binding MoveUpAutomationText}"
                                  Margin="0 9 4 0"
                                  IsEnabled="{Binding CanMoveUp, Mode=OneWay}" 
@@ -105,8 +116,8 @@
                                         Width="16" 
                                         Moniker="{x:Static imagecatalog:KnownMonikers.MoveUp}"
                                         Grayscale="{Binding IsEnabled, ElementName=UpButton, Converter={StaticResource NegateBooleanConverter}}"/>
-                    </vs:DialogButton>
-                    <vs:DialogButton Name="DownButton" 
+                    </Button>
+                    <Button Name="DownButton" 
                                  AutomationProperties.Name="{Binding MoveDownAutomationText}"
                                  Margin="0 9 4 0"
                                  IsEnabled="{Binding CanMoveDown, Mode=OneWay}" 
@@ -119,7 +130,7 @@
                                         Moniker="{x:Static imagecatalog:KnownMonikers.MoveDown}" 
                                         Grayscale="{Binding IsEnabled, ElementName=DownButton, Converter={StaticResource NegateBooleanConverter}}"/>
 
-                    </vs:DialogButton>
+                    </Button>
 
                     <Button x:Uid="SelectAllButton"
                             Content="{Binding ElementName=dialog, Path=SelectAll}" 

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -4,6 +4,7 @@
              x:Name="dialog"
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -32,6 +33,8 @@
             <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBorderBrushKey}}"/>
         </Style>
+        <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
+        <Style TargetType="u:AutomationDelegatingListViewItem" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewItemStyleKey}}" />
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
         <Thickness x:Key="selectDeselectButtonPadding">9,2,9,2</Thickness>
@@ -75,10 +78,7 @@
                           SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}"
                           PreviewKeyDown="OnListViewPreviewKeyDown"
                           MouseDoubleClick="OnListViewDoubleClick"
-                          ItemsSource="{Binding MemberContainers, Mode=TwoWay}"
-                          Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
-                                           <!-- TODO: Setting the AutomationDelegatingListView's Background should not be necessary.
-                                                The AutomationDelegatingListView should inherit styles from ListView -->
+                          ItemsSource="{Binding MemberContainers, Mode=TwoWay}">
                     <u:AutomationDelegatingListView.ItemTemplate x:Uid="SelectableMemberListItem">
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
@@ -93,10 +93,7 @@
                                        Margin="8,0,0,0"
                                                Source="{Binding Glyph}"/>
                                 <TextBlock x:Uid="SelectableMemberName"
-                                           Text="{Binding SymbolName}"
-                                           Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
-                                           <!-- TODO: Setting the TextBlock's Foreground should not be necessary.
-                                                The AutomationDelegatingListView should inherit styles from ListView -->
+                                           Text="{Binding SymbolName}"/>
                             </StackPanel>
                         </DataTemplate>
                     </u:AutomationDelegatingListView.ItemTemplate>

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -32,7 +32,6 @@
         </Style>
         <Style TargetType="GroupBox">
             <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBorderBrushKey}}"/>
         </Style>
         <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
         <Style TargetType="u:AutomationDelegatingListViewItem" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewItemStyleKey}}" />

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -26,7 +26,7 @@
              WindowStartupLocation="CenterOwner"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
              vs2:ImageThemingUtilities.ThemeScrollBars="True"
-             Background="{DynamicResource {x:Static vs:EnvironmentColors.EnvironmentBackgroundBrushKey}}">
+             Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
     <Window.Resources>
         <Style TargetType="ListBoxItem">
             <Setter Property="IsTabStop" Value="False" />

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -4,6 +4,7 @@
              x:Name="dialog"
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:vs3="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -35,6 +36,7 @@
         </Style>
         <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
         <Style TargetType="u:AutomationDelegatingListViewItem" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewItemStyleKey}}" />
+        <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
         <Thickness x:Key="selectDeselectButtonPadding">9,2,9,2</Thickness>
@@ -106,6 +108,7 @@
                                  IsEnabled="{Binding CanMoveUp, Mode=OneWay}" 
                                  AutomationProperties.AutomationId="Up"
                                  Height="Auto" Width="Auto"
+                                 vs2:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, RelativeSource={RelativeSource Self},Converter={StaticResource BrushToColorConverter}}"
                                  Command="{StaticResource MoveUp}">
                         <imaging:CrispImage Name="UpArrowImage" 
                                         Height="16" 
@@ -119,6 +122,7 @@
                                  IsEnabled="{Binding CanMoveDown, Mode=OneWay}" 
                                  AutomationProperties.AutomationId="Down"
                                  Height="Auto" Width="Auto"
+                                 vs2:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, RelativeSource={RelativeSource Self},Converter={StaticResource BrushToColorConverter}}"
                                  Command="{StaticResource MoveDown}">
                         <imaging:CrispImage Name="DownArrowImage" 
                                         Height="16" 

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -28,6 +28,8 @@
              vs2:ImageThemingUtilities.ThemeScrollBars="True"
              Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
     <Window.Resources>
+        <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
+        <vs2:ThemedImageSourceConverter x:Key="ThemedImageSourceConverter" />
         <Style TargetType="ListBoxItem">
             <Setter Property="IsTabStop" Value="False" />
         </Style>
@@ -36,7 +38,6 @@
         </Style>
         <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
         <Style TargetType="u:AutomationDelegatingListViewItem" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewItemStyleKey}}" />
-        <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
         <Thickness x:Key="selectDeselectButtonPadding">9,2,9,2</Thickness>
@@ -90,9 +91,18 @@
                                           Focusable="False"
                                           AutomationProperties.AutomationId="{Binding SymbolName}">
                                 </CheckBox>
-                                <Image x:Uid="SelectableMemberGlyph" 
-                                       Margin="8,0,0,0"
-                                               Source="{Binding Glyph}"/>
+                                <Image x:Uid="SelectableMemberGlyph" Margin="8,0,0,0">
+                                    <Image.Source>
+                                        <MultiBinding Converter="{StaticResource ThemedImageSourceConverter}">
+                                            <Binding Path="Glyph" />
+                                            <Binding Path="Background"
+                                                     Mode="OneWay"
+                                                     RelativeSource="{RelativeSource AncestorType=u:AutomationDelegatingListView,Mode=FindAncestor}"
+                                                     Converter="{StaticResource BrushToColorConverter}"/>
+                                            <Binding Source="{x:Static vs3:Boxes.BooleanTrue}" />
+                                        </MultiBinding>
+                                    </Image.Source>
+                                </Image>
                                 <TextBlock x:Uid="SelectableMemberName"
                                            Text="{Binding SymbolName}"/>
                             </StackPanel>

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -24,7 +24,7 @@
              HasDialogFrame="True"
              WindowStartupLocation="CenterOwner"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
-             Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+             Background="{DynamicResource {x:Static vs:EnvironmentColors.EnvironmentBackgroundBrushKey}}">
     <Window.Resources>
         <Style TargetType="ListBoxItem">
             <Setter Property="IsTabStop" Value="False" />

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -3,11 +3,11 @@
              x:ClassModifier="internal"
              x:Name="dialog"
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:s="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:u="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Utilities"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
@@ -43,7 +43,8 @@
         <KeyBinding Key="Up" Modifiers="Alt" Command="{StaticResource MoveUp}" />
         <KeyBinding Key="Down" Modifiers="Alt" Command="{StaticResource MoveDown}" />
     </Window.InputBindings>
-    <Grid Margin="11,6,11,11">
+    <Grid Margin="11,6,11,11"
+          vs2:ImageThemingUtilities.ThemeScrollBars="True">
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml
@@ -26,7 +26,7 @@
              WindowStartupLocation="CenterOwner"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
              vs2:ImageThemingUtilities.ThemeScrollBars="True"
-             Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}">
+             Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
     <Window.Resources>
         <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
         <vs2:ThemedImageSourceConverter x:Key="ThemedImageSourceConverter" />

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml.cs
@@ -152,9 +152,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers
 
             public Button CancelButton => _dialog.CancelButton;
 
-            public DialogButton UpButton => _dialog.UpButton;
+            public Button UpButton => _dialog.UpButton;
 
-            public DialogButton DownButton => _dialog.DownButton;
+            public Button DownButton => _dialog.DownButton;
 
             public AutomationDelegatingListView Members => _dialog.Members;
         }

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -4,6 +4,8 @@
     x:Class="Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.MainDialog.PullMemberUpDialog"
     x:ClassModifier="internal"
     xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+    xmlns:vs3="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -19,8 +21,16 @@
     HasDialogFrame="True"
     ShowInTaskbar="False"
     ResizeMode="CanResizeWithGrip"
-    Title="{Binding ElementName=dialog, Path=PullMembersUpTitle}">
+    Title="{Binding ElementName=dialog, Path=PullMembersUpTitle}"
+    vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+    vs2:ImageThemingUtilities.ThemeScrollBars="True"
+    Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
     <Window.Resources>
+        <vs3:BrushToColorConverter x:Key="BrushToColorConverter"/>
+        <vs2:ThemedImageSourceConverter x:Key="ThemedImageSourceConverter" />
+        <Style TargetType="GroupBox">
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+        </Style>
         <Thickness x:Key="ButtonPadding">9, 2, 9, 2</Thickness>
         <Thickness x:Key="SelectDependantsAndSelectPublicButtonPadding">2, 4, 4, 2</Thickness>
         <sys:Double x:Key="ButtonWidth">73</sys:Double>
@@ -85,7 +95,18 @@
                             HorizontalAlignment="Stretch"
                             Focusable="False"
                             VerticalAlignment="Stretch">
-                            <Image Source="{Binding Glyph}" Margin="0, 0, 5, 0" />
+                            <Image Margin="0, 0, 5, 0">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThemedImageSourceConverter}">
+                                        <Binding Path="Glyph" />
+                                        <Binding Path="Background"
+                                                     Mode="OneWay"
+                                                     RelativeSource="{RelativeSource AncestorType=TreeView,Mode=FindAncestor}"
+                                                     Converter="{StaticResource BrushToColorConverter}"/>
+                                        <Binding Source="{x:Static vs3:Boxes.BooleanTrue}" />
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
                             <TextBlock
                                 x:Uid="DestinationTextBlock"
                                 Text="{Binding SymbolName}"


### PR DESCRIPTION
Posting this early in the process to bring up issues with the platform & UX team as they arise.

**Issues:**
- [ ] 1. Platform/UX: GroupBoxes and DataGrids are [not styled](https://dev.azure.com/devdiv/DevDiv/_git/VS?path=%2Fsrc%2Fenv%2Fshell%2FWindowManager%2FThemes%2FThemedDialogDefaultStyles.xaml&version=GBmaster&_a=contents) by the platform, but many of them exist in the product so what should we do?
- [ ] 2. Platform/UX: ListViews with GridViews are not styled correctly (e.g. the column headers are missing)
- [ ] 3. Platform: ListViews backgrounds don't stand apart from the window brush color.
- [ ] 4. Platform: The themed ListView template leaves a bottom border visible
- [ ] 5. MoveToNamespace: The error icon appears in two places now?
- [ ] 6. Platform/UX: ComboBoxes aren't tall enough IMO.
- [ ] 7. Platform: LiveTextBlock / TextBlock do not automatically set foreground (worked around)
- [ ] 8. Platform: I now can't see our dialogs in the designers. ArgumentNullException
<details>
<summary>ArgumentNullException</summary>
   at System.Windows.ResourceDictionaryCollection.InsertItem(Int32 index, ResourceDictionary item)
   at System.Collections.ObjectModel.Collection`1.Add(T item)
   at Microsoft.VisualStudio.PlatformUI.ThemedDialogStyleLoader.MergeDefaultThemedDialogStyles(FrameworkElement element)
   at Microsoft.VisualStudio.PlatformUI.ThemedDialogStyleLoader.OnElementInitialized(Object sender, EventArgs args)
   at System.Windows.FrameworkElement.RaiseInitialized(EventPrivateKey key, EventArgs e)
   at System.Windows.FrameworkElement.OnInitialized(EventArgs e)
   at System.Windows.FrameworkElement.TryFireInitialized()
   at System.Windows.FrameworkElement.EndInit()
</details>

- [ ] 9. TreeViews have some problems. Dark theme unselected text is dark on dark (I think this is because they're TextBlocks, see 7 above), and selected inactive is a bright white instead of a medium-dark gray like Solution Explorer.

**Dialogs**
- [ ] Pick Members (except 1, 3, 4)
- [ ] Change Signature (except 1, 2 (major blocker))
- [ ] Generate Type (except 6)
- [ ] Move to Namespace (except 5, 6, 7)
- [x] ~Detailed Error Info~ (previously themed)
- [ ] ~Extract Interface~ // Combining into Extract Anything, nothing novel in this dialog
- [ ] ~Pull Member Up~ (except 1, 2 (major blocker), 9)  // Combining into Extract Anything

**Example (Pick Members):** (see issue numbers 1, 3, 4 above)
Blue Theme Before & After:
![image](https://user-images.githubusercontent.com/235241/77855920-8818ea00-71a8-11ea-8b01-811fedf443bc.png)

Dark Theme After:
![image](https://user-images.githubusercontent.com/235241/77855939-b4cd0180-71a8-11ea-8cff-d8b2d711e56f.png)

**Example (Move to Namespace):** (see issue number 5, 6, 7 above, note the bit of red to the right of the textbox in the After image)
Blue Theme Before & After:
![image](https://user-images.githubusercontent.com/235241/77856028-4b99be00-71a9-11ea-8901-7082810e99fb.png)

**Example (Change Signature):** (see issue number 1, 2 above)
Dark Theme After (ignore the black punctuation in the signature preview):
![image](https://user-images.githubusercontent.com/235241/77856088-91568680-71a9-11ea-8263-1c7c16b64fa9.png)

**Example (Generate Type):** (see issue number 6 above, all I changed was the theme...)
Blue Theme Before & After:
![image](https://user-images.githubusercontent.com/235241/77856190-56a11e00-71aa-11ea-9266-d01a5eb089e1.png)

**Example (Pull Members Up):** (see issue number 1, 2, 9 above)
Dark Theme After:
![image](https://user-images.githubusercontent.com/235241/77864835-da293200-71df-11ea-9252-e6c4dffbfe58.png)
