### PR TITLE
Ensure that the public GetOption API returns the public CodeStyle opt…

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             private async Task<SyntaxNode> AddFinalNewLineIfDesiredAsync(Document document, SyntaxNode modifiedRoot)
             {
                 var options = await document.GetOptionsAsync(CancellationToken).ConfigureAwait(false);
-                var insertFinalNewLine = options.GetOption(FormattingOptions.InsertFinalNewLine);
+                var insertFinalNewLine = options.GetOption(FormattingOptions2.InsertFinalNewLine);
                 if (insertFinalNewLine)
                 {
                     var endOfFileToken = ((ICompilationUnitSyntax)modifiedRoot).EndOfFileToken;

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _optionSet = optionSet;
         }
 
-        public override object GetOption(OptionKey optionKey)
+        private protected override object GetOptionCore(OptionKey optionKey)
         {
             // First try to find the option from the .editorconfig options parsed by the compiler.
             if (_analyzerConfigOptions.TryGetEditorConfigOption<object>(optionKey.Option, out var value))

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -140,7 +140,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 #pragma warning disable CS0612 // Type or member is obsolete
             var optionSet = await analyzerOptions.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).ConfigureAwait(false);
 #pragma warning restore CS0612 // Type or member is obsolete
-            return (T)optionSet?.GetOption(new OptionKey(option, language)) ?? (T)option.DefaultValue!;
+
+            if (optionSet != null)
+            {
+                value = optionSet.GetOption<T>(new OptionKey(option, language));
+            }
+
+            return value ?? (T)option.DefaultValue!;
         }
 
         [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/23582", OftenCompletesSynchronously = true)]

--- a/src/Features/Core/Portable/Wrapping/AbstractCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractCodeActionComputer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
                 UseTabs = options.GetOption(FormattingOptions.UseTabs);
                 TabSize = options.GetOption(FormattingOptions.TabSize);
                 NewLine = options.GetOption(FormattingOptions.NewLine);
-                WrappingColumn = options.GetOption(FormattingOptions.PreferredWrappingColumn);
+                WrappingColumn = options.GetOption(FormattingOptions2.PreferredWrappingColumn);
 
                 var generator = SyntaxGenerator.GetGenerator(document);
                 NewLineTrivia = new SyntaxTriviaList(generator.EndOfLine(NewLine));

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
@@ -67,29 +67,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         public void SetOptionAndUpdatePreview<T>(T value, IOption option, string preview)
         {
-            if (option is Option<CodeStyleOption<T>>)
+            var key = new OptionKey(option, option.IsPerLanguage ? Language : null);
+            if (option.DefaultValue is ICodeStyleOption codeStyleOption)
             {
-                var opt = OptionStore.GetOption((Option<CodeStyleOption<T>>)option);
-                opt.Value = value;
-                OptionStore.SetOption((Option<CodeStyleOption<T>>)option, opt);
-            }
-            else if (option is PerLanguageOption<CodeStyleOption<T>>)
-            {
-                var opt = OptionStore.GetOption((PerLanguageOption<CodeStyleOption<T>>)option, Language);
-                opt.Value = value;
-                OptionStore.SetOption((PerLanguageOption<CodeStyleOption<T>>)option, Language, opt);
-            }
-            else if (option is Option<T>)
-            {
-                OptionStore.SetOption((Option<T>)option, value);
-            }
-            else if (option is PerLanguageOption<T>)
-            {
-                OptionStore.SetOption((PerLanguageOption<T>)option, Language, value);
+                OptionStore.SetOption(key, codeStyleOption.WithValue(value));
             }
             else
             {
-                throw new InvalidOperationException("Unexpected option type");
+                OptionStore.SetOption(key, value);
             }
 
             UpdateDocument(preview);

--- a/src/VisualStudio/Core/Impl/Options/OptionStore.cs
+++ b/src/VisualStudio/Core/Impl/Options/OptionStore.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         }
 
         public object GetOption(OptionKey optionKey) => _optionSet.GetOption(optionKey);
+        public T GetOption<T>(OptionKey optionKey) => _optionSet.GetOption<T>(optionKey);
         public T GetOption<T>(Option<T> option) => _optionSet.GetOption(option);
         internal T GetOption<T>(Option2<T> option) => _optionSet.GetOption(option);
         public T GetOption<T>(PerLanguageOption<T> option, string language) => _optionSet.GetOption(option, language);

--- a/src/VisualStudio/Core/Test.Next/Mocks/TestOptionSet.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/TestOptionSet.cs
@@ -23,7 +23,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Mocks
             _values = values;
         }
 
