### PR TITLE
Fix assert in AnalyzerDriver.GetOperationsToAnalyze

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -3424,5 +3424,54 @@ internal class A
             var diagnostics = await compWithAnalyzers.GetAnalyzerSemanticDiagnosticsAsync(model, filterSpan: null, CancellationToken.None);
             diagnostics.Verify(Diagnostic("ID0001", "M").WithLocation(4, 17));
         }
+
+        [Fact, WorkItem(26217, "https://github.com/dotnet/roslyn/issues/26217")]
+        public void TestConstructorInitializerWithExpressionBody()
+        {
+            string source = @"
+class C
+{
+    C() : base() => _ = 0;
+}";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new RegisterOperationBlockAndOperationActionAnalyzer() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers,
+                expected: Diagnostic("ID0001", "C").WithLocation(4, 5));
+        }
+
+        [Fact, WorkItem(43106, "https://github.com/dotnet/roslyn/issues/43106")]
+        public void TestConstructorInitializerWithoutBody()
+        {
+            string source = @"
+class B
+{
+    // Haven't typed { } on the next line yet
+    public B() : this(1) 
+
+    public B(int a) { } 
+}";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics(
+                // (5,12): error CS0501: 'B.B()' must declare a body because it is not marked abstract, extern, or partial
+                //     public B() : this(1) 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "B").WithArguments("B.B()").WithLocation(5, 12),
+                // (5,25): error CS1002: ; expected
+                //     public B() : this(1) 
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(5, 25));
+
+            var analyzers = new DiagnosticAnalyzer[] { new RegisterOperationBlockAndOperationActionAnalyzer() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers,
+                expected: new[]
+                {
+                    Diagnostic("ID0001", "B").WithLocation(5, 12),
+                    Diagnostic("ID0001", "B").WithLocation(7, 12)
+                });
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2619,6 +2619,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 operationsToAnalyze.Add(operationBlock.Parent);
                                 break;
 
+                            case OperationKind.ExpressionStatement:
+                                // For constructor initializer, we generate an IInvocationOperation with an implicit IExpressionStatementOperation parent.
+                                Debug.Assert(operationBlock.Kind == OperationKind.Invocation && operationBlock.Parent.IsImplicit);
+                                break;
+
                             default:
                                 Debug.Fail($"Expected operation with kind '{operationBlock.Kind}' to be the root operation with null 'Parent', but instead it has a non-null Parent with kind '{operationBlock.Parent.Kind}'");
                                 break;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2621,7 +2621,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                             case OperationKind.ExpressionStatement:
                                 // For constructor initializer, we generate an IInvocationOperation with an implicit IExpressionStatementOperation parent.
-                                Debug.Assert(operationBlock.Kind == OperationKind.Invocation && operationBlock.Parent.IsImplicit);
+                                Debug.Assert(operationBlock.Kind == OperationKind.Invocation);
+                                Debug.Assert(operationBlock.Parent.IsImplicit);
+                                Debug.Assert(operationBlock.Parent.Parent is IConstructorBodyOperation ctorBody &&
+                                    ctorBody.Initializer == operationBlock.Parent);
                                 break;
 
                             default:


### PR DESCRIPTION
Adjust the assert to handle the constructor initializer case.
Fixes #26217
Fixes #43106