### PR TITLE
Return partial results if cache/index for unimported items are not fully populated

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.vb
@@ -22,9 +22,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Private Property ShowImportCompletionItemsOptionValue As Boolean = True
 
-        ' -1 would disable timebox, whereas 0 means always timeout.
-        Private Property TimeoutInMilliseconds As Integer = -1
-
         Protected Overrides Function WithChangedOptions(options As OptionSet) As OptionSet
             Return options _
                 .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, ShowImportCompletionItemsOptionValue).WithChangedOption(CompletionServiceOptions.IsExpandedCompletion, IsExpandedCompletion)

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -24,13 +24,12 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             TypeImportCompletionTicks,
             TypeImportCompletionItemCount,
             TypeImportCompletionReferenceCount,
-            TypeImportCompletionCacheMissCount,
+            TypeImportCompletionPartialResultsCount,
             CommitsOfTypeImportCompletionItem,
 
             TargetTypeCompletionTicks,
 
-            ExtensionMethodCompletionSuccessCount,
-            // following are only reported when successful (i.e. filter is available)
+            ExtensionMethodCompletionPartialResultsCount,
             ExtensionMethodCompletionTicks,
             ExtensionMethodCompletionMethodsProvided,
             ExtensionMethodCompletionGetFilterTicks,
@@ -52,8 +51,8 @@ namespace Microsoft.CodeAnalysis.Completion.Log
         internal static void LogTypeImportCompletionReferenceCountDataPoint(int count) =>
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TypeImportCompletionReferenceCount, count);
 
-        internal static void LogTypeImportCompletionCacheMiss() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionCacheMissCount);
+        internal static void LogTypeImportCompletionPartialResults() =>
+            s_logAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionPartialResultsCount);
 
         internal static void LogCommitOfTypeImportCompletionItem() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfTypeImportCompletionItem);
