### PR TITLE
Use expression-bodies for very simple members.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.Analyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.Analyzer.cs
@@ -115,9 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             }
 
             public override SyntaxKind VisitSwitchStatement(SwitchStatementSyntax node)
-            {
-                return AnalyzeSwitchStatement(node, out _);
-            }
+                => AnalyzeSwitchStatement(node, out _);
 
             private SyntaxKind AnalyzeSwitchStatement(SwitchStatementSyntax switchStatement, out bool shouldRemoveNextStatement)
             {

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForIndexersHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForIndexersHelper.cs
@@ -54,9 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         }
 
         protected override IndexerDeclarationSyntax WithGenerateBody(SemanticModel semanticModel, IndexerDeclarationSyntax declaration)
-        {
-            return WithAccessorList(semanticModel, declaration);
-        }
+            => WithAccessorList(semanticModel, declaration);
 
         protected override bool CreateReturnStatementForExpression(SemanticModel semanticModel, IndexerDeclarationSyntax declaration) => true;
 

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForPropertiesHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForPropertiesHelper.cs
@@ -54,9 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         }
 
         protected override PropertyDeclarationSyntax WithGenerateBody(SemanticModel semanticModel, PropertyDeclarationSyntax declaration)
-        {
-            return WithAccessorList(semanticModel, declaration);
-        }
+            => WithAccessorList(semanticModel, declaration);
 
         protected override bool CreateReturnStatementForExpression(SemanticModel semanticModel, PropertyDeclarationSyntax declaration) => true;
 

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             private readonly bool _isAllThrowStatements;
 
             private Rewriter(bool isAllThrowStatements)
-            {
-                _isAllThrowStatements = isAllThrowStatements;
-            }
+                => _isAllThrowStatements = isAllThrowStatements;
 
             public static StatementSyntax Rewrite(
                 SwitchStatementSyntax switchStatement,
@@ -145,9 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             }
 
             public override ExpressionSyntax VisitSwitchStatement(SwitchStatementSyntax node)
-            {
-                return RewriteSwitchStatement(node);
-            }
+                => RewriteSwitchStatement(node);
 
             private static SwitchLabelSyntax SingleOrDefaultSwitchLabel(SyntaxList<SwitchLabelSyntax> labels)
             {
@@ -204,9 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             }
 
             public override ExpressionSyntax VisitExpressionStatement(ExpressionStatementSyntax node)
-            {
-                return Visit(node.Expression);
-            }
+                => Visit(node.Expression);
 
             public override ExpressionSyntax DefaultVisit(SyntaxNode node)
             {

--- a/src/Analyzers/CSharp/CodeFixes/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public UseExpressionBodyCodeFixProvider()
-        {
-            FixableDiagnosticIds = _helpers.SelectAsArray(h => h.DiagnosticId);
-        }
+            => FixableDiagnosticIds = _helpers.SelectAsArray(h => h.DiagnosticId);
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
             => !diagnostic.IsSuppressed ||

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
@@ -200,14 +200,10 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         }
 
         private static void AddDiagnosticIdToOptionMapping(string diagnosticId, ImmutableHashSet<IPerLanguageOption> options)
-        {
-            IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options);
-        }
+            => IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options);
 
         private static void AddDiagnosticIdToOptionMapping(string diagnosticId, ImmutableHashSet<ILanguageSpecificOption> options, string language)
-        {
-            IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options, language);
-        }
+            => IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options, language);
 
         public abstract DiagnosticAnalyzerCategory GetAnalyzerCategory();
 

--- a/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
@@ -162,9 +162,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private readonly string[] _formatArguments;
 
             static LocalizableStringWithArguments()
-            {
-                ObjectBinder.RegisterTypeReader(typeof(LocalizableStringWithArguments), reader => new LocalizableStringWithArguments(reader));
-            }
+                => ObjectBinder.RegisterTypeReader(typeof(LocalizableStringWithArguments), reader => new LocalizableStringWithArguments(reader));
 
             public LocalizableStringWithArguments(LocalizableString messageFormat, params object[] formatArguments)
             {

--- a/src/Analyzers/Core/Analyzers/MakeFieldReadonly/MakeFieldReadonlyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MakeFieldReadonly/MakeFieldReadonlyDiagnosticAnalyzer.cs
@@ -214,8 +214,6 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
         }
 
         private static CodeStyleOption2<bool> GetCodeStyleOption(IFieldSymbol field, AnalyzerOptions options, CancellationToken cancellationToken)
-        {
-            return options.GetOption(CodeStyleOptions2.PreferReadonly, field.Language, field.Locations[0].SourceTree, cancellationToken);
-        }
+            => options.GetOption(CodeStyleOptions2.PreferReadonly, field.Language, field.Locations[0].SourceTree, cancellationToken);
     }
 }

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -162,9 +162,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
         }
 
         protected virtual Func<SyntaxNode, SyntaxToken> GetLastTokenDelegateForContiguousSpans()
-        {
-            return null;
-        }
+            => null;
 
         // Create one diagnostic for each unnecessary span that will be classified as Unnecessary
         private IEnumerable<Diagnostic> CreateClassificationDiagnostics(

--- a/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
@@ -49,9 +49,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
         }
 
         private async Task<Document> GetTransformedDocumentAsync(Document document, CancellationToken cancellationToken)
-        {
-            return document.WithSyntaxRoot(await GetTransformedSyntaxRootAsync(document, cancellationToken).ConfigureAwait(false));
-        }
+            => document.WithSyntaxRoot(await GetTransformedSyntaxRootAsync(document, cancellationToken).ConfigureAwait(false));
 
         private async Task<SyntaxNode> GetTransformedSyntaxRootAsync(Document document, CancellationToken cancellationToken)
         {
@@ -242,9 +240,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             private readonly AbstractFileHeaderCodeFixProvider _codeFixProvider;
 
             public FixAll(AbstractFileHeaderCodeFixProvider codeFixProvider)
-            {
-                _codeFixProvider = codeFixProvider;
-            }
+                => _codeFixProvider = codeFixProvider;
 
             protected override string CodeActionTitle => CodeFixesResources.Add_file_banner;
 

--- a/src/Analyzers/Core/CodeFixes/PopulateSwitch/AbstractPopulateSwitchCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/PopulateSwitch/AbstractPopulateSwitchCodeFixProvider.cs
@@ -36,9 +36,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
         public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
 
         protected AbstractPopulateSwitchCodeFixProvider(string diagnosticId)
-        {
-            FixableDiagnosticIds = ImmutableArray.Create(diagnosticId);
-        }
+            => FixableDiagnosticIds = ImmutableArray.Create(diagnosticId);
 
         protected abstract ITypeSymbol GetSwitchType(TSwitchOperation switchStatement);
         protected abstract ICollection<ISymbol> GetMissingEnumMembers(TSwitchOperation switchOperation);

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -40,14 +40,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private static bool InvalidLevel(int? level)
-        {
-            return level.HasValue && level.Value <= 0;
-        }
+            => level.HasValue && level.Value <= 0;
 
         private static int? DecrementLevel(int? level)
-        {
-            return level.HasValue ? level - 1 : level;
-        }
+            => level.HasValue ? level - 1 : level;
 
         private static void ComputeDeclarations(
             SemanticModel model,

--- a/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
@@ -125,9 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             };
 
         public static bool IsNotLambdaBody(SyntaxNode node)
-        {
-            return !IsLambdaBody(node);
-        }
+            => !IsLambdaBody(node);
 
         /// <summary>
         /// Returns true if the specified <paramref name="node"/> represents a body of a lambda.
@@ -262,9 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// We define this function to minimize differences between C# and VB implementation.
         /// </remarks>
         public static bool IsLambdaBodyStatementOrExpression(SyntaxNode node)
-        {
-            return IsLambdaBody(node);
-        }
+            => IsLambdaBody(node);
 
         public static bool IsLambdaBodyStatementOrExpression(SyntaxNode node, out SyntaxNode lambdaBody)
         {
@@ -473,8 +469,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private static SyntaxNode GetLocalFunctionBody(LocalFunctionStatementSyntax localFunctionStatementSyntax)
-        {
-            return (SyntaxNode)localFunctionStatementSyntax.Body ?? localFunctionStatementSyntax.ExpressionBody?.Expression;
-        }
+            => (SyntaxNode)localFunctionStatementSyntax.Body ?? localFunctionStatementSyntax.ExpressionBody?.Expression;
     }
 }

--- a/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
+++ b/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
@@ -21,19 +21,13 @@ namespace Microsoft.CodeAnalysis
         }
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken)
-        {
-            return GetDeclarationInfo(model, node, getSymbol, (IEnumerable<SyntaxNode>)null, cancellationToken);
-        }
+            => GetDeclarationInfo(model, node, getSymbol, (IEnumerable<SyntaxNode>)null, cancellationToken);
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, SyntaxNode executableCodeBlock, CancellationToken cancellationToken)
-        {
-            return GetDeclarationInfo(model, node, getSymbol, SpecializedCollections.SingletonEnumerable(executableCodeBlock), cancellationToken);
-        }
+            => GetDeclarationInfo(model, node, getSymbol, SpecializedCollections.SingletonEnumerable(executableCodeBlock), cancellationToken);
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken, params SyntaxNode[] executableCodeBlocks)
-        {
-            return GetDeclarationInfo(model, node, getSymbol, executableCodeBlocks.AsEnumerable(), cancellationToken);
-        }
+            => GetDeclarationInfo(model, node, getSymbol, executableCodeBlocks.AsEnumerable(), cancellationToken);
 
         private static ISymbol GetDeclaredSymbol(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken)
         {

--- a/src/Compilers/Core/Portable/Text/TextUtilities.cs
+++ b/src/Compilers/Core/Portable/Text/TextUtilities.cs
@@ -84,8 +84,6 @@ namespace Microsoft.CodeAnalysis.Text
         /// Determine if the character in question is any line break character
         /// </summary>
         internal static bool IsAnyLineBreakCharacter(char c)
-        {
-            return c == '\n' || c == '\r' || c == '\u0085' || c == '\u2028' || c == '\u2029';
-        }
+            => c == '\n' || c == '\r' || c == '\u0085' || c == '\u2028' || c == '\u2029';
     }
 }

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -333,9 +333,7 @@ namespace Microsoft.CodeAnalysis.Debugging
         /// Skips past a record.
         /// </summary>
         private static void SkipRecord(byte[] bytes, ref int offset, int size)
-        {
-            offset += size - CustomDebugInfoConstants.RecordHeaderSize;
-        }
+            => offset += size - CustomDebugInfoConstants.RecordHeaderSize;
 
         /// <summary>
         /// Get the import strings for a given method, following forward pointers as necessary.
@@ -570,9 +568,7 @@ RETRY:
         }
 
         private static bool IsCSharpExternAliasInfo(string import)
-        {
-            return import.Length > 0 && import[0] == 'Z';
-        }
+            => import.Length > 0 && import[0] == 'Z';
 
         /// <summary>
         /// Parse a string representing a C# using (or extern alias) directive.
@@ -859,9 +855,7 @@ RETRY:
         }
 
         private static string FormatMethodToken(int methodToken)
-        {
-            return string.Format("0x{0:x8}", methodToken);
-        }
+            => string.Format("0x{0:x8}", methodToken);
 
         /// <summary>
         /// Read UTF8 string with null terminator.

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -263,14 +263,10 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         }
 
         private bool InfoBoundSuccessfully(SymbolInfo symbolInfo)
-        {
-            return InfoBoundSuccessfully(symbolInfo.Symbol);
-        }
+            => InfoBoundSuccessfully(symbolInfo.Symbol);
 
         private bool InfoBoundSuccessfully(QueryClauseInfo semanticInfo)
-        {
-            return InfoBoundSuccessfully(semanticInfo.OperationInfo);
-        }
+            => InfoBoundSuccessfully(semanticInfo.OperationInfo);
 
         private static bool InfoBoundSuccessfully(ISymbol operation)
         {
@@ -279,9 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         }
 
         protected override string GetDescription(IReadOnlyList<string> nameParts)
-        {
-            return $"using { string.Join(".", nameParts) };";
-        }
+            => $"using { string.Join(".", nameParts) };";
 
         protected override (string description, bool hasExistingImport) GetDescription(
             Document document,

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -655,8 +655,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         }
 
         protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
-        {
-            return SpecializedCollections.SingletonEnumerable(new ChangeSignatureFormattingRule()).Concat(Formatter.GetDefaultFormattingRules(document));
-        }
+            => SpecializedCollections.SingletonEnumerable(new ChangeSignatureFormattingRule()).Concat(Formatter.GetDefaultFormattingRules(document));
     }
 }

--- a/src/Features/CSharp/Portable/ChangeSignature/UnifiedArgumentSyntax.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/UnifiedArgumentSyntax.cs
@@ -20,14 +20,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         }
 
         public static IUnifiedArgumentSyntax Create(ArgumentSyntax argument)
-        {
-            return new UnifiedArgumentSyntax(argument);
-        }
+            => new UnifiedArgumentSyntax(argument);
 
         public static IUnifiedArgumentSyntax Create(AttributeArgumentSyntax argument)
-        {
-            return new UnifiedArgumentSyntax(argument);
-        }
+            => new UnifiedArgumentSyntax(argument);
 
         public SyntaxNode NameColon
         {
@@ -49,9 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         }
 
         public string GetName()
-        {
-            return NameColon == null ? string.Empty : ((NameColonSyntax)NameColon).Name.Identifier.ToString();
-        }
+            => NameColon == null ? string.Empty : ((NameColonSyntax)NameColon).Name.Identifier.ToString();
 
         public IUnifiedArgumentSyntax WithName(string name)
         {
@@ -61,9 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         }
 
         public IUnifiedArgumentSyntax WithAdditionalAnnotations(SyntaxAnnotation annotation)
-        {
-            return new UnifiedArgumentSyntax(_argument.WithAdditionalAnnotations(annotation));
-        }
+            => new UnifiedArgumentSyntax(_argument.WithAdditionalAnnotations(annotation));
 
         public SyntaxNode Expression
         {
@@ -92,8 +84,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         }
 
         public static explicit operator SyntaxNode(UnifiedArgumentSyntax unified)
-        {
-            return unified._argument;
-        }
+            => unified._argument;
     }
 }

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -189,8 +189,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
         }
 
         public EnabledDiagnosticOptions GetAllDiagnostics()
-        {
-            return new EnabledDiagnosticOptions(s_diagnosticSets, new OrganizeUsingsSet(isRemoveUnusedImportEnabled: true, isSortImportsEnabled: true));
-        }
+            => new EnabledDiagnosticOptions(s_diagnosticSets, new OrganizeUsingsSet(isRemoveUnusedImportEnabled: true, isSortImportsEnabled: true));
     }
 }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateEnumMember
         }
 
         protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
-        {
-            return node is IdentifierNameSyntax;
-        }
+            => node is IdentifierNameSyntax;
     }
 }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
@@ -60,9 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateType
         }
 
         protected override SyntaxNode GetTargetNode(SyntaxNode node)
-        {
-            return ((ExpressionSyntax)node).GetRightmostName();
-        }
+            => ((ExpressionSyntax)node).GetRightmostName();
 
         protected override Task<ImmutableArray<CodeAction>> GetCodeActionsAsync(
             Document document, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.cs
@@ -27,9 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CS0108);
 
         public override FixAllProvider GetFixAllProvider()
-        {
-            return WellKnownFixAllProviders.BatchFixer;
-        }
+            => WellKnownFixAllProviders.BatchFixer;
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -160,9 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
         }
 
         private static SyntaxAnnotation CreateConflictAnnotation()
-        {
-            return ConflictAnnotation.Create(CSharpFeaturesResources.Conflict_s_detected);
-        }
+            => ConflictAnnotation.Create(CSharpFeaturesResources.Conflict_s_detected);
 
         private async Task<Document> InlineTemporaryAsync(Document document, VariableDeclaratorSyntax declarator, CancellationToken cancellationToken)
         {
@@ -263,14 +261,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
         }
 
         private static async Task<VariableDeclaratorSyntax> FindDeclaratorAsync(Document document, CancellationToken cancellationToken)
-        {
-            return await FindNodeWithAnnotationAsync<VariableDeclaratorSyntax>(document, DefinitionAnnotation, cancellationToken).ConfigureAwait(false);
-        }
+            => await FindNodeWithAnnotationAsync<VariableDeclaratorSyntax>(document, DefinitionAnnotation, cancellationToken).ConfigureAwait(false);
 
         private static async Task<ExpressionSyntax> FindInitializerAsync(Document document, CancellationToken cancellationToken)
-        {
-            return await FindNodeWithAnnotationAsync<ExpressionSyntax>(document, InitializerAnnotation, cancellationToken).ConfigureAwait(false);
-        }
+            => await FindNodeWithAnnotationAsync<ExpressionSyntax>(document, InitializerAnnotation, cancellationToken).ConfigureAwait(false);
 
         private static async Task<T> FindNodeWithAnnotationAsync<T>(Document document, SyntaxAnnotation annotation, CancellationToken cancellationToken)
             where T : SyntaxNode
@@ -473,9 +467,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
         }
 
         private static SyntaxNode GetTopMostParentingExpression(ExpressionSyntax expression)
-        {
-            return expression.AncestorsAndSelf().OfType<ExpressionSyntax>().Last();
-        }
+            => expression.AncestorsAndSelf().OfType<ExpressionSyntax>().Last();
 
         private static async Task<Document> DetectSemanticConflictsAsync(
             Document inlinedDocument,

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -24,9 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
 
         [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-        {
-            return new CSharpCompletionService(languageServices.WorkspaceServices.Workspace);
-        }
+            => new CSharpCompletionService(languageServices.WorkspaceServices.Workspace);
     }
 
     internal class CSharpCompletionService : CommonCompletionService
@@ -43,9 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
         public override string Language => LanguageNames.CSharp;
 
         public override TextSpan GetDefaultCompletionListSpan(SourceText text, int caretPosition)
-        {
-            return CompletionUtilities.GetCompletionItemSpan(text, caretPosition);
-        }
+            => CompletionUtilities.GetCompletionItemSpan(text, caretPosition);
 
         private CompletionRules _latestRules = CompletionRules.Default;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
@@ -42,9 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 
@@ -201,9 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             => SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken);
 
         private bool IsValid(ImmutableArray<IParameterSymbol> parameterList, ISet<string> existingNamedParameters)
-        {
-            return existingNamedParameters.Except(parameterList.Select(p => p.Name)).IsEmpty();
-        }
+            => existingNamedParameters.Except(parameterList.Select(p => p.Name)).IsEmpty();
 
         private ISet<string> GetExistingNamedParameters(AttributeArgumentListSyntax argumentList, int position)
         {
@@ -247,9 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         protected override Task<TextChange?> GetTextChangeAsync(CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(GetTextChange(selectedItem, ch));
-        }
+            => Task.FromResult(GetTextChange(selectedItem, ch));
 
         private TextChange? GetTextChange(CompletionItem selectedItem, char? ch)
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -16,24 +16,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     internal static class CompletionUtilities
     {
         internal static TextSpan GetCompletionItemSpan(SourceText text, int position)
-        {
-            return CommonCompletionUtilities.GetWordSpan(text, position, IsCompletionItemStartCharacter, IsWordCharacter);
-        }
+            => CommonCompletionUtilities.GetWordSpan(text, position, IsCompletionItemStartCharacter, IsWordCharacter);
 
         public static bool IsWordStartCharacter(char ch)
-        {
-            return SyntaxFacts.IsIdentifierStartCharacter(ch);
-        }
+            => SyntaxFacts.IsIdentifierStartCharacter(ch);
 
         public static bool IsWordCharacter(char ch)
-        {
-            return SyntaxFacts.IsIdentifierStartCharacter(ch) || SyntaxFacts.IsIdentifierPartCharacter(ch);
-        }
+            => SyntaxFacts.IsIdentifierStartCharacter(ch) || SyntaxFacts.IsIdentifierPartCharacter(ch);
 
         public static bool IsCompletionItemStartCharacter(char ch)
-        {
-            return ch == '@' || IsWordCharacter(ch);
-        }
+            => ch == '@' || IsWordCharacter(ch);
 
         internal static bool IsTriggerCharacter(SourceText text, int characterPosition, OptionSet options)
         {
@@ -80,9 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             => IsArgumentListCharacter(text[characterPosition]);
 
         internal static bool IsArgumentListCharacter(char ch)
-        {
-            return ch == '(' || ch == '[' || ch == ' ';
-        }
+            => ch == '(' || ch == '[' || ch == ' ';
 
         internal static bool IsTriggerAfterSpaceOrStartOfWordCharacter(SourceText text, int characterPosition, OptionSet options)
         {
@@ -95,9 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         internal static ImmutableHashSet<char> SpaceTriggerCharacter => ImmutableHashSet.Create(' ');
 
         private static bool SpaceTypedNotBeforeWord(char ch, SourceText text, int characterPosition)
-        {
-            return ch == ' ' && (characterPosition == text.Length - 1 || !IsWordStartCharacter(text[characterPosition + 1]));
-        }
+            => ch == ' ' && (characterPosition == text.Length - 1 || !IsWordStartCharacter(text[characterPosition + 1]));
 
         public static bool IsStartingNewWord(SourceText text, int characterPosition)
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -70,9 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 
@@ -439,9 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             private readonly CrefCompletionProvider _crefCompletionProvider;
 
             public TestAccessor(CrefCompletionProvider crefCompletionProvider)
-            {
-                _crefCompletionProvider = crefCompletionProvider;
-            }
+                => _crefCompletionProvider = crefCompletionProvider;
 
             public void SetSpeculativeNodeCallback(Action<SyntaxNode> value)
                 => _crefCompletionProvider._testSpeculativeNodeCallbackOpt = value;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
@@ -68,9 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
 
             private static Words GetLongestForwardSubsequence(int length, ArrayBuilder<TextSpan> breaks, string baseName, bool pluralize)
-            {
-                return GetWords(0, length, breaks, baseName, pluralize);
-            }
+                => GetWords(0, length, breaks, baseName, pluralize);
 
             private static Words GetWords(int start, int end, ArrayBuilder<TextSpan> breaks, string baseName, bool pluralize)
             {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -36,9 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int insertedCharacterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, insertedCharacterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, insertedCharacterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.SpaceTriggerCharacter;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
@@ -47,9 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return text[characterPosition] == '.';
-        }
+            => text[characterPosition] == '.';
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = ImmutableHashSet.Create('.');
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExternAliasCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExternAliasCompletionProvider.cs
@@ -31,9 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/TypeImportCompletionServiceFactory.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/TypeImportCompletionServiceFactory.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-        {
-            return new CSharpTypeImportCompletionService(languageServices.WorkspaceServices.Workspace);
-        }
+            => new CSharpTypeImportCompletionService(languageServices.WorkspaceServices.Workspace);
 
         private class CSharpTypeImportCompletionService : AbstractTypeImportCompletionService
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -172,9 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 
@@ -202,8 +200,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override TextSpan GetCurrentSpan(TextSpan span, SourceText text)
-        {
-            return CompletionUtilities.GetCompletionItemSpan(text, span.End);
-        }
+            => CompletionUtilities.GetCompletionItemSpan(text, span.End);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -44,9 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 
@@ -256,14 +254,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         bool IEqualityComparer<IParameterSymbol>.Equals(IParameterSymbol x, IParameterSymbol y)
-        {
-            return x.Name.Equals(y.Name);
-        }
+            => x.Name.Equals(y.Name);
 
         int IEqualityComparer<IParameterSymbol>.GetHashCode(IParameterSymbol obj)
-        {
-            return obj.Name.GetHashCode();
-        }
+            => obj.Name.GetHashCode();
 
         protected override Task<TextChange?> GetTextChangeAsync(CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.SpaceTriggerCharacter;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.cs
@@ -96,9 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options) || text[characterPosition] == ' ';
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options) || text[characterPosition] == ' ';
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters.Add(' ');
 
@@ -192,8 +190,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         protected override string EscapeIdentifier(ISymbol symbol)
-        {
-            return symbol.Name.EscapeIdentifier();
-        }
+            => symbol.Name.EscapeIdentifier();
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
@@ -40,9 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.SpaceTriggerCharacter;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialMethodCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialMethodCompletionProvider.cs
@@ -141,8 +141,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         protected override string GetDisplayText(IMethodSymbol method, SemanticModel semanticModel, int position)
-        {
-            return method.ToMinimalDisplayString(semanticModel, position, SignatureDisplayFormat);
-        }
+            => method.ToMinimalDisplayString(semanticModel, position, SignatureDisplayFormat);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -59,14 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.SpaceTriggerCharacter;
 
         protected override SyntaxNode GetPartialTypeSyntaxNode(SyntaxTree tree, int position, CancellationToken cancellationToken)
-        {
-            return tree.IsPartialTypeDeclarationNameContext(position, cancellationToken, out var declaration) ? declaration : null;
-        }
+            => tree.IsPartialTypeDeclarationNameContext(position, cancellationToken, out var declaration) ? declaration : null;
 
         protected override Task<SyntaxContext> CreateSyntaxContextAsync(Document document, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<SyntaxContext>(CSharpSyntaxContext.CreateContext(document.Project.Solution.Workspace, semanticModel, position, cancellationToken));
-        }
+            => Task.FromResult<SyntaxContext>(CSharpSyntaxContext.CreateContext(document.Project.Solution.Workspace, semanticModel, position, cancellationToken));
 
         protected override (string displayText, string suffix, string insertionText) GetDisplayAndSuffixAndInsertionText(
             INamedTypeSymbol symbol, SyntaxContext context)
@@ -85,9 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private static bool IsPartialTypeDeclaration(SyntaxNode syntax)
-        {
-            return syntax is BaseTypeDeclarationSyntax declarationSyntax && declarationSyntax.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword));
-        }
+            => syntax is BaseTypeDeclarationSyntax declarationSyntax && declarationSyntax.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword));
 
         protected override ImmutableDictionary<string, string> GetProperties(
             INamedTypeSymbol symbol, SyntaxContext context)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
-        {
-            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
-        }
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
         internal override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -229,9 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private static CompletionItemRules MakeRule(int importDirective, int preselect, int tupleLiteral)
-        {
-            return MakeRule(importDirective == 1, preselect == 1, tupleLiteral == 1);
-        }
+            => MakeRule(importDirective == 1, preselect == 1, tupleLiteral == 1);
 
         private static CompletionItemRules MakeRule(bool importDirective, bool preselect, bool tupleLiteral)
         {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -21,8 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         protected abstract SpecialType SpecialType { get; }
 
         protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.InferredTypes.Any(t => t.SpecialType == SpecialType);
-        }
+            => context.InferredTypes.Any(t => t.SpecialType == SpecialType);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
@@ -31,9 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected virtual Task<bool> IsValidContextAsync(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(IsValidContext(position, context, cancellationToken));
-        }
+            => Task.FromResult(IsValidContext(position, context, cancellationToken));
 
         protected virtual bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken) => false;
 
@@ -83,9 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             private readonly AbstractSyntacticSingleKeywordRecommender _recommender;
 
             public TestAccessor(AbstractSyntacticSingleKeywordRecommender recommender)
-            {
-                _recommender = recommender;
-            }
+                => _recommender = recommender;
 
             internal async Task<IEnumerable<RecommendedKeyword>> RecommendKeywordsAsync(int position, CSharpSyntaxContext context)
             {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AddKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AddKeywordRecommender.cs
@@ -16,8 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.TargetToken.IsAccessorDeclarationContext<EventDeclarationSyntax>(position, SyntaxKind.AddKeyword);
-        }
+            => context.TargetToken.IsAccessorDeclarationContext<EventDeclarationSyntax>(position, SyntaxKind.AddKeyword);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
-        }
+            => !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AscendingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AscendingKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.TargetToken.IsOrderByDirectionContext();
-        }
+            => context.TargetToken.IsOrderByDirectionContext();
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DescendingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DescendingKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.TargetToken.IsOrderByDirectionContext();
-        }
+            => context.TargetToken.IsOrderByDirectionContext();
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ElifKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ElifKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EndIfKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EndIfKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EndRegionKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EndRegionKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ErrorKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ErrorKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/FieldKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/FieldKeywordRecommender.cs
@@ -24,8 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsMemberAttributeContext(s_validTypeDeclarations, cancellationToken);
-        }
+            => context.IsMemberAttributeContext(s_validTypeDeclarations, cancellationToken);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/LineKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/LineKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ParamsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ParamsKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.SyntaxTree.IsParamsModifierContext(context.Position, context.LeftToken);
-        }
+            => context.SyntaxTree.IsParamsModifierContext(context.Position, context.LeftToken);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/PragmaKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/PragmaKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/PropertyKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/PropertyKeywordRecommender.cs
@@ -16,8 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsMemberAttributeContext(SyntaxKindSet.ClassInterfaceStructTypeDeclarations, cancellationToken);
-        }
+            => context.IsMemberAttributeContext(SyntaxKindSet.ClassInterfaceStructTypeDeclarations, cancellationToken);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RegionKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RegionKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RemoveKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RemoveKeywordRecommender.cs
@@ -16,8 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.TargetToken.IsAccessorDeclarationContext<EventDeclarationSyntax>(position, SyntaxKind.RemoveKeyword);
-        }
+            => context.TargetToken.IsAccessorDeclarationContext<EventDeclarationSyntax>(position, SyntaxKind.RemoveKeyword);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/TypeKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/TypeKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsTypeAttributeContext(cancellationToken);
-        }
+            => context.IsTypeAttributeContext(cancellationToken);
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/YieldKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/YieldKeywordRecommender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsStatementContext;
-        }
+            => context.IsStatementContext;
     }
 }

--- a/src/Features/CSharp/Portable/ConvertLinq/ConvertForEachToLinqQuery/AbstractConverter.cs
+++ b/src/Features/CSharp/Portable/ConvertLinq/ConvertForEachToLinqQuery/AbstractConverter.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertLinq.ConvertForEachToLinqQuery
         public ForEachInfo<ForEachStatementSyntax, StatementSyntax> ForEachInfo { get; }
 
         public AbstractConverter(ForEachInfo<ForEachStatementSyntax, StatementSyntax> forEachInfo)
-        {
-            ForEachInfo = forEachInfo;
-        }
+            => ForEachInfo = forEachInfo;
 
         public abstract void Convert(SyntaxEditor editor, bool convertToQuery, CancellationToken cancellationToken);
 

--- a/src/Features/CSharp/Portable/Debugging/CSharpBreakpointResolutionService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpBreakpointResolutionService.cs
@@ -52,8 +52,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
         }
 
         public Task<IEnumerable<BreakpointResolutionResult>> ResolveBreakpointsAsync(Solution solution, string name, CancellationToken cancellationToken)
-        {
-            return new BreakpointResolver(solution, name).DoAsync(cancellationToken);
-        }
+            => new BreakpointResolver(solution, name).DoAsync(cancellationToken);
     }
 }

--- a/src/Features/CSharp/Portable/Debugging/CSharpLanguageDebugInfoService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpLanguageDebugInfoService.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
         }
 
         public Task<DebugLocationInfo> GetLocationInfoAsync(Document document, int position, CancellationToken cancellationToken)
-        {
-            return LocationInfoGetter.GetInfoAsync(document, position, cancellationToken);
-        }
+            => LocationInfoGetter.GetInfoAsync(document, position, cancellationToken);
 
         public Task<DebugDataTipInfo> GetDataTipInfoAsync(
             Document document, int position, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.RelevantExpressionsCollector.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.RelevantExpressionsCollector.cs
@@ -22,24 +22,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             }
 
             public override void VisitLabeledStatement(LabeledStatementSyntax node)
-            {
-                AddRelevantExpressions(node.Statement, _expressions, _includeDeclarations);
-            }
+                => AddRelevantExpressions(node.Statement, _expressions, _includeDeclarations);
 
             public override void VisitExpressionStatement(ExpressionStatementSyntax node)
-            {
-                AddExpressionTerms(node.Expression, _expressions);
-            }
+                => AddExpressionTerms(node.Expression, _expressions);
 
             public override void VisitReturnStatement(ReturnStatementSyntax node)
-            {
-                AddExpressionTerms(node.Expression, _expressions);
-            }
+                => AddExpressionTerms(node.Expression, _expressions);
 
             public override void VisitThrowStatement(ThrowStatementSyntax node)
-            {
-                AddExpressionTerms(node.Expression, _expressions);
-            }
+                => AddExpressionTerms(node.Expression, _expressions);
 
             public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
             {
@@ -48,24 +40,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             }
 
             public override void VisitDoStatement(DoStatementSyntax node)
-            {
-                AddExpressionTerms(node.Condition, _expressions);
-            }
+                => AddExpressionTerms(node.Condition, _expressions);
 
             public override void VisitLockStatement(LockStatementSyntax node)
-            {
-                AddExpressionTerms(node.Expression, _expressions);
-            }
+                => AddExpressionTerms(node.Expression, _expressions);
 
             public override void VisitWhileStatement(WhileStatementSyntax node)
-            {
-                AddExpressionTerms(node.Condition, _expressions);
-            }
+                => AddExpressionTerms(node.Condition, _expressions);
 
             public override void VisitIfStatement(IfStatementSyntax node)
-            {
-                AddExpressionTerms(node.Condition, _expressions);
-            }
+                => AddExpressionTerms(node.Condition, _expressions);
 
             public override void VisitForStatement(ForStatementSyntax node)
             {
@@ -102,9 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             }
 
             public override void VisitSwitchStatement(SwitchStatementSyntax node)
-            {
-                AddExpressionTerms(node.Expression, _expressions);
-            }
+                => AddExpressionTerms(node.Expression, _expressions);
 
             private void AddVariableExpressions(
                 SeparatedSyntaxList<VariableDeclaratorSyntax> declarators,

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.Worker.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.Worker.cs
@@ -95,9 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             }
 
             private bool IsFirstBlockStatement()
-            {
-                return _parentStatement.Parent is BlockSyntax parentBlockOpt && parentBlockOpt.Statements.FirstOrDefault() == _parentStatement;
-            }
+                => _parentStatement.Parent is BlockSyntax parentBlockOpt && parentBlockOpt.Statements.FirstOrDefault() == _parentStatement;
 
             private void AddCurrentDeclaration()
             {

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
@@ -100,14 +100,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
 
         // Internal for testing purposes
         internal static IList<string> Do(SyntaxTree syntaxTree, int position)
-        {
-            return Do(syntaxTree, position, CancellationToken.None);
-        }
+            => Do(syntaxTree, position, CancellationToken.None);
 
         private static IList<string> Do(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
-        {
-            return new Worker(syntaxTree, position).Do(cancellationToken);
-        }
+            => new Worker(syntaxTree, position).Do(cancellationToken);
 
         private static void AddRelevantExpressions(
             StatementSyntax statement,

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService_ExpressionTermCollector.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService_ExpressionTermCollector.cs
@@ -44,14 +44,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
         }
 
         private static bool IsValidTerm(ExpressionType type)
-        {
-            return (type & ExpressionType.ValidTerm) == ExpressionType.ValidTerm;
-        }
+            => (type & ExpressionType.ValidTerm) == ExpressionType.ValidTerm;
 
         private static bool IsValidExpression(ExpressionType type)
-        {
-            return (type & ExpressionType.ValidExpression) == ExpressionType.ValidExpression;
-        }
+            => (type & ExpressionType.ValidExpression) == ExpressionType.ValidExpression;
 
         private static void AddSubExpressionTerms(ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
         {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -143,8 +143,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
         }
 
         protected override string GetLanguageName()
-        {
-            return LanguageNames.CSharp;
-        }
+            => LanguageNames.CSharp;
     }
 }

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -84,14 +84,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             => CreateSpan(node.GetFirstToken(), node.GetLastToken());
 
         private static TextSpan CreateSpan(SyntaxNode node, SyntaxToken token)
-        {
-            return TextSpan.FromBounds(node.SpanStart, token.Span.End);
-        }
+            => TextSpan.FromBounds(node.SpanStart, token.Span.End);
 
         private static TextSpan CreateSpan(SyntaxToken token)
-        {
-            return TextSpan.FromBounds(token.SpanStart, token.Span.End);
-        }
+            => TextSpan.FromBounds(token.SpanStart, token.Span.End);
 
         private static TextSpan CreateSpan(SyntaxTokenList startOpt, SyntaxNodeOrToken startFallbackOpt, SyntaxNodeOrToken endOpt)
         {
@@ -332,14 +328,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static TextSpan CreateSpanForConstructorInitializer(ConstructorInitializerSyntax constructorInitializer)
-        {
-            return CreateSpan(constructorInitializer.ThisOrBaseKeyword, constructorInitializer.ArgumentList.CloseParenToken);
-        }
+            => CreateSpan(constructorInitializer.ThisOrBaseKeyword, constructorInitializer.ArgumentList.CloseParenToken);
 
         private static TextSpan? TryCreateSpanForFieldDeclaration(BaseFieldDeclarationSyntax fieldDeclaration, int position)
-        {
-            return TryCreateSpanForVariableDeclaration(fieldDeclaration.Declaration, fieldDeclaration.Modifiers, fieldDeclaration.SemicolonToken, position);
-        }
+            => TryCreateSpanForVariableDeclaration(fieldDeclaration.Declaration, fieldDeclaration.Modifiers, fieldDeclaration.SemicolonToken, position);
 
         private static TextSpan? TryCreateSpanForSwitchLabel(SwitchLabelSyntax switchLabel, int position)
         {
@@ -558,9 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static SyntaxToken LastNotMissing(SyntaxToken token1, SyntaxToken token2)
-        {
-            return token2.IsMissing ? token1 : token2;
-        }
+            => token2.IsMissing ? token1 : token2;
 
         private static TextSpan? TryCreateSpanForVariableDeclaration(VariableDeclarationSyntax declaration, int position)
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -346,9 +346,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static BlockPart GetStatementPart(BlockSyntax node, int position)
-        {
-            return position < node.OpenBraceToken.Span.End ? BlockPart.OpenBrace : BlockPart.CloseBrace;
-        }
+            => position < node.OpenBraceToken.Span.End ? BlockPart.OpenBrace : BlockPart.CloseBrace;
 
         private static TextSpan GetActiveSpan(BlockSyntax node, BlockPart part)
         {
@@ -416,9 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected override bool AreEquivalent(SyntaxNode left, SyntaxNode right)
-        {
-            return SyntaxFactory.AreEquivalent(left, right);
-        }
+            => SyntaxFactory.AreEquivalent(left, right);
 
         private static bool AreEquivalentIgnoringLambdaBodies(SyntaxNode left, SyntaxNode right)
         {
@@ -432,9 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         internal override SyntaxNode FindPartner(SyntaxNode leftRoot, SyntaxNode rightRoot, SyntaxNode leftNode)
-        {
-            return SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode);
-        }
+            => SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode);
 
         internal override SyntaxNode? FindPartnerInMemberInitializer(SemanticModel leftModel, INamedTypeSymbol leftType, SyntaxNode leftNode, INamedTypeSymbol rightType, CancellationToken cancellationToken)
         {
@@ -478,9 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         internal override bool IsClosureScope(SyntaxNode node)
-        {
-            return LambdaUtilities.IsClosureScope(node);
-        }
+            => LambdaUtilities.IsClosureScope(node);
 
         protected override SyntaxNode? FindEnclosingLambdaBody(SyntaxNode? container, SyntaxNode node)
         {
@@ -501,19 +493,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected override IEnumerable<SyntaxNode> GetLambdaBodyExpressionsAndStatements(SyntaxNode lambdaBody)
-        {
-            return SpecializedCollections.SingletonEnumerable(lambdaBody);
-        }
+            => SpecializedCollections.SingletonEnumerable(lambdaBody);
 
         protected override SyntaxNode TryGetPartnerLambdaBody(SyntaxNode oldBody, SyntaxNode newLambda)
-        {
-            return LambdaUtilities.TryGetCorrespondingLambdaBody(oldBody, newLambda);
-        }
+            => LambdaUtilities.TryGetCorrespondingLambdaBody(oldBody, newLambda);
 
         protected override Match<SyntaxNode> ComputeTopLevelMatch(SyntaxNode oldCompilationUnit, SyntaxNode newCompilationUnit)
-        {
-            return TopSyntaxComparer.Instance.ComputeMatch(oldCompilationUnit, newCompilationUnit);
-        }
+            => TopSyntaxComparer.Instance.ComputeMatch(oldCompilationUnit, newCompilationUnit);
 
         protected override Match<SyntaxNode> ComputeBodyMatch(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
         {
@@ -606,9 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         #region Syntax and Semantic Utils
 
         protected override IEnumerable<SequenceEdit> GetSyntaxSequenceEdits(ImmutableArray<SyntaxNode> oldNodes, ImmutableArray<SyntaxNode> newNodes)
-        {
-            return SyntaxComparer.GetSequenceEdits(oldNodes, newNodes);
-        }
+            => SyntaxComparer.GetSequenceEdits(oldNodes, newNodes);
 
         internal override SyntaxNode EmptyCompilationUnit
         {
@@ -628,14 +612,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             => (suspensionPoint1 is CommonForEachStatementSyntax) ? suspensionPoint2 is CommonForEachStatementSyntax : suspensionPoint1.RawKind == suspensionPoint2.RawKind;
 
         protected override bool StatementLabelEquals(SyntaxNode node1, SyntaxNode node2)
-        {
-            return StatementSyntaxComparer.GetLabelImpl(node1) == StatementSyntaxComparer.GetLabelImpl(node2);
-        }
+            => StatementSyntaxComparer.GetLabelImpl(node1) == StatementSyntaxComparer.GetLabelImpl(node2);
 
         protected override bool TryGetEnclosingBreakpointSpan(SyntaxNode root, int position, out TextSpan span)
-        {
-            return BreakpointSpans.TryGetClosestBreakpointSpan(root, position, out span);
-        }
+            => BreakpointSpans.TryGetClosestBreakpointSpan(root, position, out span);
 
         protected override bool TryGetActiveSpan(SyntaxNode node, int statementPart, int minLength, out TextSpan span)
         {
@@ -876,9 +856,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static bool AreEquivalentActiveStatements(FixedStatementSyntax oldNode, FixedStatementSyntax newNode)
-        {
-            return AreEquivalentIgnoringLambdaBodies(oldNode.Declaration, newNode.Declaration);
-        }
+            => AreEquivalentIgnoringLambdaBodies(oldNode.Declaration, newNode.Declaration);
 
         private static bool AreEquivalentActiveStatements(UsingStatementSyntax oldNode, UsingStatementSyntax newNode)
         {
@@ -922,9 +900,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             => node.IsKind(SyntaxKind.InterfaceDeclaration);
 
         internal override SyntaxNode? TryGetContainingTypeDeclaration(SyntaxNode node)
-        {
-            return node.Parent!.FirstAncestorOrSelf<TypeDeclarationSyntax>();
-        }
+            => node.Parent!.FirstAncestorOrSelf<TypeDeclarationSyntax>();
 
         internal override bool HasBackingField(SyntaxNode propertyOrIndexerDeclaration)
             => propertyOrIndexerDeclaration.IsKind(SyntaxKind.PropertyDeclaration, out PropertyDeclarationSyntax? propertyDecl) &&
@@ -946,9 +922,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         internal override bool IsConstructorWithMemberInitializers(SyntaxNode constructorDeclaration)
-        {
-            return constructorDeclaration is ConstructorDeclarationSyntax ctor && (ctor.Initializer == null || ctor.Initializer.IsKind(SyntaxKind.BaseConstructorInitializer));
-        }
+            => constructorDeclaration is ConstructorDeclarationSyntax ctor && (ctor.Initializer == null || ctor.Initializer.IsKind(SyntaxKind.BaseConstructorInitializer));
 
         internal override bool IsPartial(INamedTypeSymbol type)
         {
@@ -1056,9 +1030,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         internal override SyntaxNode? GetContainingQueryExpression(SyntaxNode node)
-        {
-            return node.FirstAncestorOrSelf<QueryExpressionSyntax>();
-        }
+            => node.FirstAncestorOrSelf<QueryExpressionSyntax>();
 
         internal override bool QueryClauseLambdasTypeEquivalent(SemanticModel oldModel, SyntaxNode oldNode, SemanticModel newModel, SyntaxNode newNode, CancellationToken cancellationToken)
         {
@@ -2145,19 +2117,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
 
             private void ClassifyFieldInsert(BaseFieldDeclarationSyntax field)
-            {
-                ClassifyModifiedMemberInsert(field, field.Modifiers);
-            }
+                => ClassifyModifiedMemberInsert(field, field.Modifiers);
 
             private void ClassifyFieldInsert(VariableDeclaratorSyntax fieldVariable)
-            {
-                ClassifyFieldInsert((VariableDeclarationSyntax)fieldVariable.Parent!);
-            }
+                => ClassifyFieldInsert((VariableDeclarationSyntax)fieldVariable.Parent!);
 
             private void ClassifyFieldInsert(VariableDeclarationSyntax fieldVariable)
-            {
-                ClassifyFieldInsert((BaseFieldDeclarationSyntax)fieldVariable.Parent!);
-            }
+                => ClassifyFieldInsert((BaseFieldDeclarationSyntax)fieldVariable.Parent!);
 
             #endregion
 
@@ -3479,9 +3445,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static bool DeclareSameIdentifiers(SeparatedSyntaxList<VariableDeclaratorSyntax> oldVariables, SeparatedSyntaxList<VariableDeclaratorSyntax> newVariables)
-        {
-            return DeclareSameIdentifiers(oldVariables.Select(v => v.Identifier).ToArray(), newVariables.Select(v => v.Identifier).ToArray());
-        }
+            => DeclareSameIdentifiers(oldVariables.Select(v => v.Identifier).ToArray(), newVariables.Select(v => v.Identifier).ToArray());
 
         private static bool DeclareSameIdentifiers(SyntaxToken[] oldVariables, SyntaxToken[] newVariables)
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -114,9 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private bool DescendIntoChildren(SyntaxNode node)
-        {
-            return !LambdaUtilities.IsLambdaBodyStatementOrExpression(node) && !HasLabel(node);
-        }
+            => !LambdaUtilities.IsLambdaBodyStatementOrExpression(node) && !HasLabel(node);
 
         protected internal sealed override IEnumerable<SyntaxNode> GetDescendants(SyntaxNode node)
         {
@@ -505,19 +503,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected internal override int GetLabel(SyntaxNode node)
-        {
-            return (int)GetLabelImpl(node);
-        }
+            => (int)GetLabelImpl(node);
 
         internal static Label GetLabelImpl(SyntaxNode node)
-        {
-            return Classify(node.Kind(), node, out _);
-        }
+            => Classify(node.Kind(), node, out _);
 
         internal static bool HasLabel(SyntaxNode node)
-        {
-            return GetLabelImpl(node) != Label.Ignored;
-        }
+            => GetLabelImpl(node) != Label.Ignored;
 
         protected internal override int LabelCount
         {
@@ -525,9 +517,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected internal override int TiedToAncestor(int label)
-        {
-            return TiedToAncestor((Label)label);
-        }
+            => TiedToAncestor((Label)label);
 
         #endregion
 

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -24,14 +24,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected internal sealed override bool TreesEqual(SyntaxNode oldNode, SyntaxNode newNode)
-        {
-            return oldNode.SyntaxTree == newNode.SyntaxTree;
-        }
+            => oldNode.SyntaxTree == newNode.SyntaxTree;
 
         protected internal sealed override TextSpan GetSpan(SyntaxNode node)
-        {
-            return node.Span;
-        }
+            => node.Span;
 
         #region Comparison
 
@@ -140,9 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// Distance is a number within [0, 1], the smaller the more similar the tokens are. 
         /// </remarks>
         public static double ComputeDistance(SyntaxToken oldToken, SyntaxToken newToken)
-        {
-            return LongestCommonSubstring.ComputeDistance(oldToken.Text, newToken.Text);
-        }
+            => LongestCommonSubstring.ComputeDistance(oldToken.Text, newToken.Text);
 
         /// <summary>
         /// Calculates the distance between two sequences of syntax tokens, disregarding trivia. 
@@ -151,9 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// Distance is a number within [0, 1], the smaller the more similar the sequences are. 
         /// </remarks>
         public static double ComputeDistance(IEnumerable<SyntaxToken>? oldTokens, IEnumerable<SyntaxToken>? newTokens)
-        {
-            return LcsTokens.Instance.ComputeDistance(oldTokens.AsImmutableOrEmpty(), newTokens.AsImmutableOrEmpty());
-        }
+            => LcsTokens.Instance.ComputeDistance(oldTokens.AsImmutableOrEmpty(), newTokens.AsImmutableOrEmpty());
 
         /// <summary>
         /// Calculates the distance between two sequences of syntax tokens, disregarding trivia. 
@@ -162,9 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// Distance is a number within [0, 1], the smaller the more similar the sequences are. 
         /// </remarks>
         public static double ComputeDistance(ImmutableArray<SyntaxToken> oldTokens, ImmutableArray<SyntaxToken> newTokens)
-        {
-            return LcsTokens.Instance.ComputeDistance(oldTokens.NullToEmpty(), newTokens.NullToEmpty());
-        }
+            => LcsTokens.Instance.ComputeDistance(oldTokens.NullToEmpty(), newTokens.NullToEmpty());
 
         /// <summary>
         /// Calculates the distance between two sequences of syntax nodes, disregarding trivia. 
@@ -173,9 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// Distance is a number within [0, 1], the smaller the more similar the sequences are. 
         /// </remarks>
         public static double ComputeDistance(IEnumerable<SyntaxNode>? oldNodes, IEnumerable<SyntaxNode>? newNodes)
-        {
-            return LcsNodes.Instance.ComputeDistance(oldNodes.AsImmutableOrEmpty(), newNodes.AsImmutableOrEmpty());
-        }
+            => LcsNodes.Instance.ComputeDistance(oldNodes.AsImmutableOrEmpty(), newNodes.AsImmutableOrEmpty());
 
         /// <summary>
         /// Calculates the distance between two sequences of syntax tokens, disregarding trivia. 
@@ -184,50 +172,38 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// Distance is a number within [0, 1], the smaller the more similar the sequences are. 
         /// </remarks>
         public static double ComputeDistance(ImmutableArray<SyntaxNode> oldNodes, ImmutableArray<SyntaxNode> newNodes)
-        {
-            return LcsNodes.Instance.ComputeDistance(oldNodes.NullToEmpty(), newNodes.NullToEmpty());
-        }
+            => LcsNodes.Instance.ComputeDistance(oldNodes.NullToEmpty(), newNodes.NullToEmpty());
 
         /// <summary>
         /// Calculates the edits that transform one sequence of syntax nodes to another, disregarding trivia.
         /// </summary>
         public static IEnumerable<SequenceEdit> GetSequenceEdits(IEnumerable<SyntaxNode>? oldNodes, IEnumerable<SyntaxNode>? newNodes)
-        {
-            return LcsNodes.Instance.GetEdits(oldNodes.AsImmutableOrEmpty(), newNodes.AsImmutableOrEmpty());
-        }
+            => LcsNodes.Instance.GetEdits(oldNodes.AsImmutableOrEmpty(), newNodes.AsImmutableOrEmpty());
 
         /// <summary>
         /// Calculates the edits that transform one sequence of syntax nodes to another, disregarding trivia.
         /// </summary>
         public static IEnumerable<SequenceEdit> GetSequenceEdits(ImmutableArray<SyntaxNode> oldNodes, ImmutableArray<SyntaxNode> newNodes)
-        {
-            return LcsNodes.Instance.GetEdits(oldNodes.NullToEmpty(), newNodes.NullToEmpty());
-        }
+            => LcsNodes.Instance.GetEdits(oldNodes.NullToEmpty(), newNodes.NullToEmpty());
 
         /// <summary>
         /// Calculates the edits that transform one sequence of syntax tokens to another, disregarding trivia.
         /// </summary>
         public static IEnumerable<SequenceEdit> GetSequenceEdits(IEnumerable<SyntaxToken>? oldTokens, IEnumerable<SyntaxToken>? newTokens)
-        {
-            return LcsTokens.Instance.GetEdits(oldTokens.AsImmutableOrEmpty(), newTokens.AsImmutableOrEmpty());
-        }
+            => LcsTokens.Instance.GetEdits(oldTokens.AsImmutableOrEmpty(), newTokens.AsImmutableOrEmpty());
 
         /// <summary>
         /// Calculates the edits that transform one sequence of syntax tokens to another, disregarding trivia.
         /// </summary>
         public static IEnumerable<SequenceEdit> GetSequenceEdits(ImmutableArray<SyntaxToken> oldTokens, ImmutableArray<SyntaxToken> newTokens)
-        {
-            return LcsTokens.Instance.GetEdits(oldTokens.NullToEmpty(), newTokens.NullToEmpty());
-        }
+            => LcsTokens.Instance.GetEdits(oldTokens.NullToEmpty(), newTokens.NullToEmpty());
 
         private sealed class LcsTokens : LongestCommonImmutableArraySubsequence<SyntaxToken>
         {
             internal static readonly LcsTokens Instance = new LcsTokens();
 
             protected override bool Equals(SyntaxToken oldElement, SyntaxToken newElement)
-            {
-                return SyntaxFactory.AreEquivalent(oldElement, newElement);
-            }
+                => SyntaxFactory.AreEquivalent(oldElement, newElement);
         }
 
         private sealed class LcsNodes : LongestCommonImmutableArraySubsequence<SyntaxNode>
@@ -235,9 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             internal static readonly LcsNodes Instance = new LcsNodes();
 
             protected override bool Equals(SyntaxNode oldElement, SyntaxNode newElement)
-            {
-                return SyntaxFactory.AreEquivalent(oldElement, newElement);
-            }
+                => SyntaxFactory.AreEquivalent(oldElement, newElement);
         }
 
         #endregion

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
@@ -177,9 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         public static bool Any(TypeParameterListSyntax listOpt)
-        {
-            return listOpt != null && listOpt.ChildNodesAndTokens().Count != 0;
-        }
+            => listOpt != null && listOpt.ChildNodesAndTokens().Count != 0;
 
         public static SyntaxNode TryGetEffectiveGetterBody(SyntaxNode declaration)
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/TopSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/TopSyntaxComparer.cs
@@ -303,20 +303,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected internal override int GetLabel(SyntaxNode node)
-        {
-            return (int)GetLabel(node.Kind());
-        }
+            => (int)GetLabel(node.Kind());
 
         internal static Label GetLabel(SyntaxKind kind)
-        {
-            return Classify(kind, out var isLeaf);
-        }
+            => Classify(kind, out var isLeaf);
 
         // internal for testing
         internal static bool HasLabel(SyntaxKind kind)
-        {
-            return Classify(kind, out var isLeaf) != Label.Ignored;
-        }
+            => Classify(kind, out var isLeaf) != Label.Ignored;
 
         protected internal override int LabelCount
         {
@@ -324,9 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected internal override int TiedToAncestor(int label)
-        {
-            return TiedToAncestor((Label)label);
-        }
+            => TiedToAncestor((Label)label);
 
         #endregion
 

--- a/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -144,9 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
         }
 
         private bool CanEncapsulate(FieldDeclarationSyntax field)
-        {
-            return field.Parent is TypeDeclarationSyntax;
-        }
+            => field.Parent is TypeDeclarationSyntax;
 
         protected override Tuple<string, string> GeneratePropertyAndFieldNames(IFieldSymbol field)
         {
@@ -183,9 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
         }
 
         private bool IsNew(IFieldSymbol field)
-        {
-            return field.DeclaringSyntaxReferences.Any(d => d.GetSyntax().GetAncestor<FieldDeclarationSyntax>().Modifiers.Any(SyntaxKind.NewKeyword));
-        }
+            => field.DeclaringSyntaxReferences.Any(d => d.GetSyntax().GetAncestor<FieldDeclarationSyntax>().Modifiers.Any(SyntaxKind.NewKeyword));
 
         private string GenerateFieldName(string correspondingPropertyName)
             => char.ToLower(correspondingPropertyName[0]).ToString() + correspondingPropertyName.Substring(1);
@@ -197,8 +193,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
         }
 
         internal override IEnumerable<SyntaxNode> GetConstructorNodes(INamedTypeSymbol containingType)
-        {
-            return containingType.Constructors.SelectMany(c => c.DeclaringSyntaxReferences.Select(d => d.GetSyntax()));
-        }
+            => containingType.Constructors.SelectMany(c => c.DeclaringSyntaxReferences.Select(d => d.GetSyntax()));
     }
 }

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/Api/PythiaSignatureHelpItemWrapper.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/Api/PythiaSignatureHelpItemWrapper.cs
@@ -15,9 +15,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
         internal readonly SignatureHelpItem UnderlyingObject;
 
         public PythiaSignatureHelpItemWrapper(SignatureHelpItem underlyingObject)
-        {
-            UnderlyingObject = underlyingObject;
-        }
+            => UnderlyingObject = underlyingObject;
 
         public static SymbolDisplayPart CreateTextDisplayPart(string text)
             => new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, text);

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaSignatureHelpProvider.cs
@@ -30,9 +30,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public PythiaSignatureHelpProvider(Lazy<IPythiaSignatureHelpProviderImplementation> implementation)
-        {
-            _lazyImplementation = implementation;
-        }
+            => _lazyImplementation = implementation;
 
         internal async override Task<(ImmutableArray<SignatureHelpItem> items, int? selectedItemIndex)> GetMethodGroupItemsAndSelectionAsync(
             ImmutableArray<IMethodSymbol> accessibleMethods,

--- a/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
@@ -67,9 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractInterface
         }
 
         internal override bool IsExtractableMember(ISymbol m)
-        {
-            return base.IsExtractableMember(m) && !m.ExplicitInterfaceImplementations().Any();
-        }
+            => base.IsExtractableMember(m) && !m.ExplicitInterfaceImplementations().Any();
 
         internal override bool ShouldIncludeAccessibilityModifier(SyntaxNode typeNode)
         {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpExtractMethodService.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpExtractMethodService.cs
@@ -22,13 +22,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         protected override CSharpSelectionValidator CreateSelectionValidator(SemanticDocument document, TextSpan textSpan, OptionSet options)
-        {
-            return new CSharpSelectionValidator(document, textSpan, options);
-        }
+            => new CSharpSelectionValidator(document, textSpan, options);
 
         protected override CSharpMethodExtractor CreateMethodExtractor(CSharpSelectionResult selectionResult, bool localFunction)
-        {
-            return new CSharpMethodExtractor(selectionResult, localFunction);
-        }
+            => new CSharpMethodExtractor(selectionResult, localFunction);
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.Analyzer.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.Analyzer.cs
@@ -122,9 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             protected override bool ContainsReturnStatementInSelectedCode(IEnumerable<SyntaxNode> jumpOutOfRegionStatements)
-            {
-                return jumpOutOfRegionStatements.Where(n => n is ReturnStatementSyntax).Any();
-            }
+                => jumpOutOfRegionStatements.Where(n => n is ReturnStatementSyntax).Any();
 
             protected override bool ReadOnlyFieldAllowed()
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
@@ -50,9 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 public SyntaxNode Generate()
-                {
-                    return Visit(_outmostCallSiteContainer);
-                }
+                    => Visit(_outmostCallSiteContainer);
 
                 private SyntaxNode ContainerOfStatementsOrFieldToReplace => _firstStatementOrFieldToReplace.Parent;
 
@@ -271,9 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 private TNode VisitNode<TNode>(TNode node) where TNode : SyntaxNode
-                {
-                    return (TNode)Visit(node);
-                }
+                    => (TNode)Visit(node);
 
                 private StatementSyntax ReplaceStatementIfNeeded(StatementSyntax statement)
                 {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 public static bool IsExtractMethodOnExpression(SelectionResult code)
-                {
-                    return code.SelectionInExpression;
-                }
+                    => code.SelectionInExpression;
 
                 protected override SyntaxToken CreateMethodName()
                 {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
@@ -108,14 +108,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 protected override SyntaxNode GetFirstStatementOrInitializerSelectedAtCallSite()
-                {
-                    return CSharpSelectionResult.GetFirstStatementUnderContainer();
-                }
+                    => CSharpSelectionResult.GetFirstStatementUnderContainer();
 
                 protected override SyntaxNode GetLastStatementOrInitializerSelectedAtCallSite()
-                {
-                    return CSharpSelectionResult.GetLastStatementUnderContainer();
-                }
+                    => CSharpSelectionResult.GetLastStatementUnderContainer();
 
                 protected override Task<SyntaxNode> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(
                     SyntaxAnnotation callSiteAnnotation, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
@@ -61,9 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 protected override SyntaxNode GetFirstStatementOrInitializerSelectedAtCallSite()
-                {
-                    return CSharpSelectionResult.GetFirstStatement();
-                }
+                    => CSharpSelectionResult.GetFirstStatement();
 
                 protected override SyntaxNode GetLastStatementOrInitializerSelectedAtCallSite()
                 {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -568,9 +568,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             protected override SyntaxToken CreateIdentifier(string name)
-            {
-                return SyntaxFactory.Identifier(name);
-            }
+                => SyntaxFactory.Identifier(name);
 
             protected override StatementSyntax CreateReturnStatement(string identifierName = null)
             {
@@ -623,9 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             protected override StatementSyntax CreateAssignmentExpressionStatement(SyntaxToken identifier, ExpressionSyntax rvalue)
-            {
-                return SyntaxFactory.ExpressionStatement(CreateAssignmentExpression(identifier, rvalue));
-            }
+                => SyntaxFactory.ExpressionStatement(CreateAssignmentExpression(identifier, rvalue));
 
             protected override StatementSyntax CreateDeclarationStatement(
                 VariableInfo variable,

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -76,9 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         protected override async Task<TriviaResult> PreserveTriviaAsync(SelectionResult selectionResult, CancellationToken cancellationToken)
-        {
-            return await CSharpTriviaResult.ProcessAsync(selectionResult, cancellationToken).ConfigureAwait(false);
-        }
+            => await CSharpTriviaResult.ProcessAsync(selectionResult, cancellationToken).ConfigureAwait(false);
 
         protected override async Task<SemanticDocument> ExpandAsync(SelectionResult selection, CancellationToken cancellationToken)
         {
@@ -93,19 +91,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         protected override Task<GeneratedCode> GenerateCodeAsync(InsertionPoint insertionPoint, SelectionResult selectionResult, AnalyzerResult analyzeResult, OptionSet options, CancellationToken cancellationToken)
-        {
-            return CSharpCodeGenerator.GenerateAsync(insertionPoint, selectionResult, analyzeResult, options, LocalFunction, cancellationToken);
-        }
+            => CSharpCodeGenerator.GenerateAsync(insertionPoint, selectionResult, analyzeResult, options, LocalFunction, cancellationToken);
 
         protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
-        {
-            return SpecializedCollections.SingletonEnumerable(new FormattingRule()).Concat(Formatter.GetDefaultFormattingRules(document));
-        }
+            => SpecializedCollections.SingletonEnumerable(new FormattingRule()).Concat(Formatter.GetDefaultFormattingRules(document));
 
         protected override SyntaxToken GetMethodNameAtInvocation(IEnumerable<SyntaxNodeOrToken> methodNames)
-        {
-            return (SyntaxToken)methodNames.FirstOrDefault(t => !t.Parent.IsKind(SyntaxKind.MethodDeclaration));
-        }
+            => (SyntaxToken)methodNames.FirstOrDefault(t => !t.Parent.IsKind(SyntaxKind.MethodDeclaration));
 
         protected override async Task<OperationStatus> CheckTypeAsync(
             Document document,

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             public override bool ContainingScopeHasAsyncKeyword()
-            {
-                return false;
-            }
+                => false;
 
             public override SyntaxNode? GetContainingScope()
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
@@ -98,14 +98,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public StatementSyntax GetFirstStatement()
-        {
-            return GetFirstStatement<StatementSyntax>();
-        }
+            => GetFirstStatement<StatementSyntax>();
 
         public StatementSyntax GetLastStatement()
-        {
-            return GetLastStatement<StatementSyntax>();
-        }
+            => GetLastStatement<StatementSyntax>();
 
         public StatementSyntax GetFirstStatementUnderContainer()
         {
@@ -194,14 +190,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public SyntaxKind UnderCheckedExpressionContext()
-        {
-            return UnderCheckedContext<CheckedExpressionSyntax>();
-        }
+            => UnderCheckedContext<CheckedExpressionSyntax>();
 
         public SyntaxKind UnderCheckedStatementContext()
-        {
-            return UnderCheckedContext<CheckedStatementSyntax>();
-        }
+            => UnderCheckedContext<CheckedStatementSyntax>();
 
         private SyntaxKind UnderCheckedContext<T>() where T : SyntaxNode
         {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.Validator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.Validator.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             };
 
         private bool CheckGlobalStatement()
-        {
-            return true;
-        }
+            => true;
 
         private bool CheckBlock(BlockSyntax block)
         {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
@@ -113,9 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         private TextSpan GetControlFlowSpan(SelectionInfo selectionInfo)
-        {
-            return TextSpan.FromBounds(selectionInfo.FirstTokenInFinalSpan.SpanStart, selectionInfo.LastTokenInFinalSpan.Span.End);
-        }
+            => TextSpan.FromBounds(selectionInfo.FirstTokenInFinalSpan.SpanStart, selectionInfo.LastTokenInFinalSpan.Span.End);
 
         private SelectionInfo AdjustFinalTokensBasedOnContext(
             SelectionInfo selectionInfo,
@@ -363,9 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public override bool ContainsNonReturnExitPointsStatements(IEnumerable<SyntaxNode> jumpsOutOfRegion)
-        {
-            return jumpsOutOfRegion.Where(n => !(n is ReturnStatementSyntax)).Any();
-        }
+            => jumpsOutOfRegion.Where(n => !(n is ReturnStatementSyntax)).Any();
 
         public override IEnumerable<SyntaxNode> GetOuterReturnStatements(SyntaxNode commonRoot, IEnumerable<SyntaxNode> jumpsOutOfRegion)
         {
@@ -478,9 +474,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             public bool SelectionInSingleStatement { get; set; }
 
             public SelectionInfo WithStatus(Func<OperationStatus, OperationStatus> statusGetter)
-            {
-                return With(s => s.Status = statusGetter(s.Status));
-            }
+                => With(s => s.Status = statusGetter(s.Status));
 
             public SelectionInfo With(Action<SelectionInfo> valueSetter)
             {
@@ -490,9 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             public SelectionInfo Clone()
-            {
-                return (SelectionInfo)MemberwiseClone();
-            }
+                => (SelectionInfo)MemberwiseClone();
         }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/Extensions.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/Extensions.cs
@@ -48,14 +48,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public static StatementSyntax GetParentLabeledStatementIfPossible(this SyntaxNode node)
-        {
-            return (StatementSyntax)((node.Parent is LabeledStatementSyntax) ? node.Parent : node);
-        }
+            => (StatementSyntax)((node.Parent is LabeledStatementSyntax) ? node.Parent : node);
 
         public static bool IsStatementContainerNode([NotNullWhen(returnValue: true)] this SyntaxNode? node)
-        {
-            return node is BlockSyntax || node is SwitchSectionSyntax;
-        }
+            => node is BlockSyntax || node is SwitchSectionSyntax;
 
         public static BlockSyntax? GetBlockBody(this SyntaxNode? node)
         {
@@ -106,9 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public static bool UnderValidContext(this SyntaxToken token)
-        {
-            return token.GetAncestors<SyntaxNode>().Any(n => n.CheckTopLevel(token.Span));
-        }
+            => token.GetAncestors<SyntaxNode>().Any(n => n.CheckTopLevel(token.Span));
 
         public static bool PartOfConstantInitializerExpression(this SyntaxNode node)
         {
@@ -230,9 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public static bool HasSyntaxAnnotation(this HashSet<SyntaxAnnotation> set, SyntaxNode node)
-        {
-            return set.Any(a => node.GetAnnotatedNodesAndTokens(a).Any());
-        }
+            => set.Any(a => node.GetAnnotatedNodesAndTokens(a).Any());
 
         public static bool HasHybridTriviaBetween(this SyntaxToken token1, SyntaxToken token2)
         {
@@ -250,19 +242,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         }
 
         public static bool IsArrayInitializer([NotNullWhen(returnValue: true)] this SyntaxNode? node)
-        {
-            return node is InitializerExpressionSyntax && node.Parent is EqualsValueClauseSyntax;
-        }
+            => node is InitializerExpressionSyntax && node.Parent is EqualsValueClauseSyntax;
 
         public static bool IsExpressionInCast([NotNullWhen(returnValue: true)] this SyntaxNode? node)
-        {
-            return node is ExpressionSyntax && node.Parent is CastExpressionSyntax;
-        }
+            => node is ExpressionSyntax && node.Parent is CastExpressionSyntax;
 
         public static bool IsObjectType(this ITypeSymbol? type)
-        {
-            return type == null || type.SpecialType == SpecialType.System_Object;
-        }
+            => type == null || type.SpecialType == SpecialType.System_Object;
 
         public static bool BetweenFieldAndNonFieldMember(this SyntaxToken token1, SyntaxToken token2)
         {

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -155,9 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
             => argument.GetRefKind();
 
         protected override bool IsNamedArgument(ArgumentSyntax argument)
-        {
-            return argument.NameColon != null;
-        }
+            => argument.NameColon != null;
 
         protected override ITypeSymbol GetArgumentType(
             SemanticModel semanticModel, ArgumentSyntax argument, CancellationToken cancellationToken)
@@ -172,9 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
         }
 
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
-        {
-            return compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
-        }
+            => compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
 
         internal override IMethodSymbol GetDelegatingConstructor(
             State state,

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateEnumMember/CSharpGenerateEnumMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateEnumMember/CSharpGenerateEnumMemberService.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateEnumMember
         }
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
-        {
-            return node is IdentifierNameSyntax;
-        }
+            => node is IdentifierNameSyntax;
 
         protected override bool TryInitializeIdentifierNameState(
             SemanticDocument document, SimpleNameSyntax identifierName, CancellationToken cancellationToken,

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpCommonGenerationServiceMethods.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpCommonGenerationServiceMethods.cs
@@ -8,13 +8,9 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateParameterizedMemb
     internal static class CSharpCommonGenerationServiceMethods
     {
         public static bool AreSpecialOptionsActive()
-        {
-            return false;
-        }
+            => false;
 
         public static bool IsValidSymbol()
-        {
-            return false;
-        }
+            => false;
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateConversionService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateConversionService.cs
@@ -37,14 +37,10 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateParameterizedMemb
         }
 
         protected override bool IsExplicitConversionGeneration(SyntaxNode node)
-        {
-            return node is CastExpressionSyntax;
-        }
+            => node is CastExpressionSyntax;
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
-        {
-            return containingType.ContainingTypesOrSelfHasUnsafeKeyword();
-        }
+            => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
 
         protected override AbstractInvocationInfo CreateInvocationMethodInfo(
             SemanticDocument document, AbstractGenerateParameterizedMemberService<CSharpGenerateConversionService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>.State state)
@@ -225,13 +221,9 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateParameterizedMemb
         }
 
         protected override string GetImplicitConversionDisplayText(AbstractGenerateParameterizedMemberService<CSharpGenerateConversionService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>.State state)
-        {
-            return string.Format(CSharpFeaturesResources.Generate_implicit_conversion_operator_in_0, state.TypeToGenerateIn.Name);
-        }
+            => string.Format(CSharpFeaturesResources.Generate_implicit_conversion_operator_in_0, state.TypeToGenerateIn.Name);
 
         protected override string GetExplicitConversionDisplayText(AbstractGenerateParameterizedMemberService<CSharpGenerateConversionService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>.State state)
-        {
-            return string.Format(CSharpFeaturesResources.Generate_explicit_conversion_operator_in_0, state.TypeToGenerateIn.Name);
-        }
+            => string.Format(CSharpFeaturesResources.Generate_explicit_conversion_operator_in_0, state.TypeToGenerateIn.Name);
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateMethodService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateMethodService.cs
@@ -38,9 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
             => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
 
         protected override AbstractInvocationInfo CreateInvocationMethodInfo(SemanticDocument document, AbstractGenerateParameterizedMemberService<CSharpGenerateMethodService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>.State state)
-        {
-            return new CSharpGenerateParameterizedMemberService<CSharpGenerateMethodService>.InvocationExpressionInfo(document, state);
-        }
+            => new CSharpGenerateParameterizedMemberService<CSharpGenerateMethodService>.InvocationExpressionInfo(document, state);
 
         protected override bool AreSpecialOptionsActive(SemanticModel semanticModel)
             => CSharpCommonGenerationServiceMethods.AreSpecialOptionsActive();

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -154,9 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 => _invocationExpression.ArgumentList.Arguments.Select(a => false).ToImmutableArray();
 
             protected override bool IsIdentifierName()
-            {
-                return State.SimpleNameOpt.Kind() == SyntaxKind.IdentifierName;
-            }
+                => State.SimpleNameOpt.Kind() == SyntaxKind.IdentifierName;
 
             protected override bool IsImplicitReferenceConversion(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
             {

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -43,14 +43,10 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
         protected override string DefaultFileExtension => ".cs";
 
         protected override ExpressionSyntax GetLeftSideOfDot(SimpleNameSyntax simpleName)
-        {
-            return simpleName.GetLeftSideOfDot();
-        }
+            => simpleName.GetLeftSideOfDot();
 
         protected override bool IsInCatchDeclaration(ExpressionSyntax expression)
-        {
-            return expression.IsParentKind(SyntaxKind.CatchDeclaration);
-        }
+            => expression.IsParentKind(SyntaxKind.CatchDeclaration);
 
         protected override bool IsArrayElementType(ExpressionSyntax expression)
         {
@@ -531,19 +527,13 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
         }
 
         public override string GetRootNamespace(CompilationOptions options)
-        {
-            return string.Empty;
-        }
+            => string.Empty;
 
         protected override bool IsInVariableTypeContext(ExpressionSyntax expression)
-        {
-            return false;
-        }
+            => false;
 
         protected override INamedTypeSymbol DetermineTypeToGenerateIn(SemanticModel semanticModel, SimpleNameSyntax simpleName, CancellationToken cancellationToken)
-        {
-            return semanticModel.GetEnclosingNamedType(simpleName.SpanStart, cancellationToken);
-        }
+            => semanticModel.GetEnclosingNamedType(simpleName.SpanStart, cancellationToken);
 
         protected override Accessibility GetAccessibility(State state, SemanticModel semanticModel, bool intoNamespace, CancellationToken cancellationToken)
         {
@@ -571,14 +561,10 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
         }
 
         protected override ITypeSymbol DetermineArgumentType(SemanticModel semanticModel, ArgumentSyntax argument, CancellationToken cancellationToken)
-        {
-            return argument.DetermineParameterType(semanticModel, cancellationToken);
-        }
+            => argument.DetermineParameterType(semanticModel, cancellationToken);
 
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
-        {
-            return compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
-        }
+            => compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
 
         public override async Task<(INamespaceSymbol, INamespaceOrTypeSymbol, Location)> GetOrGenerateEnclosingNamespaceSymbolAsync(
             INamedTypeSymbol namedTypeSymbol, string[] containers, Document selectedDocument, SyntaxNode selectedDocumentRoot, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceCodeFixProvider.cs
@@ -66,8 +66,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
         }
 
         public sealed override FixAllProvider GetFixAllProvider()
-        {
-            return WellKnownFixAllProviders.BatchFixer;
-        }
+            => WellKnownFixAllProviders.BatchFixer;
     }
 }

--- a/src/Features/CSharp/Portable/IntroduceUsingStatement/CSharpIntroduceUsingStatementCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/IntroduceUsingStatement/CSharpIntroduceUsingStatementCodeRefactoringProvider.cs
@@ -26,9 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceUsingStatement
         protected override string CodeActionTitle => CSharpFeaturesResources.Introduce_using_statement;
 
         protected override bool CanRefactorToContainBlockStatements(SyntaxNode parent)
-        {
-            return parent is BlockSyntax || parent is SwitchSectionSyntax || parent.IsEmbeddedStatementOwner();
-        }
+            => parent is BlockSyntax || parent is SwitchSectionSyntax || parent.IsEmbeddedStatementOwner();
 
         protected override SyntaxList<StatementSyntax> GetStatements(SyntaxNode parentOfStatementsToSurround)
         {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.Rewriter.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.Rewriter.cs
@@ -54,9 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             }
 
             public static SyntaxNode Visit(SyntaxNode node, SyntaxNode replacementNode, ISet<ExpressionSyntax> matches)
-            {
-                return new Rewriter(replacementNode, matches).Visit(node);
-            }
+                => new Rewriter(replacementNode, matches).Visit(node);
         }
     }
 }

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -49,19 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
         }
 
         protected override bool IsInParameterInitializer(ExpressionSyntax expression)
-        {
-            return expression.GetAncestorOrThis<EqualsValueClauseSyntax>().IsParentKind(SyntaxKind.Parameter);
-        }
+            => expression.GetAncestorOrThis<EqualsValueClauseSyntax>().IsParentKind(SyntaxKind.Parameter);
 
         protected override bool IsInConstructorInitializer(ExpressionSyntax expression)
-        {
-            return expression.GetAncestorOrThis<ConstructorInitializerSyntax>() != null;
-        }
+            => expression.GetAncestorOrThis<ConstructorInitializerSyntax>() != null;
 
         protected override bool IsInAutoPropertyInitializer(ExpressionSyntax expression)
-        {
-            return expression.GetAncestorOrThis<EqualsValueClauseSyntax>().IsParentKind(SyntaxKind.PropertyDeclaration);
-        }
+            => expression.GetAncestorOrThis<EqualsValueClauseSyntax>().IsParentKind(SyntaxKind.PropertyDeclaration);
 
         protected override bool IsInExpressionBodiedMember(ExpressionSyntax expression)
         {
@@ -136,19 +130,13 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
         }
 
         protected override IEnumerable<SyntaxNode> GetContainingExecutableBlocks(ExpressionSyntax expression)
-        {
-            return expression.GetAncestorsOrThis<BlockSyntax>();
-        }
+            => expression.GetAncestorsOrThis<BlockSyntax>();
 
         protected override IList<bool> GetInsertionIndices(TypeDeclarationSyntax destination, CancellationToken cancellationToken)
-        {
-            return destination.GetInsertionIndices(cancellationToken);
-        }
+            => destination.GetInsertionIndices(cancellationToken);
 
         protected override bool CanReplace(ExpressionSyntax expression)
-        {
-            return true;
-        }
+            => true;
 
         protected override bool IsExpressionInStaticLocalFunction(ExpressionSyntax expression)
         {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
@@ -154,9 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
         }
 
         private static bool IsConstantField(MemberDeclarationSyntax member)
-        {
-            return member is FieldDeclarationSyntax field && field.Modifiers.Any(SyntaxKind.ConstKeyword);
-        }
+            => member is FieldDeclarationSyntax field && field.Modifiers.Any(SyntaxKind.ConstKeyword);
 
         protected static int DetermineFirstChange(SyntaxList<MemberDeclarationSyntax> oldMembers, SyntaxList<MemberDeclarationSyntax> newMembers)
         {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceQueryLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceQueryLocal.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
     internal partial class CSharpIntroduceVariableService
     {
         private static bool IsAnyQueryClause(SyntaxNode node)
-        {
-            return node is QueryClauseSyntax || node is SelectOrGroupClauseSyntax;
-        }
+            => node is QueryClauseSyntax || node is SelectOrGroupClauseSyntax;
 
         protected override Task<Document> IntroduceQueryLocalAsync(
             SemanticDocument document, ExpressionSyntax expression, bool allOccurrences, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs
@@ -17,18 +17,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
         }
 
         public override ImmutableArray<SymbolDisplayPart> ToDisplayParts(ISymbol symbol, SymbolDisplayFormat format = null)
-        {
-            return Microsoft.CodeAnalysis.CSharp.SymbolDisplay.ToDisplayParts(symbol, format);
-        }
+            => Microsoft.CodeAnalysis.CSharp.SymbolDisplay.ToDisplayParts(symbol, format);
 
         public override ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(SemanticModel semanticModel, int position, ISymbol symbol, SymbolDisplayFormat format)
-        {
-            return symbol.ToMinimalDisplayParts(semanticModel, position, format);
-        }
+            => symbol.ToMinimalDisplayParts(semanticModel, position, format);
 
         protected override AbstractSymbolDescriptionBuilder CreateDescriptionBuilder(Workspace workspace, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return new SymbolDescriptionBuilder(this, semanticModel, position, workspace, AnonymousTypeDisplayService, cancellationToken);
-        }
+            => new SymbolDescriptionBuilder(this, semanticModel, position, workspace, AnonymousTypeDisplayService, cancellationToken);
     }
 }

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayServiceFactory.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayServiceFactory.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-        {
-            return new CSharpSymbolDisplayService(provider);
-        }
+            => new CSharpSymbolDisplayService(provider);
     }
 }

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -35,14 +35,10 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
             ImmutableArray.Create(CS4032, CS4033, CS4034);
 
         protected override string GetMakeAsyncTaskFunctionResource()
-        {
-            return CSharpFeaturesResources.Make_method_async;
-        }
+            => CSharpFeaturesResources.Make_method_async;
 
         protected override string GetMakeAsyncVoidFunctionResource()
-        {
-            return CSharpFeaturesResources.Make_method_async_remain_void;
-        }
+            => CSharpFeaturesResources.Make_method_async_remain_void;
 
         protected override bool IsAsyncSupportingFunctionSyntax(SyntaxNode node)
             => node.IsAsyncSupportingFunctionSyntax();

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -120,18 +120,12 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
         }
 
         private SyntaxNode FixParenthesizedLambda(ParenthesizedLambdaExpressionSyntax lambda)
-        {
-            return lambda.WithAsyncKeyword(default).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
-        }
+            => lambda.WithAsyncKeyword(default).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
 
         private SyntaxNode FixSimpleLambda(SimpleLambdaExpressionSyntax lambda)
-        {
-            return lambda.WithAsyncKeyword(default).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
-        }
+            => lambda.WithAsyncKeyword(default).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
 
         private SyntaxNode FixAnonymousMethod(AnonymousMethodExpressionSyntax method)
-        {
-            return method.WithAsyncKeyword(default).WithPrependedLeadingTrivia(method.AsyncKeyword.LeadingTrivia);
-        }
+            => method.WithAsyncKeyword(default).WithPrependedLeadingTrivia(method.AsyncKeyword.LeadingTrivia);
     }
 }

--- a/src/Features/CSharp/Portable/MakeStructFieldsWritable/CSharpMakeStructFieldsWritableDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/MakeStructFieldsWritable/CSharpMakeStructFieldsWritableDiagnosticAnalyzer.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeStructFieldsWritable
             private bool _hasTypeInstanceAssigment;
 
             private SymbolAnalyzer(INamedTypeSymbol namedTypeSymbol)
-            {
-                _namedTypeSymbol = namedTypeSymbol;
-            }
+                => _namedTypeSymbol = namedTypeSymbol;
 
             public static void CreateAndRegisterActions(CompilationStartAnalysisContext compilationStartContext)
             {

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -55,9 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
         }
 
         protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
-        {
-            return s_memberSeparationRule.Concat(Formatter.GetDefaultFormattingRules(document));
-        }
+            => s_memberSeparationRule.Concat(Formatter.GetDefaultFormattingRules(document));
 
         protected override async Task<Document> ConvertDocCommentsToRegularCommentsAsync(Document document, IDocumentationCommentFormattingService docCommentFormattingService, CancellationToken cancellationToken)
         {
@@ -123,9 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
             }
 
             protected override bool IsNewLine(char c)
-            {
-                return SyntaxFacts.IsNewLine(c);
-            }
+                => SyntaxFacts.IsNewLine(c);
         }
     }
 }

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceServiceFactory.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceServiceFactory.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-        {
-            return new CSharpMetadataAsSourceService(provider);
-        }
+            => new CSharpMetadataAsSourceService(provider);
     }
 }

--- a/src/Features/CSharp/Portable/QuickInfo/CSharpQuickInfoSevice.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpQuickInfoSevice.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-        {
-            return new CSharpQuickInfoService(languageServices.WorkspaceServices.Workspace);
-        }
+            => new CSharpQuickInfoService(languageServices.WorkspaceServices.Workspace);
     }
 
     internal class CSharpQuickInfoService : QuickInfoServiceWithProviders

--- a/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
@@ -64,9 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
         }
 
         protected override bool ShouldCheckPreviousToken(SyntaxToken token)
-        {
-            return !token.Parent.IsKind(SyntaxKind.XmlCrefAttribute);
-        }
+            => !token.Parent.IsKind(SyntaxKind.XmlCrefAttribute);
 
         protected override ImmutableArray<TaggedText> TryGetNullabilityAnalysis(Workspace workspace, SemanticModel semanticModel, SyntaxToken token, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -28,9 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
         }
 
         public void RemoveSetMethod(SyntaxEditor editor, SyntaxNode setMethodDeclaration)
-        {
-            editor.RemoveNode(setMethodDeclaration);
-        }
+            => editor.RemoveNode(setMethodDeclaration);
 
         public void ReplaceGetMethodWithProperty(
             DocumentOptionSet documentOptions,

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
@@ -19,29 +19,19 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         protected static SymbolDisplayPart Keyword(SyntaxKind kind)
-        {
-            return new SymbolDisplayPart(SymbolDisplayPartKind.Keyword, null, SyntaxFacts.GetText(kind));
-        }
+            => new SymbolDisplayPart(SymbolDisplayPartKind.Keyword, null, SyntaxFacts.GetText(kind));
 
         protected static SymbolDisplayPart Punctuation(SyntaxKind kind)
-        {
-            return new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, SyntaxFacts.GetText(kind));
-        }
+            => new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, SyntaxFacts.GetText(kind));
 
         protected static SymbolDisplayPart Text(string text)
-        {
-            return new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, text);
-        }
+            => new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, text);
 
         protected static SymbolDisplayPart Space()
-        {
-            return new SymbolDisplayPart(SymbolDisplayPartKind.Space, null, " ");
-        }
+            => new SymbolDisplayPart(SymbolDisplayPartKind.Space, null, " ");
 
         protected static SymbolDisplayPart NewLine()
-        {
-            return new SymbolDisplayPart(SymbolDisplayPartKind.LineBreak, null, "\r\n");
-        }
+            => new SymbolDisplayPart(SymbolDisplayPartKind.LineBreak, null, "\r\n");
 
         private static readonly IList<SymbolDisplayPart> _separatorParts = new List<SymbolDisplayPart>
             {
@@ -71,8 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         /// </summary>
         [Obsolete("Expected to exist by IntelliCode. This can be removed once their unnecessary use of this is removed.")]
         protected IList<TaggedText> GetAwaitableUsage(IMethodSymbol method, SemanticModel semanticModel, int position)
-        {
-            return SpecializedCollections.EmptyList<TaggedText>();
-        }
+            => SpecializedCollections.EmptyList<TaggedText>();
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -30,14 +30,10 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         public override bool IsTriggerCharacter(char ch)
-        {
-            return ch == '(' || ch == ',';
-        }
+            => ch == '(' || ch == ',';
 
         public override bool IsRetriggerCharacter(char ch)
-        {
-            return ch == ')';
-        }
+            => ch == ')';
 
         private bool TryGetAttributeExpression(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken, out AttributeSyntax attribute)
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -31,14 +31,10 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         public override bool IsTriggerCharacter(char ch)
-        {
-            return ch == '(' || ch == ',';
-        }
+            => ch == '(' || ch == ',';
 
         public override bool IsRetriggerCharacter(char ch)
-        {
-            return ch == ')';
-        }
+            => ch == ')';
 
         private bool TryGetConstructorInitializer(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken, out ConstructorInitializerSyntax expression)
         {
@@ -51,9 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         private bool IsTriggerToken(SyntaxToken token)
-        {
-            return SignatureHelpUtilities.IsTriggerParenOrComma<ConstructorInitializerSyntax>(token, IsTriggerCharacter);
-        }
+            => SignatureHelpUtilities.IsTriggerParenOrComma<ConstructorInitializerSyntax>(token, IsTriggerCharacter);
 
         private static bool IsArgumentListToken(ConstructorInitializerSyntax expression, SyntaxToken token)
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -32,19 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         public override bool IsTriggerCharacter(char ch)
-        {
-            return IsTriggerCharacterInternal(ch);
-        }
+            => IsTriggerCharacterInternal(ch);
 
         private static bool IsTriggerCharacterInternal(char ch)
-        {
-            return ch == '[' || ch == ',';
-        }
+            => ch == '[' || ch == ',';
 
         public override bool IsRetriggerCharacter(char ch)
-        {
-            return ch == ']';
-        }
+            => ch == ']';
 
         private static bool TryGetElementAccessExpression(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken, out ExpressionSyntax identifier, out SyntaxToken openBrace)
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProvider.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         protected override bool TryGetGenericIdentifier(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken, out SyntaxToken genericIdentifier, out SyntaxToken lessThanToken)
-        {
-            return root.SyntaxTree.IsInPartiallyWrittenGeneric(position, cancellationToken, out genericIdentifier, out lessThanToken);
-        }
+            => root.SyntaxTree.IsInPartiallyWrittenGeneric(position, cancellationToken, out genericIdentifier, out lessThanToken);
 
         protected override TextSpan GetTextSpan(SyntaxToken genericIdentifier, SyntaxToken lessThanToken)
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -31,14 +31,10 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         public override bool IsTriggerCharacter(char ch)
-        {
-            return ch == '<' || ch == ',';
-        }
+            => ch == '<' || ch == ',';
 
         public override bool IsRetriggerCharacter(char ch)
-        {
-            return ch == '>';
-        }
+            => ch == '>';
 
         protected virtual bool TryGetGenericIdentifier(
             SyntaxNode root, int position,

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
@@ -32,14 +32,10 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
     internal partial class InvocationExpressionSignatureHelpProviderBase : AbstractOrdinaryMethodSignatureHelpProvider
     {
         public override bool IsTriggerCharacter(char ch)
-        {
-            return ch == '(' || ch == ',';
-        }
+            => ch == '(' || ch == ',';
 
         public override bool IsRetriggerCharacter(char ch)
-        {
-            return ch == ')';
-        }
+            => ch == ')';
 
         private bool TryGetInvocationExpression(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken, out InvocationExpressionSyntax expression)
         {
@@ -52,9 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         private bool IsTriggerToken(SyntaxToken token)
-        {
-            return SignatureHelpUtilities.IsTriggerParenOrComma<InvocationExpressionSyntax>(token, IsTriggerCharacter);
-        }
+            => SignatureHelpUtilities.IsTriggerParenOrComma<InvocationExpressionSyntax>(token, IsTriggerCharacter);
 
         private static bool IsArgumentListToken(InvocationExpressionSyntax expression, SyntaxToken token)
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.cs
@@ -25,14 +25,10 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         public override bool IsTriggerCharacter(char ch)
-        {
-            return ch == '(' || ch == ',';
-        }
+            => ch == '(' || ch == ',';
 
         public override bool IsRetriggerCharacter(char ch)
-        {
-            return ch == ')';
-        }
+            => ch == ')';
 
         private bool TryGetObjectCreationExpression(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken, out ObjectCreationExpressionSyntax expression)
         {
@@ -45,9 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         private bool IsTriggerToken(SyntaxToken token)
-        {
-            return SignatureHelpUtilities.IsTriggerParenOrComma<ObjectCreationExpressionSyntax>(token, IsTriggerCharacter);
-        }
+            => SignatureHelpUtilities.IsTriggerParenOrComma<ObjectCreationExpressionSyntax>(token, IsTriggerCharacter);
 
         private static bool IsArgumentListToken(ObjectCreationExpressionSyntax expression, SyntaxToken token)
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
@@ -87,22 +87,16 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         internal static TextSpan GetSignatureHelpSpan(BaseArgumentListSyntax argumentList)
-        {
-            return CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getBaseArgumentListCloseToken);
-        }
+            => CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getBaseArgumentListCloseToken);
 
         internal static TextSpan GetSignatureHelpSpan(TypeArgumentListSyntax argumentList)
-        {
-            return CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getTypeArgumentListCloseToken);
-        }
+            => CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getTypeArgumentListCloseToken);
 
         internal static TextSpan GetSignatureHelpSpan(InitializerExpressionSyntax initializer)
             => CommonSignatureHelpUtilities.GetSignatureHelpSpan(initializer, initializer.SpanStart, s_getInitializerExpressionCloseToken);
 
         internal static TextSpan GetSignatureHelpSpan(AttributeArgumentListSyntax argumentList)
-        {
-            return CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getAttributeArgumentListCloseToken);
-        }
+            => CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getAttributeArgumentListCloseToken);
 
         internal static bool IsTriggerParenOrComma<TSyntaxNode>(SyntaxToken token, Func<char, bool> isTriggerCharacter) where TSyntaxNode : SyntaxNode
         {

--- a/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
@@ -98,14 +98,10 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         public override Boolean IsRetriggerCharacter(Char ch)
-        {
-            return ch == ')';
-        }
+            => ch == ')';
 
         public override Boolean IsTriggerCharacter(Char ch)
-        {
-            return ch == '(' || ch == ',';
-        }
+            => ch == '(' || ch == ',';
 
         protected override async Task<SignatureHelpItems> GetItemsWorkerAsync(Document document, int position, SignatureHelpTriggerInfo triggerInfo, CancellationToken cancellationToken)
         {
@@ -210,9 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         private bool IsTupleExpressionTriggerToken(SyntaxToken token)
-        {
-            return SignatureHelpUtilities.IsTriggerParenOrComma<TupleExpressionSyntax>(token, IsTriggerCharacter);
-        }
+            => SignatureHelpUtilities.IsTriggerParenOrComma<TupleExpressionSyntax>(token, IsTriggerCharacter);
 
         private static bool IsTupleArgumentListToken(TupleExpressionSyntax tupleExpression, SyntaxToken token)
         {
@@ -228,9 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         }
 
         private bool IsParenthesizedExpressionTriggerToken(SyntaxToken token)
-        {
-            return token.IsKind(SyntaxKind.OpenParenToken) && token.Parent is ParenthesizedExpressionSyntax;
-        }
+            => token.IsKind(SyntaxKind.OpenParenToken) && token.Parent is ParenthesizedExpressionSyntax;
 
         private static bool IsParenthesizedExpressionToken(ParenthesizedExpressionSyntax expr, SyntaxToken token)
         {

--- a/src/Features/CSharp/Portable/SplitOrMergeIfStatements/CSharpIfLikeStatementGenerator.cs
+++ b/src/Features/CSharp/Portable/SplitOrMergeIfStatements/CSharpIfLikeStatementGenerator.cs
@@ -119,9 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SplitOrMergeIfStatements
         }
 
         public SyntaxNode WithElseIfAndElseClausesOf(SyntaxNode ifStatement, SyntaxNode otherIfStatement)
-        {
-            return ((IfStatementSyntax)ifStatement).WithElse(((IfStatementSyntax)otherIfStatement).Else);
-        }
+            => ((IfStatementSyntax)ifStatement).WithElse(((IfStatementSyntax)otherIfStatement).Else);
 
         public SyntaxNode ToIfStatement(SyntaxNode ifOrElseIf)
             => ifOrElseIf;

--- a/src/Features/CSharp/Portable/Structure/CSharpBlockStructureService.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpBlockStructureService.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-        {
-            return new CSharpBlockStructureService(languageServices.WorkspaceServices.Workspace);
-        }
+            => new CSharpBlockStructureService(languageServices.WorkspaceServices.Workspace);
     }
 
     internal class CSharpBlockStructureService : BlockStructureServiceWithProviders

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -73,9 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
         }
 
         private static bool IsNonBlockStatement(SyntaxNode node)
-        {
-            return node is StatementSyntax && !node.IsKind(SyntaxKind.Block);
-        }
+            => node is StatementSyntax && !node.IsKind(SyntaxKind.Block);
 
         private TextSpan GetHintSpan(BlockSyntax node)
         {

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -52,9 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;
 
         public override string SuggestedVersion(ImmutableArray<Diagnostic> diagnostics)
-        {
-            return RequiredVersion(diagnostics).ToDisplayString();
-        }
+            => RequiredVersion(diagnostics).ToDisplayString();
 
         private static LanguageVersion RequiredVersion(ImmutableArray<Diagnostic> diagnostics)
         {

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -151,9 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
         }
 
         private bool SupportsReadOnlyProperties(Compilation compilation)
-        {
-            return ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
-        }
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
 
         private AccessorListSyntax UpdateAccessorList(AccessorListSyntax accessorList)
         {

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.InfoCache.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.InfoCache.cs
@@ -30,9 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                 new ConcurrentDictionary<IMethodSymbol, MemberInfo>();
 
             public InfoCache(Compilation compilation)
-            {
-                IndexType = compilation.GetTypeByMetadataName("System.Index");
-            }
+                => IndexType = compilation.GetTypeByMetadataName("System.Index");
 
             public bool TryGetMemberInfo(IMethodSymbol methodSymbol, out MemberInfo memberInfo)
             {

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
         }
 
         protected override void LanguageSpecificRemoveSuggestedNode(SyntaxEditor editor, SyntaxNode node)
-        {
-            editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia | SyntaxRemoveOptions.AddElasticMarker);
-        }
+            => editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia | SyntaxRemoveOptions.AddElasticMarker);
     }
 }

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -478,9 +478,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         }
 
         private static bool NotNull(SymbolReference reference)
-        {
-            return reference.SymbolResult.Symbol != null;
-        }
+            => reference.SymbolResult.Symbol != null;
 
         public async Task<ImmutableArray<(Diagnostic Diagnostic, ImmutableArray<AddImportFixData> Fixes)>> GetFixesForDiagnosticsAsync(
             Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, int maxResultsPerDiagnostic,

--- a/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
@@ -46,9 +46,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public override int GetHashCode()
-            {
-                return Hash.Combine(_referenceAssemblyWithType.AssemblyName, base.GetHashCode());
-            }
+                => Hash.Combine(_referenceAssemblyWithType.AssemblyName, base.GetHashCode());
         }
     }
 }

--- a/src/Features/Core/Portable/AddImport/References/Reference.cs
+++ b/src/Features/Core/Portable/AddImport/References/Reference.cs
@@ -63,9 +63,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                     (r, d) => !r.SearchResult.DesiredNameMatchesSourceName(d));
 
             public override bool Equals(object obj)
-            {
-                return Equals(obj as Reference);
-            }
+                => Equals(obj as Reference);
 
             public bool Equals(Reference other)
             {
@@ -75,9 +73,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public override int GetHashCode()
-            {
-                return Hash.CombineValues(SearchResult.NameParts);
-            }
+                => Hash.CombineValues(SearchResult.NameParts);
 
             protected async Task<(SyntaxNode, Document)> ReplaceNameNodeAsync(
                 SyntaxNode contextNode, Document document, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             private readonly ISymbolSearchService _symbolSearchService;
 
             public RemoteSymbolSearchService(ISymbolSearchService symbolSearchService)
-            {
-                _symbolSearchService = symbolSearchService;
-            }
+                => _symbolSearchService = symbolSearchService;
 
             public Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory)
             {

--- a/src/Features/Core/Portable/AddImport/SymbolResult.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolResult.cs
@@ -101,22 +101,16 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public SymbolResult<T2> WithSymbol<T2>(T2 symbol) where T2 : ISymbol
-            {
-                return new SymbolResult<T2>(DesiredName, NameNode, symbol, Weight);
-            }
+                => new SymbolResult<T2>(DesiredName, NameNode, symbol, Weight);
 
             internal SymbolResult<T> WithDesiredName(string desiredName)
-            {
-                return new SymbolResult<T>(desiredName, NameNode, Symbol, Weight);
-            }
+                => new SymbolResult<T>(desiredName, NameNode, Symbol, Weight);
         }
 
         private struct SymbolResult
         {
             public static SymbolResult<T> Create<T>(string desiredName, TSimpleNameSyntax nameNode, T symbol, double weight) where T : ISymbol
-            {
-                return new SymbolResult<T>(desiredName, nameNode, symbol, weight);
-            }
+                => new SymbolResult<T>(desiredName, nameNode, symbol, weight);
         }
     }
 }

--- a/src/Features/Core/Portable/AddPackage/InstallWithPackageManagerCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallWithPackageManagerCodeAction.cs
@@ -44,9 +44,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
             public override string Title => FeaturesResources.Install_with_package_manager;
 
             public override void Apply(Workspace workspace, CancellationToken cancellationToken)
-            {
-                _codeAction._installerService.ShowManagePackagesDialog(_codeAction._packageName);
-            }
+                => _codeAction._installerService.ShowManagePackagesDialog(_codeAction._packageName);
         }
     }
 }

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
@@ -26,9 +26,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         public override string Title => FeaturesResources.Change_signature;
 
         public override object GetOptions(CancellationToken cancellationToken)
-        {
-            return _changeSignatureService.GetChangeSignatureOptions(_context);
-        }
+            => _changeSignatureService.GetChangeSignatureOptions(_context);
 
         protected override Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(object options, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -28,9 +28,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         public static readonly IReferenceFinder DelegateInvokeMethod = new DelegateInvokeMethodReferenceFinder();
 
         protected override bool CanFind(IMethodSymbol symbol)
-        {
-            return symbol.MethodKind == MethodKind.DelegateInvoke;
-        }
+            => symbol.MethodKind == MethodKind.DelegateInvoke;
 
         protected override async Task<ImmutableArray<SymbolAndProjectId>> DetermineCascadedSymbolsAsync(
             SymbolAndProjectId<IMethodSymbol> symbolAndProjectId,

--- a/src/Features/Core/Portable/ChangeSignature/ParameterConfiguration.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ParameterConfiguration.cs
@@ -77,8 +77,6 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         }
 
         public bool IsChangeable()
-        {
-            return ParametersWithoutDefaultValues.Count > 0 || RemainingEditableParameters.Count > 0 || ParamsParameter != null;
-        }
+            => ParametersWithoutDefaultValues.Count > 0 || RemainingEditableParameters.Count > 0 || ParamsParameter != null;
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
@@ -28,9 +28,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
-        {
-            return await ComputeOperationsAsync(new ProgressTracker(), cancellationToken).ConfigureAwait(false);
-        }
+            => await ComputeOperationsAsync(new ProgressTracker(), cancellationToken).ConfigureAwait(false);
 
         internal override Task<ImmutableArray<CodeActionOperation>> ComputeOperationsAsync(
             IProgressTracker progressTracker, CancellationToken cancellationToken)
@@ -88,18 +86,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         internal TestAccessor GetTestAccessor()
-        {
-            return new TestAccessor(this);
-        }
+            => new TestAccessor(this);
 
         internal readonly struct TestAccessor
         {
             private readonly FixSomeCodeAction _fixSomeCodeAction;
 
             internal TestAccessor(FixSomeCodeAction fixSomeCodeAction)
-            {
-                _fixSomeCodeAction = fixSomeCodeAction;
-            }
+                => _fixSomeCodeAction = fixSomeCodeAction;
 
             /// <summary>
             /// Gets a reference to <see cref="_showPreviewChangesDialog"/>, which can be read or written by test code.

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningBatchFixAllProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningBatchFixAllProvider.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             private readonly AbstractSuppressionCodeFixProvider _suppressionFixProvider;
 
             public PragmaWarningBatchFixAllProvider(AbstractSuppressionCodeFixProvider suppressionFixProvider)
-            {
-                _suppressionFixProvider = suppressionFixProvider;
-            }
+                => _suppressionFixProvider = suppressionFixProvider;
 
             protected override async Task AddDocumentFixesAsync(
                 Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningCodeAction.cs
@@ -45,16 +45,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             }
 
             public PragmaWarningCodeAction CloneForFixMultipleContext()
-            {
-                return new PragmaWarningCodeAction(_suppressionTargetInfo, _document, _diagnostic, Fixer, forFixMultipleContext: true);
-            }
+                => new PragmaWarningCodeAction(_suppressionTargetInfo, _document, _diagnostic, Fixer, forFixMultipleContext: true);
             protected override string DiagnosticIdForEquivalenceKey =>
                 _forFixMultipleContext ? string.Empty : _diagnostic.Id;
 
             protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
-            {
-                return await GetChangedDocumentAsync(includeStartTokenChange: true, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
+                => await GetChangedDocumentAsync(includeStartTokenChange: true, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             public async Task<Document> GetChangedDocumentAsync(bool includeStartTokenChange, bool includeEndTokenChange, CancellationToken cancellationToken)
             {
@@ -81,9 +77,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             public SyntaxToken EndToken_TestOnly => _suppressionTargetInfo.EndToken;
 
             private SyntaxNode FormatNode(SyntaxNode node)
-            {
-                return Formatter.Format(node, _document.Project.Solution.Workspace);
-            }
+                => Formatter.Format(node, _document.Project.Solution.Workspace);
         }
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         internal abstract partial class RemoveSuppressionCodeAction
         {
             public static BatchFixAllProvider GetBatchFixer(AbstractSuppressionCodeFixProvider suppressionFixProvider)
-            {
-                return new BatchFixer(suppressionFixProvider);
-            }
+                => new BatchFixer(suppressionFixProvider);
 
             /// <summary>
             /// Batch fixer for pragma suppression removal code action.
@@ -31,9 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 private readonly AbstractSuppressionCodeFixProvider _suppressionFixProvider;
 
                 public BatchFixer(AbstractSuppressionCodeFixProvider suppressionFixProvider)
-                {
-                    _suppressionFixProvider = suppressionFixProvider;
-                }
+                    => _suppressionFixProvider = suppressionFixProvider;
 
                 protected override async Task AddDocumentFixesAsync(
                     Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Attribute.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Attribute.cs
@@ -42,9 +42,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 }
 
                 public override RemoveSuppressionCodeAction CloneForFixMultipleContext()
-                {
-                    return new AttributeRemoveAction(_attribute, _project, _diagnostic, Fixer, forFixMultipleContext: true);
-                }
+                    => new AttributeRemoveAction(_attribute, _project, _diagnostic, Fixer, forFixMultipleContext: true);
 
                 public override SyntaxTree SyntaxTreeToModify => _attribute.ApplicationSyntaxReference.SyntaxTree;
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Pragma.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Pragma.cs
@@ -51,16 +51,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 }
 
                 public override RemoveSuppressionCodeAction CloneForFixMultipleContext()
-                {
-                    return new PragmaRemoveAction(_suppressionTargetInfo, _document, _diagnostic, Fixer, forFixMultipleContext: true);
-                }
+                    => new PragmaRemoveAction(_suppressionTargetInfo, _document, _diagnostic, Fixer, forFixMultipleContext: true);
 
                 public override SyntaxTree SyntaxTreeToModify => _suppressionTargetInfo.StartToken.SyntaxTree;
 
                 protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
-                {
-                    return await GetChangedDocumentAsync(includeStartTokenChange: true, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
+                    => await GetChangedDocumentAsync(includeStartTokenChange: true, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 public async Task<Document> GetChangedDocumentAsync(bool includeStartTokenChange, bool includeEndTokenChange, CancellationToken cancellationToken)
                 {
@@ -173,9 +169,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 }
 
                 private SyntaxToken GetNewTokenWithRemovedOrToggledPragma(SyntaxToken token, int indexOfTriviaToRemoveOrToggle, bool isStartToken, bool toggle)
-                {
-                    return GetNewTokenWithPragmaUnsuppress(token, indexOfTriviaToRemoveOrToggle, _diagnostic, Fixer, isStartToken, toggle);
-                }
+                    => GetNewTokenWithPragmaUnsuppress(token, indexOfTriviaToRemoveOrToggle, _diagnostic, Fixer, isStartToken, toggle);
 
                 private static SyntaxToken GetNewTokenWithPragmaUnsuppress(SyntaxToken token, int indexOfTriviaToRemoveOrToggle, Diagnostic diagnostic, AbstractSuppressionCodeFixProvider fixer, bool isStartToken, bool toggle)
                 {
@@ -218,9 +212,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 public SyntaxToken EndToken_TestOnly => _suppressionTargetInfo.EndToken;
 
                 private SyntaxNode FormatNode(SyntaxNode node)
-                {
-                    return Formatter.Format(node, _document.Project.Solution.Workspace);
-                }
+                    => Formatter.Format(node, _document.Project.Solution.Workspace);
             }
         }
     }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
@@ -35,14 +35,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         }
 
         public FixAllProvider GetFixAllProvider()
-        {
-            return SuppressionFixAllProvider.Instance;
-        }
+            => SuppressionFixAllProvider.Instance;
 
         public bool IsFixableDiagnostic(Diagnostic diagnostic)
-        {
-            return SuppressionHelpers.CanBeSuppressed(diagnostic) || SuppressionHelpers.CanBeUnsuppressed(diagnostic);
-        }
+            => SuppressionHelpers.CanBeSuppressed(diagnostic) || SuppressionHelpers.CanBeUnsuppressed(diagnostic);
 
         protected abstract SyntaxTriviaList CreatePragmaDisableDirectiveTrivia(Diagnostic diagnostic, Func<SyntaxNode, SyntaxNode> formatNode, bool needsLeadingEndOfLine, bool needsTrailingEndOfLine);
         protected abstract SyntaxTriviaList CreatePragmaRestoreDirectiveTrivia(Diagnostic diagnostic, Func<SyntaxNode, SyntaxNode> formatNode, bool needsLeadingEndOfLine, bool needsTrailingEndOfLine);
@@ -90,14 +86,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         }
 
         protected virtual SyntaxToken GetAdjustedTokenForPragmaDisable(SyntaxToken token, SyntaxNode root, TextLineCollection lines, int indexOfLine)
-        {
-            return token;
-        }
+            => token;
 
         protected virtual SyntaxToken GetAdjustedTokenForPragmaRestore(SyntaxToken token, SyntaxNode root, TextLineCollection lines, int indexOfLine)
-        {
-            return token;
-        }
+            => token;
 
         public Task<ImmutableArray<CodeFix>> GetFixesAsync(
             Document document, TextSpan span, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
@@ -336,8 +328,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         }
 
         protected string GetTargetString(ISymbol targetSymbol)
-        {
-            return "~" + DocumentationCommentId.CreateDeclarationId(targetSymbol);
-        }
+            => "~" + DocumentationCommentId.CreateDeclarationId(targetSymbol);
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/NestedSuppressionCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/NestedSuppressionCodeAction.cs
@@ -9,9 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
     internal abstract class NestedSuppressionCodeAction : CodeAction
     {
         protected NestedSuppressionCodeAction(string title)
-        {
-            Title = title;
-        }
+            => Title = title;
 
         // Put suppressions at the end of everything.
         internal override CodeActionPriority Priority => CodeActionPriority.None;

--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         public static readonly string[] SynthesizedExternalSourceDiagnosticCustomTags = new string[] { SynthesizedExternalSourceDiagnosticTag };
 
         public static bool CanBeSuppressed(Diagnostic diagnostic)
-        {
-            return CanBeSuppressedOrUnsuppressed(diagnostic, checkCanBeSuppressed: true);
-        }
+            => CanBeSuppressedOrUnsuppressed(diagnostic, checkCanBeSuppressed: true);
 
         public static bool CanBeSuppressedWithAttribute(Diagnostic diagnostic)
         {
@@ -33,9 +31,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         }
 
         public static bool CanBeUnsuppressed(Diagnostic diagnostic)
-        {
-            return CanBeSuppressedOrUnsuppressed(diagnostic, checkCanBeSuppressed: false);
-        }
+            => CanBeSuppressedOrUnsuppressed(diagnostic, checkCanBeSuppressed: false);
 
         private static bool CanBeSuppressedOrUnsuppressed(Diagnostic diagnostic, bool checkCanBeSuppressed)
         {
@@ -67,38 +63,24 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         }
 
         public static bool IsNotConfigurableDiagnostic(DiagnosticData diagnostic)
-        {
-            return HasCustomTag(diagnostic.CustomTags, WellKnownDiagnosticTags.NotConfigurable);
-        }
+            => HasCustomTag(diagnostic.CustomTags, WellKnownDiagnosticTags.NotConfigurable);
 
         public static bool IsNotConfigurableDiagnostic(Diagnostic diagnostic)
-        {
-            return HasCustomTag(diagnostic.Descriptor.CustomTags, WellKnownDiagnosticTags.NotConfigurable);
-        }
+            => HasCustomTag(diagnostic.Descriptor.CustomTags, WellKnownDiagnosticTags.NotConfigurable);
 
         public static bool IsCompilerDiagnostic(DiagnosticData diagnostic)
-        {
-            return HasCustomTag(diagnostic.CustomTags, WellKnownDiagnosticTags.Compiler);
-        }
+            => HasCustomTag(diagnostic.CustomTags, WellKnownDiagnosticTags.Compiler);
 
         public static bool IsCompilerDiagnostic(Diagnostic diagnostic)
-        {
-            return HasCustomTag(diagnostic.Descriptor.CustomTags, WellKnownDiagnosticTags.Compiler);
-        }
+            => HasCustomTag(diagnostic.Descriptor.CustomTags, WellKnownDiagnosticTags.Compiler);
 
         public static bool IsSynthesizedExternalSourceDiagnostic(DiagnosticData diagnostic)
-        {
-            return HasCustomTag(diagnostic.CustomTags, SynthesizedExternalSourceDiagnosticTag);
-        }
+            => HasCustomTag(diagnostic.CustomTags, SynthesizedExternalSourceDiagnosticTag);
 
         public static bool IsSynthesizedExternalSourceDiagnostic(Diagnostic diagnostic)
-        {
-            return HasCustomTag(diagnostic.Descriptor.CustomTags, SynthesizedExternalSourceDiagnosticTag);
-        }
+            => HasCustomTag(diagnostic.Descriptor.CustomTags, SynthesizedExternalSourceDiagnosticTag);
 
         public static bool HasCustomTag(IEnumerable<string> customTags, string tagToFind)
-        {
-            return customTags != null && customTags.Any(c => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0);
-        }
+            => customTags != null && customTags.Any(c => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0);
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -54,8 +54,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         }
 
         public override FixAllProvider GetFixAllProvider()
-        {
-            return _suppressionFixProvider.GetFixAllProvider();
-        }
+            => _suppressionFixProvider.GetFixAllProvider();
     }
 }

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -155,8 +155,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
         }
 
         public void Dispose()
-        {
-            _aggregateCancellationTokenSource.Dispose();
-        }
+            => _aggregateCancellationTokenSource.Dispose();
     }
 }

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesServiceFactory.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesServiceFactory.cs
@@ -21,8 +21,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        {
-            return Instance;
-        }
+            => Instance;
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -255,9 +255,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             private readonly SourceText _text;
 
             public CleanUpNewLinesFormatter(SourceText text)
-            {
-                _text = text;
-            }
+                => _text = text;
 
             public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options, in NextGetAdjustNewLinesOperation nextOperation)
             {

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -18,9 +18,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
         protected abstract string CodeActionTitle { get; }
 
         public AbstractAddMissingImportsRefactoringProvider(IPasteTrackingService pasteTrackingService)
-        {
-            _pasteTrackingService = pasteTrackingService;
-        }
+            => _pasteTrackingService = pasteTrackingService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -251,9 +251,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             }
 
             public ImmutableArray<CodeRefactoringProvider> GetRefactorings(string language)
-            {
-                return ImmutableInterlocked.GetOrAdd(ref _refactoringsPerLanguage, language, (language, provider) => provider.CreateRefactorings(language), this);
-            }
+                => ImmutableInterlocked.GetOrAdd(ref _refactoringsPerLanguage, language, (language, provider) => provider.CreateRefactorings(language), this);
 
             private ImmutableArray<CodeRefactoringProvider> CreateRefactorings(string language)
             {

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             public bool IsDocumentNameAValidIdentifier { get; set; }
 
             private State(SemanticDocument document)
-            {
-                SemanticDocument = document;
-            }
+                => SemanticDocument = document;
 
             internal static State Generate(
                 SemanticDocument document, TTypeDeclarationSyntax typeDeclaration,

--- a/src/Features/Core/Portable/CodeRefactorings/ServicesLayerCodeActionHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ServicesLayerCodeActionHelpersService.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        {
-            return new CodeActionHelpersService();
-        }
+            => new CodeActionHelpersService();
 
         private class CodeActionHelpersService : ICodeRefactoringHelpersService
         {

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -311,9 +311,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
         }
 
         private static ImmutableArray<string> GetNamespaceParts(string @namespace)
-        {
-            return @namespace?.Split(s_dotSeparator).ToImmutableArray() ?? default;
-        }
+            => @namespace?.Split(s_dotSeparator).ToImmutableArray() ?? default;
 
         private static ImmutableArray<string> GetAllNamespaceImportsForDeclaringDocument(string oldNamespace, string newNamespace)
         {

--- a/src/Features/Core/Portable/CodeStyle/AbstractCodeStyleProvider.Refactoring.cs
+++ b/src/Features/Core/Portable/CodeStyle/AbstractCodeStyleProvider.Refactoring.cs
@@ -77,9 +77,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             public readonly TCodeStyleProvider _codeStyleProvider;
 
             protected CodeRefactoringProvider()
-            {
-                _codeStyleProvider = new TCodeStyleProvider();
-            }
+                => _codeStyleProvider = new TCodeStyleProvider();
 
             public sealed override Task ComputeRefactoringsAsync(CodeRefactoringContext context)
                 => _codeStyleProvider.ComputeRefactoringsAsync(context);

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -73,9 +73,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         public override string ToString()
-        {
-            return Text;
-        }
+            => Text;
     }
 
     internal static class TaggedTextExtensions
@@ -264,143 +262,87 @@ namespace Microsoft.CodeAnalysis
         }
 
         public static string GetFullText(this IEnumerable<TaggedText> parts)
-        {
-            return string.Join(string.Empty, parts.Select(p => p.ToString()));
-        }
+            => string.Join(string.Empty, parts.Select(p => p.ToString()));
 
         public static void AddAliasName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Alias, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Alias, text));
 
         public static void AddAssemblyName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Assembly, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Assembly, text));
 
         public static void AddClassName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Class, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Class, text));
 
         public static void AddDelegateName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Delegate, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Delegate, text));
 
         public static void AddEnumName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Enum, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Enum, text));
 
         public static void AddErrorTypeName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.ErrorType, text));
-        }
+            => parts.Add(new TaggedText(TextTags.ErrorType, text));
 
         public static void AddEventName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Event, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Event, text));
 
         public static void AddFieldName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Field, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Field, text));
 
         public static void AddInterfaceName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Interface, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Interface, text));
 
         public static void AddKeyword(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Keyword, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Keyword, text));
 
         public static void AddLabelName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Label, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Label, text));
 
         public static void AddLineBreak(this IList<TaggedText> parts, string text = "\r\n")
-        {
-            parts.Add(new TaggedText(TextTags.LineBreak, text));
-        }
+            => parts.Add(new TaggedText(TextTags.LineBreak, text));
 
         public static void AddNumericLiteral(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.NumericLiteral, text));
-        }
+            => parts.Add(new TaggedText(TextTags.NumericLiteral, text));
 
         public static void AddStringLiteral(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.StringLiteral, text));
-        }
+            => parts.Add(new TaggedText(TextTags.StringLiteral, text));
 
         public static void AddLocalName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Local, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Local, text));
 
         public static void AddMethodName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Method, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Method, text));
 
         public static void AddModuleName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Module, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Module, text));
 
         public static void AddNamespaceName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Namespace, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Namespace, text));
 
         public static void AddOperator(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Operator, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Operator, text));
 
         public static void AddParameterName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Parameter, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Parameter, text));
 
         public static void AddPropertyName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Property, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Property, text));
 
         public static void AddPunctuation(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Punctuation, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Punctuation, text));
 
         public static void AddRangeVariableName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.RangeVariable, text));
-        }
+            => parts.Add(new TaggedText(TextTags.RangeVariable, text));
 
         public static void AddStructName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Struct, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Struct, text));
 
         public static void AddSpace(this IList<TaggedText> parts, string text = " ")
-        {
-            parts.Add(new TaggedText(TextTags.Space, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Space, text));
 
         public static void AddText(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.Text, text));
-        }
+            => parts.Add(new TaggedText(TextTags.Text, text));
 
         public static void AddTypeParameterName(this IList<TaggedText> parts, string text)
-        {
-            parts.Add(new TaggedText(TextTags.TypeParameter, text));
-        }
+            => parts.Add(new TaggedText(TextTags.TypeParameter, text));
     }
 }

--- a/src/Features/Core/Portable/Completion/CharacterSetModificationRule.cs
+++ b/src/Features/Core/Portable/Completion/CharacterSetModificationRule.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="characters">One or more characters. These are typically punctuation characters.</param>
         /// <returns></returns>
         public static CharacterSetModificationRule Create(CharacterSetModificationKind kind, ImmutableArray<char> characters)
-        {
-            return new CharacterSetModificationRule(kind, characters);
-        }
+            => new CharacterSetModificationRule(kind, characters);
 
         /// <summary>
         /// Creates a new <see cref="CharacterSetModificationRule"/> instance.
@@ -45,8 +43,6 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="characters">One or more characters. These are typically punctuation characters.</param>
         /// <returns></returns>
         public static CharacterSetModificationRule Create(CharacterSetModificationKind kind, params char[] characters)
-        {
-            return new CharacterSetModificationRule(kind, characters.ToImmutableArray());
-        }
+            => new CharacterSetModificationRule(kind, characters.ToImmutableArray());
     }
 }

--- a/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
@@ -91,9 +91,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         public static bool HasDescription(CompletionItem item)
-        {
-            return item.Properties.ContainsKey("Description");
-        }
+            => item.Properties.ContainsKey("Description");
 
         public static CompletionDescription GetDescription(CompletionItem item)
         {
@@ -110,9 +108,7 @@ namespace Microsoft.CodeAnalysis.Completion
         private static readonly char[] s_descriptionSeparators = new char[] { '|' };
 
         private static string EncodeDescription(ImmutableArray<SymbolDisplayPart> description)
-        {
-            return EncodeDescription(description.ToTaggedText());
-        }
+            => EncodeDescription(description.ToTaggedText());
 
         private static string EncodeDescription(ImmutableArray<TaggedText> description)
         {

--- a/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
@@ -31,9 +31,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         internal virtual bool IsInsertionTrigger(SourceText text, int insertedCharacterPosition, OptionSet options)
-        {
-            return false;
-        }
+            => false;
 
         public sealed override async Task<CompletionDescription> GetDescriptionAsync(
             Document document, CompletionItem item, CancellationToken cancellationToken)
@@ -92,14 +90,10 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         public virtual Task<TextChange?> GetTextChangeAsync(Document document, CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
-        {
-            return GetTextChangeAsync(selectedItem, ch, cancellationToken);
-        }
+            => GetTextChangeAsync(selectedItem, ch, cancellationToken);
 
         protected virtual Task<TextChange?> GetTextChangeAsync(CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<TextChange?>(null);
-        }
+            => Task.FromResult<TextChange?>(null);
 
         private static readonly CompletionItemRules s_suggestionItemRules = CompletionItemRules.Create(enterKeyRule: EnterKeyRule.Never);
 

--- a/src/Features/Core/Portable/Completion/CommonCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionService.cs
@@ -48,14 +48,10 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         protected static bool IsKeywordItem(CompletionItem item)
-        {
-            return item.Tags.Contains(WellKnownTags.Keyword);
-        }
+            => item.Tags.Contains(WellKnownTags.Keyword);
 
         protected static bool IsSnippetItem(CompletionItem item)
-        {
-            return item.Tags.Contains(WellKnownTags.Snippet);
-        }
+            => item.Tags.Contains(WellKnownTags.Snippet);
 
         internal override ImmutableArray<CompletionItem> FilterItems(Document document, ImmutableArray<(CompletionItem, PatternMatch?)> itemsWithPatternMatch, string filterText)
         {

--- a/src/Features/Core/Portable/Completion/CompletionChange.cs
+++ b/src/Features/Core/Portable/Completion/CompletionChange.cs
@@ -82,29 +82,21 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         [Obsolete("Use WithTextChange instead", error: true)]
         public CompletionChange WithTextChanges(ImmutableArray<TextChange> textChanges)
-        {
-            return new CompletionChange(textChanges, NewPosition, IncludesCommitCharacter);
-        }
+            => new CompletionChange(textChanges, NewPosition, IncludesCommitCharacter);
 
         public CompletionChange WithTextChange(TextChange textChange)
-        {
-            return new CompletionChange(textChange, NewPosition, IncludesCommitCharacter);
-        }
+            => new CompletionChange(textChange, NewPosition, IncludesCommitCharacter);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionChange"/> with the <see cref="NewPosition"/> property changed.
         /// </summary>
         public CompletionChange WithNewPosition(int? newPostion)
-        {
-            return new CompletionChange(TextChange, newPostion, IncludesCommitCharacter);
-        }
+            => new CompletionChange(TextChange, newPostion, IncludesCommitCharacter);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionChange"/> with the <see cref="IncludesCommitCharacter"/> property changed.
         /// </summary>
         public CompletionChange WithIncludesCommitCharacter(bool includesCommitCharacter)
-        {
-            return new CompletionChange(TextChange, NewPosition, includesCommitCharacter);
-        }
+            => new CompletionChange(TextChange, NewPosition, includesCommitCharacter);
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionDescription.cs
+++ b/src/Features/Core/Portable/Completion/CompletionDescription.cs
@@ -24,26 +24,20 @@ namespace Microsoft.CodeAnalysis.Completion
         public ImmutableArray<TaggedText> TaggedParts { get; }
 
         private CompletionDescription(ImmutableArray<TaggedText> taggedParts)
-        {
-            TaggedParts = taggedParts.NullToEmpty();
-        }
+            => TaggedParts = taggedParts.NullToEmpty();
 
         /// <summary>
         /// Creates a new instance of <see cref="CompletionDescription"/> with the specified <see cref="TaggedText"/> parts.
         /// </summary>
         /// <param name="taggedParts">The individual tagged parts of the description.</param>
         public static CompletionDescription Create(ImmutableArray<TaggedText> taggedParts)
-        {
-            return new CompletionDescription(taggedParts);
-        }
+            => new CompletionDescription(taggedParts);
 
         /// <summary>
         /// Creates a new instance of <see cref="CompletionDescription"/> from untagged text.
         /// </summary>
         public static CompletionDescription FromText(string text)
-        {
-            return new CompletionDescription(ImmutableArray.Create(new TaggedText(TextTags.Text, text)));
-        }
+            => new CompletionDescription(ImmutableArray.Create(new TaggedText(TextTags.Text, text)));
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionDescription"/> with the <see cref="TaggedParts"/> property changed.

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -24,9 +24,7 @@ namespace Microsoft.CodeAnalysis.Completion
         private readonly bool _isCaseSensitive;
 
         public CompletionHelper(bool isCaseSensitive)
-        {
-            _isCaseSensitive = isCaseSensitive;
-        }
+            => _isCaseSensitive = isCaseSensitive;
 
         public static CompletionHelper GetHelper(Document document)
         {

--- a/src/Features/Core/Portable/Completion/CompletionHelperServiceFactory.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelperServiceFactory.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        {
-            return new Service(workspaceServices.Workspace);
-        }
+            => new Service(workspaceServices.Workspace);
 
         private class Service : ICompletionHelperService, IWorkspaceService
         {
@@ -33,9 +31,7 @@ namespace Microsoft.CodeAnalysis.Completion
             private CompletionHelper _caseInsensitiveInstance;
 
             public Service(Workspace workspace)
-            {
-                workspace.WorkspaceChanged += OnWorkspaceChanged;
-            }
+                => workspace.WorkspaceChanged += OnWorkspaceChanged;
 
             public CompletionHelper GetCompletionHelper(Document document)
             {

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -272,17 +272,13 @@ namespace Microsoft.CodeAnalysis.Completion
         [Obsolete("Not used anymore.  CompletionList.Span is used to control the span used for filtering.", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CompletionItem WithSpan(TextSpan span)
-        {
-            return this;
-        }
+            => this;
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="DisplayText"/> property changed.
         /// </summary>
         public CompletionItem WithDisplayText(string text)
-        {
-            return With(displayText: text);
-        }
+            => With(displayText: text);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="DisplayTextPrefix"/> property changed.
@@ -300,41 +296,31 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="FilterText"/> property changed.
         /// </summary>
         public CompletionItem WithFilterText(string text)
-        {
-            return With(filterText: text);
-        }
+            => With(filterText: text);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="SortText"/> property changed.
         /// </summary>
         public CompletionItem WithSortText(string text)
-        {
-            return With(sortText: text);
-        }
+            => With(sortText: text);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="Properties"/> property changed.
         /// </summary>
         public CompletionItem WithProperties(ImmutableDictionary<string, string> properties)
-        {
-            return With(properties: properties);
-        }
+            => With(properties: properties);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with a property added to the <see cref="Properties"/> collection.
         /// </summary>
         public CompletionItem AddProperty(string name, string value)
-        {
-            return With(properties: Properties.Add(name, value));
-        }
+            => With(properties: Properties.Add(name, value));
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="Tags"/> property changed.
         /// </summary>
         public CompletionItem WithTags(ImmutableArray<string> tags)
-        {
-            return With(tags: tags);
-        }
+            => With(tags: tags);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with a tag added to the <see cref="Tags"/> collection.
@@ -360,9 +346,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="Rules"/> property changed.
         /// </summary>
         public CompletionItem WithRules(CompletionItemRules rules)
-        {
-            return With(rules: rules);
-        }
+            => With(rules: rules);
 
         private string _entireDisplayText;
 

--- a/src/Features/Core/Portable/Completion/CompletionItemRules.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItemRules.cs
@@ -206,58 +206,42 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Creates a copy of this <see cref="CompletionItemRules"/> with the <see cref="FilterCharacterRules"/> property changed.
         /// </summary>
         public CompletionItemRules WithFilterCharacterRules(ImmutableArray<CharacterSetModificationRule> filterCharacterRules)
-        {
-            return With(filterRules: filterCharacterRules);
-        }
+            => With(filterRules: filterCharacterRules);
 
         internal CompletionItemRules WithFilterCharacterRule(CharacterSetModificationRule rule)
-        {
-            return With(filterRules: ImmutableArray.Create(rule));
-        }
+            => With(filterRules: ImmutableArray.Create(rule));
 
         internal CompletionItemRules WithCommitCharacterRule(CharacterSetModificationRule rule)
-        {
-            return With(commitRules: ImmutableArray.Create(rule));
-        }
+            => With(commitRules: ImmutableArray.Create(rule));
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItemRules"/> with the <see cref="CommitCharacterRules"/> property changed.
         /// </summary>
         public CompletionItemRules WithCommitCharacterRules(ImmutableArray<CharacterSetModificationRule> commitCharacterRules)
-        {
-            return With(commitRules: commitCharacterRules);
-        }
+            => With(commitRules: commitCharacterRules);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItemRules"/> with the <see cref="EnterKeyRule"/> property changed.
         /// </summary>
         public CompletionItemRules WithEnterKeyRule(EnterKeyRule enterKeyRule)
-        {
-            return With(enterKeyRule: enterKeyRule);
-        }
+            => With(enterKeyRule: enterKeyRule);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItemRules"/> with the <see cref="FormatOnCommit"/> property changed.
         /// </summary>
         public CompletionItemRules WithFormatOnCommit(bool formatOnCommit)
-        {
-            return With(formatOnCommit: formatOnCommit);
-        }
+            => With(formatOnCommit: formatOnCommit);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItemRules"/> with the <see cref="MatchPriority"/> property changed.
         /// </summary>
         public CompletionItemRules WithMatchPriority(int matchPriority)
-        {
-            return With(matchPriority: matchPriority);
-        }
+            => With(matchPriority: matchPriority);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItemRules"/> with the <see cref="SelectionBehavior"/> property changed.
         /// </summary>
         public CompletionItemRules WithSelectionBehavior(CompletionItemSelectionBehavior selectionBehavior)
-        {
-            return With(selectionBehavior: selectionBehavior);
-        }
+            => With(selectionBehavior: selectionBehavior);
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionList.cs
+++ b/src/Features/Core/Portable/Completion/CompletionList.cs
@@ -127,38 +127,28 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         [Obsolete("Not used anymore.  Use WithSpan instead.", error: true)]
         public CompletionList WithDefaultSpan(TextSpan span)
-        {
-            return With(span: span);
-        }
+            => With(span: span);
 
         public CompletionList WithSpan(TextSpan span)
-        {
-            return With(span: span);
-        }
+            => With(span: span);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionList"/> with the <see cref="Items"/> property changed.
         /// </summary>
         public CompletionList WithItems(ImmutableArray<CompletionItem> items)
-        {
-            return With(items: items);
-        }
+            => With(items: items);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionList"/> with the <see cref="Rules"/> property changed.
         /// </summary>
         public CompletionList WithRules(CompletionRules rules)
-        {
-            return With(rules: rules);
-        }
+            => With(rules: rules);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionList"/> with the <see cref="SuggestionModeItem"/> property changed.
         /// </summary>
         public CompletionList WithSuggestionModeItem(CompletionItem suggestionModeItem)
-        {
-            return With(suggestionModeItem: suggestionModeItem);
-        }
+            => With(suggestionModeItem: suggestionModeItem);
 
         /// <summary>
         /// The default <see cref="CompletionList"/> returned when no items are found to populate the list.
@@ -175,9 +165,7 @@ namespace Microsoft.CodeAnalysis.Completion
             private readonly CompletionList _completionList;
 
             public TestAccessor(CompletionList completionList)
-            {
-                _completionList = completionList;
-            }
+                => _completionList = completionList;
 
             internal bool IsExclusive => _completionList._isExclusive;
         }

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -17,9 +17,7 @@ namespace Microsoft.CodeAnalysis.Completion
         internal string Name { get; }
 
         protected CompletionProvider()
-        {
-            Name = GetType().FullName;
-        }
+            => Name = GetType().FullName;
 
         /// <summary>
         /// Implement to contribute <see cref="CompletionItem"/>'s and other details to a <see cref="CompletionList"/>
@@ -34,9 +32,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="trigger">The triggering action.</param>
         /// <param name="options">The set of options in effect.</param>
         public virtual bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
-        {
-            return false;
-        }
+            => false;
 
         /// <summary>
         /// This allows Completion Providers that indicated they were triggered textually to use syntax to
@@ -50,9 +46,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Gets the description of the specified item.
         /// </summary>
         public virtual Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(CompletionDescription.Empty);
-        }
+            => Task.FromResult(CompletionDescription.Empty);
 
         /// <summary>
         /// Gets the change to be applied when the specified item is committed.

--- a/src/Features/Core/Portable/Completion/CompletionRules.cs
+++ b/src/Features/Core/Portable/Completion/CompletionRules.cs
@@ -129,41 +129,31 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Creates a copy of this <see cref="CompletionRules"/> with the <see cref="DismissIfEmpty"/> property changed.
         /// </summary>
         public CompletionRules WithDismissIfEmpty(bool dismissIfEmpty)
-        {
-            return With(dismissIfEmpty: dismissIfEmpty);
-        }
+            => With(dismissIfEmpty: dismissIfEmpty);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionRules"/> with the <see cref="DismissIfLastCharacterDeleted"/> property changed.
         /// </summary>
         public CompletionRules WithDismissIfLastCharacterDeleted(bool dismissIfLastCharacterDeleted)
-        {
-            return With(dismissIfLastCharacterDeleted: dismissIfLastCharacterDeleted);
-        }
+            => With(dismissIfLastCharacterDeleted: dismissIfLastCharacterDeleted);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionRules"/> with the <see cref="DefaultCommitCharacters"/> property changed.
         /// </summary>
         public CompletionRules WithDefaultCommitCharacters(ImmutableArray<char> defaultCommitCharacters)
-        {
-            return With(defaultCommitCharacters: defaultCommitCharacters);
-        }
+            => With(defaultCommitCharacters: defaultCommitCharacters);
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionRules"/> with the <see cref="DefaultEnterKeyRule"/> property changed.
         /// </summary>
         public CompletionRules WithDefaultEnterKeyRule(EnterKeyRule defaultEnterKeyRule)
-        {
-            return With(defaultEnterKeyRule: defaultEnterKeyRule);
-        }
+            => With(defaultEnterKeyRule: defaultEnterKeyRule);
 
         /// <summary>
         /// Creates a copy of the this <see cref="CompletionRules"/> with the <see cref="SnippetsRule"/> property changed.
         /// </summary>
         public CompletionRules WithSnippetsRule(SnippetsRule snippetsRule)
-        {
-            return With(snippetsRule: snippetsRule);
-        }
+            => With(snippetsRule: snippetsRule);
 
         private static readonly ImmutableArray<char> s_defaultCommitKeys = ImmutableArray.Create(
                 ' ', '{', '}', '[', ']', '(', ')', '.', ',', ':',

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -67,9 +67,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="caretPosition">The position of the caret within the text.</param>
         [Obsolete("Not used anymore. CompletionService.GetDefaultCompletionListSpan is used instead.", error: true)]
         public virtual TextSpan GetDefaultItemSpan(SourceText text, int caretPosition)
-        {
-            return GetDefaultCompletionListSpan(text, caretPosition);
-        }
+            => GetDefaultCompletionListSpan(text, caretPosition);
 
         public virtual TextSpan GetDefaultCompletionListSpan(SourceText text, int caretPosition)
         {

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -48,9 +48,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         public override CompletionRules GetRules()
-        {
-            return CompletionRules.Default;
-        }
+            => CompletionRules.Default;
 
         /// <summary>
         /// Returns the providers always available to the service.
@@ -58,9 +56,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         [Obsolete("Built-in providers will be ignored in a future release, please make them MEF exports instead.")]
         protected virtual ImmutableArray<CompletionProvider> GetBuiltInProviders()
-        {
-            return ImmutableArray<CompletionProvider>.Empty;
-        }
+            => ImmutableArray<CompletionProvider>.Empty;
 
         private IEnumerable<Lazy<CompletionProvider, CompletionProviderMetadata>> GetImportedProviders()
         {
@@ -351,9 +347,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         private static bool HasAnyItems(CompletionContext cc)
-        {
-            return cc.Items.Count > 0 || cc.SuggestionModeItem != null;
-        }
+            => cc.Items.Count > 0 || cc.SuggestionModeItem != null;
 
         private async Task<(ImmutableArray<CompletionContext>, bool)> ComputeNonEmptyCompletionContextsAsync(
             Document document, int caretPosition, CompletionTrigger trigger,
@@ -596,9 +590,7 @@ namespace Microsoft.CodeAnalysis.Completion
             private readonly CompletionServiceWithProviders _completionServiceWithProviders;
 
             public TestAccessor(CompletionServiceWithProviders completionServiceWithProviders)
-            {
-                _completionServiceWithProviders = completionServiceWithProviders;
-            }
+                => _completionServiceWithProviders = completionServiceWithProviders;
 
             internal ImmutableArray<CompletionProvider> GetAllProviders(ImmutableHashSet<string> roles)
                 => _completionServiceWithProviders.GetAllProviders(roles);

--- a/src/Features/Core/Portable/Completion/FileSystemCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/FileSystemCompletionHelper.cs
@@ -116,9 +116,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 rules: _itemRules);
 
         public Task<ImmutableArray<CompletionItem>> GetItemsAsync(string directoryPath, CancellationToken cancellationToken)
-        {
-            return Task.Run(() => GetItems(directoryPath, cancellationToken), cancellationToken);
-        }
+            => Task.Run(() => GetItems(directoryPath, cancellationToken), cancellationToken);
 
         private ImmutableArray<CompletionItem> GetItems(string directoryPath, CancellationToken cancellationToken)
         {
@@ -263,9 +261,7 @@ namespace Microsoft.CodeAnalysis.Completion
             private readonly FileSystemCompletionHelper _fileSystemCompletionHelper;
 
             public TestAccessor(FileSystemCompletionHelper fileSystemCompletionHelper)
-            {
-                _fileSystemCompletionHelper = fileSystemCompletionHelper;
-            }
+                => _fileSystemCompletionHelper = fileSystemCompletionHelper;
 
             internal ImmutableArray<CompletionItem> GetItems(string directoryPath, CancellationToken cancellationToken)
                 => _fileSystemCompletionHelper.GetItems(directoryPath, cancellationToken);

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -122,8 +122,6 @@ namespace Microsoft.CodeAnalysis.Completion.Log
         }
 
         private static string CreateProperty(string parent, string child)
-        {
-            return parent + "." + child;
-        }
+            => parent + "." + child;
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -111,9 +111,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         protected IEnumerable<CompletionItem> GetAlwaysVisibleItems()
-        {
-            return new[] { GetCDataItem(), GetCommentItem(), GetItem(InheritdocElementName), GetItem(SeeElementName), GetItem(SeeAlsoElementName) };
-        }
+            => new[] { GetCDataItem(), GetCommentItem(), GetItem(InheritdocElementName), GetItem(SeeElementName), GetItem(SeeAlsoElementName) };
 
         private CompletionItem GetCommentItem()
         {
@@ -240,19 +238,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         protected IEnumerable<CompletionItem> GetItemTagItems()
-        {
-            return new[] { TermElementName, DescriptionElementName }.Select(GetItem);
-        }
+            => new[] { TermElementName, DescriptionElementName }.Select(GetItem);
 
         protected IEnumerable<CompletionItem> GetListItems()
-        {
-            return s_listTagNames.Select(GetItem);
-        }
+            => s_listTagNames.Select(GetItem);
 
         protected IEnumerable<CompletionItem> GetListHeaderItems()
-        {
-            return s_listHeaderTagNames.Select(GetItem);
-        }
+            => s_listHeaderTagNames.Select(GetItem);
 
         private IEnumerable<CompletionItem> GetParameterItems<TSymbol>(ImmutableArray<TSymbol> symbols, TSyntax syntax, string tagName) where TSymbol : ISymbol
         {
@@ -262,14 +254,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private string FormatParameter(string kind, string name)
-        {
-            return $"{kind} {NameAttributeName}=\"{name}\"";
-        }
+            => $"{kind} {NameAttributeName}=\"{name}\"";
 
         private string FormatParameterRefTag(string kind, string name)
-        {
-            return $"<{kind} {NameAttributeName}=\"{name}\"/>";
-        }
+            => $"<{kind} {NameAttributeName}=\"{name}\"/>";
 
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitChar = null, CancellationToken cancellationToken = default)
         {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
@@ -31,14 +31,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private class Comparer : IEqualityComparer<CompletionItem>
         {
             public bool Equals(CompletionItem x, CompletionItem y)
-            {
-                return x.DisplayText == y.DisplayText;
-            }
+                => x.DisplayText == y.DisplayText;
 
             public int GetHashCode(CompletionItem obj)
-            {
-                return Hash.Combine(obj.DisplayText.GetHashCode(), obj.DisplayText.GetHashCode());
-            }
+                => Hash.Combine(obj.DisplayText.GetHashCode(), obj.DisplayText.GetHashCode());
         }
 
         private static readonly Comparer s_comparer = new Comparer();
@@ -115,9 +111,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public override Task<TextChange?> GetTextChangeAsync(Document document, CompletionItem item, char? ch, CancellationToken cancellationToken)
-        {
-            return Task.FromResult((TextChange?)new TextChange(item.Span, item.DisplayText));
-        }
+            => Task.FromResult((TextChange?)new TextChange(item.Span, item.DisplayText));
 
         internal abstract TextSpan GetCurrentSpan(TextSpan span, SourceText text);
     }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -206,9 +206,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 enterKeyRule: EnterKeyRule.Never);
 
         internal virtual CompletionItemRules GetRules()
-        {
-            return s_defaultRules;
-        }
+            => s_defaultRules;
 
         protected override Task<CompletionDescription> GetDescriptionWorkerAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
             => MemberInsertionCompletionItem.GetDescriptionAsync(item, document, cancellationToken);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
@@ -44,9 +44,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         protected override Task<ImmutableArray<ISymbol>> GetSymbolsAsync(SyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken)
-        {
-            return GetSymbolsCoreAsync(context, position, options, preselect: false, cancellationToken);
-        }
+            => GetSymbolsCoreAsync(context, position, options, preselect: false, cancellationToken);
 
         protected override Task<ImmutableArray<ISymbol>> GetPreselectedSymbolsAsync(
             SyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
@@ -166,9 +166,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
 
             private bool IsOnStartLine(int position)
-            {
-                return _text.Lines.IndexOf(position) == _startLineNumber;
-            }
+                => _text.Lines.IndexOf(position) == _startLineNumber;
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.cs
@@ -70,9 +70,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             out SyntaxToken nextToken);
 
         protected bool IsOnStartLine(int position, SourceText text, int startLine)
-        {
-            return text.Lines.IndexOf(position) == startLine;
-        }
+            => text.Lines.IndexOf(position) == startLine;
 
         protected ITypeSymbol GetReturnType(ISymbol symbol)
             => symbol.Kind switch

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -107,9 +107,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private static bool InSameProject(INamedTypeSymbol symbol, Compilation compilation)
-        {
-            return symbol.DeclaringSyntaxReferences.Any(r => compilation.SyntaxTrees.Contains(r.SyntaxTree));
-        }
+            => symbol.DeclaringSyntaxReferences.Any(r => compilation.SyntaxTrees.Contains(r.SyntaxTree));
 
         private static bool NotNewDeclaredMember(INamedTypeSymbol symbol, SyntaxContext context)
         {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -104,9 +104,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private static bool IsArgumentListTriggerCharacter(char character)
-        {
-            return character == ' ' || character == '(' || character == '[';
-        }
+            => character == ' ' || character == '(' || character == '[';
 
         protected abstract CompletionItemRules GetCompletionItemRules(List<ISymbol> symbols, SyntaxContext context, bool preselect);
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -238,9 +238,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected abstract Task<ImmutableArray<ISymbol>> GetSymbolsAsync(SyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken);
 
         protected virtual Task<ImmutableArray<ISymbol>> GetPreselectedSymbolsAsync(SyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken)
-        {
-            return SpecializedTasks.EmptyImmutableArray<ISymbol>();
-        }
+            => SpecializedTasks.EmptyImmutableArray<ISymbol>();
 
         protected override Task<CompletionDescription> GetDescriptionWorkerAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
             => SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken);
@@ -348,14 +346,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         protected virtual bool IsExclusive()
-        {
-            return false;
-        }
+            => false;
 
         protected virtual Task<bool> IsSemanticTriggerCharacterAsync(Document document, int characterPosition, CancellationToken cancellationToken)
-        {
-            return SpecializedTasks.True;
-        }
+            => SpecializedTasks.True;
 
         private Task<ImmutableArray<ISymbol>> GetSymbolsAsync(int position, bool preselect, SyntaxContext context, OptionSet options, CancellationToken cancellationToken)
         {
@@ -482,9 +476,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         /// Override this if you want to provide customized insertion based on the character typed.
         /// </summary>
         protected virtual string GetInsertionText(CompletionItem item, char ch)
-        {
-            return SymbolCompletionItem.GetInsertionText(item);
-        }
+            => SymbolCompletionItem.GetInsertionText(item);
 
         // This is used to decide which provider we'd collect target type completion telemetry from.
         protected virtual bool ShouldCollectTelemetryForTargetTypeCompletion => false;
@@ -495,14 +487,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             private int _tick;
 
             public TelemetryCounter(bool shouldReport)
-            {
-                _shouldReport = shouldReport;
-            }
+                => _shouldReport = shouldReport;
 
             public void AddTick(int tick)
-            {
-                _tick += tick;
-            }
+                => _tick += tick;
 
             public void Dispose()
             {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
@@ -80,9 +80,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             public bool CacheMiss { get; set; }
 
             public TelemetryCounter()
-            {
-                Tick = Environment.TickCount;
-            }
+                => Tick = Environment.TickCount;
 
             public void Report()
             {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
         protected abstract bool IsCaseSensitive { get; }
 
         internal AbstractTypeImportCompletionService(Workspace workspace)
-        {
-            CacheService = workspace.Services.GetRequiredService<IImportCompletionCacheService<CacheEntry, CacheEntry>>();
-        }
+            => CacheService = workspace.Services.GetRequiredService<IImportCompletionCacheService<CacheEntry, CacheEntry>>();
 
         public async Task<ImmutableArray<ImmutableArray<CompletionItem>>?> GetAllTopLevelTypesAsync(
             Project currentProject,
@@ -374,9 +372,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
                 => (_properties & ItemPropertyKind.IsAttribute) != 0;
 
             public TypeImportCompletionItemInfo WithItem(CompletionItem item)
-            {
-                return new TypeImportCompletionItemInfo(item, IsPublic, IsGeneric, IsAttribute);
-            }
+                => new TypeImportCompletionItemInfo(item, IsPublic, IsGeneric, IsAttribute);
 
             [Flags]
             private enum ItemPropertyKind : byte

--- a/src/Features/Core/Portable/Completion/Providers/MemberInsertingCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/MemberInsertingCompletionItem.cs
@@ -36,9 +36,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public static Task<CompletionDescription> GetDescriptionAsync(CompletionItem item, Document document, CancellationToken cancellationToken)
-        {
-            return SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken);
-        }
+            => SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken);
 
         public static DeclarationModifiers GetModifiers(CompletionItem item)
         {

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -55,9 +55,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public static CompletionItem AddSymbolEncoding(IReadOnlyList<ISymbol> symbols, CompletionItem item)
-        {
-            return item.AddProperty("Symbols", EncodeSymbols(symbols));
-        }
+            => item.AddProperty("Symbols", EncodeSymbols(symbols));
 
         public static CompletionItem AddSymbolInfo(IReadOnlyList<ISymbol> symbols, CompletionItem item)
         {
@@ -88,14 +86,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public static string EncodeSymbol(ISymbol symbol)
-        {
-            return SymbolKey.CreateString(symbol);
-        }
+            => SymbolKey.CreateString(symbol);
 
         public static bool HasSymbols(CompletionItem item)
-        {
-            return item.Properties.ContainsKey("Symbols");
-        }
+            => item.Properties.ContainsKey("Symbols");
 
         private static readonly char[] s_symbolSplitters = new[] { '|' };
 
@@ -149,9 +143,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private static ISymbol DecodeSymbol(string id, Compilation compilation)
-        {
-            return SymbolKey.ResolveString(id, compilation).GetAnySymbol();
-        }
+            => SymbolKey.ResolveString(id, compilation).GetAnySymbol();
 
         public static async Task<CompletionDescription> GetDescriptionAsync(
             CompletionItem item, Document document, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Completion/Providers/UnionCompletionItemComparer.cs
+++ b/src/Features/Core/Portable/Completion/Providers/UnionCompletionItemComparer.cs
@@ -22,8 +22,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public int GetHashCode(CompletionItem obj)
-        {
-            return Hash.Combine(obj.DisplayText.GetHashCode(), obj.Tags.Length);
-        }
+            => Hash.Combine(obj.DisplayText.GetHashCode(), obj.Tags.Length);
     }
 }

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.AnalyzedNodes.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.AnalyzedNodes.cs
@@ -70,9 +70,7 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
                 public readonly TIsExpressionSyntax IsExpressionSyntax;
 
                 public Type(TIsExpressionSyntax expression)
-                {
-                    IsExpressionSyntax = expression;
-                }
+                    => IsExpressionSyntax = expression;
             }
 
             /// <summary>
@@ -83,9 +81,7 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
                 public readonly TPatternSyntax PatternSyntax;
 
                 public Source(TPatternSyntax patternSyntax)
-                {
-                    PatternSyntax = patternSyntax;
-                }
+                    => PatternSyntax = patternSyntax;
             }
 
             /// <summary>
@@ -96,9 +92,7 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
                 public readonly TExpressionSyntax ExpressionSyntax;
 
                 public Constant(TExpressionSyntax expression)
-                {
-                    ExpressionSyntax = expression;
-                }
+                    => ExpressionSyntax = expression;
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.cs
+++ b/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.cs
@@ -227,9 +227,7 @@ namespace Microsoft.CodeAnalysis.Debugging
         }
 
         private static IMethodSymbol GetPartialImplementationPartOrNull(ISymbol symbol)
-        {
-            return (symbol.Kind == SymbolKind.Method) ? ((IMethodSymbol)symbol).PartialImplementationPart : null;
-        }
+            => (symbol.Kind == SymbolKind.Method) ? ((IMethodSymbol)symbol).PartialImplementationPart : null;
 
         /// <summary>
         /// Is this method or property a valid place to set a breakpoint and does it match the expected parameter count?

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -27,17 +27,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public bool SupportGetDiagnostics => false;
 
         public ImmutableArray<DiagnosticData> GetDiagnostics(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics, CancellationToken cancellationToken)
-        {
-            return ImmutableArray<DiagnosticData>.Empty;
-        }
+            => ImmutableArray<DiagnosticData>.Empty;
 
         public event EventHandler<DiagnosticsUpdatedArgs>? DiagnosticsUpdated;
         public event EventHandler DiagnosticsCleared { add { } remove { } }
 
         public void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs args)
-        {
-            DiagnosticsUpdated?.Invoke(this, args);
-        }
+            => DiagnosticsUpdated?.Invoke(this, args);
 
         public void ReportAnalyzerDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, ProjectId? projectId)
         {
@@ -154,14 +150,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private readonly AbstractHostDiagnosticUpdateSource _abstractHostDiagnosticUpdateSource;
 
             public TestAccessor(AbstractHostDiagnosticUpdateSource abstractHostDiagnosticUpdateSource)
-            {
-                _abstractHostDiagnosticUpdateSource = abstractHostDiagnosticUpdateSource;
-            }
+                => _abstractHostDiagnosticUpdateSource = abstractHostDiagnosticUpdateSource;
 
             internal ImmutableArray<DiagnosticData> GetReportedDiagnostics()
-            {
-                return _abstractHostDiagnosticUpdateSource._analyzerHostDiagnosticsMap.Values.Flatten().ToImmutableArray();
-            }
+                => _abstractHostDiagnosticUpdateSource._analyzerHostDiagnosticsMap.Values.Flatten().ToImmutableArray();
 
             internal ImmutableHashSet<DiagnosticData> GetReportedDiagnostics(DiagnosticAnalyzer analyzer)
             {
@@ -196,9 +188,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             public override int GetHashCode()
-            {
-                return Hash.Combine(_source.GetHashCode(), Hash.Combine(_projectId == null ? 1 : _projectId.GetHashCode(), base.GetHashCode()));
-            }
+                => Hash.Combine(_source.GetHashCode(), Hash.Combine(_projectId == null ? 1 : _projectId.GetHashCode(), base.GetHashCode()));
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -248,9 +248,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public static IEnumerable<AnalyzerPerformanceInfo> ToAnalyzerPerformanceInfo(this IDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo> analysisResult, DiagnosticAnalyzerInfoCache analyzerInfo)
-        {
-            return analysisResult.Select(kv => new AnalyzerPerformanceInfo(kv.Key.GetAnalyzerId(), analyzerInfo.IsTelemetryCollectionAllowed(kv.Key), kv.Value.ExecutionTime));
-        }
+            => analysisResult.Select(kv => new AnalyzerPerformanceInfo(kv.Key.GetAnalyzerId(), analyzerInfo.IsTelemetryCollectionAllowed(kv.Key), kv.Value.ExecutionTime));
 
         public static async Task<CompilationWithAnalyzers?> CreateCompilationWithAnalyzersAsync(
             Project project,
@@ -498,9 +496,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         private static bool IsCanceled(Exception ex, CancellationToken cancellationToken)
-        {
-            return (ex as OperationCanceledException)?.CancellationToken == cancellationToken;
-        }
+            => (ex as OperationCanceledException)?.CancellationToken == cancellationToken;
 
         private static async Task VerifyDiagnosticLocationsAsync(ImmutableArray<Diagnostic> diagnostics, Project project, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Diagnostics/BuildToolId.cs
+++ b/src/Features/Core/Portable/Diagnostics/BuildToolId.cs
@@ -18,9 +18,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             protected readonly T _Field1;
 
             public Base(T field)
-            {
-                _Field1 = field;
-            }
+                => _Field1 = field;
 
             public override bool Equals(object obj)
             {
@@ -33,9 +31,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             public override int GetHashCode()
-            {
-                return _Field1?.GetHashCode() ?? 0;
-            }
+                => _Field1?.GetHashCode() ?? 0;
         }
 
         internal abstract class Base<T1, T2> : Base<T2>
@@ -43,9 +39,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private readonly T1 _Field2;
 
             public Base(T1 field1, T2 field2) : base(field2)
-            {
-                _Field2 = field1;
-            }
+                => _Field2 = field1;
 
             public override bool Equals(object obj)
             {
@@ -58,9 +52,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             public override int GetHashCode()
-            {
-                return Hash.Combine(_Field2?.GetHashCode() ?? 0, base.GetHashCode());
-            }
+                => Hash.Combine(_Field2?.GetHashCode() ?? 0, base.GetHashCode());
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -58,9 +58,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         internal void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs state)
-        {
-            DiagnosticsUpdated?.Invoke(this, state);
-        }
+            => DiagnosticsUpdated?.Invoke(this, state);
 
         private class DefaultDiagnosticIncrementalAnalyzer : IIncrementalAnalyzer
         {
@@ -206,9 +204,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
-            {
-                return DocumentResetAsync(document, cancellationToken);
-            }
+                => DocumentResetAsync(document, cancellationToken);
 
             private void RaiseEmptyDiagnosticUpdated(AnalysisKind kind, DocumentId documentId)
             {
@@ -217,33 +213,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
-            {
-                return Task.CompletedTask;
-            }
+                => Task.CompletedTask;
 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
-            {
-                return Task.CompletedTask;
-            }
+                => Task.CompletedTask;
 
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
-            {
-                return Task.CompletedTask;
-            }
+                => Task.CompletedTask;
 
             public Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellationToken)
-            {
-                return Task.CompletedTask;
-            }
+                => Task.CompletedTask;
 
             private class DefaultUpdateArgsId : BuildToolId.Base<int, DocumentId>, ISupportLiveUpdate
             {
                 private readonly string _workspaceKind;
 
                 public DefaultUpdateArgsId(string workspaceKind, AnalysisKind kind, DocumentId documentId) : base((int)kind, documentId)
-                {
-                    _workspaceKind = workspaceKind;
-                }
+                    => _workspaceKind = workspaceKind;
 
                 public override string BuildTool => PredefinedBuildTools.Live;
 
@@ -258,9 +244,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 public override int GetHashCode()
-                {
-                    return Hash.Combine(_workspaceKind.GetHashCode(), base.GetHashCode());
-                }
+                    => Hash.Combine(_workspaceKind.GetHashCode(), base.GetHashCode());
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -43,8 +43,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         private void OnDocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
-        {
-            Reanalyze(e.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.NewActiveContextDocumentId), highPriority: true);
-        }
+            => Reanalyze(e.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.NewActiveContextDocumentId), highPriority: true);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerTelemetry.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerTelemetry.cs
@@ -64,9 +64,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private ImmutableDictionary<Type, Data> _analyzerInfoMap;
 
         public DiagnosticAnalyzerTelemetry()
-        {
-            _analyzerInfoMap = ImmutableDictionary<Type, Data>.Empty;
-        }
+            => _analyzerInfoMap = ImmutableDictionary<Type, Data>.Empty;
 
         public void UpdateAnalyzerActionsTelemetry(DiagnosticAnalyzer analyzer, AnalyzerTelemetryInfo analyzerTelemetryInfo, bool isTelemetryCollectionAllowed)
         {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
@@ -40,9 +40,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         protected override void QueueTask(Task task)
-        {
-            _tasks.Add(task);
-        }
+            => _tasks.Add(task);
 
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ActiveFileState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ActiveFileState.cs
@@ -24,9 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private DocumentAnalysisData _semantic = DocumentAnalysisData.Empty;
 
             public ActiveFileState(DocumentId documentId)
-            {
-                DocumentId = documentId;
-            }
+                => DocumentId = documentId;
 
             public bool IsEmpty => _syntax.Items.IsEmpty && _semantic.Items.IsEmpty;
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -56,9 +56,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             public DocumentAnalysisData ToPersistData()
-            {
-                return new DocumentAnalysisData(Version, Items);
-            }
+                => new DocumentAnalysisData(Version, Items);
 
             public bool FromCache
             {
@@ -111,9 +109,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             public DiagnosticAnalysisResult GetResult(DiagnosticAnalyzer analyzer)
-            {
-                return GetResultOrEmpty(Result, analyzer, ProjectId, Version);
-            }
+                => GetResultOrEmpty(Result, analyzer, ProjectId, Version);
 
             public static async Task<ProjectAnalysisData> CreateAsync(IPersistentStorageService persistentService, Project project, IEnumerable<StateSet> stateSets, bool avoidLoadingData, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
@@ -66,9 +66,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             // make sure key is either documentId or projectId
             private static void AssertKey((object key, string stateKey) key)
-            {
-                Contract.ThrowIfFalse(key.key is DocumentId || key.key is ProjectId);
-            }
+                => Contract.ThrowIfFalse(key.key is DocumentId || key.key is ProjectId);
         }
 
         // in memory cache entry

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -37,19 +37,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             public bool FromBuild => _lastResult.FromBuild;
 
             public ImmutableHashSet<DocumentId> GetDocumentsWithDiagnostics()
-            {
-                return _lastResult.DocumentIdsOrEmpty;
-            }
+                => _lastResult.DocumentIdsOrEmpty;
 
             public bool IsEmpty()
-            {
-                return _lastResult.IsEmpty;
-            }
+                => _lastResult.IsEmpty;
 
             public bool IsEmpty(DocumentId documentId)
-            {
-                return IsEmpty(_lastResult, documentId);
-            }
+                => IsEmpty(_lastResult, documentId);
 
             /// <summary>
             /// Return all diagnostics for the given project stored in this state
@@ -452,9 +446,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private bool IsEmpty(DiagnosticAnalysisResult result, DocumentId documentId)
-            {
-                return !result.DocumentIdsOrEmpty.Contains(documentId);
-            }
+                => !result.DocumentIdsOrEmpty.Contains(documentId);
 
             // we have this builder to avoid allocating collections unnecessarily.
             private sealed class Builder
@@ -476,24 +468,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 public void AddSyntaxLocals(DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)
-                {
-                    Add(ref _syntaxLocals, documentId, diagnostics);
-                }
+                    => Add(ref _syntaxLocals, documentId, diagnostics);
 
                 public void AddSemanticLocals(DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)
-                {
-                    Add(ref _semanticLocals, documentId, diagnostics);
-                }
+                    => Add(ref _semanticLocals, documentId, diagnostics);
 
                 public void AddNonLocals(DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)
-                {
-                    Add(ref _nonLocals, documentId, diagnostics);
-                }
+                    => Add(ref _nonLocals, documentId, diagnostics);
 
                 public void AddOthers(ImmutableArray<DiagnosticData> diagnostics)
-                {
-                    _others = diagnostics;
-                }
+                    => _others = diagnostics;
 
                 private void Add(ref ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>>.Builder? locals, DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)
                 {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -75,9 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 private int PriorityComparison(StateSet state1, StateSet state2)
-                {
-                    return GetPriority(state1) - GetPriority(state2);
-                }
+                    => GetPriority(state1) - GetPriority(state2);
 
                 private int GetPriority(StateSet state)
                 {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -58,9 +58,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// This will never create new <see cref="StateSet"/> but will return ones already created.
             /// </summary>
             public IEnumerable<StateSet> GetAllStateSets()
-            {
-                return GetAllHostStateSets().Concat(GetAllProjectStateSets());
-            }
+                => GetAllHostStateSets().Concat(GetAllProjectStateSets());
 
             /// <summary>
             /// Return <see cref="StateSet"/>s for the given <see cref="ProjectId"/>. 
@@ -82,9 +80,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// this will only return <see cref="StateSet"/>s that have same language as <paramref name="project"/>.
             /// </summary>
             public IEnumerable<StateSet> GetStateSets(Project project)
-            {
-                return GetStateSets(project.Id).Where(s => s.Language == project.Language);
-            }
+                => GetStateSets(project.Id).Where(s => s.Language == project.Language);
 
             /// <summary>
             /// Return <see cref="StateSet"/>s for the given <see cref="Project"/>. 
@@ -257,9 +253,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private void RaiseProjectAnalyzerReferenceChanged(ProjectAnalyzerReferenceChangedEventArgs args)
-            {
-                ProjectAnalyzerReferenceChanged?.Invoke(this, args);
-            }
+                => ProjectAnalyzerReferenceChanged?.Invoke(this, args);
 
             private static ImmutableDictionary<DiagnosticAnalyzer, StateSet> CreateStateSetMap(
                 string language,

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -280,9 +280,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 public string NonLocalStateName { get; }
 
                 public static PersistentNames Create(DiagnosticAnalyzer diagnosticAnalyzer)
-                {
-                    return s_analyzerStateNameCache.GetOrAdd(diagnosticAnalyzer.GetAnalyzerId(), t => new PersistentNames(t));
-                }
+                    => s_analyzerStateNameCache.GetOrAdd(diagnosticAnalyzer.GetAnalyzerId(), t => new PersistentNames(t));
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -226,9 +226,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, projectId, (int)kind, stateSet.ErrorSourceName);
 
         public static Task<VersionStamp> GetDiagnosticVersionAsync(Project project, CancellationToken cancellationToken)
-        {
-            return project.GetDependentVersionAsync(cancellationToken);
-        }
+            => project.GetDependentVersionAsync(cancellationToken);
 
         private static DiagnosticAnalysisResult GetResultOrEmpty(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> map, DiagnosticAnalyzer analyzer, ProjectId projectId, VersionStamp version)
         {
@@ -241,43 +239,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         public void LogAnalyzerCountSummary()
-        {
-            _telemetry.ReportAndClear(_correlationId);
-        }
+            => _telemetry.ReportAndClear(_correlationId);
 
         internal IEnumerable<DiagnosticAnalyzer> GetAnalyzersTestOnly(Project project)
-        {
-            return _stateManager.GetOrCreateStateSets(project).Select(s => s.Analyzer);
-        }
+            => _stateManager.GetOrCreateStateSets(project).Select(s => s.Analyzer);
 
         private static string GetDocumentLogMessage(string title, Document document, DiagnosticAnalyzer analyzer)
-        {
-            return $"{title}: ({document.Id}, {document.Project.Id}), ({analyzer})";
-        }
+            => $"{title}: ({document.Id}, {document.Project.Id}), ({analyzer})";
 
         private static string GetProjectLogMessage(Project project, IEnumerable<StateSet> stateSets)
-        {
-            return $"project: ({project.Id}), ({string.Join(Environment.NewLine, stateSets.Select(s => s.Analyzer.ToString()))})";
-        }
+            => $"project: ({project.Id}), ({string.Join(Environment.NewLine, stateSets.Select(s => s.Analyzer.ToString()))})";
 
         private static string GetResetLogMessage(Document document)
-        {
-            return $"document close/reset: ({document.FilePath ?? document.Name})";
-        }
+            => $"document close/reset: ({document.FilePath ?? document.Name})";
 
         private static string GetOpenLogMessage(Document document)
-        {
-            return $"document open: ({document.FilePath ?? document.Name})";
-        }
+            => $"document open: ({document.FilePath ?? document.Name})";
 
         private static string GetRemoveLogMessage(DocumentId id)
-        {
-            return $"document remove: {id.ToString()}";
-        }
+            => $"document remove: {id.ToString()}";
 
         private static string GetRemoveLogMessage(ProjectId id)
-        {
-            return $"project remove: {id.ToString()}";
-        }
+            => $"project remove: {id.ToString()}";
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -28,24 +28,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
-        {
-            return new IdeCachedDiagnosticGetter(this, solution, projectId, documentId, includeSuppressedDiagnostics).GetDiagnosticsAsync(cancellationToken);
-        }
+            => new IdeCachedDiagnosticGetter(this, solution, projectId, documentId, includeSuppressedDiagnostics).GetDiagnosticsAsync(cancellationToken);
 
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
-        {
-            return new IdeLatestDiagnosticGetter(this, solution, projectId, documentId, diagnosticIds: null, includeSuppressedDiagnostics).GetDiagnosticsAsync(cancellationToken);
-        }
+            => new IdeLatestDiagnosticGetter(this, solution, projectId, documentId, diagnosticIds: null, includeSuppressedDiagnostics).GetDiagnosticsAsync(cancellationToken);
 
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
-        {
-            return new IdeLatestDiagnosticGetter(this, solution, projectId, documentId, diagnosticIds, includeSuppressedDiagnostics).GetDiagnosticsAsync(cancellationToken);
-        }
+            => new IdeLatestDiagnosticGetter(this, solution, projectId, documentId, diagnosticIds, includeSuppressedDiagnostics).GetDiagnosticsAsync(cancellationToken);
 
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, ImmutableHashSet<string>? diagnosticIds, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
-        {
-            return new IdeLatestDiagnosticGetter(this, solution, projectId, documentId: null, diagnosticIds: diagnosticIds, includeSuppressedDiagnostics).GetProjectDiagnosticsAsync(cancellationToken);
-        }
+            => new IdeLatestDiagnosticGetter(this, solution, projectId, documentId: null, diagnosticIds: diagnosticIds, includeSuppressedDiagnostics).GetProjectDiagnosticsAsync(cancellationToken);
 
         private abstract class DiagnosticGetter
         {
@@ -79,9 +71,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             protected virtual bool ShouldIncludeDiagnostic(DiagnosticData diagnostic) => true;
 
             protected ImmutableArray<DiagnosticData> GetDiagnosticData()
-            {
-                return (_lazyDataBuilder != null) ? _lazyDataBuilder.ToImmutableArray() : ImmutableArray<DiagnosticData>.Empty;
-            }
+                => (_lazyDataBuilder != null) ? _lazyDataBuilder.ToImmutableArray() : ImmutableArray<DiagnosticData>.Empty;
 
             protected abstract Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(StateSet stateSet, Project project, DocumentId? documentId, AnalysisKind kind, CancellationToken cancellationToken);
             protected abstract Task AppendDiagnosticsAsync(Project project, IEnumerable<DocumentId> documentIds, bool includeProjectNonLocalResult, CancellationToken cancellationToken);
@@ -163,9 +153,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private bool ShouldIncludeSuppressedDiagnostic(DiagnosticData diagnostic)
-            {
-                return IncludeSuppressedDiagnostics || !diagnostic.IsSuppressed;
-            }
+                => IncludeSuppressedDiagnostics || !diagnostic.IsSuppressed;
         }
 
         private sealed class IdeCachedDiagnosticGetter : DiagnosticGetter

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -214,9 +214,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private Task<IEnumerable<DiagnosticData>> GetSyntaxDiagnosticsAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
-            {
-                return AnalyzerHelper.ComputeDiagnosticsAsync(analyzer, _document, AnalysisKind.Syntax, _compilation, _owner.GetOrCreateSkippedAnalyzersInfo, _range, cancellationToken);
-            }
+                => AnalyzerHelper.ComputeDiagnosticsAsync(analyzer, _document, AnalysisKind.Syntax, _compilation, _owner.GetOrCreateSkippedAnalyzersInfo, _range, cancellationToken);
 
             private Task<IEnumerable<DiagnosticData>> GetSemanticDiagnosticsAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
             {
@@ -447,14 +445,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             internal static readonly DiagnosticComparer Instance = new DiagnosticComparer();
 
             public bool Equals(Diagnostic x, Diagnostic y)
-            {
-                return x.Id == y.Id && x.Location == y.Location;
-            }
+                => x.Id == y.Id && x.Location == y.Location;
 
             public int GetHashCode(Diagnostic obj)
-            {
-                return Hash.Combine(obj.Id.GetHashCode(), obj.Location.GetHashCode());
-            }
+                => Hash.Combine(obj.Id.GetHashCode(), obj.Location.GetHashCode());
         }
 #endif
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -27,14 +27,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
     internal partial class DiagnosticIncrementalAnalyzer
     {
         public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
-        {
-            return AnalyzeDocumentForKindAsync(document, AnalysisKind.Syntax, cancellationToken);
-        }
+            => AnalyzeDocumentForKindAsync(document, AnalysisKind.Syntax, cancellationToken);
 
         public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
-        {
-            return AnalyzeDocumentForKindAsync(document, AnalysisKind.Semantic, cancellationToken);
-        }
+            => AnalyzeDocumentForKindAsync(document, AnalysisKind.Semantic, cancellationToken);
 
         private async Task AnalyzeDocumentForKindAsync(Document document, AnalysisKind kind, CancellationToken cancellationToken)
         {
@@ -406,9 +402,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private void RaiseDocumentDiagnosticsIfNeeded(Document document, StateSet stateSet, AnalysisKind kind, ImmutableArray<DiagnosticData> items)
-        {
-            RaiseDocumentDiagnosticsIfNeeded(document, stateSet, kind, ImmutableArray<DiagnosticData>.Empty, items);
-        }
+            => RaiseDocumentDiagnosticsIfNeeded(document, stateSet, kind, ImmutableArray<DiagnosticData>.Empty, items);
 
         private void RaiseDocumentDiagnosticsIfNeeded(
             Document document, StateSet stateSet, AnalysisKind kind, ImmutableArray<DiagnosticData> oldItems, ImmutableArray<DiagnosticData> newItems)

--- a/src/Features/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
@@ -75,9 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Get <see cref="AnalyzerReference"/> identity and <see cref="DiagnosticAnalyzer"/>s map for given <paramref name="language"/>
         /// </summary> 
         public ImmutableDictionary<object, ImmutableArray<DiagnosticAnalyzer>> GetOrCreateHostDiagnosticAnalyzersPerReference(string language)
-        {
-            return _hostDiagnosticAnalyzersPerLanguageMap.GetOrAdd(language, CreateHostDiagnosticAnalyzersAndBuildMap);
-        }
+            => _hostDiagnosticAnalyzersPerLanguageMap.GetOrAdd(language, CreateHostDiagnosticAnalyzersAndBuildMap);
 
         public ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>> GetDiagnosticDescriptorsPerReference(DiagnosticAnalyzerInfoCache infoCache)
         {
@@ -138,9 +136,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// has only project analyzers
         /// </summary>
         public ImmutableDictionary<object, ImmutableArray<DiagnosticAnalyzer>> CreateProjectDiagnosticAnalyzersPerReference(Project project)
-        {
-            return CreateDiagnosticAnalyzersPerReferenceMap(CreateProjectAnalyzerReferencesMap(project), project.Language);
-        }
+            => CreateDiagnosticAnalyzersPerReferenceMap(CreateProjectAnalyzerReferencesMap(project), project.Language);
 
         /// <summary>
         /// Return compiler <see cref="DiagnosticAnalyzer"/> for the given language.
@@ -157,9 +153,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         private ImmutableDictionary<object, AnalyzerReference> CreateProjectAnalyzerReferencesMap(Project project)
-        {
-            return CreateAnalyzerReferencesMap(project.AnalyzerReferences.Where(reference => !_hostAnalyzerReferencesMap.Value.ContainsKey(reference.Id)));
-        }
+            => CreateAnalyzerReferencesMap(project.AnalyzerReferences.Where(reference => !_hostAnalyzerReferencesMap.Value.ContainsKey(reference.Id)));
 
         private ImmutableDictionary<object, ImmutableArray<DiagnosticDescriptor>> CreateDiagnosticDescriptorsPerReference(
             DiagnosticAnalyzerInfoCache infoCache,

--- a/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
+++ b/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public override int GetHashCode()
-        {
-            return Hash.Combine(ProjectOrDocumentId, Hash.Combine(Kind, base.GetHashCode()));
-        }
+            => Hash.Combine(ProjectOrDocumentId, Hash.Combine(Kind, base.GetHashCode()));
     }
 }

--- a/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
+++ b/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
@@ -92,9 +92,7 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
             internal TaggedTextStyle Style => _styleStack.Peek();
 
             public void AppendSingleSpace()
-            {
-                _pendingSingleSpace = true;
-            }
+                => _pendingSingleSpace = true;
 
             public void AppendString(string s)
             {
@@ -159,24 +157,16 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
             }
 
             public void PushNavigationTarget(string target, string hint)
-            {
-                _navigationTargetStack.Push((target, hint));
-            }
+                => _navigationTargetStack.Push((target, hint));
 
             public void PopNavigationTarget()
-            {
-                _navigationTargetStack.Pop();
-            }
+                => _navigationTargetStack.Pop();
 
             public void PushStyle(TaggedTextStyle style)
-            {
-                _styleStack.Push(_styleStack.Peek() | style);
-            }
+                => _styleStack.Push(_styleStack.Peek() | style);
 
             public void PopStyle()
-            {
-                _styleStack.Pop();
-            }
+                => _styleStack.Pop();
 
             public void MarkBeginOrEndPara()
             {
@@ -216,9 +206,7 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
             }
 
             public string GetText()
-            {
-                return Builder.GetFullText();
-            }
+                => Builder.GetFullText();
 
             private void EmitPendingChars()
             {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2102,9 +2102,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         private static int CompareLineChanges(LineChange x, LineChange y)
-        {
-            return x.OldLine.CompareTo(y.OldLine);
-        }
+            => x.OldLine.CompareTo(y.OldLine);
 
         #endregion
 
@@ -2129,9 +2127,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             public int GetHashCode(IAssemblySymbol obj)
-            {
-                return obj.Identity.GetHashCode();
-            }
+                => obj.Identity.GetHashCode();
         }
 
         protected static readonly SymbolEquivalenceComparer s_assemblyEqualityComparer = new SymbolEquivalenceComparer(
@@ -3409,14 +3405,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         protected SyntaxNode GetSymbolSyntax(ISymbol local, CancellationToken cancellationToken)
-        {
-            return local.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
-        }
+            => local.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
 
         private TextSpan GetThisParameterDiagnosticSpan(ISymbol member)
-        {
-            return member.Locations.First().SourceSpan;
-        }
+            => member.Locations.First().SourceSpan;
 
         private TextSpan GetVariableDiagnosticSpan(ISymbol local)
         {
@@ -3875,9 +3867,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         #region Helpers 
 
         private static SyntaxNode? TryGetNode(SyntaxNode root, int position)
-        {
-            return root.FullSpan.Contains(position) ? root.FindToken(position).Parent : null;
-        }
+            => root.FullSpan.Contains(position) ? root.FindToken(position).Parent : null;
 
         private static bool TryGetTextSpan(TextLineCollection lines, LinePositionSpan lineSpan, out TextSpan span)
         {
@@ -3905,9 +3895,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             private readonly AbstractEditAndContinueAnalyzer _abstractEditAndContinueAnalyzer;
 
             public TestAccessor(AbstractEditAndContinueAnalyzer abstractEditAndContinueAnalyzer)
-            {
-                _abstractEditAndContinueAnalyzer = abstractEditAndContinueAnalyzer;
-            }
+                => _abstractEditAndContinueAnalyzer = abstractEditAndContinueAnalyzer;
 
             internal void AnalyzeSyntax(
                 EditScript<SyntaxNode> script,

--- a/src/Features/Core/Portable/EditAndContinue/BidirectionalMap.cs
+++ b/src/Features/Core/Portable/EditAndContinue/BidirectionalMap.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         public static BidirectionalMap<T> FromMatch(Match<T> match)
-        {
-            return new BidirectionalMap<T>(match.Matches, match.ReverseMatches);
-        }
+            => new BidirectionalMap<T>(match.Matches, match.ReverseMatches);
 
         public bool IsDefaultOrEmpty => Forward == null || Forward.Count == 0;
     }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -106,9 +106,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         // test only
         internal void Test_SetNonRemappableRegions(ImmutableDictionary<ActiveMethodId, ImmutableArray<NonRemappableRegion>> nonRemappableRegions)
-        {
-            NonRemappableRegions = nonRemappableRegions;
-        }
+            => NonRemappableRegions = nonRemappableRegions;
 
         // test only
         internal EmitBaseline Test_GetProjectEmitBaseline(ProjectId id)

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
@@ -27,9 +27,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private int _emptyEditSessionCount;
 
         public DebuggingSessionTelemetry()
-        {
-            _editSessionData = new List<EditSessionTelemetry.Data>();
-        }
+            => _editSessionData = new List<EditSessionTelemetry.Data>();
 
         public Data GetDataAndClear()
         {

--- a/src/Features/Core/Portable/EditAndContinue/DocumentAnalysisResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DocumentAnalysisResults.cs
@@ -148,9 +148,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         public static DocumentAnalysisResults SyntaxErrors(ImmutableArray<RudeEditDiagnostic> rudeEdits)
-        {
-            return new DocumentAnalysisResults(rudeEdits);
-        }
+            => new DocumentAnalysisResults(rudeEdits);
 
         public static DocumentAnalysisResults Unchanged(
             ImmutableArray<ActiveStatement> activeStatements,

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -24,9 +24,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public EditAndContinueDiagnosticUpdateSource(IDiagnosticUpdateSourceRegistrationService registrationService)
-        {
-            registrationService.Register(this);
-        }
+            => registrationService.Register(this);
 
         // for testing
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
@@ -108,9 +108,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             private readonly MetadataReader _pdbReader;
 
             public Portable(MetadataReader pdbReader)
-            {
-                _pdbReader = pdbReader;
-            }
+                => _pdbReader = pdbReader;
 
             public override bool IsPortable => true;
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -75,9 +75,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal void Cancel() => _cancellationSource.Cancel();
 
         public void Dispose()
-        {
-            _cancellationSource.Dispose();
-        }
+            => _cancellationSource.Dispose();
 
         /// <summary>
         /// Errors to be reported when a project is updated but the corresponding module does not support EnC.

--- a/src/Features/Core/Portable/EditAndContinue/ILDelta.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ILDelta.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public readonly ImmutableArray<byte> Value;
 
         public ILDelta(ImmutableArray<byte> value)
-        {
-            Value = value;
-        }
+            => Value = value;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/MetadataDelta.cs
+++ b/src/Features/Core/Portable/EditAndContinue/MetadataDelta.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public readonly ImmutableArray<byte> Bytes;
 
         public MetadataDelta(ImmutableArray<byte> bytes)
-        {
-            Bytes = bytes;
-        }
+            => Bytes = bytes;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
+++ b/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
@@ -91,9 +91,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public void Write(string str) => Write(str, null);
 
         public void Write(string format, params Arg[] args)
-        {
-            Append(new Entry(format, args));
-        }
+            => Append(new Entry(format, args));
 
         [Conditional("DEBUG")]
         public void DebugWrite(string str) => DebugWrite(str, null);
@@ -114,9 +112,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             private readonly TraceLog _traceLog;
 
             public TestAccessor(TraceLog traceLog)
-            {
-                _traceLog = traceLog;
-            }
+                => _traceLog = traceLog;
 
             internal Entry[] Entries => _traceLog._log;
         }

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexDocumentHighlightsService.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
         private readonly RegexEmbeddedLanguage _language;
 
         public RegexDocumentHighlightsService(RegexEmbeddedLanguage language)
-        {
-            _language = language;
-        }
+            => _language = language;
 
         public async Task<ImmutableArray<DocumentHighlights>> GetDocumentHighlightsAsync(
             Document document, int position, IImmutableSet<Document> documentsToSearch, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedCompletionProvider.cs
@@ -36,9 +36,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
         private readonly RegexEmbeddedLanguageFeatures _language;
 
         public RegexEmbeddedCompletionProvider(RegexEmbeddedLanguageFeatures language)
-        {
-            _language = language;
-        }
+            => _language = language;
 
         public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
         {

--- a/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldCodeAction.cs
+++ b/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldCodeAction.cs
@@ -22,8 +22,6 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
         public override string Title => _title;
 
         protected override Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
-        {
-            return _result.GetSolutionAsync(cancellationToken);
-        }
+            => _result.GetSolutionAsync(cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldResult.cs
+++ b/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldResult.cs
@@ -14,9 +14,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
         private readonly AsyncLazy<AbstractEncapsulateFieldService.Result> _resultGetter;
 
         public EncapsulateFieldResult(Func<CancellationToken, Task<AbstractEncapsulateFieldService.Result>> resultGetter)
-        {
-            _resultGetter = new AsyncLazy<AbstractEncapsulateFieldService.Result>(c => resultGetter(c), cacheResult: true);
-        }
+            => _resultGetter = new AsyncLazy<AbstractEncapsulateFieldService.Result>(c => resultGetter(c), cacheResult: true);
 
         public async Task<string> GetNameAsync(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
@@ -14,9 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         private readonly IDocumentNavigationService _underlyingObject;
 
         public VSTypeScriptDocumentNavigationServiceWrapper(IDocumentNavigationService underlyingObject)
-        {
-            _underlyingObject = underlyingObject;
-        }
+            => _underlyingObject = underlyingObject;
 
         public static VSTypeScriptDocumentNavigationServiceWrapper Create(Workspace workspace)
             => new VSTypeScriptDocumentNavigationServiceWrapper(workspace.Services.GetRequiredService<IDocumentNavigationService>());

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerService.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VSTypeScriptAnalyzerService(IDiagnosticAnalyzerService service)
-        {
-            _service = service;
-        }
+            => _service = service;
 
         public void Reanalyze(Workspace workspace, IEnumerable<ProjectId>? projectIds = null, IEnumerable<DocumentId>? documentIds = null, bool highPriority = false)
             => _service.Reanalyze(workspace, projectIds, documentIds, highPriority);

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceOptionsResult.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceOptionsResult.cs
@@ -32,8 +32,6 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
         }
 
         private ExtractInterfaceOptionsResult(bool isCancelled)
-        {
-            IsCancelled = isCancelled;
-        }
+            => IsCancelled = isCancelled;
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/Extensions.cs
+++ b/src/Features/Core/Portable/ExtractMethod/Extensions.cs
@@ -14,49 +14,31 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
     internal static class Extensions
     {
         public static bool Succeeded(this OperationStatus status)
-        {
-            return status.Flag.Succeeded();
-        }
+            => status.Flag.Succeeded();
 
         public static bool FailedWithNoBestEffortSuggestion(this OperationStatus status)
-        {
-            return status.Flag.Failed() && !status.Flag.HasBestEffort();
-        }
+            => status.Flag.Failed() && !status.Flag.HasBestEffort();
 
         public static bool Failed(this OperationStatus status)
-        {
-            return status.Flag.Failed();
-        }
+            => status.Flag.Failed();
 
         public static bool Succeeded(this OperationStatusFlag flag)
-        {
-            return (flag & OperationStatusFlag.Succeeded) != 0;
-        }
+            => (flag & OperationStatusFlag.Succeeded) != 0;
 
         public static bool Failed(this OperationStatusFlag flag)
-        {
-            return !flag.Succeeded();
-        }
+            => !flag.Succeeded();
 
         public static bool HasBestEffort(this OperationStatusFlag flag)
-        {
-            return (flag & OperationStatusFlag.BestEffort) != 0;
-        }
+            => (flag & OperationStatusFlag.BestEffort) != 0;
 
         public static bool HasSuggestion(this OperationStatusFlag flag)
-        {
-            return (flag & OperationStatusFlag.Suggestion) != 0;
-        }
+            => (flag & OperationStatusFlag.Suggestion) != 0;
 
         public static bool HasMask(this OperationStatusFlag flag, OperationStatusFlag mask)
-        {
-            return (flag & mask) != 0x0;
-        }
+            => (flag & mask) != 0x0;
 
         public static OperationStatusFlag RemoveFlag(this OperationStatusFlag baseFlag, OperationStatusFlag flagToRemove)
-        {
-            return baseFlag & ~flagToRemove;
-        }
+            => baseFlag & ~flagToRemove;
 
         public static ITypeSymbol? GetLambdaOrAnonymousMethodReturnType(this SemanticModel binding, SyntaxNode node)
         {
@@ -76,17 +58,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         }
 
         public static Task<SemanticDocument> WithSyntaxRootAsync(this SemanticDocument semanticDocument, SyntaxNode root, CancellationToken cancellationToken)
-        {
-            return SemanticDocument.CreateAsync(semanticDocument.Document.WithSyntaxRoot(root), cancellationToken);
-        }
+            => SemanticDocument.CreateAsync(semanticDocument.Document.WithSyntaxRoot(root), cancellationToken);
 
         /// <summary>
         /// get tokens with given annotation in current document
         /// </summary>
         public static SyntaxToken GetTokenWithAnnotation(this SemanticDocument document, SyntaxAnnotation annotation)
-        {
-            return document.Root.GetAnnotatedNodesAndTokens(annotation).Single().AsToken();
-        }
+            => document.Root.GetAnnotatedNodesAndTokens(annotation).Single().AsToken();
 
         /// <summary>
         /// resolve the given symbol against compilation this snapshot has

--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodService.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodService.cs
@@ -13,9 +13,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
     internal static class ExtractMethodService
     {
         public static Task<ExtractMethodResult> ExtractMethodAsync(Document document, TextSpan textSpan, bool localFunction, OptionSet options = null, CancellationToken cancellationToken = default)
-        {
-            return document.GetLanguageService<IExtractMethodService>().ExtractMethodAsync(document, textSpan, localFunction, options, cancellationToken);
-        }
+            => document.GetLanguageService<IExtractMethodService>().ExtractMethodAsync(document, textSpan, localFunction, options, cancellationToken);
     }
 
 }

--- a/src/Features/Core/Portable/ExtractMethod/InsertionPoint.cs
+++ b/src/Features/Core/Portable/ExtractMethod/InsertionPoint.cs
@@ -37,24 +37,16 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public SemanticDocument SemanticDocument { get; }
 
         public SyntaxNode GetRoot()
-        {
-            return SemanticDocument.Root;
-        }
+            => SemanticDocument.Root;
 
         public SyntaxNode GetContext()
-        {
-            return _context.Value;
-        }
+            => _context.Value;
 
         public InsertionPoint With(SemanticDocument document)
-        {
-            return new InsertionPoint(document, _annotation);
-        }
+            => new InsertionPoint(document, _annotation);
 
         private Lazy<SyntaxNode> CreateLazyContextNode()
-        {
-            return new Lazy<SyntaxNode>(ComputeContextNode, isThreadSafe: true);
-        }
+            => new Lazy<SyntaxNode>(ComputeContextNode, isThreadSafe: true);
 
         private SyntaxNode ComputeContextNode()
         {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -510,9 +510,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             private void AddVariableToMap(IDictionary<ISymbol, VariableInfo> variableInfoMap, ISymbol localOrParameter, VariableInfo variableInfo)
-            {
-                variableInfoMap.Add(localOrParameter, variableInfo);
-            }
+                => variableInfoMap.Add(localOrParameter, variableInfo);
 
             private bool TryGetVariableStyle(
                 bool bestEffort,

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
@@ -160,14 +160,10 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             public IEnumerable<VariableInfo> GetVariablesToMoveIntoMethodDefinition(CancellationToken cancellationToken)
-            {
-                return _variables.Where(v => v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.MoveIn);
-            }
+                => _variables.Where(v => v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.MoveIn);
 
             public IEnumerable<VariableInfo> GetVariablesToMoveOutToCallSite(CancellationToken cancellationToken)
-            {
-                return _variables.Where(v => v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.MoveOut);
-            }
+                => _variables.Where(v => v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.MoveOut);
 
             public IEnumerable<VariableInfo> GetVariablesToMoveOutToCallSiteOrDelete(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TypeParameterCollector.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TypeParameterCollector.cs
@@ -32,14 +32,10 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             public override void VisitArrayType(IArrayTypeSymbol arrayTypeSymbol)
-            {
-                arrayTypeSymbol.ElementType.Accept(this);
-            }
+                => arrayTypeSymbol.ElementType.Accept(this);
 
             public override void VisitPointerType(IPointerTypeSymbol pointerTypeSymbol)
-            {
-                pointerTypeSymbol.PointedAtType.Accept(this);
-            }
+                => pointerTypeSymbol.PointedAtType.Accept(this);
 
             public override void VisitNamedType(INamedTypeSymbol namedTypeSymbol)
             {
@@ -50,9 +46,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             public override void VisitTypeParameter(ITypeParameterSymbol typeParameterTypeSymbol)
-            {
-                _typeParameters.Add(typeParameterTypeSymbol);
-            }
+                => _typeParameters.Add(typeParameterTypeSymbol);
         }
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
@@ -112,19 +112,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             public ITypeSymbol OriginalType => _variableSymbol.OriginalType;
 
             public ITypeSymbol GetVariableType(SemanticDocument document)
-            {
-                return document.SemanticModel.ResolveType(_variableSymbol.OriginalType);
-            }
+                => document.SemanticModel.ResolveType(_variableSymbol.OriginalType);
 
             public SyntaxToken GetIdentifierTokenAtDeclaration(SemanticDocument document)
-            {
-                return document.GetTokenWithAnnotation(_variableSymbol.IdentifierTokenAnnotation);
-            }
+                => document.GetTokenWithAnnotation(_variableSymbol.IdentifierTokenAnnotation);
 
             public SyntaxToken GetIdentifierTokenAtDeclaration(SyntaxNode node)
-            {
-                return node.GetAnnotatedTokens(_variableSymbol.IdentifierTokenAnnotation).SingleOrDefault();
-            }
+                => node.GetAnnotatedTokens(_variableSymbol.IdentifierTokenAnnotation).SingleOrDefault();
 
             public static void SortVariables(Compilation compilation, List<VariableInfo> list)
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -115,9 +115,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             public override int DisplayOrder => 0;
 
             protected override int CompareTo(VariableSymbol right)
-            {
-                return CompareTo((ParameterVariableSymbol)right);
-            }
+                => CompareTo((ParameterVariableSymbol)right);
 
             public int CompareTo(ParameterVariableSymbol other)
             {
@@ -198,9 +196,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             public override int DisplayOrder => 1;
 
             protected override int CompareTo(VariableSymbol right)
-            {
-                return CompareTo((LocalVariableSymbol<T>)right);
-            }
+                => CompareTo((LocalVariableSymbol<T>)right);
 
             public int CompareTo(LocalVariableSymbol<T> other)
             {
@@ -292,9 +288,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             private bool ContainsNoisyTrivia(SyntaxTriviaList list)
-            {
-                return list.Any(t => !_nonNoisySet.Contains(t.RawKind));
-            }
+                => list.Any(t => !_nonNoisySet.Contains(t.RawKind));
         }
 
         protected class QueryVariableSymbol : NotMovableVariableSymbol, IComparable<QueryVariableSymbol>
@@ -311,9 +305,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             public override int DisplayOrder => 2;
 
             protected override int CompareTo(VariableSymbol right)
-            {
-                return CompareTo((QueryVariableSymbol)right);
-            }
+                => CompareTo((QueryVariableSymbol)right);
 
             public int CompareTo(QueryVariableSymbol other)
             {

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus.cs
@@ -50,19 +50,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         }
 
         public OperationStatus MakeFail()
-        {
-            return new OperationStatus(OperationStatusFlag.None, Reasons);
-        }
+            => new OperationStatus(OperationStatusFlag.None, Reasons);
 
         public OperationStatus MarkSuggestion()
-        {
-            return new OperationStatus(Flag | OperationStatusFlag.Suggestion, Reasons);
-        }
+            => new OperationStatus(Flag | OperationStatusFlag.Suggestion, Reasons);
 
         public OperationStatus<T> With<T>(T data)
-        {
-            return Create(this, data);
-        }
+            => Create(this, data);
 
         public OperationStatusFlag Flag { get; }
         public IEnumerable<string> Reasons { get; }

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
@@ -19,8 +19,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         /// create operation status with the given data
         /// </summary>
         public static OperationStatus<T> Create<T>(OperationStatus status, T data)
-        {
-            return new OperationStatus<T>(status, data);
-        }
+            => new OperationStatus<T>(status, data);
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus`1.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus`1.cs
@@ -19,13 +19,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public T Data { get; }
 
         public OperationStatus<T> With(OperationStatus status)
-        {
-            return new OperationStatus<T>(status, Data);
-        }
+            => new OperationStatus<T>(status, Data);
 
         public OperationStatus<TNew> With<TNew>(TNew data)
-        {
-            return new OperationStatus<TNew>(Status, data);
-        }
+            => new OperationStatus<TNew>(Status, data);
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
@@ -85,14 +85,10 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         }
 
         public SyntaxToken GetFirstTokenInSelection()
-        {
-            return SemanticDocument.GetTokenWithAnnotation(FirstTokenAnnotation);
-        }
+            => SemanticDocument.GetTokenWithAnnotation(FirstTokenAnnotation);
 
         public SyntaxToken GetLastTokenInSelection()
-        {
-            return SemanticDocument.GetTokenWithAnnotation(LastTokenAnnotation);
-        }
+            => SemanticDocument.GetTokenWithAnnotation(LastTokenAnnotation);
 
         public TNode GetContainingScopeOf<TNode>() where TNode : SyntaxNode
         {

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -300,9 +300,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
         }
 
         private bool HasAccessibleTypes(INamespaceSymbol @namespace, SemanticModel model, CancellationToken cancellationToken)
-        {
-            return Enumerable.Any(@namespace.GetAllTypes(cancellationToken), t => t.IsAccessibleWithin(model.Compilation.Assembly));
-        }
+            => Enumerable.Any(@namespace.GetAllTypes(cancellationToken), t => t.IsAccessibleWithin(model.Compilation.Assembly));
 
         private static IEnumerable<SymbolResult> GetContainers(
             ImmutableArray<SymbolResult> symbols, Compilation compilation)

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -46,9 +46,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
         /// For testing purposes only.
         /// </summary>
         protected AbstractGenerateConstructorFromMembersCodeRefactoringProvider(IPickMembersService pickMembersService_forTesting)
-        {
-            _pickMembersService_forTesting = pickMembersService_forTesting;
-        }
+            => _pickMembersService_forTesting = pickMembersService_forTesting;
 
         protected abstract bool PrefersThrowExpression(DocumentOptionSet options);
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
@@ -20,9 +20,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             private readonly ISyntaxFactsService _syntaxFacts;
 
             public FormatLargeBinaryExpressionRule(ISyntaxFactsService syntaxFacts)
-            {
-                _syntaxFacts = syntaxFacts;
-            }
+                => _syntaxFacts = syntaxFacts;
 
             /// <summary>
             /// Wrap the large &amp;&amp; expression after every &amp;&amp; token.

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -46,9 +46,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
         public GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider(IPickMembersService pickMembersService)
-        {
-            _pickMembersService_forTestingPurposes = pickMembersService;
-        }
+            => _pickMembersService_forTestingPurposes = pickMembersService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -36,11 +36,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
             => default;
 
         protected abstract string GenerateNameForArgument(SemanticModel semanticModel, TArgumentSyntax argument, CancellationToken cancellationToken);
-        protected virtual string GenerateNameForArgument(SemanticModel semanticModel, TAttributeArgumentSyntax argument, CancellationToken cancellationToken) { return null; }
+        protected virtual string GenerateNameForArgument(SemanticModel semanticModel, TAttributeArgumentSyntax argument, CancellationToken cancellationToken) => null;
         protected abstract RefKind GetRefKind(TArgumentSyntax argument);
         protected abstract bool IsNamedArgument(TArgumentSyntax argument);
         protected abstract ITypeSymbol GetArgumentType(SemanticModel semanticModel, TArgumentSyntax argument, CancellationToken cancellationToken);
-        protected virtual ITypeSymbol GetAttributeArgumentType(SemanticModel semanticModel, TAttributeArgumentSyntax argument, CancellationToken cancellationToken) { return null; }
+        protected virtual ITypeSymbol GetAttributeArgumentType(SemanticModel semanticModel, TAttributeArgumentSyntax argument, CancellationToken cancellationToken) => null;
 
         public async Task<ImmutableArray<CodeAction>> GenerateConstructorAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.cs
@@ -28,19 +28,13 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
         protected abstract bool AreSpecialOptionsActive(SemanticModel semanticModel);
 
         protected virtual bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
-        {
-            return false;
-        }
+            => false;
 
         protected virtual string GetImplicitConversionDisplayText(State state)
-        {
-            return string.Empty;
-        }
+            => string.Empty;
 
         protected virtual string GetExplicitConversionDisplayText(State state)
-        {
-            return string.Empty;
-        }
+            => string.Empty;
 
         protected async ValueTask<ImmutableArray<CodeAction>> GetActionsAsync(Document document, State state, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -87,9 +87,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
         }
 
         protected virtual bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
-        {
-            return false;
-        }
+            => false;
 
         private void AddPropertyCodeActions(
             ArrayBuilder<CodeAction> result, SemanticDocument document, State state)

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesCodeRefactoringProvider.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
 
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
         public GenerateOverridesCodeRefactoringProvider(IPickMembersService pickMembersService)
-        {
-            _pickMembersService_forTestingPurposes = pickMembersService;
-        }
+            => _pickMembersService_forTestingPurposes = pickMembersService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
@@ -113,9 +113,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             }
 
             private bool IsPublicOnlyAccessibility(State state, Project project)
-            {
-                return _service.IsPublicOnlyAccessibility(state.NameOrMemberAccessExpression, project) || _service.IsPublicOnlyAccessibility(state.SimpleName, project);
-            }
+                => _service.IsPublicOnlyAccessibility(state.NameOrMemberAccessExpression, project) || _service.IsPublicOnlyAccessibility(state.SimpleName, project);
 
             private TypeKindOptions GetTypeKindOption(State state)
             {

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -222,9 +222,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             }
 
             private string AddGlobalDotToTheNamespace(string namespaceToBeGenerated)
-            {
-                return "Global." + namespaceToBeGenerated;
-            }
+                => "Global." + namespaceToBeGenerated;
 
             // Returns the length of the meaningful rootNamespace substring part of namespaceToGenerateInto
             private int CheckIfRootNamespacePresentInNamespace(string namespaceToGenerateInto, string rootNamespace)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -289,14 +289,10 @@ namespace Microsoft.CodeAnalysis.GenerateType
             }
 
             private Accessibility DetermineAccessibility()
-            {
-                return _service.GetAccessibility(_state, _semanticDocument.SemanticModel, _intoNamespace, _cancellationToken);
-            }
+                => _service.GetAccessibility(_state, _semanticDocument.SemanticModel, _intoNamespace, _cancellationToken);
 
             private DeclarationModifiers DetermineModifiers()
-            {
-                return default;
-            }
+                => default;
 
             private INamedTypeSymbol DetermineBaseType()
             {
@@ -329,9 +325,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             }
 
             private string DetermineName()
-            {
-                return GetTypeName(_state);
-            }
+                => GetTypeName(_state);
 
             private ImmutableArray<ITypeParameterSymbol> DetermineTypeParameters()
                 => _service.GetTypeParameters(_state, _semanticDocument.SemanticModel, _cancellationToken);

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -63,9 +63,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             public List<TSimpleNameSyntax> PropertiesToGenerate { get; private set; }
 
             private State(Compilation compilation)
-            {
-                Compilation = compilation;
-            }
+                => Compilation = compilation;
 
             public static async Task<State> GenerateAsync(
                 TService service,
@@ -247,9 +245,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             }
 
             private bool GenerateStruct(TService service, SemanticModel semanticModel, CancellationToken cancellationToken)
-            {
-                return service.IsInValueTypeConstraintContext(semanticModel, NameOrMemberAccessExpression, cancellationToken);
-            }
+                => service.IsInValueTypeConstraintContext(semanticModel, NameOrMemberAccessExpression, cancellationToken);
 
             private bool GenerateInterface(TService service)
             {

--- a/src/Features/Core/Portable/GenerateType/GenerateTypeOptionsResult.cs
+++ b/src/Features/Core/Portable/GenerateType/GenerateTypeOptionsResult.cs
@@ -52,8 +52,6 @@ namespace Microsoft.CodeAnalysis.GenerateType
         }
 
         private GenerateTypeOptionsResult(bool isCancelled)
-        {
-            IsCancelled = isCancelled;
-        }
+            => IsCancelled = isCancelled;
     }
 }

--- a/src/Features/Core/Portable/GenerateType/TypeKindOptions.cs
+++ b/src/Features/Core/Portable/GenerateType/TypeKindOptions.cs
@@ -39,34 +39,22 @@ namespace Microsoft.CodeAnalysis.GenerateType
     internal class TypeKindOptionsHelper
     {
         public static bool IsClass(TypeKindOptions option)
-        {
-            return (option & TypeKindOptions.Class) != 0 ? true : false;
-        }
+            => (option & TypeKindOptions.Class) != 0 ? true : false;
 
         public static bool IsStructure(TypeKindOptions option)
-        {
-            return (option & TypeKindOptions.Structure) != 0 ? true : false;
-        }
+            => (option & TypeKindOptions.Structure) != 0 ? true : false;
 
         public static bool IsInterface(TypeKindOptions option)
-        {
-            return (option & TypeKindOptions.Interface) != 0 ? true : false;
-        }
+            => (option & TypeKindOptions.Interface) != 0 ? true : false;
 
         public static bool IsEnum(TypeKindOptions option)
-        {
-            return (option & TypeKindOptions.Enum) != 0 ? true : false;
-        }
+            => (option & TypeKindOptions.Enum) != 0 ? true : false;
 
         public static bool IsDelegate(TypeKindOptions option)
-        {
-            return (option & TypeKindOptions.Delegate) != 0 ? true : false;
-        }
+            => (option & TypeKindOptions.Delegate) != 0 ? true : false;
 
         public static bool IsModule(TypeKindOptions option)
-        {
-            return (option & TypeKindOptions.Module) != 0 ? true : false;
-        }
+            => (option & TypeKindOptions.Module) != 0 ? true : false;
 
         public static TypeKindOptions RemoveOptions(TypeKindOptions fromValue, params TypeKindOptions[] removeValues)
         {
@@ -80,8 +68,6 @@ namespace Microsoft.CodeAnalysis.GenerateType
         }
 
         internal static TypeKindOptions AddOption(TypeKindOptions toValue, TypeKindOptions addValue)
-        {
-            return toValue | addValue;
-        }
+            => toValue | addValue;
     }
 }

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -164,9 +164,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             public override string EquivalenceKey => _equivalenceKey;
 
             protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
-            {
-                return GetUpdatedDocumentAsync(cancellationToken);
-            }
+                => GetUpdatedDocumentAsync(cancellationToken);
 
             public Task<Document> GetUpdatedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/IncrementalCaches/SyntaxTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SyntaxTreeInfoIncrementalAnalyzerProvider.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
         }
 
         public IIncrementalAnalyzer CreateIncrementalAnalyzer(Workspace workspace)
-        {
-            return new IncrementalAnalyzer();
-        }
+            => new IncrementalAnalyzer();
 
         private class IncrementalAnalyzer : IncrementalAnalyzerBase
         {

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -55,9 +55,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
         protected abstract int DetermineConstantInsertPosition(TTypeDeclarationSyntax oldDeclaration, TTypeDeclarationSyntax newDeclaration);
 
         protected virtual bool BlockOverlapsHiddenPosition(SyntaxNode block, CancellationToken cancellationToken)
-        {
-            return block.OverlapsHiddenPosition(cancellationToken);
-        }
+            => block.OverlapsHiddenPosition(cancellationToken);
 
         public async Task<CodeAction> IntroduceVariableAsync(
             Document document,

--- a/src/Features/Core/Portable/InvertIf/AbstractInvertIfCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InvertIf/AbstractInvertIfCodeRefactoringProvider.cs
@@ -239,9 +239,7 @@ namespace Microsoft.CodeAnalysis.InvertIf
         }
 
         private bool SingleSubsequentStatement(ImmutableArray<StatementRange> subsequentStatementRanges)
-        {
-            return subsequentStatementRanges.Length == 1 && IsSingleStatementStatementRange(subsequentStatementRanges[0]);
-        }
+            => subsequentStatementRanges.Length == 1 && IsSingleStatementStatementRange(subsequentStatementRanges[0]);
 
         private async Task<Document> InvertIfAsync(
             Document document,

--- a/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractAnonymousTypeDisplayService.NormalAnonymousTypeCollectorVisitor.cs
+++ b/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractAnonymousTypeDisplayService.NormalAnonymousTypeCollectorVisitor.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             private readonly ICollection<INamedTypeSymbol> _namedTypes;
 
             public NormalAnonymousTypeCollectorVisitor(ICollection<INamedTypeSymbol> namedTypes)
-            {
-                _namedTypes = namedTypes;
-            }
+                => _namedTypes = namedTypes;
 
             public override void DefaultVisit(ISymbol node)
             {
@@ -31,9 +29,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             public override void VisitArrayType(IArrayTypeSymbol symbol)
-            {
-                symbol.ElementType.Accept(this);
-            }
+                => symbol.ElementType.Accept(this);
 
             public override void VisitAssembly(IAssemblySymbol symbol)
             {
@@ -44,18 +40,14 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             public override void VisitField(IFieldSymbol symbol)
-            {
-                symbol.Type.Accept(this);
-            }
+                => symbol.Type.Accept(this);
 
             public override void VisitLabel(ILabelSymbol symbol)
             {
             }
 
             public override void VisitLocal(ILocalSymbol symbol)
-            {
-                symbol.Type.Accept(this);
-            }
+                => symbol.Type.Accept(this);
 
             public override void VisitMethod(IMethodSymbol symbol)
             {
@@ -113,14 +105,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             public override void VisitParameter(IParameterSymbol symbol)
-            {
-                symbol.Type.Accept(this);
-            }
+                => symbol.Type.Accept(this);
 
             public override void VisitPointerType(IPointerTypeSymbol symbol)
-            {
-                symbol.PointedAtType.Accept(this);
-            }
+                => symbol.PointedAtType.Accept(this);
 
             public override void VisitProperty(IPropertySymbol symbol)
             {
@@ -133,9 +121,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             public override void VisitEvent(IEventSymbol symbol)
-            {
-                symbol.Type.Accept(this);
-            }
+                => symbol.Type.Accept(this);
 
             public override void VisitTypeParameter(ITypeParameterSymbol symbol)
             {

--- a/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractAnonymousTypeDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractAnonymousTypeDisplayService.cs
@@ -150,19 +150,13 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         }
 
         protected SymbolDisplayPart PlainText(string text)
-        {
-            return Part(SymbolDisplayPartKind.Text, text);
-        }
+            => Part(SymbolDisplayPartKind.Text, text);
 
         private SymbolDisplayPart Part(SymbolDisplayPartKind kind, string text)
-        {
-            return Part(kind, null, text);
-        }
+            => Part(kind, null, text);
 
         private SymbolDisplayPart Part(SymbolDisplayPartKind kind, ISymbol symbol, string text)
-        {
-            return new SymbolDisplayPart(kind, symbol, text);
-        }
+            => new SymbolDisplayPart(kind, symbol, text);
 
         protected IEnumerable<SymbolDisplayPart> Space(int count = 1)
         {
@@ -173,13 +167,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         }
 
         protected SymbolDisplayPart Punctuation(string text)
-        {
-            return Part(SymbolDisplayPartKind.Punctuation, text);
-        }
+            => Part(SymbolDisplayPartKind.Punctuation, text);
 
         protected SymbolDisplayPart Keyword(string text)
-        {
-            return Part(SymbolDisplayPartKind.Keyword, text);
-        }
+            => Part(SymbolDisplayPartKind.Keyword, text);
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AnonymousTypeDisplayInfo.cs
+++ b/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AnonymousTypeDisplayInfo.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         }
 
         public IList<SymbolDisplayPart> ReplaceAnonymousTypes(IList<SymbolDisplayPart> parts)
-        {
-            return ReplaceAnonymousTypes(parts, AnonymousTypeToName);
-        }
+            => ReplaceAnonymousTypes(parts, AnonymousTypeToName);
 
         public static IList<SymbolDisplayPart> ReplaceAnonymousTypes(
             IList<SymbolDisplayPart> parts,

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -373,9 +373,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             private IDictionary<SymbolDescriptionGroups, ImmutableArray<TaggedText>> BuildDescriptionSections()
-            {
-                return _groupMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToTaggedText());
-            }
+                => _groupMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToTaggedText());
 
             private void AddDescriptionForDynamicType()
             {
@@ -704,9 +702,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             protected void AddToGroup(SymbolDescriptionGroups group, params SymbolDisplayPart[] partsArray)
-            {
-                AddToGroup(group, (IEnumerable<SymbolDisplayPart>)partsArray);
-            }
+                => AddToGroup(group, (IEnumerable<SymbolDisplayPart>)partsArray);
 
             protected void AddToGroup(SymbolDescriptionGroups group, params IEnumerable<SymbolDisplayPart>[] partsArray)
             {
@@ -732,9 +728,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             protected IEnumerable<SymbolDisplayPart> Keyword(string text)
-            {
-                return Part(SymbolDisplayPartKind.Keyword, text);
-            }
+                => Part(SymbolDisplayPartKind.Keyword, text);
 
             protected IEnumerable<SymbolDisplayPart> LineBreak(int count = 1)
             {
@@ -745,14 +739,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             protected IEnumerable<SymbolDisplayPart> PlainText(string text)
-            {
-                return Part(SymbolDisplayPartKind.Text, text);
-            }
+                => Part(SymbolDisplayPartKind.Text, text);
 
             protected IEnumerable<SymbolDisplayPart> Punctuation(string text)
-            {
-                return Part(SymbolDisplayPartKind.Punctuation, text);
-            }
+                => Part(SymbolDisplayPartKind.Punctuation, text);
 
             protected IEnumerable<SymbolDisplayPart> Space(int count = 1)
             {
@@ -766,9 +756,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             protected IEnumerable<SymbolDisplayPart> ToDisplayParts(ISymbol symbol, SymbolDisplayFormat format = null)
-            {
-                return _displayService.ToDisplayParts(symbol, format);
-            }
+                => _displayService.ToDisplayParts(symbol, format);
 
             private IEnumerable<SymbolDisplayPart> Part(SymbolDisplayPartKind kind, ISymbol symbol, string text)
             {
@@ -776,14 +764,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
 
             private IEnumerable<SymbolDisplayPart> Part(SymbolDisplayPartKind kind, string text)
-            {
-                return Part(kind, null, text);
-            }
+                => Part(kind, null, text);
 
             private IEnumerable<SymbolDisplayPart> TypeParameterName(string text)
-            {
-                return Part(SymbolDisplayPartKind.TypeParameterName, text);
-            }
+                => Part(SymbolDisplayPartKind.TypeParameterName, text);
         }
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
@@ -15,28 +15,20 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         protected readonly IAnonymousTypeDisplayService AnonymousTypeDisplayService;
 
         protected AbstractSymbolDisplayService(IAnonymousTypeDisplayService anonymousTypeDisplayService)
-        {
-            AnonymousTypeDisplayService = anonymousTypeDisplayService;
-        }
+            => AnonymousTypeDisplayService = anonymousTypeDisplayService;
 
         public abstract ImmutableArray<SymbolDisplayPart> ToDisplayParts(ISymbol symbol, SymbolDisplayFormat format = null);
         public abstract ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(SemanticModel semanticModel, int position, ISymbol symbol, SymbolDisplayFormat format);
         protected abstract AbstractSymbolDescriptionBuilder CreateDescriptionBuilder(Workspace workspace, SemanticModel semanticModel, int position, CancellationToken cancellationToken);
 
         public string ToDisplayString(ISymbol symbol, SymbolDisplayFormat format = null)
-        {
-            return ToDisplayParts(symbol, format).ToDisplayString();
-        }
+            => ToDisplayParts(symbol, format).ToDisplayString();
 
         public string ToMinimalDisplayString(SemanticModel semanticModel, int position, ISymbol symbol, SymbolDisplayFormat format = null)
-        {
-            return ToMinimalDisplayParts(semanticModel, position, symbol, format).ToDisplayString();
-        }
+            => ToMinimalDisplayParts(semanticModel, position, symbol, format).ToDisplayString();
 
         public Task<string> ToDescriptionStringAsync(Workspace workspace, SemanticModel semanticModel, int position, ISymbol symbol, SymbolDescriptionGroups groups, CancellationToken cancellationToken)
-        {
-            return ToDescriptionStringAsync(workspace, semanticModel, position, ImmutableArray.Create<ISymbol>(symbol), groups, cancellationToken);
-        }
+            => ToDescriptionStringAsync(workspace, semanticModel, position, ImmutableArray.Create<ISymbol>(symbol), groups, cancellationToken);
 
         public async Task<string> ToDescriptionStringAsync(Workspace workspace, SemanticModel semanticModel, int position, ImmutableArray<ISymbol> symbols, SymbolDescriptionGroups groups, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
@@ -69,49 +69,37 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             /// filtering/replacing operations returned by NextOperation
             /// </summary>
             public virtual void AddSuppressOperationsSlow(List<SuppressOperation> list, SyntaxNode node, AnalyzerConfigOptions options, ref NextSuppressOperationAction nextOperation)
-            {
-                base.AddSuppressOperations(list, node, options, in nextOperation);
-            }
+                => base.AddSuppressOperations(list, node, options, in nextOperation);
 
             /// <summary>
             /// returns AnchorIndentationOperations under a node either by itself or by filtering/replacing operations returned by NextOperation
             /// </summary>
             public virtual void AddAnchorIndentationOperationsSlow(List<AnchorIndentationOperation> list, SyntaxNode node, AnalyzerConfigOptions options, ref NextAnchorIndentationOperationAction nextOperation)
-            {
-                base.AddAnchorIndentationOperations(list, node, options, in nextOperation);
-            }
+                => base.AddAnchorIndentationOperations(list, node, options, in nextOperation);
 
             /// <summary>
             /// returns IndentBlockOperations under a node either by itself or by filtering/replacing operations returned by NextOperation
             /// </summary>
             public virtual void AddIndentBlockOperationsSlow(List<IndentBlockOperation> list, SyntaxNode node, AnalyzerConfigOptions options, ref NextIndentBlockOperationAction nextOperation)
-            {
-                base.AddIndentBlockOperations(list, node, options, in nextOperation);
-            }
+                => base.AddIndentBlockOperations(list, node, options, in nextOperation);
 
             /// <summary>
             /// returns AlignTokensOperations under a node either by itself or by filtering/replacing operations returned by NextOperation
             /// </summary>
             public virtual void AddAlignTokensOperationsSlow(List<AlignTokensOperation> list, SyntaxNode node, AnalyzerConfigOptions options, ref NextAlignTokensOperationAction nextOperation)
-            {
-                base.AddAlignTokensOperations(list, node, options, in nextOperation);
-            }
+                => base.AddAlignTokensOperations(list, node, options, in nextOperation);
 
             /// <summary>
             /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
             /// </summary>
             public virtual AdjustNewLinesOperation GetAdjustNewLinesOperationSlow(SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options, ref NextGetAdjustNewLinesOperation nextOperation)
-            {
-                return base.GetAdjustNewLinesOperation(previousToken, currentToken, options, in nextOperation);
-            }
+                => base.GetAdjustNewLinesOperation(previousToken, currentToken, options, in nextOperation);
 
             /// <summary>
             /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
             /// </summary>
             public virtual AdjustSpacesOperation GetAdjustSpacesOperationSlow(SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options, ref NextGetAdjustSpacesOperation nextOperation)
-            {
-                return base.GetAdjustSpacesOperation(previousToken, currentToken, options, in nextOperation);
-            }
+                => base.GetAdjustSpacesOperation(previousToken, currentToken, options, in nextOperation);
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
@@ -71,59 +71,37 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public bool HasUnsupportedMetadata => _symbol.HasUnsupportedMetadata;
 
             public void Accept(SymbolVisitor visitor)
-            {
-                _symbol.Accept(visitor);
-            }
+                => _symbol.Accept(visitor);
 
             public TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
-            {
-                return _symbol.Accept<TResult>(visitor);
-            }
+                => _symbol.Accept<TResult>(visitor);
 
             public ImmutableArray<AttributeData> GetAttributes()
-            {
-                return _symbol.GetAttributes();
-            }
+                => _symbol.GetAttributes();
 
             public string GetDocumentationCommentId()
-            {
-                return _symbol.GetDocumentationCommentId();
-            }
+                => _symbol.GetDocumentationCommentId();
 
             public string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default)
-            {
-                return _symbol.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
-            }
+                => _symbol.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
 
             public ImmutableArray<SymbolDisplayPart> ToDisplayParts(SymbolDisplayFormat format = null)
-            {
-                return _symbol.ToDisplayParts(format);
-            }
+                => _symbol.ToDisplayParts(format);
 
             public string ToDisplayString(SymbolDisplayFormat format = null)
-            {
-                return _symbol.ToDisplayString(format);
-            }
+                => _symbol.ToDisplayString(format);
 
             public string ToMinimalDisplayString(SemanticModel semanticModel, int position, SymbolDisplayFormat format = null)
-            {
-                return _symbol.ToMinimalDisplayString(semanticModel, position, format);
-            }
+                => _symbol.ToMinimalDisplayString(semanticModel, position, format);
 
             public ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(SemanticModel semanticModel, int position, SymbolDisplayFormat format = null)
-            {
-                return _symbol.ToMinimalDisplayParts(semanticModel, position, format);
-            }
+                => _symbol.ToMinimalDisplayParts(semanticModel, position, format);
 
             public bool Equals(ISymbol other)
-            {
-                return Equals((object)other);
-            }
+                => Equals((object)other);
 
             public bool Equals(ISymbol other, SymbolEqualityComparer equalityComparer)
-            {
-                return Equals(other);
-            }
+                => Equals(other);
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -92,9 +92,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public NullableAnnotation ReturnNullableAnnotation => _symbol.ReturnNullableAnnotation;
 
             public ImmutableArray<AttributeData> GetReturnTypeAttributes()
-            {
-                return _symbol.GetReturnTypeAttributes();
-            }
+                => _symbol.GetReturnTypeAttributes();
 
             public ImmutableArray<CustomModifier> RefCustomModifiers => _symbol.RefCustomModifiers;
 
@@ -107,19 +105,13 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public ImmutableArray<ITypeParameterSymbol> TypeParameters => _symbol.TypeParameters;
 
             public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
-            {
-                return _symbol.Construct(typeArguments);
-            }
+                => _symbol.Construct(typeArguments);
 
             public IMethodSymbol Construct(ImmutableArray<ITypeSymbol> typeArguments, ImmutableArray<CodeAnalysis.NullableAnnotation> typeArgumentNullableAnnotations)
-            {
-                return _symbol.Construct(typeArguments, typeArgumentNullableAnnotations);
-            }
+                => _symbol.Construct(typeArguments, typeArgumentNullableAnnotations);
 
             public DllImportData GetDllImportData()
-            {
-                return _symbol.GetDllImportData();
-            }
+                => _symbol.GetDllImportData();
 
             public IMethodSymbol ReduceExtensionMethod(ITypeSymbol receiverType)
             {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -84,34 +84,22 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public ImmutableArray<IFieldSymbol> TupleElements => _symbol.TupleElements;
 
             public ImmutableArray<CustomModifier> GetTypeArgumentCustomModifiers(int ordinal)
-            {
-                return _symbol.GetTypeArgumentCustomModifiers(ordinal);
-            }
+                => _symbol.GetTypeArgumentCustomModifiers(ordinal);
 
             public INamedTypeSymbol Construct(params ITypeSymbol[] typeArguments)
-            {
-                return _symbol.Construct(typeArguments);
-            }
+                => _symbol.Construct(typeArguments);
 
             public INamedTypeSymbol Construct(ImmutableArray<ITypeSymbol> typeArguments, ImmutableArray<NullableAnnotation> typeArgumentNullableAnnotations)
-            {
-                return _symbol.Construct(typeArguments, typeArgumentNullableAnnotations);
-            }
+                => _symbol.Construct(typeArguments, typeArgumentNullableAnnotations);
 
             public INamedTypeSymbol ConstructUnboundGenericType()
-            {
-                return _symbol.ConstructUnboundGenericType();
-            }
+                => _symbol.ConstructUnboundGenericType();
 
             public ISymbol FindImplementationForInterfaceMember(ISymbol interfaceMember)
-            {
-                return _symbol.FindImplementationForInterfaceMember(interfaceMember);
-            }
+                => _symbol.FindImplementationForInterfaceMember(interfaceMember);
 
             public override ImmutableArray<ISymbol> GetMembers()
-            {
-                return _members;
-            }
+                => _members;
 
             public IEnumerable<string> MemberNames => throw new NotImplementedException();
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -26,9 +26,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         private readonly ICodeGenerationService _codeGenerationService;
 
         protected AbstractMetadataAsSourceService(ICodeGenerationService codeGenerationService)
-        {
-            _codeGenerationService = codeGenerationService;
-        }
+            => _codeGenerationService = codeGenerationService;
 
         public async Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -42,9 +42,7 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         public IMoveToNamespaceOptionsService OptionsService { get; }
 
         protected AbstractMoveToNamespaceService(IMoveToNamespaceOptionsService moveToNamespaceOptionsService)
-        {
-            OptionsService = moveToNamespaceOptionsService;
-        }
+            => OptionsService = moveToNamespaceOptionsService;
 
         public async Task<ImmutableArray<AbstractMoveToNamespaceCodeAction>> GetCodeActionsAsync(
             Document document,

--- a/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceAnalysisResult.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceAnalysisResult.cs
@@ -33,9 +33,7 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         }
 
         private MoveToNamespaceAnalysisResult()
-        {
-            CanPerform = false;
-        }
+            => CanPerform = false;
 
     }
 }

--- a/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceOptionsResult.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceOptionsResult.cs
@@ -12,13 +12,9 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         public string Namespace { get; }
 
         private MoveToNamespaceOptionsResult()
-        {
-            IsCancelled = true;
-        }
+            => IsCancelled = true;
 
         public MoveToNamespaceOptionsResult(string @namespace)
-        {
-            Namespace = @namespace;
-        }
+            => Namespace = @namespace;
     }
 }

--- a/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceResult.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceResult.cs
@@ -31,8 +31,6 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         }
 
         private MoveToNamespaceResult()
-        {
-            Succeeded = false;
-        }
+            => Succeeded = false;
     }
 }

--- a/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
@@ -10,33 +10,21 @@ namespace Microsoft.CodeAnalysis.Navigation
     internal sealed class DefaultDocumentNavigationService : IDocumentNavigationService
     {
         public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
-        {
-            return false;
-        }
+            => false;
 
         public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
-        {
-            return false;
-        }
+            => false;
 
         public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace)
-        {
-            return false;
-        }
+            => false;
 
         public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
-        {
-            return false;
-        }
+            => false;
 
         public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
-        {
-            return false;
-        }
+            => false;
 
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
-        {
-            return false;
-        }
+            => false;
     }
 }

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.Navigation
         }
 
         public static INavigableItem GetItemFromDeclaredSymbolInfo(DeclaredSymbolInfo declaredSymbolInfo, Document document)
-        {
-            return new DeclaredSymbolNavigableItem(document, declaredSymbolInfo);
-        }
+            => new DeclaredSymbolNavigableItem(document, declaredSymbolInfo);
 
         public static IEnumerable<INavigableItem> GetItemsFromPreferredSourceLocations(
             Solution solution,

--- a/src/Features/Core/Portable/Organizing/AbstractOrganizingService.cs
+++ b/src/Features/Core/Portable/Organizing/AbstractOrganizingService.cs
@@ -18,21 +18,15 @@ namespace Microsoft.CodeAnalysis.Organizing
     {
         private readonly IEnumerable<ISyntaxOrganizer> _organizers;
         protected AbstractOrganizingService(IEnumerable<ISyntaxOrganizer> organizers)
-        {
-            _organizers = organizers.ToImmutableArrayOrEmpty();
-        }
+            => _organizers = organizers.ToImmutableArrayOrEmpty();
 
         public IEnumerable<ISyntaxOrganizer> GetDefaultOrganizers()
-        {
-            return _organizers;
-        }
+            => _organizers;
 
         protected abstract Task<Document> ProcessAsync(Document document, IEnumerable<ISyntaxOrganizer> organizers, CancellationToken cancellationToken);
 
         public Task<Document> OrganizeAsync(Document document, IEnumerable<ISyntaxOrganizer> organizers, CancellationToken cancellationToken)
-        {
-            return ProcessAsync(document, organizers ?? GetDefaultOrganizers(), cancellationToken);
-        }
+            => ProcessAsync(document, organizers ?? GetDefaultOrganizers(), cancellationToken);
 
         protected Func<SyntaxNode, IEnumerable<ISyntaxOrganizer>> GetNodeToOrganizers(IEnumerable<ISyntaxOrganizer> organizers)
         {

--- a/src/Features/Core/Portable/Organizing/Organizers/AbstractSyntaxNodeOrganizer.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/AbstractSyntaxNodeOrganizer.cs
@@ -18,9 +18,7 @@ namespace Microsoft.CodeAnalysis.Organizing.Organizers
         }
 
         public SyntaxNode OrganizeNode(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
-        {
-            return Organize((TSyntaxNode)node, cancellationToken);
-        }
+            => Organize((TSyntaxNode)node, cancellationToken);
 
         protected abstract TSyntaxNode Organize(TSyntaxNode node, CancellationToken cancellationToken);
     }

--- a/src/Features/Core/Portable/PickMembers/PickMembersResult.cs
+++ b/src/Features/Core/Portable/PickMembers/PickMembersResult.cs
@@ -15,9 +15,7 @@ namespace Microsoft.CodeAnalysis.PickMembers
         public readonly ImmutableArray<PickMembersOption> Options;
 
         private PickMembersResult(bool isCanceled)
-        {
-            IsCanceled = isCanceled;
-        }
+            => IsCanceled = isCanceled;
 
         public PickMembersResult(
             ImmutableArray<ISymbol> members,

--- a/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
+++ b/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
@@ -25,9 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
         /// Test purpose only
         /// </summary>
         protected AbstractPullMemberUpRefactoringProvider(IPullMemberUpOptionsService service)
-        {
-            _service = service;
-        }
+            => _service = service;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/QuickInfo/CommonQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonQuickInfoProvider.cs
@@ -33,9 +33,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
         }
 
         protected virtual bool ShouldCheckPreviousToken(SyntaxToken token)
-        {
-            return true;
-        }
+            => true;
 
         private async Task<QuickInfoItem?> GetQuickInfoAsync(
             Document document,

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.ErrorVisitor.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.ErrorVisitor.cs
@@ -17,39 +17,25 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             private static readonly ErrorVisitor s_instance = new ErrorVisitor();
 
             public static bool ContainsError(ISymbol symbol)
-            {
-                return s_instance.Visit(symbol);
-            }
+                => s_instance.Visit(symbol);
 
             public override bool DefaultVisit(ISymbol symbol)
-            {
-                return true;
-            }
+                => true;
 
             public override bool VisitAlias(IAliasSymbol symbol)
-            {
-                return false;
-            }
+                => false;
 
             public override bool VisitArrayType(IArrayTypeSymbol symbol)
-            {
-                return Visit(symbol.ElementType);
-            }
+                => Visit(symbol.ElementType);
 
             public override bool VisitEvent(IEventSymbol symbol)
-            {
-                return Visit(symbol.Type);
-            }
+                => Visit(symbol.Type);
 
             public override bool VisitField(IFieldSymbol symbol)
-            {
-                return Visit(symbol.Type);
-            }
+                => Visit(symbol.Type);
 
             public override bool VisitLocal(ILocalSymbol symbol)
-            {
-                return Visit(symbol.Type);
-            }
+                => Visit(symbol.Type);
 
             public override bool VisitMethod(IMethodSymbol symbol)
             {
@@ -86,19 +72,13 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             }
 
             public override bool VisitParameter(IParameterSymbol symbol)
-            {
-                return Visit(symbol.Type);
-            }
+                => Visit(symbol.Type);
 
             public override bool VisitProperty(IPropertySymbol symbol)
-            {
-                return Visit(symbol.Type);
-            }
+                => Visit(symbol.Type);
 
             public override bool VisitPointerType(IPointerTypeSymbol symbol)
-            {
-                return Visit(symbol.PointedAtType);
-            }
+                => Visit(symbol.PointedAtType);
         }
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoSection.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoSection.cs
@@ -37,9 +37,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
         /// <param name="kind">The kind of the section. Use <see cref="QuickInfoSectionKinds"/> for the most common kinds.</param>
         /// <param name="taggedParts">The individual tagged parts of the section.</param>
         public static QuickInfoSection Create(string? kind, ImmutableArray<TaggedText> taggedParts)
-        {
-            return new QuickInfoSection(kind, taggedParts);
-        }
+            => new QuickInfoSection(kind, taggedParts);
 
         private string? _text;
 

--- a/src/Features/Core/Portable/RQName/Nodes/RQArrayOrPointerType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQArrayOrPointerType.cs
@@ -9,8 +9,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public readonly RQType ElementType;
 
         public RQArrayOrPointerType(RQType elementType)
-        {
-            ElementType = elementType;
-        }
+            => ElementType = elementType;
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQErrorType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQErrorType.cs
@@ -11,13 +11,9 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public readonly string Name;
 
         public RQErrorType(string name)
-        {
-            Name = name;
-        }
+            => Name = name;
 
         public override SimpleTreeNode ToSimpleTree()
-        {
-            return new SimpleGroupNode(RQNameStrings.Error, Name);
-        }
+            => new SimpleGroupNode(RQNameStrings.Error, Name);
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQExplicitInterfaceMemberName.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQExplicitInterfaceMemberName.cs
@@ -23,8 +23,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         }
 
         public override SimpleGroupNode ToSimpleTree()
-        {
-            return new SimpleGroupNode(RQNameStrings.IntfExplName, InterfaceType.ToSimpleTree(), Name.ToSimpleTree());
-        }
+            => new SimpleGroupNode(RQNameStrings.IntfExplName, InterfaceType.ToSimpleTree(), Name.ToSimpleTree());
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQMember.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMember.cs
@@ -12,15 +12,11 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public readonly RQUnconstructedType ContainingType;
 
         public RQMember(RQUnconstructedType containingType)
-        {
-            ContainingType = containingType;
-        }
+            => ContainingType = containingType;
 
         public abstract string MemberName { get; }
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
-        {
-            childList.Add(ContainingType.ToSimpleTree());
-        }
+            => childList.Add(ContainingType.ToSimpleTree());
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQNormalParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQNormalParameter.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public RQNormalParameter(RQType type) : base(type) { }
 
         public override SimpleTreeNode CreateSimpleTreeForType()
-        {
-            return Type.ToSimpleTree();
-        }
+            => Type.ToSimpleTree();
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQNullType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQNullType.cs
@@ -12,8 +12,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         private RQNullType() { }
 
         public override SimpleTreeNode ToSimpleTree()
-        {
-            return new SimpleLeafNode(RQNameStrings.Null);
-        }
+            => new SimpleLeafNode(RQNameStrings.Null);
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQOrdinaryMethodPropertyOrEventName.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQOrdinaryMethodPropertyOrEventName.cs
@@ -26,38 +26,24 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         }
 
         public static RQOrdinaryMethodPropertyOrEventName CreateConstructorName()
-        {
-            return new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.MethName, RQNameStrings.SpecialConstructorName);
-        }
+            => new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.MethName, RQNameStrings.SpecialConstructorName);
 
         public static RQOrdinaryMethodPropertyOrEventName CreateDestructorName()
-        {
-            return new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.MethName, RQNameStrings.SpecialDestructorName);
-        }
+            => new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.MethName, RQNameStrings.SpecialDestructorName);
 
         public static RQOrdinaryMethodPropertyOrEventName CreateOrdinaryIndexerName()
-        {
-            return new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.PropName, RQNameStrings.SpecialIndexerName);
-        }
+            => new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.PropName, RQNameStrings.SpecialIndexerName);
 
         public static RQOrdinaryMethodPropertyOrEventName CreateOrdinaryMethodName(string name)
-        {
-            return new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.MethName, name);
-        }
+            => new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.MethName, name);
 
         public static RQOrdinaryMethodPropertyOrEventName CreateOrdinaryEventName(string name)
-        {
-            return new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.EventName, name);
-        }
+            => new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.EventName, name);
 
         public static RQOrdinaryMethodPropertyOrEventName CreateOrdinaryPropertyName(string name)
-        {
-            return new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.PropName, name);
-        }
+            => new RQOrdinaryMethodPropertyOrEventName(RQNameStrings.PropName, name);
 
         public override SimpleGroupNode ToSimpleTree()
-        {
-            return new SimpleGroupNode(_constructType, Name);
-        }
+            => new SimpleGroupNode(_constructType, Name);
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQOutParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQOutParameter.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public RQOutParameter(RQType type) : base(type) { }
 
         public override SimpleTreeNode CreateSimpleTreeForType()
-        {
-            return new SimpleGroupNode(RQNameStrings.ParamMod, new SimpleLeafNode(RQNameStrings.Out), Type.ToSimpleTree());
-        }
+            => new SimpleGroupNode(RQNameStrings.ParamMod, new SimpleLeafNode(RQNameStrings.Out), Type.ToSimpleTree());
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQParameter.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         }
 
         public SimpleTreeNode ToSimpleTree()
-        {
-            return new SimpleGroupNode(RQNameStrings.Param, CreateSimpleTreeForType());
-        }
+            => new SimpleGroupNode(RQNameStrings.Param, CreateSimpleTreeForType());
 
         public abstract SimpleTreeNode CreateSimpleTreeForType();
     }

--- a/src/Features/Core/Portable/RQName/Nodes/RQPointerType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQPointerType.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public RQPointerType(RQType elementType) : base(elementType) { }
 
         public override SimpleTreeNode ToSimpleTree()
-        {
-            return new SimpleGroupNode(RQNameStrings.Pointer, ElementType.ToSimpleTree());
-        }
+            => new SimpleGroupNode(RQNameStrings.Pointer, ElementType.ToSimpleTree());
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQRefParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQRefParameter.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public RQRefParameter(RQType type) : base(type) { }
 
         public override SimpleTreeNode CreateSimpleTreeForType()
-        {
-            return new SimpleGroupNode(RQNameStrings.ParamMod, new SimpleLeafNode(RQNameStrings.Ref), Type.ToSimpleTree());
-        }
+            => new SimpleGroupNode(RQNameStrings.ParamMod, new SimpleLeafNode(RQNameStrings.Ref), Type.ToSimpleTree());
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQTypeOrNamespace.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQTypeOrNamespace.cs
@@ -14,9 +14,7 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public readonly ReadOnlyCollection<string> NamespaceNames;
 
         protected RQTypeOrNamespace(IList<string> namespaceNames)
-        {
-            NamespaceNames = new ReadOnlyCollection<string>(namespaceNames);
-        }
+            => NamespaceNames = new ReadOnlyCollection<string>(namespaceNames);
 
         public INamespaceSymbol NamespaceIdentifier
         {
@@ -25,8 +23,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         }
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
-        {
-            childList.AddRange(NamespaceNames.Select(name => (SimpleTreeNode)new SimpleGroupNode(RQNameStrings.NsName, name)));
-        }
+            => childList.AddRange(NamespaceNames.Select(name => (SimpleTreeNode)new SimpleGroupNode(RQNameStrings.NsName, name)));
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQTypeVariableType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQTypeVariableType.cs
@@ -11,13 +11,9 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         public readonly string Name;
 
         public RQTypeVariableType(string name)
-        {
-            Name = name;
-        }
+            => Name = name;
 
         public override SimpleTreeNode ToSimpleTree()
-        {
-            return new SimpleGroupNode(RQNameStrings.TyVar, Name);
-        }
+            => new SimpleGroupNode(RQNameStrings.TyVar, Name);
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQVoidType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQVoidType.cs
@@ -12,8 +12,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         private RQVoidType() { }
 
         public override SimpleTreeNode ToSimpleTree()
-        {
-            return new SimpleLeafNode(RQNameStrings.Void);
-        }
+            => new SimpleLeafNode(RQNameStrings.Void);
     }
 }

--- a/src/Features/Core/Portable/RQName/RQNodeBuilder.cs
+++ b/src/Features/Core/Portable/RQName/RQNodeBuilder.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.Features.RQName
             };
 
         private static RQNamespace BuildNamespace(INamespaceSymbol @namespace)
-        {
-            return new RQNamespace(RQNodeBuilder.GetNameParts(@namespace));
-        }
+            => new RQNamespace(RQNodeBuilder.GetNameParts(@namespace));
 
         private static IList<string> GetNameParts(INamespaceSymbol @namespace)
         {

--- a/src/Features/Core/Portable/RQName/SimpleTree/SimpleGroupNode.cs
+++ b/src/Features/Core/Portable/RQName/SimpleTree/SimpleGroupNode.cs
@@ -12,9 +12,7 @@ namespace Microsoft.CodeAnalysis.Features.RQName.SimpleTree
         private readonly IList<SimpleTreeNode> _children;
 
         public SimpleGroupNode(string text, IList<SimpleTreeNode> children) : base(text)
-        {
-            _children = children;
-        }
+            => _children = children;
 
         public SimpleGroupNode(string text, string singleLeafChildText) : this(text, new SimpleLeafNode(singleLeafChildText)) { }
 

--- a/src/Features/Core/Portable/RQName/SimpleTree/SimpleTreeNode.cs
+++ b/src/Features/Core/Portable/RQName/SimpleTree/SimpleTreeNode.cs
@@ -9,8 +9,6 @@ namespace Microsoft.CodeAnalysis.Features.RQName.SimpleTree
         public readonly string Text;
 
         public SimpleTreeNode(string text)
-        {
-            Text = text;
-        }
+            => Text = text;
     }
 }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -91,18 +91,12 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         }
 
         private static bool HasGetPrefix(SyntaxToken identifier)
-        {
-            return HasGetPrefix(identifier.ValueText);
-        }
+            => HasGetPrefix(identifier.ValueText);
 
         private static bool HasGetPrefix(string text)
-        {
-            return HasPrefix(text, GetPrefix);
-        }
+            => HasPrefix(text, GetPrefix);
         private static bool HasPrefix(string text, string prefix)
-        {
-            return text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && text.Length > prefix.Length && !char.IsLower(text[prefix.Length]);
-        }
+            => text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && text.Length > prefix.Length && !char.IsLower(text[prefix.Length]);
 
         private IMethodSymbol FindSetMethod(IMethodSymbol getMethod)
         {

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
@@ -406,9 +406,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             }
 
             private bool ShouldReadFromBackingField()
-            {
-                return _propertyBackingField != null && _property.GetMethod == null;
-            }
+                => _propertyBackingField != null && _property.GetMethod == null;
 
             private SyntaxNode GetSetInvocationExpression(
                 TExpressionSyntax writeValue, bool keepTrivia, string? conflictMessage)
@@ -420,9 +418,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             }
 
             private bool ShouldWriteToBackingField()
-            {
-                return _propertyBackingField != null && _property.SetMethod == null;
-            }
+                => _propertyBackingField != null && _property.SetMethod == null;
 
             private static TIdentifierNameSyntax AddConflictAnnotation(TIdentifierNameSyntax name, string conflictMessage)
             {

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_Sorting.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_Sorting.cs
@@ -91,9 +91,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         private static int CompareProperties(IPropertySymbol xProperty, string[] xTypeNames, IPropertySymbol yProperty, string[] yTypeNames)
-        {
-            return CompareParameters(xProperty.Parameters, xTypeNames, yProperty.Parameters, yTypeNames);
-        }
+            => CompareParameters(xProperty.Parameters, xTypeNames, yProperty.Parameters, yTypeNames);
 
         private static int CompareMethods(IMethodSymbol xMethod, string[] xTypeNames, IMethodSymbol yMethod, string[] yTypeNames)
         {
@@ -110,9 +108,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         private static int CompareEvents(IEventSymbol xEvent, string[] xTypeNames, IEventSymbol yEvent, string[] yTypeNames)
-        {
-            return CompareParameters(GetMethodOrIndexerOrEventParameters(xEvent), xTypeNames, GetMethodOrIndexerOrEventParameters(yEvent), yTypeNames);
-        }
+            => CompareParameters(GetMethodOrIndexerOrEventParameters(xEvent), xTypeNames, GetMethodOrIndexerOrEventParameters(yEvent), yTypeNames);
 
         private static int CompareNamedTypes(INamedTypeSymbol xNamedType, INamedTypeSymbol yNamedType)
         {

--- a/src/Features/Core/Portable/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/LinkedFilesSymbolEquivalenceComparer.cs
@@ -16,13 +16,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public static readonly LinkedFilesSymbolEquivalenceComparer Instance = new LinkedFilesSymbolEquivalenceComparer();
 
         bool IEqualityComparer<ISymbol>.Equals(ISymbol x, ISymbol y)
-        {
-            return x.Name == y.Name;
-        }
+            => x.Name == y.Name;
 
         int IEqualityComparer<ISymbol>.GetHashCode(ISymbol symbol)
-        {
-            return symbol.Name.GetHashCode();
-        }
+            => symbol.Name.GetHashCode();
     }
 }

--- a/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
@@ -50,13 +50,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         }
 
         private static string Supported(bool supported)
-        {
-            return supported ? FeaturesResources.Available : FeaturesResources.Not_Available;
-        }
+            => supported ? FeaturesResources.Available : FeaturesResources.Not_Available;
 
         public bool HasValidAndInvalidProjects()
-        {
-            return InvalidProjects.Any() && InvalidProjects.Count != CandidateProjects.Count();
-        }
+            => InvalidProjects.Any() && InvalidProjects.Count != CandidateProjects.Count();
     }
 }

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
             }
 
             public override bool Equals(object obj)
-            {
-                return Equals(obj as SymbolKeySignatureHelpItem);
-            }
+                => Equals(obj as SymbolKeySignatureHelpItem);
 
             public bool Equals(SymbolKeySignatureHelpItem obj)
             {

--- a/src/Features/Core/Portable/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         protected override void InitializeWorker(AnalysisContext context)
-        {
-            context.RegisterOperationAction(AnalyzeInterpolation, OperationKind.Interpolation);
-        }
+            => context.RegisterOperationAction(AnalyzeInterpolation, OperationKind.Interpolation);
 
         private void AnalyzeInterpolation(OperationAnalysisContext context)
         {

--- a/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -233,9 +233,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
                 = new ConcurrentDictionary<SyntaxTree, (StrongBox<bool> completed, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? intervalTree)>();
 
             public AnalyzerImpl(SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum> analyzer)
-            {
-                _analyzer = analyzer;
-            }
+                => _analyzer = analyzer;
 
             public void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
@@ -48,9 +48,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         protected void UpdateLastAccessTime()
-        {
-            _lastAccessTimeInMS = Environment.TickCount;
-        }
+            => _lastAccessTimeInMS = Environment.TickCount;
 
         protected async Task WaitForIdleAsync(IExpeditableDelaySource expeditableDelaySource)
         {

--- a/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
@@ -15,53 +15,33 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public virtual Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
-        {
-            return false;
-        }
+            => false;
 
         public virtual Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
 
         public virtual Task RemoveProjectAsync(ProjectId projectId, CancellationToken cancellation)
-        {
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerProviderBase.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerProviderBase.cs
@@ -19,8 +19,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public virtual IIncrementalAnalyzer CreateIncrementalAnalyzer(Workspace workspace)
-        {
-            return new AggregateIncrementalAnalyzer(workspace, this, _providers);
-        }
+            => new AggregateIncrementalAnalyzer(workspace, this, _providers);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/MiscSolutionCrawlerWorkspaceEventListener.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/MiscSolutionCrawlerWorkspaceEventListener.cs
@@ -26,8 +26,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public void StopListening(Workspace workspace)
-        {
-            DiagnosticProvider.Disable(workspace);
-        }
+            => DiagnosticProvider.Disable(workspace);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -145,9 +145,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public static void LogWorkspaceEvent(LogAggregator logAggregator, int kind)
-        {
-            logAggregator.IncreaseCount(kind);
-        }
+            => logAggregator.IncreaseCount(kind);
 
         public static void LogWorkCoordinatorShutdown(int correlationId, LogAggregator logAggregator)
         {
@@ -164,19 +162,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public static void LogGlobalOperation(LogAggregator logAggregator)
-        {
-            logAggregator.IncreaseCount(GlobalOperation);
-        }
+            => logAggregator.IncreaseCount(GlobalOperation);
 
         public static void LogActiveFileEnqueue(LogAggregator logAggregator)
-        {
-            logAggregator.IncreaseCount(ActiveFileEnqueue);
-        }
+            => logAggregator.IncreaseCount(ActiveFileEnqueue);
 
         public static void LogWorkItemEnqueue(LogAggregator logAggregator, ProjectId projectId)
-        {
-            logAggregator.IncreaseCount(ProjectEnqueue);
-        }
+            => logAggregator.IncreaseCount(ProjectEnqueue);
 
         public static void LogWorkItemEnqueue(
             LogAggregator logAggregator, string language, DocumentId documentId, InvocationReasons reasons, bool lowPriority, SyntaxPath activeMember, bool added)
@@ -208,9 +200,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public static void LogResetStates(LogAggregator logAggregator)
-        {
-            logAggregator.IncreaseCount(ResetStates);
-        }
+            => logAggregator.IncreaseCount(ResetStates);
 
         public static void LogIncrementalAnalyzerProcessorStatistics(int correlationId, Solution solution, LogAggregator logAggregator, ImmutableArray<IIncrementalAnalyzer> analyzers)
         {
@@ -275,9 +265,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         private static string CreateProperty(string parent, string child)
-        {
-            return parent + "." + child;
-        }
+            => parent + "." + child;
 
         public static void LogProcessCloseDocument(LogAggregator logAggregator, Guid documentId)
         {
@@ -318,9 +306,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public static void LogProcessDocumentNotExist(LogAggregator logAggregator)
-        {
-            logAggregator.IncreaseCount(DocumentNotExist);
-        }
+            => logAggregator.IncreaseCount(DocumentNotExist);
 
         public static void LogProcessProject(LogAggregator logAggregator, Guid projectId, bool processed)
         {
@@ -337,8 +323,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public static void LogProcessProjectNotExist(LogAggregator logAggregator)
-        {
-            logAggregator.IncreaseCount(ProjectNotExist);
-        }
+            => logAggregator.IncreaseCount(ProjectNotExist);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -62,9 +62,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             /// actually revert back to the paused state where no work proceeds.
             /// </summary>
             public IDisposable GetEvaluatingScope()
-            {
-                return new ProgressStatusRAII(this);
-            }
+                => new ProgressStatusRAII(this);
 
             private void ChangeProgressStatus(ref int referenceCount, ProgressStatus status)
             {
@@ -77,9 +75,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
 
             private void OnProgressChanged(ProgressData progressData)
-            {
-                ProgressChanged?.Invoke(this, progressData);
-            }
+                => ProgressChanged?.Invoke(this, progressData);
 
             private struct ProgressStatusRAII : IDisposable
             {
@@ -92,9 +88,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 public void Dispose()
-                {
-                    _owner.Pause();
-                }
+                    => _owner.Pause();
             }
         }
 

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -48,9 +48,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public void Register(Workspace workspace)
-        {
-            EnsureRegistration(workspace, initializeLazily: true);
-        }
+            => EnsureRegistration(workspace, initializeLazily: true);
 
         /// <summary>
         /// make sure solution cralwer is registered for the given workspace.
@@ -268,9 +266,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         private static bool IsDefaultProvider(IncrementalAnalyzerProviderMetadata providerMetadata)
-        {
-            return providerMetadata.WorkspaceKinds == null || providerMetadata.WorkspaceKinds.Count == 0;
-        }
+            => providerMetadata.WorkspaceKinds == null || providerMetadata.WorkspaceKinds.Count == 0;
 
         private class Registration
         {
@@ -288,9 +284,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             public Solution CurrentSolution => Workspace.CurrentSolution;
 
             public TService GetService<TService>() where TService : IWorkspaceService
-            {
-                return Workspace.Services.GetService<TService>();
-            }
+                => Workspace.Services.GetService<TService>();
         }
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/State/AbstractDocumentAnalyzerState.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/State/AbstractDocumentAnalyzerState.cs
@@ -15,28 +15,18 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler.State
         protected abstract string StateName { get; }
 
         protected override DocumentId GetCacheKey(Document value)
-        {
-            return value.Id;
-        }
+            => value.Id;
 
         protected override Solution GetSolution(Document value)
-        {
-            return value.Project.Solution;
-        }
+            => value.Project.Solution;
 
         protected override bool ShouldCache(Document value)
-        {
-            return value.IsOpen();
-        }
+            => value.IsOpen();
 
         protected override Task<Stream> ReadStreamAsync(IPersistentStorage storage, Document value, CancellationToken cancellationToken)
-        {
-            return storage.ReadStreamAsync(value, StateName, cancellationToken);
-        }
+            => storage.ReadStreamAsync(value, StateName, cancellationToken);
 
         protected override Task<bool> WriteStreamAsync(IPersistentStorage storage, Document value, Stream stream, CancellationToken cancellationToken)
-        {
-            return storage.WriteStreamAsync(value, StateName, stream, cancellationToken);
-        }
+            => storage.WriteStreamAsync(value, StateName, stream, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AbstractPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AbstractPriorityProcessor.cs
@@ -66,9 +66,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     protected override void PauseOnGlobalOperation()
-                    {
-                        SolutionCrawlerLogger.LogGlobalOperation(Processor._logAggregator);
-                    }
+                        => SolutionCrawlerLogger.LogGlobalOperation(Processor._logAggregator);
 
                     protected abstract Task HigherQueueOperationTask { get; }
                     protected abstract bool HigherQueueHasWorkItem { get; }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -72,9 +72,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 public virtual Task WaitAsync(CancellationToken cancellationToken)
-                {
-                    return _semaphore.WaitAsync(cancellationToken);
-                }
+                    => _semaphore.WaitAsync(cancellationToken);
 
                 public bool AddOrReplace(WorkItem item)
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -113,9 +113,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     protected override Task WaitAsync(CancellationToken cancellationToken)
-                    {
-                        return _workItemQueue.WaitAsync(cancellationToken);
-                    }
+                        => _workItemQueue.WaitAsync(cancellationToken);
 
                     protected override async Task ExecuteAsync()
                     {
@@ -220,9 +218,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     public void Shutdown()
-                    {
-                        _workItemQueue.Dispose();
-                    }
+                        => _workItemQueue.Dispose();
                 }
             }
         }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -222,19 +222,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 private IDisposable EnableCaching(ProjectId projectId)
-                {
-                    return _cacheService?.EnableCaching(projectId) ?? NullDisposable.Instance;
-                }
+                    => _cacheService?.EnableCaching(projectId) ?? NullDisposable.Instance;
 
                 private IEnumerable<DocumentId> GetOpenDocumentIds()
-                {
-                    return _registration.Workspace.GetOpenDocumentIds();
-                }
+                    => _registration.Workspace.GetOpenDocumentIds();
 
                 private void ResetLogAggregator()
-                {
-                    _logAggregator = new LogAggregator();
-                }
+                    => _logAggregator = new LogAggregator();
 
                 private void ReportPendingWorkItemCount()
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -44,9 +44,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     public int WorkItemCount => _workItemQueue.WorkItemCount;
 
                     protected override Task WaitAsync(CancellationToken cancellationToken)
-                    {
-                        return _workItemQueue.WaitAsync(cancellationToken);
-                    }
+                        => _workItemQueue.WaitAsync(cancellationToken);
 
                     protected override async Task ExecuteAsync()
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -220,9 +220,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     private static void DisposeProjectCache(IDisposable projectCache)
-                    {
-                        projectCache?.Dispose();
-                    }
+                        => projectCache?.Dispose();
 
                     private void DisposeProjectCache()
                     {
@@ -452,9 +450,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     private Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
-                    {
-                        return RemoveDocumentAsync(Analyzers, documentId, cancellationToken);
-                    }
+                        => RemoveDocumentAsync(Analyzers, documentId, cancellationToken);
 
                     private static async Task RemoveDocumentAsync(ImmutableArray<IIncrementalAnalyzer> analyzers, DocumentId documentId, CancellationToken cancellationToken)
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -75,9 +75,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 protected override Task WaitAsync(CancellationToken cancellationToken)
-                {
-                    return _gate.WaitAsync(cancellationToken);
-                }
+                    => _gate.WaitAsync(cancellationToken);
 
                 protected override async Task ExecuteAsync()
                 {
@@ -96,9 +94,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 private Data Dequeue()
-                {
-                    return DequeueWorker(_workGate, _pendingWork, CancellationToken);
-                }
+                    => DequeueWorker(_workGate, _pendingWork, CancellationToken);
 
                 private async Task<bool> TryEnqueueFromHintAsync(Document document, SyntaxPath changedMember)
                 {
@@ -176,9 +172,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 private Task EnqueueWorkItemAsync(Document document, ISymbol symbol)
-                {
-                    return EnqueueWorkItemAsync(document, symbol.ContainingType != null ? symbol.ContainingType.Locations : symbol.Locations);
-                }
+                    => EnqueueWorkItemAsync(document, symbol.ContainingType != null ? symbol.ContainingType.Locations : symbol.Locations);
 
                 private async Task EnqueueWorkItemAsync(Document thisDocument, ImmutableArray<Location> locations)
                 {
@@ -207,9 +201,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 private bool IsType(ISymbol symbol)
-                {
-                    return symbol.Kind == SymbolKind.NamedType;
-                }
+                    => symbol.Kind == SymbolKind.NamedType;
 
                 private bool IsMember(ISymbol symbol)
                 {
@@ -415,9 +407,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     protected override Task WaitAsync(CancellationToken cancellationToken)
-                    {
-                        return _gate.WaitAsync(cancellationToken);
-                    }
+                        => _gate.WaitAsync(cancellationToken);
 
                     protected override async Task ExecuteAsync()
                     {
@@ -448,9 +438,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     private Data Dequeue()
-                    {
-                        return DequeueWorker(_workGate, _pendingWork, CancellationToken);
-                    }
+                        => DequeueWorker(_workGate, _pendingWork, CancellationToken);
 
                     private async Task EnqueueWorkItemAsync(Project project)
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.WorkItem.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.WorkItem.cs
@@ -176,9 +176,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 public override string ToString()
-                {
-                    return $"{DocumentId?.ToString() ?? ProjectId.ToString()}, ({InvocationReasons}), LowPriority:{IsLowPriority}, ActiveMember:{ActiveMember != null}, Retry:{IsRetry}, ({string.Join("|", SpecificAnalyzers.Select(a => a.GetType().Name))})";
-                }
+                    => $"{DocumentId?.ToString() ?? ProjectId.ToString()}, ({InvocationReasons}), LowPriority:{IsLowPriority}, ActiveMember:{ActiveMember != null}, Retry:{IsRetry}, ({string.Join("|", SpecificAnalyzers.Select(a => a.GetType().Name))})";
             }
         }
     }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -275,9 +275,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
 
             private bool NotOurShutdownToken(OperationCanceledException oce)
-            {
-                return oce.CancellationToken == _shutdownToken;
-            }
+                => oce.CancellationToken == _shutdownToken;
 
             private void ProcessEvent(WorkspaceChangeEventArgs args, string eventName)
             {
@@ -661,9 +659,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
 
             internal void WaitUntilCompletion_ForTestingPurposesOnly()
-            {
-                _documentAndProjectWorkerProcessor.WaitUntilCompletion_ForTestingPurposesOnly();
-            }
+                => _documentAndProjectWorkerProcessor.WaitUntilCompletion_ForTestingPurposesOnly();
         }
 
         private readonly struct ReanalyzeScope

--- a/src/Features/Core/Portable/Structure/BlockStructure.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructure.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Structure
         public ImmutableArray<BlockSpan> Spans { get; }
 
         public BlockStructure(ImmutableArray<BlockSpan> spans)
-        {
-            Spans = spans;
-        }
+            => Spans = spans;
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -23,8 +23,6 @@ namespace Microsoft.CodeAnalysis.Structure
         }
 
         public void AddBlockSpan(BlockSpan span)
-        {
-            _spans.Add(span);
-        }
+            => _spans.Add(span);
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureProvider.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Structure
         public abstract Task ProvideBlockStructureAsync(BlockStructureContext context);
 
         public virtual void ProvideBlockStructure(BlockStructureContext context)
-        {
-            ProvideBlockStructureAsync(context).Wait(context.CancellationToken);
-        }
+            => ProvideBlockStructureAsync(context).Wait(context.CancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureService.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureService.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.Structure
         /// Gets the service corresponding to the specified document.
         /// </summary>
         public static BlockStructureService GetService(Document document)
-        {
-            return document.GetLanguageService<BlockStructureService>();
-        }
+            => document.GetLanguageService<BlockStructureService>();
 
         /// <summary>
         /// The language from <see cref="LanguageNames"/> this service corresponds to.
@@ -34,8 +32,6 @@ namespace Microsoft.CodeAnalysis.Structure
         /// implementations that do not block on async operations if possible.
         /// </summary>
         public virtual BlockStructure GetBlockStructure(Document document, CancellationToken cancellationToken)
-        {
-            return GetBlockStructureAsync(document, cancellationToken).WaitAndGetResult(cancellationToken);
-        }
+            => GetBlockStructureAsync(document, cancellationToken).WaitAndGetResult(cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
@@ -27,9 +27,7 @@ namespace Microsoft.CodeAnalysis.Structure
         /// This does not included providers imported via MEF composition.
         /// </summary>
         protected virtual ImmutableArray<BlockStructureProvider> GetBuiltInProviders()
-        {
-            return ImmutableArray<BlockStructureProvider>.Empty;
-        }
+            => ImmutableArray<BlockStructureProvider>.Empty;
 
         private ImmutableArray<BlockStructureProvider> GetImportedProviders()
         {

--- a/src/Features/Core/Portable/Structure/BlockTypes.cs
+++ b/src/Features/Core/Portable/Structure/BlockTypes.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.Structure
         }
 
         internal static bool IsExpressionLevelConstruct(string type)
-        {
-            return type == Expression;
-        }
+            => type == Expression;
 
         internal static bool IsStatementLevelConstruct(string type)
         {
@@ -57,13 +55,9 @@ namespace Microsoft.CodeAnalysis.Structure
         }
 
         internal static bool IsCodeLevelConstruct(string type)
-        {
-            return IsExpressionLevelConstruct(type) || IsStatementLevelConstruct(type);
-        }
+            => IsExpressionLevelConstruct(type) || IsStatementLevelConstruct(type);
 
         internal static bool IsDeclarationLevelConstruct(string type)
-        {
-            return !IsCodeLevelConstruct(type) && !IsCommentOrPreprocessorRegion(type);
-        }
+            => !IsCodeLevelConstruct(type) && !IsCommentOrPreprocessorRegion(type);
     }
 }

--- a/src/Features/Core/Portable/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
@@ -89,9 +89,7 @@ namespace Microsoft.CodeAnalysis.UpgradeProject
         }
 
         private bool CanUpgrade(Project project, string language, string version)
-        {
-            return project.Language == language && IsUpgrade(project, version);
-        }
+            => project.Language == language && IsUpgrade(project, version);
     }
 
     internal class ProjectOptionsChangeAction : SolutionChangeAction

--- a/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
@@ -53,14 +53,10 @@ namespace Microsoft.CodeAnalysis.Host
         }
 
         private void OnDocumentOpened(object sender, DocumentEventArgs args)
-        {
-            Rebuild(args.Document.Project.Solution, args.Document.Project.Id);
-        }
+            => Rebuild(args.Document.Project.Solution, args.Document.Project.Id);
 
         private void OnDocumentClosed(object sender, DocumentEventArgs args)
-        {
-            Rebuild(args.Document.Project.Solution, args.Document.Project.Id);
-        }
+            => Rebuild(args.Document.Project.Solution, args.Document.Project.Id);
 
         private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
         {

--- a/src/Features/Core/Portable/Workspace/BackgroundParser.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundParser.cs
@@ -49,14 +49,10 @@ namespace Microsoft.CodeAnalysis.Host
         }
 
         private void OnDocumentOpened(object sender, DocumentEventArgs args)
-        {
-            Parse(args.Document);
-        }
+            => Parse(args.Document);
 
         private void OnDocumentClosed(object sender, DocumentEventArgs args)
-        {
-            CancelParse(args.Document.Id);
-        }
+            => CancelParse(args.Document.Id);
 
         private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
         {

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
@@ -71,9 +71,7 @@ namespace Microsoft.CodeAnalysis.Host
             }
 
             public void Clear()
-            {
-                Array.Clear(_nodes, 0, _nodes.Length);
-            }
+                => Array.Clear(_nodes, 0, _nodes.Length);
 
             private struct Node
             {

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.Host
         private readonly ImplicitCacheMonitor? _implicitCacheMonitor;
 
         public ProjectCacheService(Workspace workspace)
-        {
-            _workspace = workspace;
-        }
+            => _workspace = workspace;
 
         public ProjectCacheService(Workspace workspace, int implicitCacheTimeout)
         {
@@ -174,9 +172,7 @@ namespace Microsoft.CodeAnalysis.Host
             }
 
             public void Dispose()
-            {
-                _cacheService.DisableCaching(_key, this);
-            }
+                => _cacheService.DisableCaching(_key, this);
 
             internal void CreateStrongReference(object key, object? instance)
             {
@@ -192,9 +188,7 @@ namespace Microsoft.CodeAnalysis.Host
             }
 
             internal void CreateOwnerEntry(ICachedObjectOwner owner)
-            {
-                _ownerObjects.Add(new WeakReference<ICachedObjectOwner>(owner));
-            }
+                => _ownerObjects.Add(new WeakReference<ICachedObjectOwner>(owner));
 
             internal void FreeOwnerEntries()
             {

--- a/src/Features/Core/Portable/Wrapping/AbstractWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractWrapper.cs
@@ -28,9 +28,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
         protected IIndentationService IndentationService { get; }
 
         protected AbstractSyntaxWrapper(IIndentationService indentationService)
-        {
-            IndentationService = indentationService;
-        }
+            => IndentationService = indentationService;
 
         public abstract Task<ICodeActionComputer> TryCreateComputerAsync(Document document, int position, SyntaxNode node, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/ChainedExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/ChainedExpressionCodeActionComputer.cs
@@ -110,9 +110,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
             }
 
             private async Task AddUnwrapCodeActionAsync(ArrayBuilder<WrapItemsAction> actions)
-            {
-                actions.Add(await TryCreateCodeActionAsync(GetUnwrapEdits(), FeaturesResources.Wrapping, FeaturesResources.Unwrap_call_chain).ConfigureAwait(false));
-            }
+                => actions.Add(await TryCreateCodeActionAsync(GetUnwrapEdits(), FeaturesResources.Wrapping, FeaturesResources.Unwrap_call_chain).ConfigureAwait(false));
 
             private async Task AddWrapLongCodeActionAsync(ArrayBuilder<WrapItemsAction> actions)
             {

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -343,9 +343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         }
 
         private static bool IsExtensionMethod(MethodDeclarationSyntax methodDeclaration)
-        {
-            return methodDeclaration.ParameterList.Parameters.FirstOrDefault()?.Modifiers.Any(SyntaxKind.ThisKeyword) == true;
-        }
+            => methodDeclaration.ParameterList.Parameters.FirstOrDefault()?.Modifiers.Any(SyntaxKind.ThisKeyword) == true;
 
         private static string? GetClassificationForTypeDeclarationIdentifier(SyntaxToken identifier)
             => identifier.Parent!.Kind() switch

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/CSharpSyntaxClassificationServiceFactory.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/CSharpSyntaxClassificationServiceFactory.cs
@@ -23,8 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.SyntaxClassification
 
         [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-        {
-            return new CSharpSyntaxClassificationService(languageServices);
-        }
+            => new CSharpSyntaxClassificationService(languageServices);
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -47,9 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         }
 
         protected override bool IsParentAnAttribute(SyntaxNode node)
-        {
-            return node.IsParentKind(SyntaxKind.Attribute);
-        }
+            => node.IsParentKind(SyntaxKind.Attribute);
 
         private void ClassifyTypeSyntax(
             NameSyntax name,

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -59,19 +59,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         }
 
         private bool ShouldAddSpan(TextSpan span)
-        {
-            return span.Length > 0 && _textSpan.OverlapsWith(span);
-        }
+            => span.Length > 0 && _textSpan.OverlapsWith(span);
 
         private void AddClassification(SyntaxTrivia trivia, string type)
-        {
-            AddClassification(trivia.Span, type);
-        }
+            => AddClassification(trivia.Span, type);
 
         private void AddClassification(SyntaxToken token, string type)
-        {
-            AddClassification(token.Span, type);
-        }
+            => AddClassification(token.Span, type);
 
         private void ClassifyNodeOrToken(SyntaxNodeOrToken nodeOrToken)
         {
@@ -237,9 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         }
 
         private void ClassifyConflictMarker(SyntaxTrivia trivia)
-        {
-            AddClassification(trivia, ClassificationTypeNames.Comment);
-        }
+            => AddClassification(trivia, ClassificationTypeNames.Comment);
 
         private void ClassifyDisabledText(SyntaxTrivia trivia, SyntaxTriviaList triviaList)
         {

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
@@ -292,9 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         }
 
         private void ClassifyXmlText(XmlTextSyntax node)
-        {
-            ClassifyXmlTextTokens(node.TextTokens);
-        }
+            => ClassifyXmlTextTokens(node.TextTokens);
 
         private void ClassifyXmlComment(XmlCommentSyntax node)
         {

--- a/src/Workspaces/CSharp/Portable/CodeCleanup/CSharpCodeCleanerServiceFactory.cs
+++ b/src/Workspaces/CSharp/Portable/CodeCleanup/CSharpCodeCleanerServiceFactory.cs
@@ -22,8 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-        {
-            return new CSharpCodeCleanerService();
-        }
+            => new CSharpCodeCleanerService();
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/ArgumentGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/ArgumentGenerator.cs
@@ -23,13 +23,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public static ArgumentListSyntax GenerateArgumentList(IList<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(GenerateArgument)));
-        }
+            => SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(GenerateArgument)));
 
         public static BracketedArgumentListSyntax GenerateBracketedArgumentList(IList<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.BracketedArgumentList(SyntaxFactory.SeparatedList(arguments.Select(GenerateArgument)));
-        }
+            => SyntaxFactory.BracketedArgumentList(SyntaxFactory.SeparatedList(arguments.Select(GenerateArgument)));
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationHelpers.cs
@@ -141,34 +141,22 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public static MemberDeclarationSyntax FirstMember(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return members.FirstOrDefault();
-        }
+            => members.FirstOrDefault();
 
         public static MemberDeclarationSyntax FirstMethod(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return members.FirstOrDefault(m => m is MethodDeclarationSyntax);
-        }
+            => members.FirstOrDefault(m => m is MethodDeclarationSyntax);
 
         public static MemberDeclarationSyntax LastField(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return members.LastOrDefault(m => m is FieldDeclarationSyntax);
-        }
+            => members.LastOrDefault(m => m is FieldDeclarationSyntax);
 
         public static MemberDeclarationSyntax LastConstructor(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return members.LastOrDefault(m => m is ConstructorDeclarationSyntax);
-        }
+            => members.LastOrDefault(m => m is ConstructorDeclarationSyntax);
 
         public static MemberDeclarationSyntax LastMethod(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return members.LastOrDefault(m => m is MethodDeclarationSyntax);
-        }
+            => members.LastOrDefault(m => m is MethodDeclarationSyntax);
 
         public static MemberDeclarationSyntax LastOperator(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return members.LastOrDefault(m => m is OperatorDeclarationSyntax || m is ConversionOperatorDeclarationSyntax);
-        }
+            => members.LastOrDefault(m => m is OperatorDeclarationSyntax || m is ConversionOperatorDeclarationSyntax);
 
         public static SyntaxList<TDeclaration> Insert<TDeclaration>(
             SyntaxList<TDeclaration> declarationList,
@@ -199,9 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static bool AreBracesMissing<TDeclaration>(TDeclaration declaration) where TDeclaration : SyntaxNode
-        {
-            return declaration.ChildTokens().Where(t => t.IsKind(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken) && t.IsMissing).Any();
-        }
+            => declaration.ChildTokens().Where(t => t.IsKind(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken) && t.IsMissing).Any();
 
         public static SyntaxNode GetContextNode(
             Location location, CancellationToken cancellationToken)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationService.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationService.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override CodeGenerationDestination GetDestination(SyntaxNode node)
-        {
-            return CSharpCodeGenerationHelpers.GetDestination(node);
-        }
+            => CSharpCodeGenerationHelpers.GetDestination(node);
 
         protected override IComparer<SyntaxNode> GetMemberComparer()
             => CSharpDeclarationComparer.WithoutNamesInstance;
@@ -50,9 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private IList<bool> GetInsertionIndices(TypeDeclarationSyntax destination, CancellationToken cancellationToken)
-        {
-            return destination.GetInsertionIndices(cancellationToken);
-        }
+            => destination.GetInsertionIndices(cancellationToken);
 
         public override async Task<Document> AddEventAsync(
             Solution solution, INamedTypeSymbol destination, IEventSymbol @event,

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationServiceFactory.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationServiceFactory.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-        {
-            return new CSharpCodeGenerationService(provider);
-        }
+            => new CSharpCodeGenerationService(provider);
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
@@ -63,9 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private readonly bool _includeName;
 
         private CSharpDeclarationComparer(bool includeName)
-        {
-            _includeName = includeName;
-        }
+            => _includeName = includeName;
 
         public int Compare(SyntaxNode x, SyntaxNode y)
         {
@@ -308,9 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static bool ContainsToken(SyntaxTokenList list, SyntaxKind kind)
-        {
-            return list.Contains(token => token.Kind() == kind);
-        }
+            => list.Contains(token => token.Kind() == kind);
 
         private enum Accessibility
         {

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpFlagsEnumGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpFlagsEnumGenerator.cs
@@ -47,13 +47,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         protected override SyntaxGenerator GetSyntaxGenerator()
-        {
-            return s_generatorInstance;
-        }
+            => s_generatorInstance;
 
         protected override bool IsValidName(INamedTypeSymbol enumType, string name)
-        {
-            return SyntaxFacts.IsValidIdentifier(name);
-        }
+            => SyntaxFacts.IsValidIdentifier(name);
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -110,9 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode NamespaceImportDeclaration(SyntaxNode name)
-        {
-            return SyntaxFactory.UsingDirective((NameSyntax)name);
-        }
+            => SyntaxFactory.UsingDirective((NameSyntax)name);
 
         public override SyntaxNode AliasImportDeclaration(string aliasIdentifierName, SyntaxNode name)
             => SyntaxFactory.UsingDirective(SyntaxFactory.NameEquals(aliasIdentifierName), (NameSyntax)name);
@@ -585,9 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static AccessorListSyntax WithBodies(AccessorListSyntax accessorList)
-        {
-            return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(x => WithBody(x))));
-        }
+            => accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(x => WithBody(x))));
 
         private static AccessorDeclarationSyntax WithBody(AccessorDeclarationSyntax accessor)
         {
@@ -602,14 +598,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static AccessorListSyntax WithoutBodies(AccessorListSyntax accessorList)
-        {
-            return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(WithoutBody)));
-        }
+            => accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(WithoutBody)));
 
         private static AccessorDeclarationSyntax WithoutBody(AccessorDeclarationSyntax accessor)
-        {
-            return accessor.Body != null ? accessor.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : accessor;
-        }
+            => accessor.Body != null ? accessor.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : accessor;
 
         public override SyntaxNode ClassDeclaration(
             string name,
@@ -826,9 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private SeparatedSyntaxList<EnumMemberDeclarationSyntax> AsEnumMembers(IEnumerable<SyntaxNode> members)
-        {
-            return members != null ? SyntaxFactory.SeparatedList(members.Select(this.AsEnumMember)) : default;
-        }
+            => members != null ? SyntaxFactory.SeparatedList(members.Select(this.AsEnumMember)) : default;
 
         public override SyntaxNode DelegateDeclaration(
             string name,
@@ -849,9 +839,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode Attribute(SyntaxNode name, IEnumerable<SyntaxNode> attributeArguments)
-        {
-            return AsAttributeList(SyntaxFactory.Attribute((NameSyntax)name, AsAttributeArgumentList(attributeArguments)));
-        }
+            => AsAttributeList(SyntaxFactory.Attribute((NameSyntax)name, AsAttributeArgumentList(attributeArguments)));
 
         public override SyntaxNode AttributeArgument(string name, SyntaxNode expression)
         {
@@ -953,14 +941,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static bool IsReturnAttribute(AttributeListSyntax list)
-        {
-            return list.Target?.Identifier.IsKind(SyntaxKind.ReturnKeyword) ?? false;
-        }
+            => list.Target?.Identifier.IsKind(SyntaxKind.ReturnKeyword) ?? false;
 
         public override SyntaxNode InsertAttributes(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributes)
-        {
-            return this.Isolate(declaration, d => this.InsertAttributesInternal(d, index, attributes));
-        }
+            => this.Isolate(declaration, d => this.InsertAttributesInternal(d, index, attributes));
 
         private SyntaxNode InsertAttributesInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributes)
         {
@@ -1054,9 +1038,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode InsertAttributeArguments(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
-        {
-            return this.Isolate(declaration, d => InsertAttributeArgumentsInternal(d, index, attributeArguments));
-        }
+            => this.Isolate(declaration, d => InsertAttributeArgumentsInternal(d, index, attributeArguments));
 
         private static SyntaxNode InsertAttributeArgumentsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
         {
@@ -1152,9 +1134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             };
 
         public override SyntaxNode InsertNamespaceImports(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
-        {
-            return PreserveTrivia(declaration, d => this.InsertNamespaceImportsInternal(d, index, imports));
-        }
+            => PreserveTrivia(declaration, d => this.InsertNamespaceImportsInternal(d, index, imports));
 
         private SyntaxNode InsertNamespaceImportsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
         {
@@ -1297,9 +1277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private IEnumerable<MemberDeclarationSyntax> AsMembersOf(SyntaxNode declaration, IEnumerable<SyntaxNode> members)
-        {
-            return members?.Select(m => this.AsMemberOf(declaration, m)).OfType<MemberDeclarationSyntax>();
-        }
+            => members?.Select(m => this.AsMemberOf(declaration, m)).OfType<MemberDeclarationSyntax>();
 
         private SyntaxNode AsMemberOf(SyntaxNode declaration, SyntaxNode member)
         {
@@ -1503,9 +1481,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode WithModifiers(SyntaxNode declaration, DeclarationModifiers modifiers)
-        {
-            return this.Isolate(declaration, d => this.WithModifiersInternal(d, modifiers));
-        }
+            => this.Isolate(declaration, d => this.WithModifiersInternal(d, modifiers));
 
         private SyntaxNode WithModifiersInternal(SyntaxNode declaration, DeclarationModifiers modifiers)
         {
@@ -1541,9 +1517,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             };
 
         private static SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers, SyntaxKind kind)
-        {
-            return AsModifierList(accessibility, GetAllowedModifiers(kind) & modifiers);
-        }
+            => AsModifierList(accessibility, GetAllowedModifiers(kind) & modifiers);
 
         private static SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers)
         {
@@ -1796,9 +1770,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode WithName(SyntaxNode declaration, string name)
-        {
-            return this.Isolate(declaration, d => this.WithNameInternal(d, name));
-        }
+            => this.Isolate(declaration, d => this.WithNameInternal(d, name));
 
         private SyntaxNode WithNameInternal(SyntaxNode declaration, string name)
         {
@@ -1912,14 +1884,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static TypeSyntax NotVoid(TypeSyntax type)
-        {
-            return type is PredefinedTypeSyntax pd && pd.Keyword.IsKind(SyntaxKind.VoidKeyword) ? null : type;
-        }
+            => type is PredefinedTypeSyntax pd && pd.Keyword.IsKind(SyntaxKind.VoidKeyword) ? null : type;
 
         public override SyntaxNode WithType(SyntaxNode declaration, SyntaxNode type)
-        {
-            return this.Isolate(declaration, d => WithTypeInternal(d, type));
-        }
+            => this.Isolate(declaration, d => WithTypeInternal(d, type));
 
         private static SyntaxNode WithTypeInternal(SyntaxNode declaration, SyntaxNode type)
             => declaration.Kind() switch
@@ -2118,9 +2086,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             private bool _firstVisit = true;
 
             public AddMissingTokensRewriter(bool recurse)
-            {
-                _recurse = recurse;
-            }
+                => _recurse = recurse;
 
             public override SyntaxNode Visit(SyntaxNode node)
             {
@@ -2219,9 +2185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode WithExpression(SyntaxNode declaration, SyntaxNode expression)
-        {
-            return this.Isolate(declaration, d => WithExpressionInternal(d, expression));
-        }
+            => this.Isolate(declaration, d => WithExpressionInternal(d, expression));
 
         private static SyntaxNode WithExpressionInternal(SyntaxNode declaration, SyntaxNode expression)
         {
@@ -2513,9 +2477,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private SyntaxNode WithAccessor(SyntaxNode declaration, SyntaxKind kind, AccessorDeclarationSyntax accessor)
-        {
-            return this.WithAccessor(declaration, GetAccessorList(declaration), kind, accessor);
-        }
+            => this.WithAccessor(declaration, GetAccessorList(declaration), kind, accessor);
 
         private SyntaxNode WithAccessor(SyntaxNode declaration, AccessorListSyntax accessorList, SyntaxKind kind, AccessorDeclarationSyntax accessor)
         {
@@ -2548,14 +2510,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode WithGetAccessorStatements(SyntaxNode declaration, IEnumerable<SyntaxNode> statements)
-        {
-            return this.WithAccessorStatements(declaration, SyntaxKind.GetAccessorDeclaration, statements);
-        }
+            => this.WithAccessorStatements(declaration, SyntaxKind.GetAccessorDeclaration, statements);
 
         public override SyntaxNode WithSetAccessorStatements(SyntaxNode declaration, IEnumerable<SyntaxNode> statements)
-        {
-            return this.WithAccessorStatements(declaration, SyntaxKind.SetAccessorDeclaration, statements);
-        }
+            => this.WithAccessorStatements(declaration, SyntaxKind.SetAccessorDeclaration, statements);
 
         private SyntaxNode WithAccessorStatements(SyntaxNode declaration, SyntaxKind kind, IEnumerable<SyntaxNode> statements)
         {
@@ -2857,9 +2815,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private SyntaxNode WithSubDeclarationsRemoved(SyntaxNode declaration, int index, int count)
-        {
-            return this.RemoveNodes(declaration, GetSubDeclarations(declaration).Skip(index).Take(count));
-        }
+            => this.RemoveNodes(declaration, GetSubDeclarations(declaration).Skip(index).Take(count));
 
         private static IReadOnlyList<SyntaxNode> GetSubDeclarations(SyntaxNode declaration)
             => declaration.Kind() switch
@@ -2873,9 +2829,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             };
 
         public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode node)
-        {
-            return this.RemoveNode(root, node, DefaultRemoveOptions);
-        }
+            => this.RemoveNode(root, node, DefaultRemoveOptions);
 
         public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode node, SyntaxRemoveOptions options)
         {
@@ -2972,19 +2926,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         #region Statements and Expressions
 
         public override SyntaxNode AddEventHandler(SyntaxNode @event, SyntaxNode handler)
-        {
-            return SyntaxFactory.AssignmentExpression(SyntaxKind.AddAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
-        }
+            => SyntaxFactory.AssignmentExpression(SyntaxKind.AddAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
 
         public override SyntaxNode RemoveEventHandler(SyntaxNode @event, SyntaxNode handler)
-        {
-            return SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
-        }
+            => SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
 
         public override SyntaxNode AwaitExpression(SyntaxNode expression)
-        {
-            return SyntaxFactory.AwaitExpression((ExpressionSyntax)expression);
-        }
+            => SyntaxFactory.AwaitExpression((ExpressionSyntax)expression);
 
         public override SyntaxNode NameOfExpression(SyntaxNode expression)
             => this.InvocationExpression(s_nameOfIdentifier, expression);
@@ -2999,9 +2947,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => SyntaxFactory.ThrowStatement((ExpressionSyntax)expressionOpt);
 
         public override SyntaxNode ThrowExpression(SyntaxNode expression)
-        {
-            return SyntaxFactory.ThrowExpression((ExpressionSyntax)expression);
-        }
+            => SyntaxFactory.ThrowExpression((ExpressionSyntax)expression);
 
         internal override bool SupportsThrowExpression() => true;
 
@@ -3036,9 +2982,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => SyntaxFactory.Block(AsStatementList(statements)).WithAdditionalAnnotations(Simplifier.Annotation);
 
         private static SyntaxList<StatementSyntax> AsStatementList(IEnumerable<SyntaxNode> nodes)
-        {
-            return nodes == null ? default : SyntaxFactory.List(nodes.Select(AsStatement));
-        }
+            => nodes == null ? default : SyntaxFactory.List(nodes.Select(AsStatement));
 
         private static StatementSyntax AsStatement(SyntaxNode node)
         {
@@ -3092,9 +3036,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static SeparatedSyntaxList<ExpressionSyntax> AsExpressionList(IEnumerable<SyntaxNode> expressions)
-        {
-            return SyntaxFactory.SeparatedList(expressions.OfType<ExpressionSyntax>());
-        }
+            => SyntaxFactory.SeparatedList(expressions.OfType<ExpressionSyntax>());
 
         public override SyntaxNode ArrayCreationExpression(SyntaxNode elementType, SyntaxNode size)
         {
@@ -3110,32 +3052,22 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode ObjectCreationExpression(SyntaxNode type, IEnumerable<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.ObjectCreationExpression((TypeSyntax)type, CreateArgumentList(arguments), null);
-        }
+            => SyntaxFactory.ObjectCreationExpression((TypeSyntax)type, CreateArgumentList(arguments), null);
 
         private static ArgumentListSyntax CreateArgumentList(IEnumerable<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.ArgumentList(CreateArguments(arguments));
-        }
+            => SyntaxFactory.ArgumentList(CreateArguments(arguments));
 
         private static SeparatedSyntaxList<ArgumentSyntax> CreateArguments(IEnumerable<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.SeparatedList(arguments.Select(AsArgument));
-        }
+            => SyntaxFactory.SeparatedList(arguments.Select(AsArgument));
 
         private static ArgumentSyntax AsArgument(SyntaxNode argOrExpression)
             => argOrExpression as ArgumentSyntax ?? SyntaxFactory.Argument((ExpressionSyntax)argOrExpression);
 
         public override SyntaxNode InvocationExpression(SyntaxNode expression, IEnumerable<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.InvocationExpression(ParenthesizeLeft((ExpressionSyntax)expression), CreateArgumentList(arguments));
-        }
+            => SyntaxFactory.InvocationExpression(ParenthesizeLeft((ExpressionSyntax)expression), CreateArgumentList(arguments));
 
         public override SyntaxNode ElementAccessExpression(SyntaxNode expression, IEnumerable<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.ElementAccessExpression(ParenthesizeLeft((ExpressionSyntax)expression), SyntaxFactory.BracketedArgumentList(CreateArguments(arguments)));
-        }
+            => SyntaxFactory.ElementAccessExpression(ParenthesizeLeft((ExpressionSyntax)expression), SyntaxFactory.BracketedArgumentList(CreateArguments(arguments)));
 
         internal override SyntaxNode InterpolatedStringExpression(SyntaxToken startToken, IEnumerable<SyntaxNode> content, SyntaxToken endToken)
             => SyntaxFactory.InterpolatedStringExpression(startToken, SyntaxFactory.List(content.Cast<InterpolatedStringContentSyntax>()), endToken);
@@ -3203,175 +3135,109 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         internal override SyntaxNode AddParentheses(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
-        {
-            return Parenthesize(expression, includeElasticTrivia, addSimplifierAnnotation);
-        }
+            => Parenthesize(expression, includeElasticTrivia, addSimplifierAnnotation);
 
         private static ExpressionSyntax Parenthesize(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
-        {
-            return ((ExpressionSyntax)expression).Parenthesize(includeElasticTrivia, addSimplifierAnnotation);
-        }
+            => ((ExpressionSyntax)expression).Parenthesize(includeElasticTrivia, addSimplifierAnnotation);
 
         public override SyntaxNode IsTypeExpression(SyntaxNode expression, SyntaxNode type)
-        {
-            return SyntaxFactory.BinaryExpression(SyntaxKind.IsExpression, Parenthesize(expression), (TypeSyntax)type);
-        }
+            => SyntaxFactory.BinaryExpression(SyntaxKind.IsExpression, Parenthesize(expression), (TypeSyntax)type);
 
         public override SyntaxNode TypeOfExpression(SyntaxNode type)
-        {
-            return SyntaxFactory.TypeOfExpression((TypeSyntax)type);
-        }
+            => SyntaxFactory.TypeOfExpression((TypeSyntax)type);
 
         public override SyntaxNode TryCastExpression(SyntaxNode expression, SyntaxNode type)
-        {
-            return SyntaxFactory.BinaryExpression(SyntaxKind.AsExpression, Parenthesize(expression), (TypeSyntax)type);
-        }
+            => SyntaxFactory.BinaryExpression(SyntaxKind.AsExpression, Parenthesize(expression), (TypeSyntax)type);
 
         public override SyntaxNode CastExpression(SyntaxNode type, SyntaxNode expression)
             => SyntaxFactory.CastExpression((TypeSyntax)type, Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
 
         public override SyntaxNode ConvertExpression(SyntaxNode type, SyntaxNode expression)
-        {
-            return SyntaxFactory.CastExpression((TypeSyntax)type, Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
-        }
+            => SyntaxFactory.CastExpression((TypeSyntax)type, Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
 
         public override SyntaxNode AssignmentStatement(SyntaxNode left, SyntaxNode right)
             => SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, (ExpressionSyntax)left, Parenthesize(right));
 
         private static SyntaxNode CreateBinaryExpression(SyntaxKind syntaxKind, SyntaxNode left, SyntaxNode right)
-        {
-            return SyntaxFactory.BinaryExpression(syntaxKind, Parenthesize(left), Parenthesize(right));
-        }
+            => SyntaxFactory.BinaryExpression(syntaxKind, Parenthesize(left), Parenthesize(right));
 
         public override SyntaxNode ValueEqualsExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.EqualsExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.EqualsExpression, left, right);
 
         public override SyntaxNode ReferenceEqualsExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.EqualsExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.EqualsExpression, left, right);
 
         public override SyntaxNode ValueNotEqualsExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.NotEqualsExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.NotEqualsExpression, left, right);
 
         public override SyntaxNode ReferenceNotEqualsExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.NotEqualsExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.NotEqualsExpression, left, right);
 
         public override SyntaxNode LessThanExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.LessThanExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.LessThanExpression, left, right);
 
         public override SyntaxNode LessThanOrEqualExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.LessThanOrEqualExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.LessThanOrEqualExpression, left, right);
 
         public override SyntaxNode GreaterThanExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.GreaterThanExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.GreaterThanExpression, left, right);
 
         public override SyntaxNode GreaterThanOrEqualExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.GreaterThanOrEqualExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.GreaterThanOrEqualExpression, left, right);
 
         public override SyntaxNode NegateExpression(SyntaxNode expression)
-        {
-            return SyntaxFactory.PrefixUnaryExpression(SyntaxKind.UnaryMinusExpression, Parenthesize(expression));
-        }
+            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.UnaryMinusExpression, Parenthesize(expression));
 
         public override SyntaxNode AddExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.AddExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.AddExpression, left, right);
 
         public override SyntaxNode SubtractExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.SubtractExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.SubtractExpression, left, right);
 
         public override SyntaxNode MultiplyExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.MultiplyExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.MultiplyExpression, left, right);
 
         public override SyntaxNode DivideExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.DivideExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.DivideExpression, left, right);
 
         public override SyntaxNode ModuloExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.ModuloExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.ModuloExpression, left, right);
 
         public override SyntaxNode BitwiseAndExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.BitwiseAndExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.BitwiseAndExpression, left, right);
 
         public override SyntaxNode BitwiseOrExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.BitwiseOrExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.BitwiseOrExpression, left, right);
 
         public override SyntaxNode BitwiseNotExpression(SyntaxNode operand)
-        {
-            return SyntaxFactory.PrefixUnaryExpression(SyntaxKind.BitwiseNotExpression, Parenthesize(operand));
-        }
+            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.BitwiseNotExpression, Parenthesize(operand));
 
         public override SyntaxNode LogicalAndExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.LogicalAndExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.LogicalAndExpression, left, right);
 
         public override SyntaxNode LogicalOrExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.LogicalOrExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.LogicalOrExpression, left, right);
 
         public override SyntaxNode LogicalNotExpression(SyntaxNode expression)
-        {
-            return SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, Parenthesize(expression));
-        }
+            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, Parenthesize(expression));
 
         public override SyntaxNode ConditionalExpression(SyntaxNode condition, SyntaxNode whenTrue, SyntaxNode whenFalse)
-        {
-            return SyntaxFactory.ConditionalExpression(Parenthesize(condition), Parenthesize(whenTrue), Parenthesize(whenFalse));
-        }
+            => SyntaxFactory.ConditionalExpression(Parenthesize(condition), Parenthesize(whenTrue), Parenthesize(whenFalse));
 
         public override SyntaxNode CoalesceExpression(SyntaxNode left, SyntaxNode right)
-        {
-            return CreateBinaryExpression(SyntaxKind.CoalesceExpression, left, right);
-        }
+            => CreateBinaryExpression(SyntaxKind.CoalesceExpression, left, right);
 
         public override SyntaxNode ThisExpression()
-        {
-            return SyntaxFactory.ThisExpression();
-        }
+            => SyntaxFactory.ThisExpression();
 
         public override SyntaxNode BaseExpression()
-        {
-            return SyntaxFactory.BaseExpression();
-        }
+            => SyntaxFactory.BaseExpression();
 
         public override SyntaxNode LiteralExpression(object value)
-        {
-            return ExpressionGenerator.GenerateNonEnumValueExpression(null, value, canUseFieldReference: true);
-        }
+            => ExpressionGenerator.GenerateNonEnumValueExpression(null, value, canUseFieldReference: true);
 
         public override SyntaxNode TypedConstantExpression(TypedConstant value)
-        {
-            return ExpressionGenerator.GenerateExpression(value);
-        }
+            => ExpressionGenerator.GenerateExpression(value);
 
         public override SyntaxNode IdentifierName(string identifier)
             => identifier.ToIdentifierName();
@@ -3425,9 +3291,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => namespaceOrTypeSymbol.GenerateNameSyntax();
 
         public override SyntaxNode TypeExpression(ITypeSymbol typeSymbol)
-        {
-            return typeSymbol.GenerateTypeSyntax();
-        }
+            => typeSymbol.GenerateTypeSyntax();
 
         public override SyntaxNode TypeExpression(SpecialType specialType)
             => specialType switch
@@ -3451,9 +3315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             };
 
         public override SyntaxNode ArrayTypeExpression(SyntaxNode type)
-        {
-            return SyntaxFactory.ArrayType((TypeSyntax)type, SyntaxFactory.SingletonList(SyntaxFactory.ArrayRankSpecifier()));
-        }
+            => SyntaxFactory.ArrayType((TypeSyntax)type, SyntaxFactory.SingletonList(SyntaxFactory.ArrayRankSpecifier()));
 
         public override SyntaxNode NullableTypeExpression(SyntaxNode type)
         {
@@ -3524,9 +3386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode WhileStatement(SyntaxNode condition, IEnumerable<SyntaxNode> statements)
-        {
-            return SyntaxFactory.WhileStatement((ExpressionSyntax)condition, CreateBlock(statements));
-        }
+            => SyntaxFactory.WhileStatement((ExpressionSyntax)condition, CreateBlock(statements));
 
         public override SyntaxNode SwitchStatement(SyntaxNode expression, IEnumerable<SyntaxNode> caseClauses)
         {
@@ -3550,9 +3410,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode SwitchSection(IEnumerable<SyntaxNode> expressions, IEnumerable<SyntaxNode> statements)
-        {
-            return SyntaxFactory.SwitchSection(AsSwitchLabels(expressions), AsStatementList(statements));
-        }
+            => SyntaxFactory.SwitchSection(AsSwitchLabels(expressions), AsStatementList(statements));
 
         internal override SyntaxNode SwitchSectionFromLabels(IEnumerable<SyntaxNode> labels, IEnumerable<SyntaxNode> statements)
         {
@@ -3562,9 +3420,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode DefaultSwitchSection(IEnumerable<SyntaxNode> statements)
-        {
-            return SyntaxFactory.SwitchSection(SyntaxFactory.SingletonList(SyntaxFactory.DefaultSwitchLabel() as SwitchLabelSyntax), AsStatementList(statements));
-        }
+            => SyntaxFactory.SwitchSection(SyntaxFactory.SingletonList(SyntaxFactory.DefaultSwitchLabel() as SwitchLabelSyntax), AsStatementList(statements));
 
         private static SyntaxList<SwitchLabelSyntax> AsSwitchLabels(IEnumerable<SyntaxNode> expressions)
         {
@@ -3579,9 +3435,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode ExitSwitchStatement()
-        {
-            return SyntaxFactory.BreakStatement();
-        }
+            => SyntaxFactory.BreakStatement();
 
         internal override SyntaxNode ScopeBlock(IEnumerable<SyntaxNode> statements)
             => SyntaxFactory.Block(statements.Cast<StatementSyntax>());
@@ -3604,24 +3458,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => node is ParameterSyntax p && p.Type == null && p.Default == null && p.Modifiers.Count == 0;
 
         public override SyntaxNode VoidReturningLambdaExpression(IEnumerable<SyntaxNode> lambdaParameters, SyntaxNode expression)
-        {
-            return this.ValueReturningLambdaExpression(lambdaParameters, expression);
-        }
+            => this.ValueReturningLambdaExpression(lambdaParameters, expression);
 
         public override SyntaxNode ValueReturningLambdaExpression(IEnumerable<SyntaxNode> parameterDeclarations, IEnumerable<SyntaxNode> statements)
-        {
-            return this.ValueReturningLambdaExpression(parameterDeclarations, CreateBlock(statements));
-        }
+            => this.ValueReturningLambdaExpression(parameterDeclarations, CreateBlock(statements));
 
         public override SyntaxNode VoidReturningLambdaExpression(IEnumerable<SyntaxNode> lambdaParameters, IEnumerable<SyntaxNode> statements)
-        {
-            return this.ValueReturningLambdaExpression(lambdaParameters, statements);
-        }
+            => this.ValueReturningLambdaExpression(lambdaParameters, statements);
 
         public override SyntaxNode LambdaParameter(string identifier, SyntaxNode type = null)
-        {
-            return this.ParameterDeclaration(identifier, type, null, RefKind.None);
-        }
+            => this.ParameterDeclaration(identifier, type, null, RefKind.None);
 
         internal override SyntaxNode IdentifierName(SyntaxToken identifier)
             => SyntaxFactory.IdentifierName(identifier);

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
     internal static class ConstructorGenerator
     {
         private static MemberDeclarationSyntax LastConstructorOrField(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return LastConstructor(members) ?? LastField(members);
-        }
+            => LastConstructor(members) ?? LastField(members);
 
         internal static TypeDeclarationSyntax AddConstructorTo(
             TypeDeclarationSyntax destination,
@@ -106,9 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static ArgumentListSyntax GenerateArgumentList(ImmutableArray<SyntaxNode> arguments)
-        {
-            return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(ArgumentGenerator.GenerateArgument)));
-        }
+            => SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(ArgumentGenerator.GenerateArgument)));
 
         private static BlockSyntax GenerateBlock(
             IMethodSymbol constructor)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/DestructorGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/DestructorGenerator.cs
@@ -15,9 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
     internal static class DestructorGenerator
     {
         private static MemberDeclarationSyntax LastConstructorOrField(SyntaxList<MemberDeclarationSyntax> members)
-        {
-            return LastConstructor(members) ?? LastField(members);
-        }
+            => LastConstructor(members) ?? LastField(members);
 
         internal static TypeDeclarationSyntax AddDestructorTo(
             TypeDeclarationSyntax destination,

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
@@ -279,8 +279,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static SyntaxList<TypeParameterConstraintClauseSyntax> GenerateConstraintClauses(INamedTypeSymbol namedType)
-        {
-            return namedType.TypeParameters.GenerateConstraintClauses();
-        }
+            => namedType.TypeParameters.GenerateConstraintClauses();
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
@@ -22,9 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
     internal static class PropertyGenerator
     {
         public static bool CanBeGenerated(IPropertySymbol property)
-        {
-            return property.IsIndexer || property.Parameters.Length == 0;
-        }
+            => property.IsIndexer || property.Parameters.Length == 0;
 
         private static MemberDeclarationSyntax LastPropertyOrField(
             SyntaxList<MemberDeclarationSyntax> members)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/StatementGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/StatementGenerator.cs
@@ -13,9 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
     internal static class StatementGenerator
     {
         internal static SyntaxList<StatementSyntax> GenerateStatements(IEnumerable<SyntaxNode> statements)
-        {
-            return statements.OfType<StatementSyntax>().ToSyntaxList();
-        }
+            => statements.OfType<StatementSyntax>().ToSyntaxList();
 
         internal static BlockSyntax GenerateBlock(IMethodSymbol method)
         {

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberAccessExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberAccessExpressionSyntaxExtensions.cs
@@ -31,8 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         private static IEnumerable<SyntaxTrivia> WithoutElasticTrivia(IEnumerable<SyntaxTrivia> list)
-        {
-            return list.Where(t => !t.IsElastic());
-        }
+            => list.Where(t => !t.IsElastic());
     }
 }

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.cs
@@ -34,9 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
         }
 
         protected override AbstractFormattingRule GetSpecializedIndentationFormattingRule(FormattingOptions.IndentStyle indentStyle)
-        {
-            return s_instance;
-        }
+            => s_instance;
 
         public static bool ShouldUseSmartTokenFormatterInsteadOfIndenter(
             IEnumerable<AbstractFormattingRule> formattingRules,
@@ -167,9 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
             }
 
             private bool IsBracketedArgumentListMissingBrackets(BracketedArgumentListSyntax node)
-            {
-                return node != null && node.OpenBracketToken.IsMissing && node.CloseBracketToken.IsMissing;
-            }
+                => node != null && node.OpenBracketToken.IsMissing && node.CloseBracketToken.IsMissing;
 
             private void ReplaceCaseIndentationRules(List<IndentBlockOperation> list, SyntaxNode node)
             {

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -1143,9 +1143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         /// <param name="token">The token to get the complexification target for.</param>
         /// <returns></returns>
         public SyntaxNode GetExpansionTargetForLocation(SyntaxToken token)
-        {
-            return GetExpansionTarget(token);
-        }
+            => GetExpansionTarget(token);
 
         private static SyntaxNode GetExpansionTarget(SyntaxToken token)
         {

--- a/src/Workspaces/CSharp/Portable/Rename/LabelConflictVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/LabelConflictVisitor.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         private readonly ConflictingIdentifierTracker _tracker;
 
         public LabelConflictVisitor(SyntaxToken tokenBeingRenamed)
-        {
-            _tracker = new ConflictingIdentifierTracker(tokenBeingRenamed, StringComparer.Ordinal);
-        }
+            => _tracker = new ConflictingIdentifierTracker(tokenBeingRenamed, StringComparer.Ordinal);
 
         public override void DefaultVisit(SyntaxNode node)
         {

--- a/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         private readonly ConflictingIdentifierTracker _tracker;
 
         public LocalConflictVisitor(SyntaxToken tokenBeingRenamed)
-        {
-            _tracker = new ConflictingIdentifierTracker(tokenBeingRenamed, StringComparer.Ordinal);
-        }
+            => _tracker = new ConflictingIdentifierTracker(tokenBeingRenamed, StringComparer.Ordinal);
 
         public override void DefaultVisit(SyntaxNode node)
         {
@@ -40,9 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         }
 
         public override void VisitBlock(BlockSyntax node)
-        {
-            VisitBlockStatements(node, node.Statements);
-        }
+            => VisitBlockStatements(node, node.Statements);
 
         private void VisitBlockStatements(SyntaxNode node, IEnumerable<SyntaxNode> statements)
         {
@@ -131,9 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         }
 
         public override void VisitQueryExpression(QueryExpressionSyntax node)
-        {
-            VisitQueryInternal(node.FromClause, node.Body);
-        }
+            => VisitQueryInternal(node.FromClause, node.Body);
 
         private void VisitQueryInternal(FromClauseSyntax fromClause, QueryBodySyntax body)
         {

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -97,9 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             }
 
             private SpeculationAnalyzer GetSpeculationAnalyzer(ExpressionSyntax expression, ExpressionSyntax newExpression)
-            {
-                return new SpeculationAnalyzer(expression, newExpression, _semanticModel, _cancellationToken);
-            }
+                => new SpeculationAnalyzer(expression, newExpression, _semanticModel, _cancellationToken);
 
             private bool TryCastTo(ITypeSymbol targetType, ExpressionSyntax expression, ExpressionSyntax newExpression, out ExpressionSyntax newExpressionWithCast)
             {

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -166,14 +166,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
         }
 
         protected override ImmutableArray<NodeOrTokenToReduce> GetNodesAndTokensToReduce(SyntaxNode root, Func<SyntaxNodeOrToken, bool> isNodeOrTokenOutsideSimplifySpans)
-        {
-            return NodesAndTokensToReduceComputer.Compute(root, isNodeOrTokenOutsideSimplifySpans);
-        }
+            => NodesAndTokensToReduceComputer.Compute(root, isNodeOrTokenOutsideSimplifySpans);
 
         protected override bool CanNodeBeSimplifiedWithoutSpeculation(SyntaxNode node)
-        {
-            return false;
-        }
+            => false;
 
         private const string s_CS8019_UnusedUsingDirective = "CS8019";
 

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
@@ -258,9 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             }
 
             public int GetHashCode(ISymbol obj)
-            {
-                return obj?.OriginalDefinition.GetHashCode() ?? 0;
-            }
+                => obj?.OriginalDefinition.GetHashCode() ?? 0;
         }
 
         private static bool TrySimplify(

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpCompilationFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpCompilationFactoryService.cs
@@ -44,13 +44,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         bool ICompilationFactoryService.IsCompilationReference(MetadataReference reference)
-        {
-            return reference is CompilationReference;
-        }
+            => reference is CompilationReference;
 
         CompilationOptions ICompilationFactoryService.GetDefaultCompilationOptions()
-        {
-            return s_defaultOptions;
-        }
+            => s_defaultOptions;
     }
 }

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactory.PathSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactory.PathSyntaxReference.cs
@@ -144,9 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 public override SyntaxNode GetSyntax(CancellationToken cancellationToken)
-                {
-                    return this.GetNode(_tree.GetRoot(cancellationToken));
-                }
+                    => this.GetNode(_tree.GetRoot(cancellationToken));
 
                 public async override Task<SyntaxNode> GetSyntaxAsync(CancellationToken cancellationToken = default)
                 {

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.NullSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.NullSyntaxReference.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 private readonly SyntaxTree _tree;
 
                 public NullSyntaxReference(SyntaxTree tree)
-                {
-                    _tree = tree;
-                }
+                    => _tree = tree;
 
                 public override SyntaxTree SyntaxTree
                 {
@@ -36,9 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 public override SyntaxNode GetSyntax(CancellationToken cancellationToken)
-                {
-                    return null;
-                }
+                    => null;
 
                 public override TextSpan Span
                 {

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
@@ -93,19 +93,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 public override bool TryGetText(out SourceText text)
-                {
-                    return _info.TryGetText(out text);
-                }
+                    => _info.TryGetText(out text);
 
                 public override SourceText GetText(CancellationToken cancellationToken)
-                {
-                    return _info.TextSource.GetValue(cancellationToken).Text;
-                }
+                    => _info.TextSource.GetValue(cancellationToken).Text;
 
                 public override Task<SourceText> GetTextAsync(CancellationToken cancellationToken)
-                {
-                    return _info.GetTextAsync(cancellationToken);
-                }
+                    => _info.GetTextAsync(cancellationToken);
 
                 public override Encoding Encoding
                 {
@@ -113,9 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 private CompilationUnitSyntax CacheRootNode(CompilationUnitSyntax node)
-                {
-                    return _projectCacheService.CacheObjectIfCachingEnabledForKey(_cacheKey, this, node);
-                }
+                    => _projectCacheService.CacheObjectIfCachingEnabledForKey(_cacheKey, this, node);
 
                 public override bool TryGetRoot(out CSharpSyntaxNode root)
                 {
@@ -126,14 +118,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 public override CSharpSyntaxNode GetRoot(CancellationToken cancellationToken = default)
-                {
-                    return CacheRootNode(_recoverableRoot.GetValue(cancellationToken));
-                }
+                    => CacheRootNode(_recoverableRoot.GetValue(cancellationToken));
 
                 public override async Task<CSharpSyntaxNode> GetRootAsync(CancellationToken cancellationToken)
-                {
-                    return CacheRootNode(await _recoverableRoot.GetValueAsync(cancellationToken).ConfigureAwait(false));
-                }
+                    => CacheRootNode(await _recoverableRoot.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                 public override bool HasCompilationUnitRoot
                 {
@@ -162,9 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 CompilationUnitSyntax IRecoverableSyntaxTree<CompilationUnitSyntax>.CloneNodeAsRoot(CompilationUnitSyntax root)
-                {
-                    return CloneNodeAsRoot(root);
-                }
+                    => CloneNodeAsRoot(root);
 
                 public override SyntaxTree WithRootAndOptions(SyntaxNode root, ParseOptions options)
                 {

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -28,9 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-        {
-            return new CSharpSyntaxTreeFactoryService(provider);
-        }
+            => new CSharpSyntaxTreeFactoryService(provider);
 
         private partial class CSharpSyntaxTreeFactoryService : AbstractSyntaxTreeFactoryService
         {
@@ -39,14 +37,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             public override ParseOptions GetDefaultParseOptions()
-            {
-                return CSharpParseOptions.Default;
-            }
+                => CSharpParseOptions.Default;
 
             public override ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion()
-            {
-                return _parseOptionWithLatestLanguageVersion;
-            }
+                => _parseOptionWithLatestLanguageVersion;
 
             public override SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, Encoding encoding, SyntaxNode root, AnalyzerConfigOptionsResult analyzerConfigOptionsResult)
             {
@@ -68,9 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 => CSharpSyntaxNode.DeserializeFrom(stream, cancellationToken);
 
             public override bool CanCreateRecoverableTree(SyntaxNode root)
-            {
-                return base.CanCreateRecoverableTree(root) && root is CompilationUnitSyntax cu && cu.AttributeLists.Count == 0;
-            }
+                => base.CanCreateRecoverableTree(root) && root is CompilationUnitSyntax cu && cu.AttributeLists.Count == 0;
 
             public override SyntaxTree CreateRecoverableTree(
                 ProjectId cacheKey,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/DirectiveSyntaxExtensions.DirectiveSyntaxEqualityComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/DirectiveSyntaxExtensions.DirectiveSyntaxEqualityComparer.cs
@@ -18,14 +18,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             public bool Equals(DirectiveTriviaSyntax x, DirectiveTriviaSyntax y)
-            {
-                return x.SpanStart == y.SpanStart;
-            }
+                => x.SpanStart == y.SpanStart;
 
             public int GetHashCode(DirectiveTriviaSyntax obj)
-            {
-                return obj.SpanStart;
-            }
+                => obj.SpanStart;
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/DirectiveSyntaxExtensions.DirectiveWalker.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/DirectiveSyntaxExtensions.DirectiveWalker.cs
@@ -79,24 +79,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             private void HandleIfDirective(DirectiveTriviaSyntax directive)
-            {
-                _ifStack.Push(directive);
-            }
+                => _ifStack.Push(directive);
 
             private void HandleRegionDirective(DirectiveTriviaSyntax directive)
-            {
-                _regionStack.Push(directive);
-            }
+                => _regionStack.Push(directive);
 
             private void HandleElifDirective(DirectiveTriviaSyntax directive)
-            {
-                _ifStack.Push(directive);
-            }
+                => _ifStack.Push(directive);
 
             private void HandleElseDirective(DirectiveTriviaSyntax directive)
-            {
-                _ifStack.Push(directive);
-            }
+                => _ifStack.Push(directive);
 
             private void HandleEndIfDirective(DirectiveTriviaSyntax directive)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -33,9 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsQualifiedCrefName(this ExpressionSyntax expression)
-        {
-            return expression.IsParentKind(SyntaxKind.NameMemberCref) && expression.Parent.IsParentKind(SyntaxKind.QualifiedCref);
-        }
+            => expression.IsParentKind(SyntaxKind.NameMemberCref) && expression.Parent.IsParentKind(SyntaxKind.QualifiedCref);
 
         public static bool IsMemberAccessExpressionName(this ExpressionSyntax expression)
             => (expression.IsParentKind(SyntaxKind.SimpleMemberAccessExpression, out MemberAccessExpressionSyntax memberAccess) && memberAccess.Name == expression) ||
@@ -63,24 +61,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             => expression.IsParentKind(SyntaxKind.AliasQualifiedName, out AliasQualifiedNameSyntax aliasName) && aliasName.Name == expression;
 
         public static bool IsRightSideOfDot(this ExpressionSyntax name)
-        {
-            return IsMemberAccessExpressionName(name) || IsRightSideOfQualifiedName(name) || IsQualifiedCrefName(name);
-        }
+            => IsMemberAccessExpressionName(name) || IsRightSideOfQualifiedName(name) || IsQualifiedCrefName(name);
 
         public static bool IsRightSideOfDotOrArrow(this ExpressionSyntax name)
-        {
-            return IsAnyMemberAccessExpressionName(name) || IsRightSideOfQualifiedName(name);
-        }
+            => IsAnyMemberAccessExpressionName(name) || IsRightSideOfQualifiedName(name);
 
         public static bool IsRightSideOfDotOrColonColon(this ExpressionSyntax name)
-        {
-            return IsRightSideOfDot(name) || IsRightSideOfColonColon(name);
-        }
+            => IsRightSideOfDot(name) || IsRightSideOfColonColon(name);
 
         public static bool IsRightSideOfDotOrArrowOrColonColon(this ExpressionSyntax name)
-        {
-            return IsRightSideOfDotOrArrow(name) || IsRightSideOfColonColon(name);
-        }
+            => IsRightSideOfDotOrArrow(name) || IsRightSideOfColonColon(name);
 
         public static bool IsRightOfCloseParen(this ExpressionSyntax expression)
         {
@@ -368,9 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsNamedArgumentIdentifier(this ExpressionSyntax expression)
-        {
-            return expression is IdentifierNameSyntax && expression.Parent is NameColonSyntax;
-        }
+            => expression is IdentifierNameSyntax && expression.Parent is NameColonSyntax;
 
         public static bool IsInsideNameOfExpression(
             this ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/MemberDeclarationSyntaxExtensions.LocalDeclarationMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/MemberDeclarationSyntaxExtensions.LocalDeclarationMap.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             private readonly Dictionary<string, ImmutableArray<SyntaxToken>> _dictionary;
 
             internal LocalDeclarationMap(Dictionary<string, ImmutableArray<SyntaxToken>> dictionary)
-            {
-                _dictionary = dictionary;
-            }
+                => _dictionary = dictionary;
 
             public ImmutableArray<SyntaxToken> this[string identifier]
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxListExtensions.cs
@@ -22,13 +22,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static SyntaxList<T> ToSyntaxList<T>(this IEnumerable<T> sequence) where T : SyntaxNode
-        {
-            return SyntaxFactory.List(sequence);
-        }
+            => SyntaxFactory.List(sequence);
 
         public static SyntaxList<T> Insert<T>(this SyntaxList<T> list, int index, T item) where T : SyntaxNode
-        {
-            return list.Take(index).Concat(item).Concat(list.Skip(index)).ToSyntaxList();
-        }
+            => list.Take(index).Concat(item).Concat(list.Skip(index)).ToSyntaxList();
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.SingleLineRewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.SingleLineRewriter.cs
@@ -17,9 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             private bool _lastTokenEndedInWhitespace;
 
             public SingleLineRewriter(bool useElasticTrivia)
-            {
-                this._useElasticTrivia = useElasticTrivia;
-            }
+                => this._useElasticTrivia = useElasticTrivia;
 
             public override SyntaxToken VisitToken(SyntaxToken token)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -745,9 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                equalsValue.Value == node;
 
         public static BlockSyntax? FindInnermostCommonBlock(this IEnumerable<SyntaxNode> nodes)
-        {
-            return nodes.FindInnermostCommonNode<BlockSyntax>();
-        }
+            => nodes.FindInnermostCommonNode<BlockSyntax>();
 
         public static IEnumerable<SyntaxNode> GetAncestorsOrThis(this SyntaxNode? node, Func<SyntaxNode, bool> predicate)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
@@ -25,14 +25,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsKindOrHasMatchingText(this SyntaxToken token, SyntaxKind kind)
-        {
-            return token.Kind() == kind || token.HasMatchingText(kind);
-        }
+            => token.Kind() == kind || token.HasMatchingText(kind);
 
         public static bool HasMatchingText(this SyntaxToken token, SyntaxKind kind)
-        {
-            return token.ToString() == SyntaxFacts.GetText(kind);
-        }
+            => token.ToString() == SyntaxFacts.GetText(kind);
 
         public static bool IsKind(this SyntaxToken token, SyntaxKind kind1, SyntaxKind kind2)
         {
@@ -65,9 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsKind(this SyntaxToken token, params SyntaxKind[] kinds)
-        {
-            return kinds.Contains(token.Kind());
-        }
+            => kinds.Contains(token.Kind());
 
         public static bool IsOpenBraceOrCommaOfObjectInitializer(this SyntaxToken token)
         {
@@ -76,9 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsOpenBraceOfAccessorList(this SyntaxToken token)
-        {
-            return token.IsKind(SyntaxKind.OpenBraceToken) && token.Parent.IsKind(SyntaxKind.AccessorList);
-        }
+            => token.IsKind(SyntaxKind.OpenBraceToken) && token.Parent.IsKind(SyntaxKind.AccessorList);
 
         /// <summary>
         /// Returns true if this token is something that looks like a C# keyword. This includes 
@@ -121,9 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IntersectsWith(this SyntaxToken token, int position)
-        {
-            return token.Span.IntersectsWith(position);
-        }
+            => token.Span.IntersectsWith(position);
 
         public static SyntaxToken GetPreviousTokenIfTouchingWord(this SyntaxToken token, int position)
         {
@@ -133,14 +123,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         private static bool IsWord(SyntaxToken token)
-        {
-            return CSharpSyntaxFacts.Instance.IsWord(token);
-        }
+            => CSharpSyntaxFacts.Instance.IsWord(token);
 
         public static SyntaxToken GetNextNonZeroWidthTokenOrEndOfFile(this SyntaxToken token)
-        {
-            return token.GetNextTokenOrEndOfFile();
-        }
+            => token.GetNextTokenOrEndOfFile();
 
         /// <summary>
         /// Determines whether the given SyntaxToken is the first token on a line in the specified SourceText.
@@ -181,9 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsRegularStringLiteral(this SyntaxToken token)
-        {
-            return token.Kind() == SyntaxKind.StringLiteralToken && !token.IsVerbatimStringLiteral();
-        }
+            => token.Kind() == SyntaxKind.StringLiteralToken && !token.IsVerbatimStringLiteral();
 
         public static bool IsValidAttributeTarget(this SyntaxToken token)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -128,9 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsRightOfDotOrArrow(this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
-        {
-            return syntaxTree.IsRightOf(position, s_isDotOrArrow, cancellationToken);
-        }
+            => syntaxTree.IsRightOf(position, s_isDotOrArrow, cancellationToken);
 
         private static bool IsRightOf(
             this SyntaxTree syntaxTree, int position, Func<SyntaxKind, bool> predicate, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaExtensions.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     internal static class SyntaxTriviaExtensions
     {
         public static bool MatchesKind(this SyntaxTrivia trivia, SyntaxKind kind)
-        {
-            return trivia.Kind() == kind;
-        }
+            => trivia.Kind() == kind;
 
         public static bool MatchesKind(this SyntaxTrivia trivia, SyntaxKind kind1, SyntaxKind kind2)
         {
@@ -27,9 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool MatchesKind(this SyntaxTrivia trivia, params SyntaxKind[] kinds)
-        {
-            return kinds.Contains(trivia.Kind());
-        }
+            => kinds.Contains(trivia.Kind());
 
         public static bool IsSingleOrMultiLineComment(this SyntaxTrivia trivia)
             => trivia.IsKind(SyntaxKind.MultiLineCommentTrivia) || trivia.IsKind(SyntaxKind.SingleLineCommentTrivia);
@@ -41,9 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             => trivia.IsWhitespace() || trivia.IsSingleOrMultiLineComment();
 
         public static bool IsRegularOrDocComment(this SyntaxTrivia trivia)
-        {
-            return trivia.IsRegularComment() || trivia.IsDocComment();
-        }
+            => trivia.IsRegularComment() || trivia.IsDocComment();
 
         public static bool IsSingleLineComment(this SyntaxTrivia trivia)
             => trivia.Kind() == SyntaxKind.SingleLineCommentTrivia;
@@ -68,19 +62,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsDocComment(this SyntaxTrivia trivia)
-        {
-            return trivia.IsSingleLineDocComment() || trivia.IsMultiLineDocComment();
-        }
+            => trivia.IsSingleLineDocComment() || trivia.IsMultiLineDocComment();
 
         public static bool IsSingleLineDocComment(this SyntaxTrivia trivia)
-        {
-            return trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia;
-        }
+            => trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia;
 
         public static bool IsMultiLineDocComment(this SyntaxTrivia trivia)
-        {
-            return trivia.Kind() == SyntaxKind.MultiLineDocumentationCommentTrivia;
-        }
+            => trivia.Kind() == SyntaxKind.MultiLineDocumentationCommentTrivia;
 
         public static string GetCommentText(this SyntaxTrivia trivia)
         {
@@ -161,9 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static SyntaxTriviaList AsTrivia(this string s)
-        {
-            return SyntaxFactory.ParseLeadingTrivia(s ?? string.Empty);
-        }
+            => SyntaxFactory.ParseLeadingTrivia(s ?? string.Empty);
 
         public static bool IsWhitespaceOrEndOfLine(this SyntaxTrivia trivia)
             => IsWhitespace(trivia) || IsEndOfLine(trivia);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaListExtensions.cs
@@ -48,9 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static IEnumerable<SyntaxTrivia> SkipInitialWhitespace(this SyntaxTriviaList triviaList)
-        {
-            return triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
-        }
+            => triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
 
         private static ImmutableArray<ImmutableArray<SyntaxTrivia>> GetLeadingBlankLines(SyntaxTriviaList triviaList)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingService.cs
@@ -49,18 +49,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public override IEnumerable<AbstractFormattingRule> GetDefaultFormattingRules()
-        {
-            return _rules;
-        }
+            => _rules;
 
         protected override IFormattingResult CreateAggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector> formattingSpans = null)
-        {
-            return new AggregatedFormattingResult(node, results, formattingSpans);
-        }
+            => new AggregatedFormattingResult(node, results, formattingSpans);
 
         protected override AbstractFormattingResult Format(SyntaxNode node, AnalyzerConfigOptions options, IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken token1, SyntaxToken token2, CancellationToken cancellationToken)
-        {
-            return new CSharpFormatEngine(node, options, formattingRules, token1, token2).Format(cancellationToken);
-        }
+            => new CSharpFormatEngine(node, options, formattingRules, token1, token2).Format(cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
@@ -37,9 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options, in NextGetAdjustNewLinesOperation nextOperation)
-        {
-            return null;
-        }
+            => null;
 
         // return 1 space for every token pairs as a default operation
         public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options, in NextGetAdjustSpacesOperation nextOperation)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
@@ -26,13 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected override AbstractTriviaDataFactory CreateTriviaFactory()
-        {
-            return new TriviaDataFactory(this.TreeData, this.Options);
-        }
+            => new TriviaDataFactory(this.TreeData, this.Options);
 
         protected override AbstractFormattingResult CreateFormattingResult(TokenStream tokenStream)
-        {
-            return new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
-        }
+            => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
@@ -38,14 +38,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected override AbstractTriviaDataFactory CreateTriviaFactory()
-        {
-            return new TriviaDataFactory(this.TreeData, this.Options);
-        }
+            => new TriviaDataFactory(this.TreeData, this.Options);
 
         protected override FormattingContext CreateFormattingContext(TokenStream tokenStream, CancellationToken cancellationToken)
-        {
-            return new FormattingContext(this, tokenStream);
-        }
+            => new FormattingContext(this, tokenStream);
 
         protected override NodeOperations CreateNodeOperations(CancellationToken cancellationToken)
         {
@@ -54,8 +50,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected override AbstractFormattingResult CreateFormattingResult(TokenStream tokenStream)
-        {
-            return new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
-        }
+            => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -33,34 +33,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected override bool Succeeded()
-        {
-            return _succeeded;
-        }
+            => _succeeded;
 
         protected override bool IsWhitespace(SyntaxTrivia trivia)
-        {
-            return trivia.RawKind == (int)SyntaxKind.WhitespaceTrivia;
-        }
+            => trivia.RawKind == (int)SyntaxKind.WhitespaceTrivia;
 
         protected override bool IsEndOfLine(SyntaxTrivia trivia)
-        {
-            return trivia.RawKind == (int)SyntaxKind.EndOfLineTrivia;
-        }
+            => trivia.RawKind == (int)SyntaxKind.EndOfLineTrivia;
 
         protected override bool IsWhitespace(char ch)
-        {
-            return SyntaxFacts.IsWhitespace(ch);
-        }
+            => SyntaxFacts.IsWhitespace(ch);
 
         protected override bool IsNewLine(char ch)
-        {
-            return SyntaxFacts.IsNewLine(ch);
-        }
+            => SyntaxFacts.IsNewLine(ch);
 
         protected override SyntaxTrivia CreateWhitespace(string text)
-        {
-            return SyntaxFactory.Whitespace(text);
-        }
+            => SyntaxFactory.Whitespace(text);
 
         protected override SyntaxTrivia CreateEndOfLine()
         {
@@ -175,14 +163,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private bool IsStartOrEndOfFile(SyntaxTrivia trivia1, SyntaxTrivia trivia2)
-        {
-            return (this.Token1.RawKind == 0 || this.Token2.RawKind == 0) && (trivia1.Kind() == 0 || trivia2.Kind() == 0);
-        }
+            => (this.Token1.RawKind == 0 || this.Token2.RawKind == 0) && (trivia1.Kind() == 0 || trivia2.Kind() == 0);
 
         private static bool IsMultilineComment(SyntaxTrivia trivia1)
-        {
-            return trivia1.IsMultiLineComment() || trivia1.IsMultiLineDocComment();
-        }
+            => trivia1.IsMultiLineComment() || trivia1.IsMultiLineDocComment();
 
         private bool TryFormatMultiLineCommentTrivia(LineColumn lineColumn, SyntaxTrivia trivia, out SyntaxTrivia result)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -27,24 +27,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             protected override void ExtractLineAndSpace(string text, out int lines, out int spaces)
-            {
-                text.ProcessTextBetweenTokens(this.TreeInfo, this.Token1, this.Options.GetOption(FormattingOptions2.TabSize), out lines, out spaces);
-            }
+                => text.ProcessTextBetweenTokens(this.TreeInfo, this.Token1, this.Options.GetOption(FormattingOptions2.TabSize), out lines, out spaces);
 
             protected override TriviaData CreateComplexTrivia(int line, int space)
-            {
-                return CreateModifiedComplexTrivia(line, space);
-            }
+                => CreateModifiedComplexTrivia(line, space);
 
             protected override TriviaData CreateComplexTrivia(int line, int space, int indentation)
-            {
-                return CreateModifiedComplexTrivia(line, space);
-            }
+                => CreateModifiedComplexTrivia(line, space);
 
             private TriviaData CreateModifiedComplexTrivia(int line, int space)
-            {
-                return new ModifiedComplexTrivia(this.Options, this, line, space);
-            }
+                => new ModifiedComplexTrivia(this.Options, this, line, space);
 
             protected override TriviaDataWithList Format(
                 FormattingContext context, ChainedFormattingRules formattingRules, int lines, int spaces, CancellationToken cancellationToken)
@@ -53,9 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             protected override bool ContainsSkippedTokensOrText(TriviaList list)
-            {
-                return CodeShapeAnalyzer.ContainsSkippedTokensOrText(list);
-            }
+                => CodeShapeAnalyzer.ContainsSkippedTokensOrText(list);
 
             private bool ShouldFormat(FormattingContext context)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -56,9 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             public override IEnumerable<TextChange> GetTextChanges(TextSpan span)
-            {
-                return _textChanges;
-            }
+                => _textChanges;
 
             public override SyntaxTriviaList GetTriviaList(CancellationToken cancellationToken)
                 => _formatter.FormatToSyntaxTrivia(cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -50,9 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             public override TriviaData WithSpace(int space, FormattingContext context, ChainedFormattingRules formattingRules)
-            {
-                return _original.WithSpace(space, context, formattingRules);
-            }
+                => _original.WithSpace(space, context, formattingRules);
 
             public override TriviaData WithLine(
                 int line, int indentation, FormattingContext context, ChainedFormattingRules formattingRules, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.cs
@@ -24,9 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private static bool IsCSharpWhitespace(char c)
-        {
-            return SyntaxFacts.IsWhitespace(c) || SyntaxFacts.IsNewLine(c);
-        }
+            => SyntaxFacts.IsWhitespace(c) || SyntaxFacts.IsNewLine(c);
 
         public override TriviaData CreateLeadingTrivia(SyntaxToken token)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -49,9 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public SyntaxNode Transform()
-        {
-            return Visit(_node);
-        }
+            => Visit(_node);
 
         private void PreprocessTriviaListMap(
             Dictionary<ValueTuple<SyntaxToken, SyntaxToken>, TriviaData> map,
@@ -214,8 +212,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private static SyntaxToken CreateNewToken(SyntaxTriviaList leadingTrivia, SyntaxToken token, SyntaxTriviaList trailingTrivia)
-        {
-            return token.With(leadingTrivia, trailingTrivia);
-        }
+            => token.With(leadingTrivia, trailingTrivia);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/FormattingHelpers.cs
@@ -46,9 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static ValueTuple<SyntaxToken, SyntaxToken> GetBracePair(this SyntaxNode node)
-        {
-            return node.GetBraces();
-        }
+            => node.GetBraces();
 
         public static bool IsValidBracePair(this ValueTuple<SyntaxToken, SyntaxToken> bracePair)
         {
@@ -64,24 +62,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static bool IsOpenParenInParameterListOfAConversionOperatorDeclaration(this SyntaxToken token)
-        {
-            return token.IsOpenParenInParameterList() && token.Parent.IsParentKind(SyntaxKind.ConversionOperatorDeclaration);
-        }
+            => token.IsOpenParenInParameterList() && token.Parent.IsParentKind(SyntaxKind.ConversionOperatorDeclaration);
 
         public static bool IsOpenParenInParameterListOfAOperationDeclaration(this SyntaxToken token)
-        {
-            return token.IsOpenParenInParameterList() && token.Parent.IsParentKind(SyntaxKind.OperatorDeclaration);
-        }
+            => token.IsOpenParenInParameterList() && token.Parent.IsParentKind(SyntaxKind.OperatorDeclaration);
 
         public static bool IsOpenParenInParameterList(this SyntaxToken token)
-        {
-            return token.Kind() == SyntaxKind.OpenParenToken && token.Parent.Kind() == SyntaxKind.ParameterList;
-        }
+            => token.Kind() == SyntaxKind.OpenParenToken && token.Parent.Kind() == SyntaxKind.ParameterList;
 
         public static bool IsCloseParenInParameterList(this SyntaxToken token)
-        {
-            return token.Kind() == SyntaxKind.CloseParenToken && token.Parent.Kind() == SyntaxKind.ParameterList;
-        }
+            => token.Kind() == SyntaxKind.CloseParenToken && token.Parent.Kind() == SyntaxKind.ParameterList;
 
         public static bool IsOpenParenInArgumentListOrPositionalPattern(this SyntaxToken token)
         {
@@ -114,14 +104,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static bool IsColonInTypeBaseList(this SyntaxToken token)
-        {
-            return token.Kind() == SyntaxKind.ColonToken && token.Parent.Kind() == SyntaxKind.BaseList;
-        }
+            => token.Kind() == SyntaxKind.ColonToken && token.Parent.Kind() == SyntaxKind.BaseList;
 
         public static bool IsCommaInArgumentOrParameterList(this SyntaxToken token)
-        {
-            return token.Kind() == SyntaxKind.CommaToken && (token.Parent.IsAnyArgumentList() || token.Parent.Kind() == SyntaxKind.ParameterList);
-        }
+            => token.Kind() == SyntaxKind.CommaToken && (token.Parent.IsAnyArgumentList() || token.Parent.Kind() == SyntaxKind.ParameterList);
 
         public static bool IsLambdaBodyBlock(this SyntaxNode node)
         {
@@ -304,9 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static bool IsDotInMemberAccessOrQualifiedName(this SyntaxToken token)
-        {
-            return token.IsDotInMemberAccess() || (token.Kind() == SyntaxKind.DotToken && token.Parent.Kind() == SyntaxKind.QualifiedName);
-        }
+            => token.IsDotInMemberAccess() || (token.Kind() == SyntaxKind.DotToken && token.Parent.Kind() == SyntaxKind.QualifiedName);
 
         public static bool IsDotInMemberAccess(this SyntaxToken token)
         {
@@ -356,9 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static bool IsColonInSwitchLabel(this SyntaxToken token)
-        {
-            return FormattingRangeHelper.IsColonInSwitchLabel(token);
-        }
+            => FormattingRangeHelper.IsColonInSwitchLabel(token);
 
         public static bool IsColonInLabeledStatement(this SyntaxToken token)
         {
@@ -548,9 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static bool IsInterpolation(this SyntaxToken currentToken)
-        {
-            return currentToken.Parent.IsKind(SyntaxKind.Interpolation);
-        }
+            => currentToken.Parent.IsKind(SyntaxKind.Interpolation);
 
         /// <summary>
         /// Checks whether currentToken is the opening paren of a deconstruction-declaration in var form, such as <c>var (x, y) = ...</c>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/AnchorIndentationFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/AnchorIndentationFormattingRule.cs
@@ -88,8 +88,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private void AddAnchorIndentationOperation(List<AnchorIndentationOperation> list, SyntaxNode node)
-        {
-            AddAnchorIndentationOperation(list, node.GetFirstToken(includeZeroWidth: true), node.GetLastToken(includeZeroWidth: true));
-        }
+            => AddAnchorIndentationOperation(list, node.GetFirstToken(includeZeroWidth: true), node.GetLastToken(includeZeroWidth: true));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/BaseFormattingRule.cs
@@ -116,14 +116,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected void AddSuppressWrappingIfOnSingleLineOperation(List<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption extraOption = SuppressOption.None)
-        {
-            AddSuppressOperation(list, startToken, endToken, SuppressOption.NoWrappingIfOnSingleLine | extraOption);
-        }
+            => AddSuppressOperation(list, startToken, endToken, SuppressOption.NoWrappingIfOnSingleLine | extraOption);
 
         protected void AddSuppressAllOperationIfOnMultipleLine(List<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption extraOption = SuppressOption.None)
-        {
-            AddSuppressOperation(list, startToken, endToken, SuppressOption.NoSpacingIfOnMultipleLine | SuppressOption.NoWrapping | extraOption);
-        }
+            => AddSuppressOperation(list, startToken, endToken, SuppressOption.NoSpacingIfOnMultipleLine | SuppressOption.NoWrapping | extraOption);
 
         protected void AddSuppressOperation(List<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption option)
         {
@@ -156,14 +152,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         protected AdjustNewLinesOperation CreateAdjustNewLinesOperation(int line, AdjustNewLinesOption option)
-        {
-            return FormattingOperations.CreateAdjustNewLinesOperation(line, option);
-        }
+            => FormattingOperations.CreateAdjustNewLinesOperation(line, option);
 
         protected AdjustSpacesOperation CreateAdjustSpacesOperation(int space, AdjustSpacesOption option)
-        {
-            return FormattingOperations.CreateAdjustSpacesOperation(space, option);
-        }
+            => FormattingOperations.CreateAdjustSpacesOperation(space, option);
 
         protected void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -435,8 +435,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private int GetNumberOfLines(IEnumerable<SyntaxTrivia> triviaList)
-        {
-            return triviaList.Sum(t => t.ToFullString().Replace("\r\n", "\r").Cast<char>().Count(c => SyntaxFacts.IsNewLine(c)));
-        }
+            => triviaList.Sum(t => t.ToFullString().Replace("\r\n", "\r").Cast<char>().Count(c => SyntaxFacts.IsNewLine(c)));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -411,14 +411,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private bool HasFormattableBracketParent(SyntaxToken token)
-        {
-            return token.Parent.IsKind(SyntaxKind.ArrayRankSpecifier, SyntaxKind.BracketedArgumentList, SyntaxKind.BracketedParameterList, SyntaxKind.ImplicitArrayCreationExpression);
-        }
+            => token.Parent.IsKind(SyntaxKind.ArrayRankSpecifier, SyntaxKind.BracketedArgumentList, SyntaxKind.BracketedParameterList, SyntaxKind.ImplicitArrayCreationExpression);
 
         private bool IsFunctionLikeKeywordExpressionKind(SyntaxKind syntaxKind)
-        {
-            return (syntaxKind == SyntaxKind.TypeOfExpression || syntaxKind == SyntaxKind.DefaultExpression || syntaxKind == SyntaxKind.SizeOfExpression);
-        }
+            => (syntaxKind == SyntaxKind.TypeOfExpression || syntaxKind == SyntaxKind.DefaultExpression || syntaxKind == SyntaxKind.SizeOfExpression);
 
         private bool IsControlFlowLikeKeywordStatementKind(SyntaxKind syntaxKind)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -140,9 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                objectCreation.Type == node;
 
         public bool IsAttributeName(SyntaxNode node)
-        {
-            return SyntaxFacts.IsAttributeName(node);
-        }
+            => SyntaxFacts.IsAttributeName(node);
 
         public bool IsAnonymousFunction(SyntaxNode node)
         {
@@ -654,9 +652,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         }
 
         public bool IsElementAccessExpression(SyntaxNode node)
-        {
-            return node.Kind() == SyntaxKind.ElementAccessExpression;
-        }
+            => node.Kind() == SyntaxKind.ElementAccessExpression;
 
         public SyntaxNode ConvertToSingleLine(SyntaxNode node, bool useElasticTrivia = false)
             => node.ConvertToSingleLine(useElasticTrivia);
@@ -956,9 +952,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         }
 
         private TextSpan GetBlockBodySpan(BlockSyntax body)
-        {
-            return TextSpan.FromBounds(body.OpenBraceToken.Span.End, body.CloseBraceToken.SpanStart);
-        }
+            => TextSpan.FromBounds(body.OpenBraceToken.Span.End, body.CloseBraceToken.SpanStart);
 
         public int GetMethodLevelMemberId(SyntaxNode root, SyntaxNode node)
         {
@@ -1191,9 +1185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         }
 
         public bool IsLeftSideOfDot(SyntaxNode node)
-        {
-            return (node as ExpressionSyntax).IsLeftSideOfDot();
-        }
+            => (node as ExpressionSyntax).IsLeftSideOfDot();
 
         public SyntaxNode GetRightSideOfDot(SyntaxNode node)
         {
@@ -1235,14 +1227,10 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                node.IsParentKind(SyntaxKind.PreDecrementExpression);
 
         public bool IsOperandOfIncrementOrDecrementExpression(SyntaxNode node)
-        {
-            return IsOperandOfIncrementExpression(node) || IsOperandOfDecrementExpression(node);
-        }
+            => IsOperandOfIncrementExpression(node) || IsOperandOfDecrementExpression(node);
 
         public SyntaxList<SyntaxNode> GetContentsOfInterpolatedString(SyntaxNode interpolatedString)
-        {
-            return ((interpolatedString as InterpolatedStringExpressionSyntax)?.Contents).Value;
-        }
+            => ((interpolatedString as InterpolatedStringExpressionSyntax)?.Contents).Value;
 
         public bool IsVerbatimStringLiteral(SyntaxToken token)
             => token.IsVerbatimStringLiteral();
@@ -1337,9 +1325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         }
 
         public bool IsDeclaration(SyntaxNode node)
-        {
-            return SyntaxFacts.IsNamespaceMemberDeclaration(node.Kind()) || IsMemberDeclaration(node);
-        }
+            => SyntaxFacts.IsNamespaceMemberDeclaration(node.Kind()) || IsMemberDeclaration(node);
 
         public bool IsTypeDeclaration(SyntaxNode node)
             => SyntaxFacts.IsTypeDeclaration(node.Kind());
@@ -1993,18 +1979,12 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         }
 
         internal static bool ParentIsFieldDeclaration(SyntaxNode node)
-        {
-            return node?.Parent.IsKind(SyntaxKind.FieldDeclaration) ?? false;
-        }
+            => node?.Parent.IsKind(SyntaxKind.FieldDeclaration) ?? false;
 
         internal static bool ParentIsEventFieldDeclaration(SyntaxNode node)
-        {
-            return node?.Parent.IsKind(SyntaxKind.EventFieldDeclaration) ?? false;
-        }
+            => node?.Parent.IsKind(SyntaxKind.EventFieldDeclaration) ?? false;
 
         internal static bool ParentIsLocalDeclarationStatement(SyntaxNode node)
-        {
-            return node?.Parent.IsKind(SyntaxKind.LocalDeclarationStatement) ?? false;
-        }
+            => node?.Parent.IsKind(SyntaxKind.LocalDeclarationStatement) ?? false;
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/NameSyntaxComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/NameSyntaxComparer.cs
@@ -13,14 +13,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         internal TypeSyntaxComparer TypeComparer;
 
         internal NameSyntaxComparer(IComparer<SyntaxToken> tokenComparer)
-        {
-            _tokenComparer = tokenComparer;
-        }
+            => _tokenComparer = tokenComparer;
 
         public static IComparer<NameSyntax> Create()
-        {
-            return Create(TokenComparer.NormalInstance);
-        }
+            => Create(TokenComparer.NormalInstance);
 
         public static IComparer<NameSyntax> Create(IComparer<SyntaxToken> tokenComparer)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
@@ -94,9 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         protected override SemanticModel CreateSpeculativeSemanticModel(SyntaxNode originalNode, SyntaxNode nodeToSpeculate, SemanticModel semanticModel)
-        {
-            return CreateSpeculativeSemanticModelForNode(originalNode, nodeToSpeculate, semanticModel);
-        }
+            => CreateSpeculativeSemanticModelForNode(originalNode, nodeToSpeculate, semanticModel);
 
         public static SemanticModel CreateSpeculativeSemanticModelForNode(SyntaxNode originalNode, SyntaxNode nodeToSpeculate, SemanticModel semanticModel)
         {
@@ -603,39 +601,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         protected override bool IsInNamespaceOrTypeContext(ExpressionSyntax node)
-        {
-            return SyntaxFacts.IsInNamespaceOrTypeContext(node);
-        }
+            => SyntaxFacts.IsInNamespaceOrTypeContext(node);
 
         protected override ExpressionSyntax GetForEachStatementExpression(CommonForEachStatementSyntax forEachStatement)
-        {
-            return forEachStatement.Expression;
-        }
+            => forEachStatement.Expression;
 
         protected override ExpressionSyntax GetThrowStatementExpression(ThrowStatementSyntax throwStatement)
-        {
-            return throwStatement.Expression;
-        }
+            => throwStatement.Expression;
 
         protected override bool IsForEachTypeInferred(CommonForEachStatementSyntax forEachStatement, SemanticModel semanticModel)
-        {
-            return forEachStatement.IsTypeInferred(semanticModel);
-        }
+            => forEachStatement.IsTypeInferred(semanticModel);
 
         protected override bool IsParenthesizedExpression(SyntaxNode node)
-        {
-            return node.IsKind(SyntaxKind.ParenthesizedExpression);
-        }
+            => node.IsKind(SyntaxKind.ParenthesizedExpression);
 
         protected override bool IsNamedArgument(ArgumentSyntax argument)
-        {
-            return argument.NameColon != null && !argument.NameColon.IsMissing;
-        }
+            => argument.NameColon != null && !argument.NameColon.IsMissing;
 
         protected override string GetNamedArgumentIdentifierValueText(ArgumentSyntax argument)
-        {
-            return argument.NameColon.Name.Identifier.ValueText;
-        }
+            => argument.NameColon.Name.Identifier.ValueText;
 
         private bool ReplacementBreaksBinaryExpression(BinaryExpressionSyntax binaryExpression, BinaryExpressionSyntax newBinaryExpression)
         {
@@ -660,9 +644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         private bool ReplacementBreaksInterpolation(InterpolationSyntax interpolation, InterpolationSyntax newInterpolation)
-        {
-            return !TypesAreCompatible(interpolation.Expression, newInterpolation.Expression);
-        }
+            => !TypesAreCompatible(interpolation.Expression, newInterpolation.Expression);
 
         private bool ReplacementBreaksIsOrAsExpression(BinaryExpressionSyntax originalIsOrAsExpression, BinaryExpressionSyntax newIsOrAsExpression)
         {
@@ -715,9 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         protected override bool ConversionsAreCompatible(SemanticModel originalModel, ExpressionSyntax originalExpression, SemanticModel newModel, ExpressionSyntax newExpression)
-        {
-            return ConversionsAreCompatible(originalModel.GetConversion(originalExpression), newModel.GetConversion(newExpression));
-        }
+            => ConversionsAreCompatible(originalModel.GetConversion(originalExpression), newModel.GetConversion(newExpression));
 
         protected override bool ConversionsAreCompatible(ExpressionSyntax originalExpression, ITypeSymbol originalTargetType, ExpressionSyntax newExpression, ITypeSymbol newTargetType)
         {
@@ -771,9 +751,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         protected override bool IsReferenceConversion(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
-        {
-            return compilation.ClassifyConversion(sourceType, targetType).IsReference;
-        }
+            => compilation.ClassifyConversion(sourceType, targetType).IsReference;
 
         protected override Conversion ClassifyConversion(SemanticModel model, ExpressionSyntax expression, ITypeSymbol targetType) =>
             model.ClassifyConversion(expression, targetType);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TokenComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TokenComparer.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         private readonly bool _specialCaseSystem;
 
         private TokenComparer(bool specialCaseSystem)
-        {
-            _specialCaseSystem = specialCaseSystem;
-        }
+            => _specialCaseSystem = specialCaseSystem;
 
         public int Compare(SyntaxToken x, SyntaxToken y)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeSyntaxComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeSyntaxComparer.cs
@@ -17,9 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         internal IComparer<NameSyntax> NameComparer;
 
         internal TypeSyntaxComparer(IComparer<SyntaxToken> tokenComparer)
-        {
-            _tokenComparer = tokenComparer;
-        }
+            => _tokenComparer = tokenComparer;
 
         public int Compare(TypeSyntax x, TypeSyntax y)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
@@ -139,9 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         private static bool IsDocCommentOrElastic(SyntaxTrivia t)
-        {
-            return t.IsDocComment() || t.IsElastic();
-        }
+            => t.IsDocComment() || t.IsElastic();
 
         private static List<UsingDirectiveSyntax> AddUsingDirectives(
             CompilationUnitSyntax root, IList<UsingDirectiveSyntax> usingDirectives)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -149,9 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         }
 
         public static CSharpSyntaxContext CreateContext(Workspace workspace, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return CreateContextWorker(workspace, semanticModel, position, cancellationToken);
-        }
+            => CreateContextWorker(workspace, semanticModel, position, cancellationToken);
 
         private static CSharpSyntaxContext CreateContextWorker(Workspace workspace, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
         {
@@ -371,9 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         }
 
         internal override ITypeInferenceService GetTypeInferenceServiceWithoutWorkspace()
-        {
-            return new CSharpTypeInferenceService();
-        }
+            => new CSharpTypeInferenceService();
 
         /// <summary>
         /// Is this a possible position for an await statement (`await using` or `await foreach`)?

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1293,9 +1293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         }
 
         private static SyntaxToken FindTokenOnLeftOfNode(SyntaxNode node)
-        {
-            return node.FindTokenOnLeftOfPosition(node.SpanStart);
-        }
+            => node.FindTokenOnLeftOfPosition(node.SpanStart);
 
 
         public static bool IsPossibleTupleOpenParenOrComma(this SyntaxToken possibleCommaOrParen)
@@ -1436,9 +1434,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         }
 
         public static bool HasNames(this TupleExpressionSyntax tuple)
-        {
-            return tuple.Arguments.Any(a => a.NameColon != null);
-        }
+            => tuple.Arguments.Any(a => a.NameColon != null);
 
         public static bool IsValidContextForFromClause(
             this SyntaxTree syntaxTree,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.ExpressionSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.ExpressionSyntaxGeneratorVisitor.cs
@@ -26,9 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             public override ExpressionSyntax DefaultVisit(ISymbol symbol)
-            {
-                return symbol.Accept(TypeSyntaxGeneratorVisitor.Create());
-            }
+                => symbol.Accept(TypeSyntaxGeneratorVisitor.Create());
 
             private TExpressionSyntax AddInformationTo<TExpressionSyntax>(TExpressionSyntax syntax, ISymbol symbol)
                 where TExpressionSyntax : ExpressionSyntax

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -24,14 +24,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             private static readonly TypeSyntaxGeneratorVisitor NotNameOnlyInstance = new TypeSyntaxGeneratorVisitor(nameOnly: false);
 
             private TypeSyntaxGeneratorVisitor(bool nameOnly)
-            {
-                _nameOnly = nameOnly;
-            }
+                => _nameOnly = nameOnly;
 
             public static TypeSyntaxGeneratorVisitor Create(bool nameOnly = false)
-            {
-                return nameOnly ? NameOnlyInstance : NotNameOnlyInstance;
-            }
+                => nameOnly ? NameOnlyInstance : NotNameOnlyInstance;
 
             public override TypeSyntax DefaultVisit(ISymbol node)
             {
@@ -48,9 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             public override TypeSyntax VisitAlias(IAliasSymbol symbol)
-            {
-                return AddInformationTo(symbol.Name.ToIdentifierName(), symbol);
-            }
+                => AddInformationTo(symbol.Name.ToIdentifierName(), symbol);
 
             private void ThrowIfNameOnly()
             {
@@ -172,9 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             private static IdentifierNameSyntax CreateGlobalIdentifier()
-            {
-                return SyntaxFactory.IdentifierName(SyntaxFactory.Token(SyntaxKind.GlobalKeyword));
-            }
+                => SyntaxFactory.IdentifierName(SyntaxFactory.Token(SyntaxKind.GlobalKeyword));
 
             private TypeSyntax TryCreateSpecializedNamedTypeSyntax(INamedTypeSymbol symbol)
             {
@@ -313,9 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             public override TypeSyntax VisitTypeParameter(ITypeParameterSymbol symbol)
-            {
-                return AddInformationTo(symbol.Name.ToIdentifierName(), symbol);
-            }
+                => AddInformationTo(symbol.Name.ToIdentifierName(), symbol);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/NameSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/NameSyntaxExtensions.cs
@@ -17,9 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     internal static class NameSyntaxExtensions
     {
         public static IList<NameSyntax> GetNameParts(this NameSyntax nameSyntax)
-        {
-            return new NameSyntaxIterator(nameSyntax).ToList();
-        }
+            => new NameSyntaxIterator(nameSyntax).ToList();
 
         public static NameSyntax GetLastDottedName(this NameSyntax nameSyntax)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/SemanticModelExtensions.cs
@@ -487,8 +487,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         private static TypeSyntax GetOutermostType(TypeSyntax type)
-        {
-            return type.GetAncestorsOrThis<TypeSyntax>().Last();
-        }
+            => type.GetAncestorsOrThis<TypeSyntax>().Last();
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/StringExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/StringExtensions.cs
@@ -55,8 +55,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static IdentifierNameSyntax ToIdentifierName(this string identifier)
-        {
-            return SyntaxFactory.IdentifierName(identifier.ToIdentifierToken());
-        }
+            => SyntaxFactory.IdentifierName(identifier.ToIdentifierToken());
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/SyntaxTokenListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/SyntaxTokenListExtensions.cs
@@ -10,8 +10,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     internal static class SyntaxTokenListExtensions
     {
         public static IEnumerable<SyntaxToken> SkipKinds(this SyntaxTokenList tokenList, params SyntaxKind[] kinds)
-        {
-            return tokenList.SkipWhile(t => t.IsKind(kinds));
-        }
+            => tokenList.SkipWhile(t => t.IsKind(kinds));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpAddImportsService.cs
@@ -76,9 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImports
             };
 
         protected override bool IsEquivalentImport(SyntaxNode a, SyntaxNode b)
-        {
-            return SyntaxFactory.AreEquivalent(a, b, kind => kind == SyntaxKind.NullableDirectiveTrivia);
-        }
+            => SyntaxFactory.AreEquivalent(a, b, kind => kind == SyntaxKind.NullableDirectiveTrivia);
 
         private class Rewriter : CSharpSyntaxRewriter
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.Rewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.Rewriter.cs
@@ -94,9 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
             }
 
             private bool ShouldPreserveTrivia(SyntaxTriviaList trivia)
-            {
-                return trivia.Any(t => !t.IsWhitespaceOrEndOfLine());
-            }
+                => trivia.Any(t => !t.IsWhitespaceOrEndOfLine());
 
             private ISet<UsingDirectiveSyntax> GetUsingsToRemove(
                 SyntaxList<UsingDirectiveSyntax> oldUsings,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
@@ -97,8 +97,6 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
         }
 
         private int GetEndPosition(SyntaxNode container, SyntaxList<MemberDeclarationSyntax> list)
-        {
-            return list.Count > 0 ? list[0].SpanStart : container.Span.End;
-        }
+            => list.Count > 0 ? list[0].SpanStart : container.Span.End;
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsService.cs
@@ -79,19 +79,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public bool IsTypeContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return semanticModel.SyntaxTree.IsTypeContext(position, cancellationToken, semanticModel);
-        }
+            => semanticModel.SyntaxTree.IsTypeContext(position, cancellationToken, semanticModel);
 
         public bool IsNamespaceContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return semanticModel.SyntaxTree.IsNamespaceContext(position, cancellationToken, semanticModel);
-        }
+            => semanticModel.SyntaxTree.IsNamespaceContext(position, cancellationToken, semanticModel);
 
         public bool IsNamespaceDeclarationNameContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return semanticModel.SyntaxTree.IsNamespaceDeclarationNameContext(position, cancellationToken);
-        }
+            => semanticModel.SyntaxTree.IsNamespaceDeclarationNameContext(position, cancellationToken);
 
         public bool IsTypeDeclarationContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
         {
@@ -112,19 +106,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public bool IsGlobalStatementContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return semanticModel.SyntaxTree.IsGlobalStatementContext(position, cancellationToken);
-        }
+            => semanticModel.SyntaxTree.IsGlobalStatementContext(position, cancellationToken);
 
         public bool IsLabelContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return semanticModel.SyntaxTree.IsLabelContext(position, cancellationToken);
-        }
+            => semanticModel.SyntaxTree.IsLabelContext(position, cancellationToken);
 
         public bool IsAttributeNameContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
-        {
-            return semanticModel.SyntaxTree.IsAttributeNameContext(position, cancellationToken);
-        }
+            => semanticModel.SyntaxTree.IsAttributeNameContext(position, cancellationToken);
 
         public bool IsWrittenTo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
             => (node as ExpressionSyntax).IsWrittenTo();
@@ -142,9 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => (node as ExpressionSyntax).IsInInContext();
 
         public bool CanReplaceWithRValue(SemanticModel semanticModel, SyntaxNode expression, CancellationToken cancellationToken)
-        {
-            return (expression as ExpressionSyntax).CanReplaceWithRValue(semanticModel, cancellationToken);
-        }
+            => (expression as ExpressionSyntax).CanReplaceWithRValue(semanticModel, cancellationToken);
 
         public string GenerateNameForExpression(SemanticModel semanticModel, SyntaxNode expression, bool capitalize, CancellationToken cancellationToken)
             => semanticModel.GenerateNameForExpression((ExpressionSyntax)expression, capitalize, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsService.cs
@@ -67,9 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 private bool _addedFirstCloseCurly = false;
 
                 public AddFirstMissingCloseBraceRewriter(SyntaxNode contextNode)
-                {
-                    _contextNode = contextNode;
-                }
+                    => _contextNode = contextNode;
 
                 public override SyntaxNode Visit(SyntaxNode node)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -556,9 +556,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInAttributeArgument(int index, IEnumerable<IMethodSymbol> methods, AttributeArgumentSyntax argumentOpt = null)
-            {
-                return InferTypeInAttributeArgument(index, methods.Select(m => m.Parameters), argumentOpt);
-            }
+                => InferTypeInAttributeArgument(index, methods.Select(m => m.Parameters), argumentOpt);
 
             private IEnumerable<TypeInferenceInfo> InferTypeInArgument(int index, IEnumerable<IMethodSymbol> methods, ArgumentSyntax argumentOpt, InvocationExpressionSyntax parentInvocationExpressionToTypeInfer)
             {
@@ -1120,9 +1118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInConditionalAccessExpression(ConditionalAccessExpressionSyntax expression)
-            {
-                return InferTypes(expression);
-            }
+                => InferTypes(expression);
 
             private IEnumerable<TypeInferenceInfo> InferTypeInConditionalExpression(ConditionalExpressionSyntax conditional, ExpressionSyntax expressionOpt = null, SyntaxToken? previousToken = null)
             {
@@ -1155,9 +1151,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInDefaultExpression(DefaultExpressionSyntax defaultExpression)
-            {
-                return InferTypes(defaultExpression);
-            }
+                => InferTypes(defaultExpression);
 
             private IEnumerable<TypeInferenceInfo> InferTypeInDoStatement(DoStatementSyntax doStatement, SyntaxToken? previousToken = null)
             {
@@ -1266,9 +1260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInImplicitArrayCreation(ImplicitArrayCreationExpressionSyntax implicitArray, SyntaxToken previousToken)
-            {
-                return InferTypes(implicitArray.SpanStart);
-            }
+                => InferTypes(implicitArray.SpanStart);
 
             private IEnumerable<TypeInferenceInfo> InferTypeInInitializerExpression(
                 InitializerExpressionSyntax initializerExpression,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.cs
@@ -23,8 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         protected override AbstractTypeInferrer CreateTypeInferrer(SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
-            return new TypeInferrer(semanticModel, cancellationToken);
-        }
+            => new TypeInferrer(semanticModel, cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/NameSyntaxIterator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/NameSyntaxIterator.cs
@@ -16,9 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         private readonly NameSyntax _name;
 
         public NameSyntaxIterator(NameSyntax name)
-        {
-            _name = name ?? throw new ArgumentNullException(nameof(name));
-        }
+            => _name = name ?? throw new ArgumentNullException(nameof(name));
 
         public IEnumerator<NameSyntax> GetEnumerator()
         {
@@ -44,8 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+            => GetEnumerator();
     }
 }


### PR DESCRIPTION
This was only run on members with the following characteristics:

1. the member header itself must be a single line (i.e. no wrapped parameters).
2. The body of the method must be a single line.  
3. there must be no non-whitespace trivia in any of the code that is removed.

Furthermore, if the original member+block is on a single line, we preserve that.  Otherwise, if the member+block is on multiple lines, then we make a multi-line expression body.