-        public override object GetOption(OptionKey optionKey)
+        private protected override object GetOptionCore(OptionKey optionKey)
         {
             Contract.ThrowIfFalse(_values.TryGetValue(optionKey, out var value));
 

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         ICodeStyleOption ICodeStyleOption.WithNotification(NotificationOption2 notification) => new CodeStyleOption<T>(Value, (NotificationOption)notification);
         ICodeStyleOption ICodeStyleOption.AsCodeStyleOption<TCodeStyleOption>()
             => this is TCodeStyleOption ? this : (ICodeStyleOption)_codeStyleOptionImpl;
+        ICodeStyleOption ICodeStyleOption.AsPublicCodeStyleOption() => this;
 
         public NotificationOption Notification
         {

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Options
             _language = language;
         }
 
-        public override object? GetOption(OptionKey optionKey)
+        private protected override object? GetOptionCore(OptionKey optionKey)
             => _backingOptionSet.GetOption(optionKey);
 
         public T GetOption<T>(PerLanguageOption<T> option)

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -29,6 +29,9 @@ namespace Microsoft.CodeAnalysis.Options
         private protected override object? GetOptionCore(OptionKey optionKey)
             => _backingOptionSet.GetOption(optionKey);
 
+        public new object? GetOption(OptionKey optionKey)
+            => base.GetOption(optionKey);
+
         public T GetOption<T>(PerLanguageOption<T> option)
             => _backingOptionSet.GetOption(option, _language);
 

--- a/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Options
                 }
 
                 [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowLocks = false)]