@@ -62,8 +61,8 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TargetTypeCompletionTicks, count);
 
 
-        internal static void LogExtensionMethodCompletionSuccess() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.ExtensionMethodCompletionSuccessCount);
+        internal static void LogExtensionMethodCompletionPartialResults() =>
+            s_logAggregator.IncreaseCount((int)ActionInfo.ExtensionMethodCompletionPartialResultsCount);
 
         internal static void LogExtensionMethodCompletionTicksDataPoint(int count)
         {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -34,16 +34,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
         internal AbstractTypeImportCompletionService(Workspace workspace)
             => CacheService = workspace.Services.GetRequiredService<IImportCompletionCacheService<CacheEntry, CacheEntry>>();
 
-        public async Task<ImmutableArray<ImmutableArray<CompletionItem>>?> GetAllTopLevelTypesAsync(
+        public async Task<(bool, ImmutableArray<ImmutableArray<CompletionItem>>)> GetAllTopLevelTypesAsync(
             Project currentProject,
             SyntaxContext syntaxContext,
             bool forceCacheCreation,
             CancellationToken cancellationToken)
         {
-            var getCacheResults = await GetCacheEntriesAsync(currentProject, syntaxContext, forceCacheCreation, cancellationToken).ConfigureAwait(false);
+            var (hasFullResults, getCacheResults) = await GetCacheEntriesAsync(currentProject, syntaxContext, forceCacheCreation, cancellationToken).ConfigureAwait(false);
 
-            if (getCacheResults == null)
+            // Queue a background task to populate cache in case we are missing any.
+            // But we still want to return what we have found, even if it's incomplete.
+            if (!hasFullResults)
             {
+                Debug.Assert(!forceCacheCreation);
+
                 // We use a very simple approach to build the cache in the background:
                 // queue a new task only if the previous task is completed, regardless of what
                 // that task is doing.
@@ -51,29 +55,32 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
                 {
                     if (s_cachingTask.IsCompleted)
                     {
-                        s_cachingTask = Task.Run(() => GetCacheEntriesAsync(currentProject, syntaxContext, forceCacheCreation: true, CancellationToken.None));
+                        s_cachingTask = Task.Run(() => PopulateCacheEntriesAsync(currentProject, syntaxContext));
                     }
                 }
-
-                return null;
             }
 
             var currentCompilation = await currentProject.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            return getCacheResults.Value.SelectAsArray(GetItemsFromCacheResult);
+            return (hasFullResults, getCacheResults.SelectAsArray(GetItemsFromCacheResult));
 
             ImmutableArray<CompletionItem> GetItemsFromCacheResult(GetCacheResult cacheResult)
+                => cacheResult.Entry.GetItemsForContext(
+                    syntaxContext.SemanticModel.Language,
+                    GenericTypeSuffix,
+                    currentCompilation.Assembly.IsSameAssemblyOrHasFriendAccessTo(cacheResult.Assembly),
+                    syntaxContext.IsAttributeNameContext,
+                    IsCaseSensitive);
+
+            async Task PopulateCacheEntriesAsync(Project currentProject, SyntaxContext syntaxContext)
             {
-                return cacheResult.Entry.GetItemsForContext(
-                         syntaxContext.SemanticModel.Language,
-                         GenericTypeSuffix,
-                         currentCompilation.Assembly.IsSameAssemblyOrHasFriendAccessTo(cacheResult.Assembly),
-                         syntaxContext.IsAttributeNameContext,
-                         IsCaseSensitive);
+                // Just need to populate the cache so we don't care about the returned value.
+                _ = await GetCacheEntriesAsync(currentProject, syntaxContext, forceCacheCreation: true, CancellationToken.None).ConfigureAwait(false);
             }
         }
 
-        private async Task<ImmutableArray<GetCacheResult>?> GetCacheEntriesAsync(Project currentProject, SyntaxContext syntaxContext, bool forceCacheCreation, CancellationToken cancellationToken)
+        private async Task<(bool hasFullResults, ImmutableArray<GetCacheResult> cacheEntries)> GetCacheEntriesAsync(Project currentProject, SyntaxContext syntaxContext, bool forceCacheCreation, CancellationToken cancellationToken)
         {
+            var hasFullResults = true;
             var _ = ArrayBuilder<GetCacheResult>.GetInstance(out var builder);
 
             var cacheResult = await GetCacheForProjectAsync(currentProject, syntaxContext, forceCacheCreation: true, cancellationToken).ConfigureAwait(false);
@@ -107,9 +114,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
                     }
                     else
                     {
-                        // If there's cache miss, we just don't return any item.
+                        // If there's cache miss, we just don't return any item from this reference,
                         // This way, we will not block completion building our cache.
-                        return null;
+                        hasFullResults = false;
+                        continue;
                     }
                 }
             }
@@ -126,14 +134,15 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
                     }
                     else
                     {
-                        // If there's cache miss, we just don't return any item.
+                        // If there's cache miss, we just don't return any item from this reference,
                         // This way, we will not block completion building our cache.
-                        return null;
+                        hasFullResults = false;
+                        continue;
                     }
                 }
             }
 
-            return builder.ToImmutable();
+            return (hasFullResults, builder.ToImmutable());
 
             static bool HasGlobalAlias(MetadataReference? metadataReference)
                 => metadataReference != null && (metadataReference.Properties.Aliases.IsEmpty || metadataReference.Properties.Aliases.Any(alias => alias == MetadataReferenceProperties.GlobalAlias));

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             using var _2 = PooledDictionary<INamespaceSymbol, string>.GetInstance(out var namespaceNameCache);
 
             // Get extension method items from source
