### PR TITLE
Do not simplify away field as clause - it breaks compilation

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/TypeInferenceSimplifierTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeInferenceSimplifierTests.vb
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
                     Imports System
                     Imports I = System.Int32
                     Module Program
-                        Public Dim x = 5
+                        Public Dim x As Integer = 5
                         Function Goo() As Integer
                         End Function
                         Sub Main(args As String())

--- a/src/EditorFeatures/Test2/Simplification/TypeInferenceSimplifierTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeInferenceSimplifierTests.vb
@@ -557,7 +557,7 @@ End Namespace
               <text>
 Namespace X
     Module Program
-        Public Dim t = A.getInt()
+        Public Dim t as Integer = A.getInt()
         Sub Main(args As String())
         End Sub
     End Module
@@ -606,7 +606,7 @@ End Namespace
 Namespace Y
     Namespace X
         Module Program
-            Public Dim t = A.getInt()
+            Public Dim t as Integer = A.getInt()
             Sub Main(args As String())
             End Function
         End Module

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicVariableDeclaratorReducer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicVariableDeclaratorReducer.vb
@@ -57,8 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                     SyntaxKind.LocalDeclarationStatement,
                     SyntaxKind.UsingStatement,
                     SyntaxKind.ForStatement,
-                    SyntaxKind.ForEachStatement,
-                    SyntaxKind.FieldDeclaration) Then
+                    SyntaxKind.ForEachStatement) Then
                 Return False
             End If
 
@@ -74,7 +73,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 Return False
             End If
 
-            If (parent.IsKind(SyntaxKind.LocalDeclarationStatement, SyntaxKind.UsingStatement, SyntaxKind.FieldDeclaration) AndAlso
+            If (parent.IsKind(SyntaxKind.LocalDeclarationStatement, SyntaxKind.UsingStatement) AndAlso
                 variableDeclarator.Initializer IsNot Nothing) Then
 
                 ' Type Check
@@ -150,12 +149,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             Dim localSymbol = TryCast(declaredSymbol, ILocalSymbol)
             If localSymbol IsNot Nothing AndAlso TypeOf localSymbol IsNot IErrorTypeSymbol AndAlso TypeOf localSymbol.Type IsNot IErrorTypeSymbol Then
                 typeSymbol = localSymbol.Type
-                Return True
-            End If
-
-            Dim fieldSymbol = TryCast(declaredSymbol, IFieldSymbol)
-            If fieldSymbol IsNot Nothing AndAlso TypeOf fieldSymbol IsNot IErrorTypeSymbol AndAlso TypeOf fieldSymbol.Type IsNot IErrorTypeSymbol Then
-                typeSymbol = fieldSymbol.Type
                 Return True
             End If
 


### PR DESCRIPTION
Fixes #43123

If there's a case when the As clause actually should be removed (e.g. if you want to do so when option strict is off), let me know and I'll update.

I fixed the obvious explicit test of this. I expect there will be some other tests that need fixing up. My system struggles to run the tests locally so I'll deal with them as they appear from CI.