### PR TITLE
Add tests to demonstrate that string patterns no longer produce a redundant null check

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -4056,7 +4056,9 @@ public class C
 ");
         }
 
-        [Fact, WorkItem(42912, "https://github.com/dotnet/roslyn/issues/42912")]
+        [Fact]
+        [WorkItem(42912, "https://github.com/dotnet/roslyn/issues/42912")]
+        [WorkItem(31494, "https://github.com/dotnet/roslyn/issues/31494")]
         public void NoRedundantNullCheckForNullableConstantPattern_04()
         {
             // Note that we do not produce the same code for `x is 1` and `x == 1`.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -3933,6 +3933,183 @@ public class C
 ");
         }
 
+        [Fact, WorkItem(31494, "https://github.com/dotnet/roslyn/issues/31494")]
+        public void NoRedundantNullCheckForStringConstantPattern_01()
+        {
+            var source =
+@"public class C
+{
+    public static bool M1(string s) => s is ""Frog"";
+    public static bool M2(string s) => s == ""Frog"";
+    public static bool M3(string s) => s switch { ""Frog"" => true, _ => false };
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1(string)", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldstr      ""Frog""
+  IL_0006:  call       ""bool string.op_Equality(string, string)""
+  IL_000b:  ret
+}
+");
+            compVerifier.VerifyIL("C.M2(string)", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldstr      ""Frog""
+  IL_0006:  call       ""bool string.op_Equality(string, string)""
+  IL_000b:  ret
+}
+");
+            compVerifier.VerifyIL("C.M3(string)", @"
+{
+  // Code size       21 (0x15)
+  .maxstack  2
+  .locals init (bool V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldstr      ""Frog""
+  IL_0006:  call       ""bool string.op_Equality(string, string)""
+  IL_000b:  brfalse.s  IL_0011
+  IL_000d:  ldc.i4.1
+  IL_000e:  stloc.0
+  IL_000f:  br.s       IL_0013
+  IL_0011:  ldc.i4.0
+  IL_0012:  stloc.0
+  IL_0013:  ldloc.0
+  IL_0014:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(31494, "https://github.com/dotnet/roslyn/issues/31494")]
+        public void NoRedundantNullCheckForStringConstantPattern_02()
+        {
+            var source =
+@"public class C
+{
+    public static bool M1(string s) => s switch { ""Frog"" => true, ""Newt"" => true, _ => false };
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1(string)", @"
+{
+  // Code size       40 (0x28)
+  .maxstack  2
+  .locals init (bool V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldstr      ""Frog""
+  IL_0006:  call       ""bool string.op_Equality(string, string)""
+  IL_000b:  brtrue.s   IL_001c
+  IL_000d:  ldarg.0
+  IL_000e:  ldstr      ""Newt""
+  IL_0013:  call       ""bool string.op_Equality(string, string)""
+  IL_0018:  brtrue.s   IL_0020
+  IL_001a:  br.s       IL_0024
+  IL_001c:  ldc.i4.1
+  IL_001d:  stloc.0
+  IL_001e:  br.s       IL_0026
+  IL_0020:  ldc.i4.1
+  IL_0021:  stloc.0
+  IL_0022:  br.s       IL_0026
+  IL_0024:  ldc.i4.0
+  IL_0025:  stloc.0
+  IL_0026:  ldloc.0
+  IL_0027:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(31494, "https://github.com/dotnet/roslyn/issues/31494")]
+        public void NoRedundantNullCheckForStringConstantPattern_03()
+        {
+            var source =
+@"public class C
+{
+    public static bool M1(System.Type x) => x is { Name: ""Program"" };
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1(System.Type)", @"
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0014
+  IL_0003:  ldarg.0
+  IL_0004:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
+  IL_0009:  ldstr      ""Program""
+  IL_000e:  call       ""bool string.op_Equality(string, string)""
+  IL_0013:  ret
+  IL_0014:  ldc.i4.0
+  IL_0015:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(42912, "https://github.com/dotnet/roslyn/issues/42912")]
+        public void NoRedundantNullCheckForNullableConstantPattern_04()
+        {
+            // Note that we do not produce the same code for `x is 1` and `x == 1`.
+            // The latter has been optimized to avoid branches.
+
+            var source =
+@"public class C
+{
+    public static bool M1(int? x) => x is 1;
+    public static bool M2(int? x) => x == 1;
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1(int?)", @"
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  call       ""bool int?.HasValue.get""
+  IL_0007:  brfalse.s  IL_0014
+  IL_0009:  ldarga.s   V_0
+  IL_000b:  call       ""int int?.GetValueOrDefault()""
+  IL_0010:  ldc.i4.1
+  IL_0011:  ceq
+  IL_0013:  ret
+  IL_0014:  ldc.i4.0
+  IL_0015:  ret
+}
+");
+            compVerifier.VerifyIL("C.M2(int?)", @"
+{
+  // Code size       23 (0x17)
+  .maxstack  2
+  .locals init (int? V_0,
+                int V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.1
+  IL_0003:  stloc.1
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  call       ""int int?.GetValueOrDefault()""
+  IL_000b:  ldloc.1
+  IL_000c:  ceq
+  IL_000e:  ldloca.s   V_0
+  IL_0010:  call       ""bool int?.HasValue.get""
+  IL_0015:  and
+  IL_0016:  ret
+}
+");
+        }
+
         #endregion Miscellaneous
 
         #region Target Typed Switch


### PR DESCRIPTION
Fixes #31494