### PR TITLE
Function Pointer Conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -928,7 +928,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
 
-                return targetKind == TypeKind.FunctionPointer && ConversionsBase.HasImplicitPointerConversion(source, destination);
+                return targetKind == TypeKind.FunctionPointer
+                       && (ConversionsBase.HasImplicitPointerToVoidConversion(source, destination)
+                           || conversions.HasImplicitPointerConversion(source, destination, ref useSiteDiagnostics));
             }
 
             static ErrorCode getMethodMismatchErrorCode(TypeKind type)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -244,6 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion InterpolatedString => new Conversion(ConversionKind.InterpolatedString);
         internal static Conversion Deconstruction => new Conversion(ConversionKind.Deconstruction);
         internal static Conversion PinnedObjectToPointer => new Conversion(ConversionKind.PinnedObjectToPointer);
+        internal static Conversion ImplicitPointer => new Conversion(ConversionKind.ImplicitPointer);
 
         // trivial conversions that could be underlying in nullable conversion
         // NOTE: tuple conversions can be underlying as well, but they are not trivial 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -56,5 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         PinnedObjectToPointer,
 
         DefaultLiteral, // a conversion from a `default` literal to any type
+
+        ImplicitPointer,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case Deconstruction:
                 case StackAllocToPointerType:
                 case StackAllocToSpanType:
+                case ImplicitPointer:
                     return true;
 
                 case ExplicitNumeric:
@@ -95,6 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case PointerToInteger:
                 case IntegerToPointer:
                 case NullToPointer:
+                case ImplicitPointer:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1005,7 +1005,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: The set of implicit conversions is extended to include...
             // SPEC: ... from the null literal to any pointer type.
 
-            if (destination is PointerTypeSymbol)
+            if (destination.IsPointerOrFunctionPointer())
             {
                 return Conversion.NullToPointer;
             }
@@ -2927,9 +2927,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: The set of implicit conversions is extended to include...
             // SPEC: ... from any pointer type to the type void*.
 
-            PointerTypeSymbol pd = destination as PointerTypeSymbol;
-            PointerTypeSymbol ps = source as PointerTypeSymbol;
-            return (object)pd != null && (object)ps != null && pd.PointedAtType.IsVoidType();
+            return source.IsPointerOrFunctionPointer() && destination is PointerTypeSymbol { PointedAtType: { SpecialType: SpecialType.System_Void } };
         }
 
         private bool HasIdentityOrReferenceConversion(TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -3376,7 +3374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
-            return source is PointerTypeSymbol && destination is PointerTypeSymbol;
+            return source.IsPointerOrFunctionPointer() && destination.IsPointerOrFunctionPointer();
         }
 
         private static bool HasPointerToIntegerConversion(TypeSymbol source, TypeSymbol destination)
@@ -3384,7 +3382,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
-            if (!(source is PointerTypeSymbol))
+            if (!source.IsPointerOrFunctionPointer())
             {
                 return false;
             }
@@ -3415,7 +3413,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
-            if (!(destination is PointerTypeSymbol))
+            if (!destination.IsPointerOrFunctionPointer())
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     returnsMatch = Conversions.HasIdentityOrImplicitReferenceConversion(method.ReturnType, returnType, ref useSiteDiagnostics);
                     if (!returnsMatch && isFunctionPointerConversion)
                     {
-                        returnsMatch = ConversionsBase.HasImplicitPointerConversion(method.ReturnType, returnType);
+                        returnsMatch = ConversionsBase.HasImplicitPointerToVoidConversion(method.ReturnType, returnType);
                     }
                 }
                 else

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         case Microsoft.Cci.PrimitiveTypeCode.IntPtr:
                         case Microsoft.Cci.PrimitiveTypeCode.UIntPtr:
                         case Microsoft.Cci.PrimitiveTypeCode.Pointer:
+                        case Microsoft.Cci.PrimitiveTypeCode.FunctionPointer:
                             Debug.Assert(toPredefTypeKind.IsNumeric());
                             break;
                         default:
@@ -128,7 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             Debug.Assert(
                                 toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.IntPtr ||
                                 toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.UIntPtr ||
-                                toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.Pointer);
+                                toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.Pointer ||
+                                toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.FunctionPointer);
                             break;
                     }
 #endif

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -106,6 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     throw ExceptionUtilities.UnexpectedValue(conversion.ConversionKind);
                 case ConversionKind.PointerToVoid:
                 case ConversionKind.PointerToPointer:
