### PR TITLE
🐇 Use config cache to avoid tree creation

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -164,6 +164,7 @@ namespace Microsoft.CodeAnalysis
                         analyzerOptionsBuilder.Clear();
                         treeOptionsBuilder.Clear();
                         diagnosticBuilder.Clear();
+                        sectionKey.Clear();
                     }
 
                     int dirLength = config.NormalizedDirectory.Length;


### PR DESCRIPTION
Measurement scenario: AnalyzerRunner on Roslyn.sln for C# code style analyzers.

Prior to this change:

> Found 165523 diagnostics in 100403ms (159156980384 bytes allocated)

After this change:

> Found 165523 diagnostics in 65947ms (99865561720 bytes allocated)