-                public override object? GetOption(OptionKey optionKey)
+                private protected override object? GetOptionCore(OptionKey optionKey)
                 {
                     // If we already know the document specific value, we're done
                     if (_values.TryGetValue(optionKey, out var value))

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -22,40 +22,43 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         private ImmutableDictionary<string, AnalyzerConfigOptions> _lazyAnalyzerConfigOptions = s_emptyAnalyzerConfigOptions;
 
+        private protected abstract object? GetOptionCore(OptionKey optionKey);
+
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
-        public abstract object? GetOption(OptionKey optionKey);
+        public object? GetOption(OptionKey optionKey)
+            => OptionsHelpers.GetPublicOption(optionKey, GetOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal object? GetOption(OptionKey2 optionKey)
-            => OptionsHelpers.GetOption<object?>(optionKey, GetOption);
+            => OptionsHelpers.GetOption<object?>(optionKey, GetOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         public T GetOption<T>(Option<T> option)
-            => OptionsHelpers.GetOption(option, GetOption);
+            => OptionsHelpers.GetOption(option, GetOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal T GetOption<T>(Option2<T> option)
-            => OptionsHelpers.GetOption(option, GetOption);
+            => OptionsHelpers.GetOption(option, GetOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         public T GetOption<T>(PerLanguageOption<T> option, string? language)
-            => OptionsHelpers.GetOption(option, language, GetOption);
+            => OptionsHelpers.GetOption(option, language, GetOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal T GetOption<T>(PerLanguageOption2<T> option, string? language)
-            => OptionsHelpers.GetOption(option, language, GetOption);
+            => OptionsHelpers.GetOption(option, language, GetOptionCore);
 
         /// <summary>
         /// Creates a new <see cref="OptionSet" /> that contains the changed value.

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Options
             => OptionsHelpers.GetOption<object?>(optionKey, GetOptionCore);
 
         /// <summary>
-        /// Gets the value of the option, or the default value if not otherwise set.
+        /// Gets the value of the option cast to type <typeparamref name="T"/>, or the default value if not otherwise set.
         /// </summary>
         internal T GetOption<T>(OptionKey2 optionKey)
             => OptionsHelpers.GetOption<T>(optionKey, GetOptionCore);

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -31,10 +31,22 @@ namespace Microsoft.CodeAnalysis.Options
             => OptionsHelpers.GetPublicOption(optionKey, GetOptionCore);
 
         /// <summary>
+        /// Gets the value of the option cast to type <typeparamref name="T"/>, or the default value if not otherwise set.
+        /// </summary>
+        public T GetOption<T>(OptionKey optionKey)
+            => OptionsHelpers.GetOption<T>(optionKey, GetOptionCore);
+
+        /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal object? GetOption(OptionKey2 optionKey)
             => OptionsHelpers.GetOption<object?>(optionKey, GetOptionCore);
+
+        /// <summary>
+        /// Gets the value of the option, or the default value if not otherwise set.
+        /// </summary>
+        internal T GetOption<T>(OptionKey2 optionKey)
+            => OptionsHelpers.GetOption<T>(optionKey, GetOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.

--- a/src/Workspaces/Core/Portable/Options/OptionsHelpers.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionsHelpers.cs
@@ -36,5 +36,16 @@ namespace Microsoft.CodeAnalysis.Options
 
             return (T)value!;
         }
+
+        public static object? GetPublicOption(OptionKey optionKey, Func<OptionKey, object?> getOption)
+        {
+            var value = getOption(optionKey);
+            if (value is ICodeStyleOption codeStyleOption)
+            {
+                return codeStyleOption.AsPublicCodeStyleOption();
+            }
+
+            return value;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.WorkspaceOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.WorkspaceOptionSet.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Options
             }
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowLocks = false)]
-            public override object? GetOption(OptionKey optionKey)
+            private protected override object? GetOptionCore(OptionKey optionKey)
             {
                 if (_values.TryGetValue(optionKey, out var value))
                 {

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Options
         }
 
         [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowLocks = false)]
-        public override object? GetOption(OptionKey optionKey)
+        private protected override object? GetOptionCore(OptionKey optionKey)
         {
             if (_serializableOptionValues.TryGetValue(optionKey, out var value))
             {

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,6 +3,9 @@ Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsVolatile.get -> bool
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsExtern(bool isExtern) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ElementBindingExpression(params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+*REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+*REMOVED*abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 Microsoft.CodeAnalysis.Project.RemoveDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Project
 Microsoft.CodeAnalysis.Solution.RemoveAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,8 +3,9 @@ Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsVolatile.get -> bool
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsExtern(bool isExtern) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ElementBindingExpression(params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
-Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 Microsoft.CodeAnalysis.Options.OptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> T
 Microsoft.CodeAnalysis.Project.RemoveDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Project

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ElementBindingExpression(params M
 Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+Microsoft.CodeAnalysis.Options.OptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> T
 Microsoft.CodeAnalysis.Project.RemoveDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Project
 Microsoft.CodeAnalysis.Solution.RemoveAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -316,25 +316,32 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var optionKey = new OptionKey(option, language);
             var optionKey2 = new OptionKey2(option, language);
 
+            // Value return from "object GetOption(OptionKey)" should always be public CodeStyleOption type.
+            var newPublicValue = newValue.AsPublicCodeStyleOption();
+
             //  1. WithChangedOption(OptionKey), GetOption(OptionKey)
             var newOptionSet = originalOptionSet.WithChangedOption(optionKey, newValue);
-            Assert.Equal(newValue, newOptionSet.GetOption(optionKey));
+            Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey));
+            // Value returned from public API should always be castable to public CodeStyleOption type.
+            Assert.NotNull((CodeStyleOption<bool>)newOptionSet.GetOption(optionKey)!);
 
             //  2. WithChangedOption(OptionKey), GetOption(OptionKey2)
             newOptionSet = originalOptionSet.WithChangedOption(optionKey, newValue);
-            Assert.Equal(newValue, newOptionSet.GetOption(optionKey2));
+            Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey2));
 
             //  3. WithChangedOption(OptionKey2), GetOption(OptionKey)
             newOptionSet = originalOptionSet.WithChangedOption(optionKey2, newValue);
-            Assert.Equal(newValue, newOptionSet.GetOption(optionKey));
+            Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey));
+            // Value returned from public API should always be castable to public CodeStyleOption type.
+            Assert.NotNull((CodeStyleOption<bool>)newOptionSet.GetOption(optionKey)!);
 
             //  4. WithChangedOption(OptionKey2), GetOption(OptionKey2)
             newOptionSet = originalOptionSet.WithChangedOption(optionKey2, newValue);
-            Assert.Equal(newValue, newOptionSet.GetOption(optionKey2));
+            Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey2));
 
             //  5. IOptionService.GetOption(OptionKey)
             optionService.SetOptions(newOptionSet);
-            Assert.Equal(newValue, optionService.GetOption(optionKey));
+            Assert.Equal(newPublicValue, optionService.GetOption(optionKey));
         }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -319,25 +319,37 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             // Value return from "object GetOption(OptionKey)" should always be public CodeStyleOption type.
             var newPublicValue = newValue.AsPublicCodeStyleOption();
 
