### PR TITLE
Fix EditorFeatures2 flakiness

### DIFF
--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
     [Export(typeof(IExtensionErrorHandler))]
     [Export(typeof(ITestErrorHandler))]
-    internal class TestExtensionErrorHandler : IExtensionErrorHandler
+    internal class TestExtensionErrorHandler : IExtensionErrorHandler, ITestErrorHandler
     {
         private ImmutableList<Exception> _exceptions = ImmutableList<Exception>.Empty;
 

--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -14,9 +14,12 @@ using Microsoft.VisualStudio.Text;
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
     [Export(typeof(IExtensionErrorHandler))]
+    [Export(typeof(TestExtensionErrorHandler))]
     internal class TestExtensionErrorHandler : IExtensionErrorHandler
     {
         private ImmutableList<Exception> _exceptions = ImmutableList<Exception>.Empty;
+
+        public ImmutableList<Exception> Exceptions => _exceptions;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -27,12 +30,24 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         public void HandleError(object sender, Exception exception)
         {
             // Work around bug that is fixed in https://devdiv.visualstudio.com/DevDiv/_git/VS-Platform/pullrequest/209513
-            if (exception is NullReferenceException && exception.StackTrace.Contains("SpanTrackingWpfToolTipPresenter"))
+            if (exception is NullReferenceException &&
+                exception.StackTrace.Contains("SpanTrackingWpfToolTipPresenter"))
             {
                 return;
             }
 
-            ExceptionUtilities.FailFast(exception);
+            // Work around for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1091056
+            if (exception is InvalidOperationException &&
+                exception.StackTrace.Contains("Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Implementation.CompletionTelemetryHost"))
+            {
+                return;
+            }
+
+            // This exception is unexpected and as such we want the containing test case to
+            // fail. Unfortuntately throwing an exception here is not going to help because
+            // the editor is going to catch and swallow it. Store it here and wait for the 
+            // containing workspace to notice it and throw.
+            _exceptions = _exceptions.Add(exception);
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -36,6 +36,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 return;
             }
 
+            // Work around for https://github.com/dotnet/roslyn/issues/42982
+            if (exception is NullReferenceException &&
+                exception.StackTrace.Contains("Microsoft.CodeAnalysis.Completion.Providers.AbstractEmbeddedLanguageCompletionProvider.GetLanguageProviders"))
+            {
+                return;
+            }
+
             // Work around for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1091056
             if (exception is InvalidOperationException &&
                 exception.StackTrace.Contains("Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Implementation.CompletionTelemetryHost"))

--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.Text;
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
     [Export(typeof(IExtensionErrorHandler))]
-    [Export(typeof(TestExtensionErrorHandler))]
+    [Export(typeof(ITestErrorHandler))]
     internal class TestExtensionErrorHandler : IExtensionErrorHandler
     {
         private ImmutableList<Exception> _exceptions = ImmutableList<Exception>.Empty;

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private readonly BackgroundCompiler _backgroundCompiler;
         private readonly BackgroundParser _backgroundParser;
         private readonly IMetadataAsSourceFileService _metadataAsSourceFileService;
+        private readonly TestExtensionErrorHandler _testExtensionErrorHandler;
 
         private readonly Dictionary<string, ITextBuffer> _createdTextBuffers = new Dictionary<string, ITextBuffer>();
 
@@ -75,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _backgroundParser.Start();
 
             _metadataAsSourceFileService = exportProvider.GetExportedValues<IMetadataAsSourceFileService>().FirstOrDefault();
+            _testExtensionErrorHandler = exportProvider.GetExportedValue<TestExtensionErrorHandler>();
 
             RegisterDocumentOptionProviders(exportProvider.GetExports<IDocumentOptionsProviderFactory, OrderableMetadata>());
         }
@@ -140,6 +142,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             if (_backgroundParser != null)
             {
                 _backgroundParser.CancelAllParses();
+            }
+
+            var exceptions = _testExtensionErrorHandler.Exceptions;
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException("Extensions threw unexpected exceptions", exceptions);
             }
 
             base.Dispose(finalize);

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -48,7 +48,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private readonly BackgroundCompiler _backgroundCompiler;
         private readonly BackgroundParser _backgroundParser;
         private readonly IMetadataAsSourceFileService _metadataAsSourceFileService;
-        private readonly TestExtensionErrorHandler _testExtensionErrorHandler;
 
         private readonly Dictionary<string, ITextBuffer> _createdTextBuffers = new Dictionary<string, ITextBuffer>();
 
@@ -76,7 +75,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _backgroundParser.Start();
 
             _metadataAsSourceFileService = exportProvider.GetExportedValues<IMetadataAsSourceFileService>().FirstOrDefault();
-            _testExtensionErrorHandler = exportProvider.GetExportedValue<TestExtensionErrorHandler>();
 
             RegisterDocumentOptionProviders(exportProvider.GetExports<IDocumentOptionsProviderFactory, OrderableMetadata>());
         }
@@ -142,12 +140,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             if (_backgroundParser != null)
             {
                 _backgroundParser.CancelAllParses();
-            }
-
-            var exceptions = _testExtensionErrorHandler.Exceptions;
-            if (exceptions.Count > 0)
-            {
-                throw new AggregateException("Extensions threw unexpected exceptions", exceptions);
             }
 
             base.Dispose(finalize);

--- a/src/Workspaces/CoreTestUtilities/ITestErrorHandler.cs
+++ b/src/Workspaces/CoreTestUtilities/ITestErrorHandler.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    public interface ITestErrorHandler
+    {
+        /// <summary>
+        /// Records unexpected exceptions thrown during test executino that can't be immediately
+        /// reported.
+        /// </summary>
+        ImmutableList<Exception> Exceptions { get; }
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/MEF/UseExportProviderAttribute.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/UseExportProviderAttribute.cs
@@ -133,6 +133,15 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     {
                         synchronizationContext.ThrowIfSwitchOccurred();
                     }
+
+                    foreach (var testErrorHandler in exportProvider.GetExportedValues<ITestErrorHandler>())
+                    {
+                        var exceptions = testErrorHandler.Exceptions;
+                        if (exceptions.Count > 0)
+                        {
+                            throw new AggregateException("Tests threw unexpected exceptions", exceptions);
+                        }
+                    }
                 }
             }
             finally


### PR DESCRIPTION
The EditorFeatures2 flakiness was being caused by two separate issues.
The first underlying problem is a simple bug in async completion. This
issue is being tracked by the VS editor team here

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1091056

The second issue is how the Roslyn test framework handles unexpected
extension exceptions. It was using a `FailFast` call when this happened
vs. using `Assert.Fail` or similar. The reason being that at the point
the unexpected exception is detected using `Assert.Fail` isn't effective
because the editor is going to catch and swallow all exceptions. The
`FailFast` is the only way to guarantee that the test will fail.

The downside to `FailFast` though is that it doesn't produce actionable
information. The xUnit process will simply exit with no stack trace,
failure message, etc .... just a fail fast error code. This makes
failures like this incredibly hard to track down.

To fix this the `TestExtensionErrorHandler` will now store the
unexpected `Exception` object and the containing workspace will look for
it and fail the test in `Dispose`. This will reliably fail the tests
that use `TestWorkspace` in this manner.

closes #42586