### PR TITLE
Set Microsoft.CodeAnalysis.Analyzers package to a release version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -136,6 +136,9 @@ dotnet_naming_symbols.all_members.applicable_kinds = *
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
+# error RS2008: Enable analyzer release tracking for the analyzer project containing rule '{0}'
+dotnet_diagnostic.RS2008.severity = none
+
 # CSharp code style settings:
 [*.cs]
 # Newline settings
@@ -206,7 +209,5 @@ csharp_prefer_braces = true:silent
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
-# error RS2008: Enable analyzer release tracking for the analyzer project containing rule '{0}'
-dotnet_diagnostic.RS2008.severity = none
 # warning RS0037: PublicAPI.txt is missing '#nullable enable'
 dotnet_diagnostic.RS0037.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -206,5 +206,7 @@ csharp_prefer_braces = true:silent
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
+# error RS2008: Enable analyzer release tracking for the analyzer project containing rule '{0}'
+dotnet_diagnostic.RS2008.severity = none
 # warning RS0037: PublicAPI.txt is missing '#nullable enable'
 dotnet_diagnostic.RS0037.severity = none

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -54,7 +54,12 @@
     <MicrosoftBuildLocatorVersion>1.2.2</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildRuntimeVersion>15.1.548</MicrosoftBuildRuntimeVersion>
     <MicrosoftBuildTasksCoreVersion>15.1.548</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
+    <!-- 
+      Since the Microsoft.CodeAnalysis.Analyzers package is a public dependency of our NuGet
+      packages we will keep it untied to the RoslynDiagnosticsNugetPackageVersion we use for
+      other analyzers to ensure it stays on a release version.
+    -->
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.0.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisBuildTasksVersion>2.0.0-rc2-61102-09</MicrosoftCodeAnalysisBuildTasksVersion>
     <MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