+                case ConversionKind.ImplicitPointer:
                     return; //no-op since they all have the same runtime representation
                 case ConversionKind.PointerToInteger:
                 case ConversionKind.IntegerToPointer:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -944,6 +944,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     case Microsoft.Cci.PrimitiveTypeCode.IntPtr:
                     case Microsoft.Cci.PrimitiveTypeCode.UIntPtr:
                     case Microsoft.Cci.PrimitiveTypeCode.Pointer:
+                        // PROTOTYPE(func-ptr): Support arrays of function pointers
                         _builder.EmitOpCode(ILOpCode.Ldelem_i);
                         break;
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolDistinguisher.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolDistinguisher.cs
@@ -66,8 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SymbolKind.PointerType:
                 case SymbolKind.Parameter:
                     break; // Can sensibly append location, after unwrapping.
-                case SymbolKind.DynamicType:
-                    break; // Can't sensibly append location, but it should never be ambiguous.
+                case SymbolKind.DynamicType: // Can't sensibly append location, but it should never be ambiguous.
+                case SymbolKind.FunctionPointer: // Can't sensible append location
+                    break;
                 case SymbolKind.Namespace:
                 case SymbolKind.Alias:
                 case SymbolKind.Assembly:
@@ -190,7 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return containingAssembly.Identity.ToString();
             }
 
-            Debug.Assert(unwrappedSymbol.Kind == SymbolKind.DynamicType || unwrappedSymbol.Kind == SymbolKind.ErrorType);
+            Debug.Assert(unwrappedSymbol.Kind == SymbolKind.DynamicType || unwrappedSymbol.Kind == SymbolKind.ErrorType || unwrappedSymbol.Kind == SymbolKind.FunctionPointer);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -504,14 +504,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Gets corresponding primitive type code for this type declaration.
         /// </summary>
         internal Microsoft.Cci.PrimitiveTypeCode PrimitiveTypeCode
-        {
-            get
+            => TypeKind switch
             {
-                return this.IsPointerType()
-                    ? Microsoft.Cci.PrimitiveTypeCode.Pointer
-                    : SpecialTypes.GetTypeCode(SpecialType);
-            }
-        }
+                TypeKind.Pointer => Microsoft.Cci.PrimitiveTypeCode.Pointer,
+                TypeKind.FunctionPointer => Microsoft.Cci.PrimitiveTypeCode.FunctionPointer,
+                _ => SpecialTypes.GetTypeCode(SpecialType)
+            };
 
         #region Use-Site Diagnostics
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -340,6 +340,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.TypeKind == TypeKind.FunctionPointer;
         }
 
+        public static bool IsPointerOrFunctionPointer(this TypeSymbol type)
+            => type.TypeKind switch
+            {
+                TypeKind.Pointer => true,
+                TypeKind.FunctionPointer => true,
+                _ => false
+            };
+
         // If the type is a delegate type, it returns it. If the type is an
         // expression tree type associated with a delegate type, it returns
         // the delegate type. Otherwise, null.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -1,0 +1,424 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class FunctionPointerTests : CompilingTestBase
