### PR TITLE
Handle null IGoToDefinitionService in peek

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
@@ -97,11 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                     symbol = symbol.GetOriginalUnreducedDefinition();
 
                     // Get the symbol back from the originating workspace
-                    var symbolMappingService = document.Project.Solution.Workspace.Services.GetService<ISymbolMappingService>();
-                    if (symbolMappingService == null)
-                    {
-                        return;
-                    }
+                    var symbolMappingService = document.Project.Solution.Workspace.Services.GetRequiredService<ISymbolMappingService>();
 
                     var mappingResult = symbolMappingService.MapSymbolAsync(document, symbol, cancellationToken)
                                                             .WaitAndGetResult(cancellationToken);
@@ -124,11 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
             if (navigableItems != null)
             {
                 var workspace = project.Solution.Workspace;
-                var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
-                if (navigationService == null)
-                {
-                    yield break;
-                }
+                var navigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
 
                 foreach (var item in navigableItems)
                 {

--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
@@ -67,6 +67,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                     // For documents without semantic models, just try to use the goto-def service
                     // as a reasonable place to peek at.
                     var goToDefinitionService = document.GetLanguageService<IGoToDefinitionService>();
+                    if (goToDefinitionService == null)
+                    {
+                        return;
+                    }
+                    
                     var navigableItems = goToDefinitionService.FindDefinitionsAsync(document, triggerPoint.Value.Position, cancellationToken)
                                                               .WaitAndGetResult(cancellationToken);
 


### PR DESCRIPTION
Currently, the `PeekableItemSource` assumes that if a language exports an `IGoToDefinitionService`, then it's non-null - however, this is incorrect, and can cause a null reference exception dialog in VS.

Here, we gracefully handle the potential null.