### PR TITLE
Fix assertion failure in bootstrap build

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/NullableContextStateMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/NullableContextStateMap.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     continue;
                 }
 
-                var position = nn.Location.SourceSpan.End;
+                var position = nn.EndPosition;
                 var setting = (nn.SettingToken.Kind()) switch
                 {
                     SyntaxKind.EnableKeyword => NullableContextState.State.Enabled,


### PR DESCRIPTION
Closes #42837 

The implementation change fixes this particular assertion failure in the bootstrap build, but my reproducer isn't quite right. The failure occurs in the RemoveCastAnalyzer. I tried to create the reproducer by copy-pasting and modifying the method that we failed on, and speculating on it in a similar way to the analyzer. But I think I am missing something.

<details>
  <summary>Stack trace where the root of the problem occurs (accessing a missing Location on the syntax node):</summary>

```
Microsoft.CodeAnalysis.CSharp.Syntax.NullableContextStateMap.GetContexts(Microsoft.CodeAnalysis.SyntaxTree tree, bool isGeneratedCode) Line 139
Microsoft.CodeAnalysis.CSharp.Syntax.NullableContextStateMap.Create(Microsoft.CodeAnalysis.SyntaxTree tree, bool isGeneratedCode) Line 52
Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.EnsureNullableContextMapInitialized() Line 642
Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.GetNullableContextState(int position) Line 648
Microsoft.CodeAnalysis.CSharp.Binder.AreNullableAnnotationsEnabled(Microsoft.CodeAnalysis.SyntaxTree syntaxTree, int position) Line 238
Microsoft.CodeAnalysis.CSharp.Binder.AreNullableAnnotationsEnabled(Microsoft.CodeAnalysis.SyntaxToken token) Line 253
Microsoft.CodeAnalysis.CSharp.Binder.BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol(Microsoft.CodeAnalysis.CSharp.Syntax.IdentifierNameSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics, Microsoft.CodeAnalysis.CSharp.Symbols.NamespaceOrTypeSymbol qualifierOpt) Line 845
Microsoft.CodeAnalysis.CSharp.Binder.BindNamespaceOrTypeOrAliasSymbol(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics) Line 408
Microsoft.CodeAnalysis.CSharp.Binder.BindTypeOrAlias(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol> basesBeingResolved) Line 314
Microsoft.CodeAnalysis.CSharp.Binder.BindType(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol> basesBeingResolved) Line 294
Microsoft.CodeAnalysis.CSharp.Binder.BindCast(Microsoft.CodeAnalysis.CSharp.Syntax.CastExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2032
Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionInternal(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 500
Microsoft.CodeAnalysis.CSharp.Binder.BindExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 423
Microsoft.CodeAnalysis.CSharp.Binder.BindValue(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Microsoft.CodeAnalysis.CSharp.Binder.BindValueKind valueKind) Line 230
Microsoft.CodeAnalysis.CSharp.Binder.BindConditionalOperator(Microsoft.CodeAnalysis.CSharp.Syntax.ConditionalExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 3743
Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionInternal(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 567
Microsoft.CodeAnalysis.CSharp.Binder.BindExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 423
Microsoft.CodeAnalysis.CSharp.Binder.BindValue(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Microsoft.CodeAnalysis.CSharp.Binder.BindValueKind valueKind) Line 230
Microsoft.CodeAnalysis.CSharp.Binder.BindAssignment(Microsoft.CodeAnalysis.CSharp.Syntax.AssignmentExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 1415
Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionInternal(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 498
Microsoft.CodeAnalysis.CSharp.Binder.BindExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 423
Microsoft.CodeAnalysis.CSharp.Binder.BindValue(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Microsoft.CodeAnalysis.CSharp.Binder.BindValueKind valueKind) Line 230
Microsoft.CodeAnalysis.CSharp.Binder.BindRValueWithoutTargetType(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool reportDefaultMissingType) Line 236
Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionStatement(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax syntax, bool allowsAnyExpression, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 638
Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionStatement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionStatementSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 631
Microsoft.CodeAnalysis.CSharp.Binder.BindStatement(Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 73
Microsoft.CodeAnalysis.CSharp.Binder.BindBlockParts(Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 1720
Microsoft.CodeAnalysis.CSharp.Binder.BindBlock(Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 1708
Microsoft.CodeAnalysis.CSharp.Binder.BindStatement(Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 64
Microsoft.CodeAnalysis.CSharp.Binder.BindPossibleEmbeddedStatement(Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 387
Microsoft.CodeAnalysis.CSharp.Binder.BindIfStatement(Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2248
Microsoft.CodeAnalysis.CSharp.Binder.BindStatement(Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 76
Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.Bind(Microsoft.CodeAnalysis.CSharp.Binder binder, Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2249
Microsoft.CodeAnalysis.CSharp.MethodBodySemanticModel.Bind(Microsoft.CodeAnalysis.CSharp.Binder binder, Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 99
Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.EnsureNullabilityAnalysisPerformedIfNecessary() Line 1948
Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetBoundNodes(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node) Line 2013
Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetLowerBoundNode(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node) Line 537
Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetBoundNodes(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node, out Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode bindableNode, out Microsoft.CodeAnalysis.CSharp.BoundNode lowestBoundNode, out Microsoft.CodeAnalysis.CSharp.BoundNode highestBoundNode, out Microsoft.CodeAnalysis.CSharp.BoundNode boundParent) Line 1332
Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetSymbolInfoWorker(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node, Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.SymbolInfoOptions options, System.Threading.CancellationToken cancellationToken) Line 1210
Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.GetSymbolInfo(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression, System.Threading.CancellationToken cancellationToken) Line 571
Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.GetSymbolInfoFromNode(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) Line 4701
Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.GetSymbolInfoCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) Line 4796
Microsoft.CodeAnalysis.SemanticModel.GetSymbolInfo(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) Line 112
Microsoft.CodeAnalysis.ModelExtensions.GetSymbolInfo(Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) Line 28
Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer<Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ThrowStatementSyntax, Microsoft.CodeAnalysis.CSharp.Conversion>.SymbolsAreCompatible(Microsoft.CodeAnalysis.SyntaxNode originalNode, Microsoft.CodeAnalysis.SyntaxNode newNode, bool requireNonNullSymbols) Line 271
Microsoft.CodeAnalysis.CSharp.Utilities.SpeculationAnalyzer.ReplacementBreaksAssignmentExpression(Microsoft.CodeAnalysis.CSharp.Syntax.AssignmentExpressionSyntax assignmentExpression, Microsoft.CodeAnalysis.CSharp.Syntax.AssignmentExpressionSyntax newAssignmentExpression) Line 702
Microsoft.CodeAnalysis.CSharp.Utilities.SpeculationAnalyzer.ReplacementChangesSemanticsForNodeLanguageSpecific(Microsoft.CodeAnalysis.SyntaxNode currentOriginalNode, Microsoft.CodeAnalysis.SyntaxNode currentReplacedNode, Microsoft.CodeAnalysis.SyntaxNode previousOriginalNode, Microsoft.CodeAnalysis.SyntaxNode previousReplacedNode) Line 308
Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer<Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ThrowStatementSyntax, Microsoft.CodeAnalysis.CSharp.Conversion>.ReplacementChangesSemanticsForNode(Microsoft.CodeAnalysis.SyntaxNode currentOriginalNode, Microsoft.CodeAnalysis.SyntaxNode currentReplacedNode, Microsoft.CodeAnalysis.SyntaxNode previousOriginalNode, Microsoft.CodeAnalysis.SyntaxNode previousReplacedNode) Line 508
Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer<Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ThrowStatementSyntax, Microsoft.CodeAnalysis.CSharp.Conversion>.ReplacementChangesSemantics(Microsoft.CodeAnalysis.SyntaxNode currentOriginalNode, Microsoft.CodeAnalysis.SyntaxNode currentReplacedNode, Microsoft.CodeAnalysis.SyntaxNode originalRoot, bool skipVerificationForCurrentNode) Line 431
Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer<Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.ThrowStatementSyntax, Microsoft.CodeAnalysis.CSharp.Conversion>.ReplacementChangesSemantics() Line 407
Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers.CastSimplifier.IsUnnecessaryCast(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax castNode, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax castedExpressionNode, Microsoft.CodeAnalysis.SemanticModel semanticModel, System.Threading.CancellationToken cancellationToken) Line 297
Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers.CastSimplifier.IsUnnecessaryCast(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax cast, Microsoft.CodeAnalysis.SemanticModel semanticModel, System.Threading.CancellationToken cancellationToken) Line 17
Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryCast.CSharpRemoveUnnecessaryCastDiagnosticAnalyzer.IsUnnecessaryCast(Microsoft.CodeAnalysis.SemanticModel model, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax cast, System.Threading.CancellationToken cancellationToken) Line 29
Microsoft.CodeAnalysis.RemoveUnnecessaryCast.AbstractRemoveUnnecessaryCastDiagnosticAnalyzer<Microsoft.CodeAnalysis.CSharp.SyntaxKind, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax>.TryRemoveCastExpression(Microsoft.CodeAnalysis.SemanticModel model, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, System.Threading.CancellationToken cancellationToken) Line 58
Microsoft.CodeAnalysis.RemoveUnnecessaryCast.AbstractRemoveUnnecessaryCastDiagnosticAnalyzer<Microsoft.CodeAnalysis.CSharp.SyntaxKind, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax>.AnalyzeSyntax(Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext context) L
```
</details>