+    {
+        private CSharpCompilation CreateCompilationWithFunctionPointers(string source)
+        {
+            return CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void ImplicitConversionToVoid()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe class C
+{
+    void M1(delegate*<void> p1)
+    {
+        void* v1 = p1;
+        delegate*<string> p2 = &M4;
+        M2(p2);
+        void* v2 = M3();
+    }
+
+    void M2(void* v1) {}
+    delegate*<string, int> M3() => throw null;
+    static string M4() => throw null;
+}");
+
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL("C.M1", expectedIL: @"
+{
+  // Code size       24 (0x18)
+  .maxstack  2
+  .locals init (void* V_0, //v1
+                delegate*<string> V_1, //p2
+                void* V_2) //v2
+  IL_0000:  ldarg.1
+  IL_0001:  stloc.0
+  IL_0002:  ldftn      ""string C.M4()""
+  IL_0008:  stloc.1
+  IL_0009:  ldarg.0
+  IL_000a:  ldloc.1
+  IL_000b:  call       ""void C.M2(void*)""
+  IL_0010:  ldarg.0
+  IL_0011:  call       ""delegate*<string,int> C.M3()""
+  IL_0016:  stloc.2
+  IL_0017:  ret
+}
+            ");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var initializer1 = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().First().Initializer!.Value;
+            assertResult(model, initializer1);
+            var parameter = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First().ArgumentList.Arguments.Single();
+            assertResult(model, parameter.Expression);
+            var initializer2 = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Last().Initializer!.Value;
+            assertResult(model, initializer2);
+
+            static void assertResult(SemanticModel model, ExpressionSyntax initializer1)
+            {
+                var typeInfo = model.GetTypeInfo(initializer1);
+                Assert.True(typeInfo.ConvertedType is IPointerTypeSymbol { PointedAtType: { SpecialType: SpecialType.System_Void } });
+                Assert.Equal(TypeKind.FunctionPointer, typeInfo.Type!.TypeKind);
+                var conversion = model.GetConversion(initializer1);
+                Assert.Equal(ConversionKind.PointerToVoid, conversion.Kind);
+            }
+        }
+
+        [Fact]
+        public void ImplicitNullToFunctionPointer()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe class C
+{
+    void M()
+    {
+        delegate*<void> ptr1 = null;
+        delegate* cdecl<void> ptr2 = null;
+        delegate*<string> ptr3 = null;
+        delegate*<C, int> ptr4 = null;
+    }
+}");
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL("C.M", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldc.i4.0
+  IL_0001:  conv.u
+  IL_0002:  pop
+  IL_0003:  ldc.i4.0
+  IL_0004:  conv.u
+  IL_0005:  pop
+  IL_0006:  ldc.i4.0
+  IL_0007:  conv.u
+  IL_0008:  pop
+  IL_0009:  ldc.i4.0
+  IL_000a:  conv.u
+  IL_000b:  pop
+  IL_000c:  ret
+}
+");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            foreach (var literal in tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(v => v.Initializer!.Value))
+            {
+                var conversion = model.GetConversion(literal);
+                var typeInfo = model.GetTypeInfo(literal);
+                Assert.Null(typeInfo.Type);
+                Assert.Equal(TypeKind.FunctionPointer, typeInfo.ConvertedType!.TypeKind);
+                Assert.Equal(ConversionKind.NullToPointer, conversion.Kind);
+            }
+        }
+
+        [Theory]
+        [InlineData("sbyte", "conv.i1", "conv.ovf.i1")]
+        [InlineData("byte", "conv.u1", "conv.ovf.u1")]
+        [InlineData("short", "conv.i2", "conv.ovf.i2")]
+        [InlineData("ushort", "conv.u2", "conv.ovf.u2")]
+        [InlineData("int", "conv.i4", "conv.ovf.i4")]
+        [InlineData("uint", "conv.u4", "conv.ovf.u4")]
+        [InlineData("long", "conv.u8", "conv.ovf.i8.un")]
+        [InlineData("ulong", "conv.u8", "conv.u8")]
+        public void FunctionPointerToNumericConversions(string type, string convKind, string checkedKind)
+        {
+            var comp = CreateCompilationWithFunctionPointers($@"
+unsafe class C
+{{
+    public void M(delegate*<void> p)
+    {{
+        {type} num = ({type})p;
+        {type}? numNullable = ({type}?)p;
+        num = checked(({type})p);
+    }}
+}}");
+
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL(@"C.M", expectedIL: $@"
+{{
+  // Code size       10 (0xa)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  {convKind}
+  IL_0002:  pop
+  IL_0003:  ldarg.1
+  IL_0004:  {convKind}
+  IL_0005:  pop
+  IL_0006:  ldarg.1
+  IL_0007:  {checkedKind}
+  IL_0008:  pop
+  IL_0009:  ret
+}}
+");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var conversions = tree.GetRoot().DescendantNodes().OfType<CastExpressionSyntax>().ToList();
+            Assert.Equal(3, conversions.Count);
+
+            var typeInfoOuter = model.GetTypeInfo(conversions[0]);
+            var conversion = model.ClassifyConversion(conversions[0].Expression, typeInfoOuter.Type!);
+            Assert.Equal(ConversionKind.PointerToInteger, conversion.Kind);
+
+            typeInfoOuter = model.GetTypeInfo(conversions[1]);
+            conversion = model.ClassifyConversion(conversions[1].Expression, typeInfoOuter.Type!);
+            Assert.Equal(ConversionKind.ExplicitNullable, conversion.Kind);
+            Assert.Equal(ConversionKind.PointerToInteger, conversion.UnderlyingConversions.Single().Kind);
+        }
+
+        [Theory]
+        [InlineData("IntPtr")]
+        [InlineData("UIntPtr")]
+        public void FunctionPointerToNumericConversions_IntUIntPtr(string type)
+        {
+            var comp = CreateCompilationWithFunctionPointers($@"
+using System;
+unsafe class C
+{{
+    public void M(delegate*<void> p)
+    {{
+        {type} num = ({type})p;
+        delegate*<void> ptr = (delegate*<void>)num;
+    }}
+}}");
+
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL(@"C.M", expectedIL: $@"
+{{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  call       ""System.{type} System.{type}.op_Explicit(void*)""
+  IL_0006:  call       ""void* System.{type}.op_Explicit(System.{type})""
+  IL_000b:  pop
+  IL_000c:  ret
+}}
+");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var conversions = tree.GetRoot().DescendantNodes().OfType<CastExpressionSyntax>().ToList();
+            Assert.Equal(2, conversions.Count);
+
+            var typeInfoOuter = model.GetTypeInfo(conversions[0]);
+            var conversion = model.ClassifyConversion(conversions[0].Expression, typeInfoOuter.Type!);
+            Assert.Equal(ConversionKind.ExplicitUserDefined, conversion.Kind);
+            Assert.Equal(ConversionKind.PointerToVoid, conversion.UserDefinedFromConversion.Kind);
+
+            typeInfoOuter = model.GetTypeInfo(conversions[1]);
+            conversion = model.ClassifyConversion(conversions[1].Expression, typeInfoOuter.Type!);
+            Assert.Equal(ConversionKind.ExplicitUserDefined, conversion.Kind);
+            Assert.Equal(ConversionKind.PointerToPointer, conversion.UserDefinedToConversion.Kind);
+        }
+
+        [Theory]
+        [InlineData("sbyte", "conv.i", "conv.ovf.u")]
+        [InlineData("byte", "conv.u", "conv.u")]
+        [InlineData("short", "conv.i", "conv.ovf.u")]
+        [InlineData("ushort", "conv.u", "conv.u")]
+        [InlineData("int", "conv.i", "conv.ovf.u")]
+        [InlineData("uint", "conv.u", "conv.u")]
+        [InlineData("long", "conv.u", "conv.ovf.u")]
+        [InlineData("ulong", "conv.u", "conv.ovf.u.un")]
+        public void NumericToFunctionPointerConversions(string type, string convKind, string checkedKind)
+        {
+            var comp = CreateCompilationWithFunctionPointers($@"
+unsafe class C
+{{
+    public void M({type} num, {type}? numNullable)
+    {{
+        delegate*<void> ptr = (delegate*<void>)num;
+        ptr = checked((delegate*<void>)num);
+    }}
+}}");
+
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL("C.M", $@"
+{{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  {convKind}
+  IL_0002:  pop
+  IL_0003:  ldarg.1
+  IL_0004:  {checkedKind}
+  IL_0005:  pop
+  IL_0006:  ret
+}}
+");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var conversions = tree.GetRoot().DescendantNodes().OfType<CastExpressionSyntax>().ToList();
+            Assert.Equal(2, conversions.Count);
+
+            var typeInfoOuter = model.GetTypeInfo(conversions[0]);
+            var conversion = model.ClassifyConversion(conversions[0].Expression, typeInfoOuter.Type!);
+            Assert.Equal(ConversionKind.IntegerToPointer, conversion.Kind);
+        }
+
+        [Fact]
+        public void PointerToPointerConversion()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe struct S
+{
+    void M(delegate*<void> f, S* s, int* i, void* v)
+    {
+        f = (delegate*<void>)i;
+        f = (delegate*<void>)s;
+        f = (delegate*<void>)v;
+        i = (int*)f;
+        s = (S*)f;
+    }
+}");
+
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL("S.M", @"
+{
+  // Code size       17 (0x11)
+  .maxstack  1
+  IL_0000:  ldarg.3
+  IL_0001:  starg.s    V_1
+  IL_0003:  ldarg.2
+  IL_0004:  starg.s    V_1
+  IL_0006:  ldarg.s    V_4
+  IL_0008:  starg.s    V_1
+  IL_000a:  ldarg.1
+  IL_000b:  starg.s    V_3
+  IL_000d:  ldarg.1
+  IL_000e:  starg.s    V_2
+  IL_0010:  ret
+}
+");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var conversions = tree.GetRoot().DescendantNodes().OfType<CastExpressionSyntax>().ToList();
+            Assert.Equal(5, conversions.Count);
+
+            foreach (var conv in conversions)
+            {
+                var typeInfoOuter = model.GetTypeInfo(conv);
+                var conversion = model.ClassifyConversion(conv.Expression, typeInfoOuter.Type!);
+                Assert.Equal(ConversionKind.PointerToPointer, conversion.Kind);
+            }
+        }
+
+        [Fact]
+        public void InvalidConversion()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe class A
+{
+    public static implicit operator delegate*<void>(A a) => throw null;
+}
+
+unsafe class C : A
+{
+    public static implicit operator delegate*<void>(A a) => throw null;
+    void M(int i, C c, S s)
+    {
+        delegate*<void> ptr = i; // Missing explicit cast
+        i = ptr;
+        ptr = c; // Ambiguous user-defined conversion
+        ptr = s; // Conversion does not exist
+        s = ptr;
+        ptr = undefined; // No type
+        undefined = ptr;
+        
+    }
+}
+struct S {}");
+
+            comp.VerifyDiagnostics(
+                // (9,37): error CS0556: User-defined conversion must convert to or from the enclosing type
+                //     public static implicit operator delegate*<void>(A a) => throw null;
+                Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "delegate*<void>").WithLocation(9, 37),
+                // (12,31): error CS0266: Cannot implicitly convert type 'int' to 'delegate*<void>'. An explicit conversion exists (are you missing a cast?)
+                //         delegate*<void> ptr = i; // Missing explicit cast
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "i").WithArguments("int", "delegate*<void>").WithLocation(12, 31),
+                // (13,13): error CS0266: Cannot implicitly convert type 'delegate*<void>' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         i = ptr;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "ptr").WithArguments("delegate*<void>", "int").WithLocation(13, 13),
+                // (14,15): error CS0457: Ambiguous user defined conversions 'C.implicit operator delegate*<void>(A)' and 'A.implicit operator delegate*<void>(A)' when converting from 'C' to 'delegate*<void>'
+                //         ptr = c; // Ambiguous user-defined conversion
+                Diagnostic(ErrorCode.ERR_AmbigUDConv, "c").WithArguments("C.implicit operator delegate*<void>(A)", "A.implicit operator delegate*<void>(A)", "C", "delegate*<void>").WithLocation(14, 15),
+                // (15,15): error CS0029: Cannot implicitly convert type 'S' to 'delegate*<void>'
+                //         ptr = s; // Conversion does not exist
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("S", "delegate*<void>").WithLocation(15, 15),
+                // (16,13): error CS0029: Cannot implicitly convert type 'delegate*<void>' to 'S'
+                //         s = ptr;
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "ptr").WithArguments("delegate*<void>", "S").WithLocation(16, 13),
+                // (17,15): error CS0103: The name 'undefined' does not exist in the current context
+                //         ptr = undefined; // No type
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "undefined").WithArguments("undefined").WithLocation(17, 15),
+                // (18,9): error CS0103: The name 'undefined' does not exist in the current context
+                //         undefined = ptr;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "undefined").WithArguments("undefined").WithLocation(18, 9)
+            );
+        }
+
+        [Fact]
+        public void UserDefinedConversion()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe class C
+{
+    public static implicit operator delegate*<void>(C c) => throw null;
+    public static implicit operator C(delegate*<void> ptr) => throw null;
+    public void M()
+    {
+        delegate*<void> ptr = this;
+        C c = ptr;
+    }
+}");
+
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyIL("C.M", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""delegate*<void> C.op_Implicit(C)""
+  IL_0006:  call       ""C C.op_Implicit(delegate*<void>)""
+  IL_000b:  pop
+  IL_000c:  ret
+}
+");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var decls = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => d.Initializer!.Value).ToList();
+            Assert.Equal(2, decls.Count);
+
+            foreach (var decl in decls)
+            {
+                var conversion = model.GetConversion(decl);
+                Assert.Equal(ConversionKind.ImplicitUserDefined, conversion.Kind);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilderConversions.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilderConversions.cs
@@ -206,6 +206,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                             this.EmitOpCode(ILOpCode.Conv_u8); // 0 extend
                             break;
                         case Microsoft.Cci.PrimitiveTypeCode.Pointer:
+                        case Microsoft.Cci.PrimitiveTypeCode.FunctionPointer:
                         case Microsoft.Cci.PrimitiveTypeCode.UIntPtr:
                             if (@checked)
                                 this.EmitOpCode(ILOpCode.Conv_ovf_i8_un);
@@ -235,6 +236,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                         case Microsoft.Cci.PrimitiveTypeCode.UInt16:
                         case Microsoft.Cci.PrimitiveTypeCode.UInt32:
                         case Microsoft.Cci.PrimitiveTypeCode.Pointer:
+                        case Microsoft.Cci.PrimitiveTypeCode.FunctionPointer:
                         case Microsoft.Cci.PrimitiveTypeCode.UIntPtr:
                         case Microsoft.Cci.PrimitiveTypeCode.Char:
                             this.EmitOpCode(ILOpCode.Conv_u8); // 0 extend
@@ -285,6 +287,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                     break;
 
                 case Microsoft.Cci.PrimitiveTypeCode.Pointer:
+                case Microsoft.Cci.PrimitiveTypeCode.FunctionPointer:
                     if (@checked)
                     {
                         switch (fromPredefTypeKind)


### PR DESCRIPTION
Support all conversions involving function pointers. @dotnet/roslyn-compiler @AlekseyTs for review.