-            //  1. WithChangedOption(OptionKey), GetOption(OptionKey)
+            //  1. WithChangedOption(OptionKey), GetOption(OptionKey)/GetOption<T>(OptionKey)
             var newOptionSet = originalOptionSet.WithChangedOption(optionKey, newValue);
             Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey));
             // Value returned from public API should always be castable to public CodeStyleOption type.
             Assert.NotNull((CodeStyleOption<bool>)newOptionSet.GetOption(optionKey)!);
+            // Verify "T GetOption<T>(OptionKey)" works for both cases of T being a public and internal code style option type.
+            Assert.Equal(newPublicValue, newOptionSet.GetOption<CodeStyleOption<bool>>(optionKey));
+            Assert.Equal(newValue, newOptionSet.GetOption<TCodeStyleOption>(optionKey));
 
-            //  2. WithChangedOption(OptionKey), GetOption(OptionKey2)
+            //  2. WithChangedOption(OptionKey), GetOption(OptionKey2)/GetOption<T>(OptionKey2)
             newOptionSet = originalOptionSet.WithChangedOption(optionKey, newValue);
             Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey2));
+            // Verify "T GetOption<T>(OptionKey2)" works for both cases of T being a public and internal code style option type.
+            Assert.Equal(newPublicValue, newOptionSet.GetOption<CodeStyleOption<bool>>(optionKey2));
+            Assert.Equal(newValue, newOptionSet.GetOption<TCodeStyleOption>(optionKey2));
 
-            //  3. WithChangedOption(OptionKey2), GetOption(OptionKey)
+            //  3. WithChangedOption(OptionKey2), GetOption(OptionKey)/GetOption<T>(OptionKey)
             newOptionSet = originalOptionSet.WithChangedOption(optionKey2, newValue);
             Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey));
             // Value returned from public API should always be castable to public CodeStyleOption type.
             Assert.NotNull((CodeStyleOption<bool>)newOptionSet.GetOption(optionKey)!);
+            // Verify "T GetOption<T>(OptionKey)" works for both cases of T being a public and internal code style option type.
+            Assert.Equal(newPublicValue, newOptionSet.GetOption<CodeStyleOption<bool>>(optionKey));
+            Assert.Equal(newValue, newOptionSet.GetOption<TCodeStyleOption>(optionKey));
 
-            //  4. WithChangedOption(OptionKey2), GetOption(OptionKey2)
+            //  4. WithChangedOption(OptionKey2), GetOption(OptionKey2)/GetOption<T>(OptionKey2)
             newOptionSet = originalOptionSet.WithChangedOption(optionKey2, newValue);
             Assert.Equal(newPublicValue, newOptionSet.GetOption(optionKey2));
+            // Verify "T GetOption<T>(OptionKey2)" works for both cases of T being a public and internal code style option type.
+            Assert.Equal(newPublicValue, newOptionSet.GetOption<CodeStyleOption<bool>>(optionKey2));
+            Assert.Equal(newValue, newOptionSet.GetOption<TCodeStyleOption>(optionKey2));
 
             //  5. IOptionService.GetOption(OptionKey)
             optionService.SetOptions(newOptionSet);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
@@ -56,12 +56,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         ICodeStyleOption ICodeStyleOption.WithValue(object value) => new CodeStyleOption2<T>((T)value, Notification);
         ICodeStyleOption ICodeStyleOption.WithNotification(NotificationOption2 notification) => new CodeStyleOption2<T>(Value, notification);
 
