### PR TITLE
🐇 Use Regex.IsMatch instead of Regex.Match when no groups are needed

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -31,6 +31,11 @@ namespace Microsoft.CodeAnalysis
 
             public bool IsMatch(string s)
             {
+                if (_numberRangePairs.IsEmpty)
+                {
+                    return Regex.IsMatch(s);
+                }
+
                 var match = Regex.Match(s);
                 if (!match.Success)
                 {


### PR DESCRIPTION
Measurement scenario: AnalyzerRunner on Roslyn.sln for C# code style analyzers.

With just #43095 applied:

> Found 165523 diagnostics in 65947ms (99865561720 bytes allocated)

With both #43095 and this change:

> Found 165523 diagnostics in 63681ms (89585238160 bytes allocated)