### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,7 @@ Want to start developing in C# and Visual Basic? Download [Visual Studio 2019](h
 also [prebuilt Azure VM images](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/compute?search=visual%20studio%202019) available with 
 Visual Studio 2019 already installed.
 
-To install the latest release without Visual Studio, run one of the following [nuget](https://dist.nuget.org/index.html) command lines:
-
-```
-nuget install Microsoft.Net.Compilers   # Install C# and VB compilers
-nuget install Microsoft.CodeAnalysis    # Install Language APIs and Services
-```
-
-Daily NuGet builds of the project are also available in our MyGet feed:
-
-> [https://dotnet.myget.org/F/roslyn/api/v3/index.json](https://dotnet.myget.org/F/roslyn/api/v3/index.json)
+To install the latest release without Visual Studio, download the [].NET SDK nightlies](https://github.com/dotnet/installer/blob/master/README.md#installers-and-binaries).
 
 See [what's new with the C# and VB compilers](https://github.com/dotnet/roslyn/wiki/Changelog-for-C%23-and-VB-compilers).
 
@@ -94,9 +85,9 @@ Some of the best ways to contribute are to try things out, file bugs, and join i
 
 Looking for something to work on? The list of [up for grabs issues](https://github.com/dotnet/roslyn/labels/help%20wanted) is a great place to start.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).  For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This [project](CODE-OF-CONDUCT.md) has adopted the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
 ### .NET Foundation
 
 This project is part of the [.NET Foundation](http://www.dotnetfoundation.org/projects) along with other
-projects like [the class libraries for .NET Core](https://github.com/dotnet/corefx/).
+projects like [the .NET Runtime](https://github.com/dotnet/runtime/).

--- a/docs/compilers/Compiler Toolset NuPkgs.md
+++ b/docs/compilers/Compiler Toolset NuPkgs.md
@@ -1,0 +1,44 @@
+Compiler Toolset NuPkgs
+===
+## Summary
+The compiler produces the [Microsoft.Net.Compilers.Toolset NuPkg](https://www.nuget.org/packages/Microsoft.Net.Compilers.Toolset)
+from all of Roslyn's main branches. When this NuPkg is installed it will
+override the compiler that comes with MSBuild with the version from the branch
+it was built in.
+
+This package is meant to support the following scenarios:
+1. Allows compiler team to provide rapid hot fixes to customers who hit a blocking
+issue. This package can be installed until the fix is available in .NET SDK or 
+Visual Studio servicing.
+1. Serves as a transport mechanism for the Roslyn binaries in the greater .NET
+SDK build process.
+1. Allows customers to conduct experiments on various Roslyn builds, many of
+which aren't in an official shipping product yet.
+
+This package is **not** meant to support using newer compiler versions in an
+older version of MSBuild. For example using Microsoft.Net.Compilers.Toolset
+3.5 (C# 8) inside MSBuild 15 is explicitly not a supported scenario.
+
+Customers who want to use the compiler as a part of their supported build 
+infrastructure should use the [Visual Studio Build Tools SKU](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019])
+) or [.NET SDK](https://dotnet.microsoft.com/download/visual-studio-sdks)
+
+## NuPkg Installation
+
+To install the NuPgk run the following:
+
+```cmd
+> nuget install Microsoft.Net.Compilers.Toolset   # Install C# and VB compilers
+```
+
+Daily NuGet builds of the project are also available in our MyGet feed:
+
+> [https://dotnet.myget.org/F/roslyn/api/v3/index.json](https://dotnet.myget.org/F/roslyn/api/v3/index.json)
+
+## Microsoft.Net.Compilers
+
+The [Microsoft.Net.Compilers](https://www.nuget.org/packages/Microsoft.Net.Compilers)
+NuPkg is deprecated. It is a .NET Desktop specific version of
+Microsoft.Net.Compilers.Toolset and will not be produced anymore after the 
+3.6.0 release. The Microsoft.Net.Compilers.Toolset package is a drop in
+replacement for it for all supported scenarios.


### PR DESCRIPTION
Makes the following updates:

1. Corrects our Code of Conduct references to the correct version
1. Moves the toolset NuPkg instructions to a separate MD file and gives
   a better explanation of the current rules and usage expectation
1. Cleans up a link to CoreFX