-        ICodeStyleOption ICodeStyleOption.AsCodeStyleOption<TCodeStyleOption>()
 #if CODE_STYLE
-            => this;
+        ICodeStyleOption ICodeStyleOption.AsCodeStyleOption<TCodeStyleOption>() => this;
 #else
+        ICodeStyleOption ICodeStyleOption.AsCodeStyleOption<TCodeStyleOption>()
             => this is TCodeStyleOption ? this : (ICodeStyleOption)new CodeStyleOption<T>(this);
-
         ICodeStyleOption ICodeStyleOption.AsPublicCodeStyleOption() => new CodeStyleOption<T>(this);
 #endif
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         ICodeStyleOption WithValue(object value);
         ICodeStyleOption WithNotification(NotificationOption2 notification);
         ICodeStyleOption AsCodeStyleOption<TCodeStyleOption>();
+        ICodeStyleOption AsPublicCodeStyleOption();
     }
 
     /// <summary>
@@ -59,6 +60,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 #else
             => this is TCodeStyleOption ? this : (ICodeStyleOption)new CodeStyleOption<T>(this);
 #endif
+
+        ICodeStyleOption ICodeStyleOption.AsPublicCodeStyleOption() => new CodeStyleOption<T>(this);
 
         private int EnumValueAsInt32 => (int)(object)Value;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
@@ -17,7 +17,9 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         ICodeStyleOption WithValue(object value);
         ICodeStyleOption WithNotification(NotificationOption2 notification);
         ICodeStyleOption AsCodeStyleOption<TCodeStyleOption>();
+#if !CODE_STYLE
         ICodeStyleOption AsPublicCodeStyleOption();
+#endif
     }
 
     /// <summary>
@@ -59,9 +61,9 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             => this;
 #else
             => this is TCodeStyleOption ? this : (ICodeStyleOption)new CodeStyleOption<T>(this);
-#endif
 
         ICodeStyleOption ICodeStyleOption.AsPublicCodeStyleOption() => new CodeStyleOption<T>(this);
+#endif
 
         private int EnumValueAsInt32 => (int)(object)Value;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfig/EditorConfigStorageLocation`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfig/EditorConfigStorageLocation`1.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Roslyn.Utilities;
 
 #if CODE_STYLE
@@ -104,6 +105,18 @@ namespace Microsoft.CodeAnalysis.Options
             => $"{KeyName} = {((IEditorConfigStorageLocation2)this).GetEditorConfigStringValue(value, optionSet)}";
 
         string IEditorConfigStorageLocation2.GetEditorConfigStringValue(object? value, OptionSet optionSet)
-            => GetEditorConfigStringValue((T)value!, optionSet);
+        {
+            T typedValue;
+            if (value is ICodeStyleOption codeStyleOption)
+            {
+                typedValue = (T)codeStyleOption.AsCodeStyleOption<T>();
+            }
+            else
+            {
+                typedValue = (T)value;
+            }
+
+            return GetEditorConfigStringValue(typedValue!, optionSet);
+        }
     }
 }


### PR DESCRIPTION
…ion value

Fixes `InvalidCastException` from #42923
We already ensured that we return the correct CodeStyle option value for `T OptionSet.GetOption<T>` overloads to fetch option. However, for `object? OptionSet.GetOption(OptionKey)`, we did not ensure that the public CodeStyleOption is returned, which could lead to a cast exception if an external consumer tries to cast the return value to CodeStyleOption.

**NOTE:** Even though theoretically this change introduces a breaking change for all public sub-types of `OptionSet` by making an abstract public method a non-abstract method, it is not really a breaking change as `OptionSet` already has internal abstract methods, hence cannot be sub-typed outside Roslyn. I also verified none of our IVT partners sub-type `OptionSet`. Another possible approach here is to revert the abstract to non-abstract breaking API change, and call out `(T)GetOption(optionKey)` as an unsupported/deprecated operation in favor of invoking `GetOption<T>(optionKey)`, which provides type safe access to option value. Former was relying on internal implementation details, which were never part of the Options API contract.

Verified the repro case + also unit test failure for the modified test before the fix.