-            foreach (var (project, syntaxIndex) in indices.SyntaxIndices!)
+            foreach (var (project, syntaxIndex) in indices.ProjectExtensionMethodInfo!)
             {
                 var filter = CreateAggregatedFilter(targetTypeNames, syntaxIndex);
                 var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
 
             // Get extension method items from PE
-            foreach (var (peReference, symbolInfo) in indices.SymbolInfos!)
+            foreach (var (peReference, symbolInfo) in indices.PEExtensionMethodInfo!)
             {
                 var filter = CreateAggregatedFilter(targetTypeNames, symbolInfo);
                 if (currentCompilation.GetAssemblyOrModuleSymbol(peReference) is IAssemblySymbol assembly)
@@ -411,14 +411,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private readonly struct GetIndicesResult
         {
             public bool HasResult { get; }
-            public Dictionary<Project, CacheEntry>? SyntaxIndices { get; }
-            public Dictionary<PortableExecutableReference, SymbolTreeInfo>? SymbolInfos { get; }
+            public Dictionary<Project, CacheEntry>? ProjectExtensionMethodInfo { get; }
+            public Dictionary<PortableExecutableReference, SymbolTreeInfo>? PEExtensionMethodInfo { get; }
 
-            public GetIndicesResult(Dictionary<Project, CacheEntry> syntaxIndices, Dictionary<PortableExecutableReference, SymbolTreeInfo> symbolInfos)
+            public GetIndicesResult(Dictionary<Project, CacheEntry> projectExtensionMethodInfo, Dictionary<PortableExecutableReference, SymbolTreeInfo> peExtensionMethodInfo)
             {
                 HasResult = true;
-                SyntaxIndices = syntaxIndices;
-                SymbolInfos = symbolInfos;
+                ProjectExtensionMethodInfo = projectExtensionMethodInfo;
+                PEExtensionMethodInfo = peExtensionMethodInfo;
             }
 
             public static GetIndicesResult NoneResult => default;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -130,7 +130,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             static async Task PopulateCacheEntries(Project currentProject)
             {
-                // Just need to populate the cache so we don't want to hold on to the returned value.
+                // Just need to populate the cache so we don't want to hold on to the returned value,
+                // also don't cancel the task when completion is canceled.
                 await TryGetIndicesAsync(currentProject, forceIndexCreation: true, CancellationToken.None).ConfigureAwait(false);
             }
         }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ITypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ITypeImportCompletionService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
         /// Because items from each entity are cached as a separate array, we simply return them as is instead of an 
         /// aggregated array to avoid unnecessary allocations.
         /// </remarks>
-        Task<ImmutableArray<ImmutableArray<CompletionItem>>?> GetAllTopLevelTypesAsync(
+        Task<(bool hasFullResults, ImmutableArray<ImmutableArray<CompletionItem>>)> GetAllTopLevelTypesAsync(
             Project project,
             SyntaxContext syntaxContext,
             bool forceCacheCreation,

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ITypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ITypeImportCompletionService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion
         /// Because items from each entity are cached as a separate array, we simply return them as is instead of an 
         /// aggregated array to avoid unnecessary allocations.
         /// </remarks>
-        Task<(bool hasFullResults, ImmutableArray<ImmutableArray<CompletionItem>>)> GetAllTopLevelTypesAsync(
+        Task<(bool hasFullResults, ImmutableArray<ImmutableArray<CompletionItem>> items)> GetAllTopLevelTypesAsync(
             Project project,
             SyntaxContext syntaxContext,
             bool forceCacheCreation,


### PR DESCRIPTION
Per discussion in [this PR](https://github.com/dotnet/roslyn/pull/42585#discussion_r395359722), allow import completion returns partial results when cache/index isn't fully populated.  

We expect this to be a relatively rare situation. For types, this practically means the very first time completion is triggered, the only unimported items shown would be from the current project (w/o any from its references.) For extension methods, the result depends on the availability of persisted data and/or the progress of solution crawler. For example, if persisted data is up-to-date for the solution, we won't run into this scenario.

The behavior before this change is not showing any unimported items plus setting completion list's expander button as unselected to indicate this. If user clicked the expander in the same completion session, it would ensure the return of a complete list of unimported items. A background task to force creating the cache would be triggered as well to avoid running into this again, which is still the case after this change. 

One down side of this change is the expander button can no longer be used as an indication of completeness of the items or as a way to ask for a complete list. With this change, if only a subset of unimported items is returned, the expander will be shown as selected, de-select and then re-select it in the same session would give you the same result (this is the design of current expander API). Dismiss and trigger completion again is likely to have all the items returned(due to the work done by background task).