### PR TITLE
Disable component governance

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -14,6 +14,16 @@ pr:
 - features/*
 - demos/*
 
+variables:
+    # Disable component governance in our CI builds. These builds are not shipping nor
+    # are they a service. Also the component governance jobs issue lots of inconsequential
+    # warnings and errors into our build timelines that make it hard to track down 
+    # real errors in the build
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: runCodesignValidationInjection
+      value: false
+
 jobs:
 - job: VS_Integration
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,17 @@ pr:
 - features/*
 - demos/*
 
+variables:
+    # Disable component governance in our CI builds. These builds are not shipping nor
+    # are they a service. Also the component governance jobs issue lots of inconsequential
+    # warnings and errors into our build timelines that make it hard to track down 
+    # real errors in the build
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: runCodesignValidationInjection
+      value: false
+
+
 jobs:
 - job: Windows_Desktop_Unit_Tests
   pool:


### PR DESCRIPTION
Disable component governance in our CI builds. These builds are not
shipping nor are they services hence they don't need governance.

These injected tasks just add extra time to our build, and in some cases
produce spurious warnings. Removing as it's unnecessary to incur this
cost