@@ -66,15 +66,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
             List<AnalysisResult> analysisResults, HashSet<IFieldSymbol> ineligibleFields,
             Compilation compilation, CancellationToken cancellationToken)
         {
-            var groups = analysisResults.Select(r => (TypeDeclarationSyntax)r.PropertyDeclaration.Parent)
+            var groups = analysisResults.Select(r => (typeDeclaration: (TypeDeclarationSyntax)r.PropertyDeclaration.Parent, r.SemanticModel))
                                         .Distinct()
-                                        .GroupBy(n => n.SyntaxTree);
+                                        .GroupBy(n => n.typeDeclaration.SyntaxTree);
 
             foreach (var (tree, typeDeclarations) in groups)
             {
-                var semanticModel = compilation.GetSemanticModel(tree);
-
-                foreach (var typeDeclaration in typeDeclarations)
+                foreach (var (typeDeclaration, semanticModel) in typeDeclarations)
                 {
                     foreach (var argument in typeDeclaration.DescendantNodesAndSelf().OfType<ArgumentSyntax>())
                     {

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -223,7 +223,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
             var updatedCompilation = semanticModel.Compilation.ReplaceSyntaxTree(
                 semanticModel.SyntaxTree, updatedSyntaxTree);
+#pragma warning disable RS1030 // Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
             return updatedCompilation.GetSemanticModel(updatedSyntaxTree);
+#pragma warning restore RS1030 // Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
         }
 
         private SyntaxNode GetContainer(BinaryExpressionSyntax isExpression)

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -230,7 +231,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
             // Looks like a viable property/field to convert into an auto property.
             analysisResults.Add(new AnalysisResult(property, getterField, propertyDeclaration,
-                fieldDeclaration, variableDeclarator, property.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+                fieldDeclaration, variableDeclarator, semanticModel, property.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
         }
 
         protected virtual bool CanConvert(IPropertySymbol property)
@@ -358,6 +359,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             public readonly TPropertyDeclaration PropertyDeclaration;
             public readonly TFieldDeclaration FieldDeclaration;
             public readonly TVariableDeclarator VariableDeclarator;
+            public readonly SemanticModel SemanticModel;
             public readonly string SymbolEquivalenceKey;
 
             public AnalysisResult(
@@ -366,6 +368,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 TPropertyDeclaration propertyDeclaration,
                 TFieldDeclaration fieldDeclaration,
                 TVariableDeclarator variableDeclarator,
+                SemanticModel semanticModel,
                 string symbolEquivalenceKey)
             {
                 Property = property;
@@ -373,6 +376,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 PropertyDeclaration = propertyDeclaration;
                 FieldDeclaration = fieldDeclaration;
                 VariableDeclarator = variableDeclarator;
+                SemanticModel = semanticModel;
                 SymbolEquivalenceKey = symbolEquivalenceKey;
             }
         }

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -74,8 +74,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             var throwOperation = (IThrowOperation)context.Operation;
             var throwStatementSyntax = throwOperation.Syntax;
 
-            var compilation = context.Compilation;
-            var semanticModel = compilation.GetSemanticModel(throwStatementSyntax.SyntaxTree);
+            var semanticModel = throwOperation.SemanticModel;
 
             var ifOperation = GetContainingIfOperation(
                 semanticModel, throwOperation, cancellationToken);

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             var throwOperation = (IThrowOperation)context.Operation;
             var throwStatementSyntax = throwOperation.Syntax;
 
-            var semanticModel = throwOperation.SemanticModel;
+            var semanticModel = context.Operation.SemanticModel;
 
             var ifOperation = GetContainingIfOperation(
                 semanticModel, throwOperation, cancellationToken);

--- a/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
@@ -172,7 +172,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             For Each ref In containingType.DeclaringSyntaxReferences
                 Dim containingNode = ref.GetSyntax(cancellationToken)?.Parent
                 If containingNode IsNot Nothing Then
+#Disable Warning RS1030 ' Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
                     Dim semanticModel = compilation.GetSemanticModel(containingNode.SyntaxTree)
+#Enable Warning RS1030 ' Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
                     If IsWrittenOutsideOfConstructorOrProperty(field, propertyDeclaration, containingNode, semanticModel, cancellationToken) Then
                         Return False
                     End If

--- a/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                            Optional<object> constantValue = new Optional<object>(1);
                                            bool isImplicit = increment.IsImplicit;
                                            var value = new LiteralOperation(increment.SemanticModel, syntax, type, constantValue, isImplicit);
+
                                            AssignTo(increment.Target, localsSourceTypes, fieldsSourceTypes, value);
                                        }
                                        else

--- a/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
@@ -65,8 +65,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                            ITypeSymbol type = increment.Type;
                                            Optional<object> constantValue = new Optional<object>(1);
                                            bool isImplicit = increment.IsImplicit;
+#pragma warning disable RS1030 // Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
                                            var value = new LiteralOperation(operationContext.Compilation.GetSemanticModel(syntax.SyntaxTree), syntax, type, constantValue, isImplicit);
-
+#pragma warning restore RS1030
                                            AssignTo(increment.Target, localsSourceTypes, fieldsSourceTypes, value);
                                        }
                                        else

--- a/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
@@ -65,9 +65,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                            ITypeSymbol type = increment.Type;
                                            Optional<object> constantValue = new Optional<object>(1);
                                            bool isImplicit = increment.IsImplicit;
-#pragma warning disable RS1030 // Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
-                                           var value = new LiteralOperation(operationContext.Compilation.GetSemanticModel(syntax.SyntaxTree), syntax, type, constantValue, isImplicit);
-#pragma warning restore RS1030
+                                           var value = new LiteralOperation(increment.SemanticModel, syntax, type, constantValue, isImplicit);
                                            AssignTo(increment.Target, localsSourceTypes, fieldsSourceTypes, value);
                                        }
                                        else


### PR DESCRIPTION
As mentioned in https://github.com/dotnet/roslyn/issues/42493#event-3190057875, The 3.5.0 NuGet packages still referenced a pre-release Analyzer package. This seems to install fine for .NET Core and .NET Standard projects but fails to install for .NET Framework. This PR updates the reference to a release version and decouples it from the RoslynAnalyzersVersion property.