### PR TITLE
Removed Unneeded int cast

### DIFF
--- a/src/Compilers/Core/CommandLine/NativeMethods.cs
+++ b/src/Compilers/Core/CommandLine/NativeMethods.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         #region Constants
 
         internal static readonly IntPtr NullPtr = IntPtr.Zero;
-        internal static readonly IntPtr InvalidIntPtr = new IntPtr((int)-1);
+        internal static readonly IntPtr InvalidIntPtr = new IntPtr(-1);
 
         internal const uint NORMAL_PRIORITY_CLASS = 0x0020;
         internal const uint CREATE_NO_WINDOW = 0x08000000;

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
 
 #if NET472
 
-        const int s_currentUserOnlyValue = unchecked((int)0x20000000);
+        const int s_currentUserOnlyValue = unchecked(0x20000000);
 
         /// <summary>
         /// Mono supports CurrentUserOnly even though it's not exposed on the reference assemblies for net472. This 

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
 
 #if NET472
 
-        const int s_currentUserOnlyValue = unchecked(0x20000000);
+        const int s_currentUserOnlyValue = 0x20000000;
 
         /// <summary>
         /// Mono supports CurrentUserOnly even though it's not exposed on the reference assemblies for net472. This 


### PR DESCRIPTION
In the Native Methods and PipeUntil, there is a cast to int. However, since -1 is determined to be an int and the hexadecimal as well, such as cast is unneeded.