### PR TITLE
Remove IEnumerator<T> from ArrayBuilder.Enumerator

### DIFF
--- a/src/Compilers/Core/Portable/Collections/OrderedSet.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderedSet.cs
@@ -69,14 +69,19 @@ namespace Microsoft.CodeAnalysis.Collections
             return _set.Contains(item);
         }
 
-        public IEnumerator<T> GetEnumerator()
+        public ArrayBuilder<T>.Enumerator GetEnumerator()
         {
             return _list.GetEnumerator();
         }
 
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return ((IEnumerable<T>)_list).GetEnumerator();
+        }
+
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return _list.GetEnumerator();
+            return ((IEnumerable)_list).GetEnumerator();
         }
 
         public void Clear()

--- a/src/Compilers/Core/Portable/InternalUtilities/SetWithInsertionOrder.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SetWithInsertionOrder.cs
@@ -92,7 +92,7 @@ namespace Roslyn.Utilities
         public bool Contains(T value) => _set?.Contains(value) ?? false;
 
         public IEnumerator<T> GetEnumerator()
-            => _elements?.GetEnumerator() ?? SpecializedCollections.EmptyEnumerator<T>();
+            => _elements is null ? SpecializedCollections.EmptyEnumerator<T>() : ((IEnumerable<T>)_elements).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Dependencies/PooledObjects/ArrayBuilder.Enumerator.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.Enumerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     internal partial class ArrayBuilder<T>
@@ -11,7 +9,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <summary>
         /// struct enumerator used in foreach.
         /// </summary>
-        internal struct Enumerator : IEnumerator<T>
+        internal struct Enumerator
         {
             private readonly ArrayBuilder<T> _builder;
             private int _index;
@@ -34,23 +32,6 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             {
                 _index++;
                 return _index < _builder.Count;
-            }
-
-            public void Dispose()
-            {
-            }
-
-            object System.Collections.IEnumerator.Current
-            {
-                get
-                {
-                    return this.Current;
-                }
-            }
-
-            public void Reset()
-            {
-                _index = -1;
             }
         }
     }

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -390,12 +390,12 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
-            return GetEnumerator();
+            return _builder.GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            return _builder.GetEnumerator();
         }
 
         internal Dictionary<K, ImmutableArray<T>> ToDictionary<K>(Func<T, K> keySelector, IEqualityComparer<K> comparer = null)


### PR DESCRIPTION
Avoids the `try / finally` and the call to `IDisposable.Dispose()` when using `foreach`.