### PR TITLE
Active statements in switch expression

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -6179,8 +6179,8 @@ class C
 
             edits.VerifyRudeDiagnostics(active,
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "switch { 0 => 10, _ => 20 }"),
-                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", "method"),
-                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", "method"));
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method),
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -341,7 +341,7 @@ class C : IDisposable
 
         for (int i = 0; i < 10; <AS:10>i++</AS:10>) { }
 
-        <AS:11>foreach</AS:11> (var i in new[] { 1, 2 }) { }
+        foreach (var i <AS:11>in</AS:11> new[] { 1, 2 }) { }
 
         using (<AS:12>var z = new C()</AS:12>) { }
 
@@ -370,7 +370,7 @@ class C : IDisposable
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "while (true)"),
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "do"),
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "for (int i = 0; i < 10;        i++        )"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "foreach         (var i in new[] { 1, 2 })"),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "foreach (var i        in         new[] { 1, 2 })"),
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "using (       var z = new C()        )"),
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "fixed (       char* p = \"s\"        )"),
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "label"));
@@ -4119,6 +4119,60 @@ class C
             edits.VerifyRudeDiagnostics(active);
         }
 
+        [Fact]
+        public void ForEach_DeleteBody()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    {
+        foreach (var s in new[] { 1 }) <AS:0>G();</AS:0>
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static void F()
+    {
+        foreach (var s in new[] { 1 }) <AS:0>;</AS:0>
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void ForEachVariable_DeleteBody()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    {
+        foreach ((var a1, var a2) in new[] { (1,1) }) <AS:0>G();</AS:0>
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static void F()
+    {
+        foreach ((var a1, var a2) in new[] { (1,1) }) <AS:0>;</AS:0>
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
         #endregion
 
         #region For Statement
@@ -5386,6 +5440,33 @@ class C
         }
 
         [Fact]
+        public void DoWhileBody_Delete()
+        {
+            string src1 = @"
+class C
+{
+    static void F()
+    {
+        do <AS:0>G();</AS:0> while (true);
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    static void F()
+    {
+        do <AS:0>;</AS:0> while (true);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
         public void SwitchCase_Update1()
         {
             var src1 = @"
@@ -5461,7 +5542,7 @@ class C
 
         #endregion
 
-        #region Switch When Clauses, Patterns
+        #region Switch Statement When Clauses, Patterns
 
         [Fact]
         public void SwitchWhenClause_PatternUpdate1()
@@ -5977,6 +6058,238 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active);
+        }
+
+        #endregion
+
+        #region Switch Expression
+
+        [Fact]
+        public void SwitchExpression()
+        {
+            var src = @"
+class C
+{
+	public static int Main()
+	{
+		return F() <AS:4>switch
+        {
+            int a <AS:0>when F1()</AS:0> => <AS:1>F2()</AS:1>,
+            bool b => <AS:2>F3()</AS:2>,
+            _ => <AS:3>F4()</AS:3>
+        }</AS:4>;
+    }
+}";
+
+            var edits = GetTopEdits(src, src);
+            var active = GetActiveStatements(src, src);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_MemberExpressionBody()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main() => <AS:0>F() switch { 0 => 1, _ => 2}</AS:0>;
+}";
+            var src2 = @"
+class C
+{
+	public static int Main() => <AS:0>G() switch { 0 => 10, _ => 20}</AS:0>;
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_LambdaBody()
+        {
+            var src1 = @"
+class C
+{
+	public static Func<int> M() => () => <AS:0>F() switch { 0 => 1, _ => 2}</AS:0>;
+}";
+            var src2 = @"
+class C
+{
+	public static Func<int> M() => () => <AS:0>G() switch { 0 => 10, _ => 20}</AS:0>;
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_QueryLambdaBody()
+        {
+            var src1 = @"
+class C
+{
+	public static IEnumerable<int> M()
+    {
+        return 
+           from a in new[] { 1 }
+           where <AS:0>F() <AS:1>switch { 0 => true, _ => false}</AS:0,1>
+           select a;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static IEnumerable<int> M()
+    {
+        return 
+           from a in new[] { 1 }
+           where <AS:0>F() <AS:1>switch { 0 => true, _ => false}</AS:0,1>
+           select a;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_NestedInGoverningExpression()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main() => <AS:3>(F() <AS:1>switch { 0 => 1, _ => 2 }</AS:1>) <AS:2>switch { 1 => <AS:0>10</AS:0>, _ => 20 }</AS:2,3>;
+}";
+            var src2 = @"
+class C
+{
+	public static int Main() => <AS:3>(G() <AS:1>switch { 0 => 10, _ => 20 }</AS:1>) <AS:2>switch { 10 => <AS:0>100</AS:0>, _ => 200 }</AS:2,3>;
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "switch { 0 => 10, _ => 20 }"),
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", "method"),
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", "method"));
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_NestedInArm()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main() => F1() switch
+    {
+        1 when F2() <AS:0>switch { 0 => true, _ => false }</AS:0> => F3() <AS:1>switch { 0 => 1, _ => 2 }</AS:1>, 
+        _ => 20
+    };
+}";
+            var src2 = @"
+class C
+{
+	public static int Main() => F1() switch
+    {
+        1 when F2() <AS:0>switch { 0 => true, _ => false }</AS:0> => F3() <AS:1>switch { 0 => 1, _ => 2 }</AS:1>,
+        _ => 20
+    };
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_Delete1()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+    {
+        return Method() switch { true => G(), _ => F2() switch { 1 => <AS:0>0</AS:0>, _ => 2 } };
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+    {
+        return Method() switch { true => G(), _ => <AS:0>1</AS:0> };
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_Delete2()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+    {
+        return F1() switch { 1 => 0, _ => F2() switch { 1 => <AS:0>0</AS:0>, _ => 2 } };
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+    {
+        return F1() switch { 1 => <AS:0>0</AS:0>, _ => 1 };
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
+        }
+
+        [Fact]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
+        public void SwitchExpression_Delete3()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+    {
+        return F1() switch { 1 when F2() switch { 1 => <AS:0>true</AS:0>, _ => false } => 0, _ => 2 };
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+    {
+        return F1() switch { 1 <AS:0>when F3()</AS:0> => 0, _ => 1 };
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
         }
 
         #endregion
@@ -10297,6 +10610,37 @@ class C
 
             edits.VerifyRudeDiagnostics(active,
                 Diagnostic(RudeEditKind.DeleteActiveStatement, "{"));
+        }
+
+        [Fact]
+        public void Block_Delete()
+        {
+            string src1 = @"
+class C
+{
+    public static void F()
+    {
+        G(1);
+        <AS:0>{</AS:0> G(2); }
+        G(3);
+    }
+}
+";
+            string src2 = @"
+class C
+{
+    public static void F()
+    {
+        G(1);
+        <AS:0>G(3);</AS:0>
+    }
+}
+";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -9419,7 +9419,8 @@ if (o3 is (string k, int l2, int m)) return;
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [r = (x, y, z) switch { (0, var b, int c) when c > 1 => 2, _ => 4 }]@6 -> [r = ((x, y, z)) switch { (_, int b1, double c1) when c1 > 2 => c1, _ => 4 }]@6",
+                "Update [(x, y, z) switch { (0, var b, int c) when c > 1 => 2, _ => 4 }]@10 -> [((x, y, z)) switch { (_, int b1, double c1) when c1 > 2 => c1, _ => 4 }]@10",
+                "Update [(0, var b, int c) when c > 1 => 2]@29 -> [(_, int b1, double c1) when c1 > 2 => c1]@31",
                 "Reorder [c]@44 -> @39",
                 "Update [c]@44 -> [b1]@39",
                 "Update [b]@37 -> [c1]@50",
@@ -9436,7 +9437,9 @@ if (o3 is (string k, int l2, int m)) return;
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [r = (x, y, z) switch { (var a, 3, 4) => a, (1, 1, Point { X: 0 } p) => 3, _ => 4 }]@6 -> [r = ((x, y, z)) switch { (var a1, 3, 4) => a1 * 2, (1, 1, Point { Y: 0 } p1) => 3, _ => 4 }]@6",
+                "Update [(x, y, z) switch { (var a, 3, 4) => a, (1, 1, Point { X: 0 } p) => 3, _ => 4 }]@10 -> [((x, y, z)) switch { (var a1, 3, 4) => a1 * 2, (1, 1, Point { Y: 0 } p1) => 3, _ => 4 }]@10",
+                "Update [(var a, 3, 4) => a]@29 -> [(var a1, 3, 4) => a1 * 2]@31",
+                "Update [(1, 1, Point { X: 0 } p) => 3]@49 -> [(1, 1, Point { Y: 0 } p1) => 3]@57",
                 "Update [a]@34 -> [a1]@36",
                 "Update [p]@71 -> [p1]@79");
         }
@@ -9465,21 +9468,22 @@ _ => 4
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                @"Update [r = (x, y, z) switch {
+                @"Update [(x, y, z) switch {
 (1, 2, 3) => 0,
 (var a, 3, 4) => a,
 (0, var b, int c) when c > 1 => 2,
 (1, 1, Point { X: 0 } p) => 3,
 _ => 4
-}]@6 -> [r = ((x, y, z)) switch {
+}]@10 -> [((x, y, z)) switch {
 (1, 1, Point { X: 0 } p) => 3,
 (0, var b, int c) when c > 1 => 2,
 (var a, 3, 4) => a,
 (1, 2, 3) => 0,
 _ => 4
-}]@6",
-                "Reorder [a]@52 -> @105",
-                "Reorder [p]@126 -> @54");
+}]@10",
+                "Reorder [(var a, 3, 4) => a]@47 -> @100",
+                "Reorder [(0, var b, int c) when c > 1 => 2]@68 -> @64",
+                "Reorder [(1, 1, Point { X: 0 } p) => 3]@104 -> @32");
         }
 
         [Fact]
@@ -9538,26 +9542,9 @@ if (o is string { Length: 7 } s7) return 5;
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                @"Update [r = obj switch
-{
-    string s when s.Length > 0 => (s, obj1) switch
-    {
-        (""a"", int i) => i,
-        _ => 0
-    },
-    int i => i * i,
-    _ => -1
-}]@6 -> [r = obj switch
-{
-    int i => i * i,
-    string s when s.Length > 0 => (s, obj1) switch
-    {
-        (""a"", int i) => i,
-        _ => 0
-    },
-    _ => -1
-}]@6",
-                "Reorder [i]@102 -> @33");
+                "Reorder [int i => i * i]@140 -> @29",
+                "Move [i]@102 -> @33",
+                "Move [i]@144 -> @123");
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -1042,24 +1042,24 @@ a += localF;
         [Fact]
         public void LocalFunctions4()
         {
-            var src1 = @"int a() { int b() { int c() { int d() { return 0; }; }; return c(); }; return b(); }";
-            var src2 = @"int a() { int b() { int c() { int d() { return 0; }; }; return c(); }; return b(); }";
+            var src1 = @"int a() { int b() { int c() { int d() { return 0; } } return c(); } return b(); }";
+            var src2 = @"int a() { int b() { int c() { int d() { return 0; } } return c(); } return b(); }";
 
             var matches = GetMethodMatches(src1, src2);
             var actual = ToMatchingPairs(matches);
 
             var expected = new MatchingPairs
             {
-                { "int a() { int b() { int c() { int d() { return 0; }; }; return c(); }; return b(); }",
-                    "int a() { int b() { int c() { int d() { return 0; }; }; return c(); }; return b(); }" },
-                { "{ int b() { int c() { int d() { return 0; }; }; return c(); }; return b(); }",
-                    "{ int b() { int c() { int d() { return 0; }; }; return c(); }; return b(); }" },
-                { "int b() { int c() { int d() { return 0; }; }; return c(); }",
-                    "int b() { int c() { int d() { return 0; }; }; return c(); }" },
-                { "{ int c() { int d() { return 0; }; }; return c(); }",
-                    "{ int c() { int d() { return 0; }; }; return c(); }" },
-                { "int c() { int d() { return 0; }; }", "int c() { int d() { return 0; }; }" },
-                { "{ int d() { return 0; }; }", "{ int d() { return 0; }; }" },
+                { "int a() { int b() { int c() { int d() { return 0; } } return c(); } return b(); }",
+                    "int a() { int b() { int c() { int d() { return 0; } } return c(); } return b(); }" },
+                { "{ int b() { int c() { int d() { return 0; } } return c(); } return b(); }",
+                    "{ int b() { int c() { int d() { return 0; } } return c(); } return b(); }" },
+                { "int b() { int c() { int d() { return 0; } } return c(); }",
+                    "int b() { int c() { int d() { return 0; } } return c(); }" },
+                { "{ int c() { int d() { return 0; } } return c(); }",
+                    "{ int c() { int d() { return 0; } } return c(); }" },
+                { "int c() { int d() { return 0; } }", "int c() { int d() { return 0; } }" },
+                { "{ int d() { return 0; } }", "{ int d() { return 0; } }" },
                 { "int d() { return 0; }", "int d() { return 0; }" },
                 { "{ return 0; }", "{ return 0; }" },
                 { "return 0;", "return 0;" },
@@ -1091,7 +1091,7 @@ void G6(int a)
         F(G1);
     };
     F(G4);
-};
+}
 ";
 
             var src2 = @"
@@ -1106,9 +1106,9 @@ void G6(int a)
             int G2(int c) => /*2*/d + 1; return G2(w);
         }
         F(G3); F(G1); int G6(int p) => p *2; F(G6);
-    };
+    }
     F(G4);
-};
+}
 ";
 
             var matches = GetMethodMatches(src1, src2);
@@ -1117,9 +1117,9 @@ void G6(int a)
             var expected = new MatchingPairs
             {
                 { "void G6(int a) {      int G5(int c) => /*1*/d;     F(G5);      void G4()     {         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     };     F(G4); }",
-                    "void G6(int a) {      int G5(int c) => /*1*/d + 1;F(G5);      void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     };     F(G4); }" },
+                    "void G6(int a) {      int G5(int c) => /*1*/d + 1;F(G5);      void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     }     F(G4); }" },
                 { "{      int G5(int c) => /*1*/d;     F(G5);      void G4()     {         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     };     F(G4); }",
-                    "{      int G5(int c) => /*1*/d + 1;F(G5);      void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     };     F(G4); }" },
+                    "{      int G5(int c) => /*1*/d + 1;F(G5);      void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     }     F(G4); }" },
                 { "int G5(int c) => /*1*/d;", "int G5(int c) => /*1*/d + 1;" },
                 { "F(G5);", "F(G5);" },
                 { "void G4()     {         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     }",
@@ -1775,11 +1775,17 @@ _ => 4
                 { "var r = (x, y, z) switch { (1, 2, 3) => 0, (var a, 3, 4) => a, (0, var b, int c) when c > 1 => 2, (1, 1, Point { X: 0 } p) => 3, _ => 4 };", "var r = ((x, y, z)) switch { (1, 2, 3) => 0, (var a1, 3, 4) => a1 * 2, (_, int b1, double c1) when c1 > 2 => c1, (1, 1, Point { Y: 0 } p1) => 3, _ => 4 };" },
                 { "var r = (x, y, z) switch { (1, 2, 3) => 0, (var a, 3, 4) => a, (0, var b, int c) when c > 1 => 2, (1, 1, Point { X: 0 } p) => 3, _ => 4 }", "var r = ((x, y, z)) switch { (1, 2, 3) => 0, (var a1, 3, 4) => a1 * 2, (_, int b1, double c1) when c1 > 2 => c1, (1, 1, Point { Y: 0 } p1) => 3, _ => 4 }" },
                 { "r = (x, y, z) switch { (1, 2, 3) => 0, (var a, 3, 4) => a, (0, var b, int c) when c > 1 => 2, (1, 1, Point { X: 0 } p) => 3, _ => 4 }", "r = ((x, y, z)) switch { (1, 2, 3) => 0, (var a1, 3, 4) => a1 * 2, (_, int b1, double c1) when c1 > 2 => c1, (1, 1, Point { Y: 0 } p1) => 3, _ => 4 }" },
+                { "(x, y, z) switch { (1, 2, 3) => 0, (var a, 3, 4) => a, (0, var b, int c) when c > 1 => 2, (1, 1, Point { X: 0 } p) => 3, _ => 4 }", "((x, y, z)) switch { (1, 2, 3) => 0, (var a1, 3, 4) => a1 * 2, (_, int b1, double c1) when c1 > 2 => c1, (1, 1, Point { Y: 0 } p1) => 3, _ => 4 }" },
+                { "(1, 2, 3) => 0", "(1, 2, 3) => 0" },
+                { "(var a, 3, 4) => a", "(var a1, 3, 4) => a1 * 2" },
                 { "a", "a1" },
+                { "(0, var b, int c) when c > 1 => 2", "(_, int b1, double c1) when c1 > 2 => c1" },
                 { "b", "c1" },
                 { "c", "b1" },
                 { "when c > 1", "when c1 > 2" },
-                { "p", "p1" }
+                { "(1, 1, Point { X: 0 } p) => 3", "(1, 1, Point { Y: 0 } p1) => 3" },
+                { "p", "p1" },
+                { "_ => 4", "_ => 4" }
             };
 
             expected.AssertEqual(actual);
@@ -1848,16 +1854,25 @@ if (o is string { Length: 7 } s7) return 5;
             var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
             var actual = ToMatchingPairs(match);
 
-            var expected = new MatchingPairs {
+            var expected = new MatchingPairs
+            {
                 { "var r = obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"a\", int i) => i,         (\"\", Task<int> t) => await t,         _ => 0     },     int i => i * i,     _ => -1 };", "var r = obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"b\", decimal i1) => i1,         (\"\", Task<object> obj2) => await obj2,         _ => 0     },     double i => i * i,     _ => -1 };" },
                 { "var r = obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"a\", int i) => i,         (\"\", Task<int> t) => await t,         _ => 0     },     int i => i * i,     _ => -1 }", "var r = obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"b\", decimal i1) => i1,         (\"\", Task<object> obj2) => await obj2,         _ => 0     },     double i => i * i,     _ => -1 }" },
                 { "r = obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"a\", int i) => i,         (\"\", Task<int> t) => await t,         _ => 0     },     int i => i * i,     _ => -1 }", "r = obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"b\", decimal i1) => i1,         (\"\", Task<object> obj2) => await obj2,         _ => 0     },     double i => i * i,     _ => -1 }" },
+                { "obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"a\", int i) => i,         (\"\", Task<int> t) => await t,         _ => 0     },     int i => i * i,     _ => -1 }", "obj switch {     string s when s.Length > 0 => (s, obj1) switch     {         (\"b\", decimal i1) => i1,         (\"\", Task<object> obj2) => await obj2,         _ => 0     },     double i => i * i,     _ => -1 }" },
+                { "string s when s.Length > 0 => (s, obj1) switch     {         (\"a\", int i) => i,         (\"\", Task<int> t) => await t,         _ => 0     }", "string s when s.Length > 0 => (s, obj1) switch     {         (\"b\", decimal i1) => i1,         (\"\", Task<object> obj2) => await obj2,         _ => 0     }" },
                 { "s", "s" },
                 { "when s.Length > 0", "when s.Length > 0" },
+                { "(s, obj1) switch     {         (\"a\", int i) => i,         (\"\", Task<int> t) => await t,         _ => 0     }", "(s, obj1) switch     {         (\"b\", decimal i1) => i1,         (\"\", Task<object> obj2) => await obj2,         _ => 0     }" },
+                { "(\"a\", int i) => i", "(\"b\", decimal i1) => i1" },
                 { "i", "i" },
+                { "(\"\", Task<int> t) => await t", "(\"\", Task<object> obj2) => await obj2" },
                 { "t", "obj2" },
                 { "await t", "await obj2" },
-                { "i", "i1" }
+                { "_ => 0", "_ => 0" },
+                { "int i => i * i", "double i => i * i" },
+                { "i", "i1" },
+                { "_ => -1", "_ => -1" }
             };
 
             expected.AssertEqual(actual);
@@ -1966,6 +1981,50 @@ switch(shape)
                 { "c", "c2" },
                 { "when (c > 100)", "when (c2 > 100)" },
                 { "return 2;", "return 2;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        #endregion
+
+        #region Switch Expression
+
+        [Fact]
+        public void SwitchExpressionArms_NestedSimilar()
+        {
+            // The inner switch is mapped to the outer one, which is assumed to be removed.
+            var src1 = @"F1() switch { 1 => 0, _ => F2() switch { 1 => 0, _ => 2 } };";
+            var src2 = @"F1() switch { 1 => 0, _ => 1 };";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs {
+                { "F1() switch { 1 => 0, _ => F2() switch { 1 => 0, _ => 2 } };", "F1() switch { 1 => 0, _ => 1 };" },
+                { "F2() switch { 1 => 0, _ => 2 }", "F1() switch { 1 => 0, _ => 1 }" },
+                { "1 => 0", "1 => 0" },
+                { "_ => 2", "_ => 1" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void SwitchExpressionArms_NestedDissimilar()
+        {
+            // The inner switch is mapped to the outer one, which is assumed to be removed.
+            var src1 = @"Method() switch { true => G(), _ => F2() switch { 1 => 0, _ => 2 } };";
+            var src2 = @"Method() switch { true => G(), _ => 1 };";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs {
+                { "Method() switch { true => G(), _ => F2() switch { 1 => 0, _ => 2 } };", "Method() switch { true => G(), _ => 1 };" },
+                { "Method() switch { true => G(), _ => F2() switch { 1 => 0, _ => 2 } }", "Method() switch { true => G(), _ => 1 }" },
+                { "true => G()", "true => G()" },
+                { "_ => F2() switch { 1 => 0, _ => 2 }", "_ => 1" }
             };
 
             expected.AssertEqual(actual);

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -3564,8 +3564,9 @@ class C
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.method));
         }
 
-        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
         [Fact]
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
         public void MethodUpdate_UpdateSwitchExpression()
         {
             var src1 = @"
@@ -5936,8 +5937,9 @@ public class C
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
         }
 
-        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
         [Fact]
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
         public void FieldInitializerUpdate_SwitchExpressionInConstructor()
         {
             var src1 = "class C { int a = 1; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
@@ -5986,8 +5988,9 @@ public class C
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
         }
 
-        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
         [Fact]
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
         public void PropertyInitializerUpdate_SwitchExpressionInConstructor1()
         {
             var src1 = "class C { int a { get; } = 1; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
@@ -5999,8 +6002,9 @@ public class C
                 Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));
         }
 
-        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
         [Fact]
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
         public void PropertyInitializerUpdate_SwitchExpressionInConstructor2()
         {
             var src1 = "class C { int a { get; } = 1; public C() : this(1) { var b = a switch { 0 => 0, _ => 1 }; } public C(int a) { } }";
@@ -6011,8 +6015,9 @@ public class C
             edits.VerifySemanticDiagnostics();
         }
 
-        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
         [Fact]
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [WorkItem(43099, "https://github.com/dotnet/roslyn/issues/43099")]
         public void PropertyInitializerUpdate_SwitchExpressionInConstructor3()
         {
             var src1 = "class C { int a { get; } = 1; public C() { } public C(int b) { var b = a switch { 0 => 0, _ => 1 }; } }";

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.EditAndContinue;
@@ -35,26 +36,28 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         #region Syntax Analysis
 
-        private enum ConstructorPart
-        {
-            None = 0,
-            DefaultBaseConstructorCall = 1,
-        }
-
         private enum BlockPart
         {
-            None = 0,
-            OpenBrace = 1,
-            CloseBrace = 2,
+            OpenBrace = DefaultStatementPart,
+            CloseBrace = 1,
         }
 
         private enum ForEachPart
         {
-            None = 0,
-            ForEach = 1,
-            VariableDeclaration = 2,
-            In = 3,
-            Expression = 4,
+            ForEach = DefaultStatementPart,
+            VariableDeclaration = 1,
+            In = 2,
+            Expression = 3,
+        }
+
+        private enum SwitchExpressionPart
+        {
+            WholeExpression = DefaultStatementPart,
+
+            // An active statement that covers IL generated for the decision tree:
+            //   <governing-expression> [|switch { <arm>, ..., <arm> }|]
+            // This active statement is never a leaf active statement (does not correspond to a breakpoint span).
+            SwitchBody = 1,
         }
 
         /// <returns>
@@ -275,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                     if (constructor.Initializer == null || position < constructor.Initializer.ColonToken.SpanStart)
                     {
-                        statementPart = (int)ConstructorPart.DefaultBaseConstructorCall;
+                        statementPart = DefaultStatementPart;
                         partner = partnerConstructor;
                         return constructor;
                     }
@@ -302,47 +305,103 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 partner = null;
             }
 
-            while (node != declarationBody && !StatementSyntaxComparer.HasLabel(node) && !LambdaUtilities.IsLambdaBodyStatementOrExpression(node))
+            while (true)
             {
+                bool isBody = node == declarationBody || LambdaUtilities.IsLambdaBodyStatementOrExpression(node);
+
+                if (isBody || StatementSyntaxComparer.HasLabel(node))
+                {
+                    switch (node.Kind())
+                    {
+                        case SyntaxKind.Block:
+                            statementPart = (int)GetStatementPart((BlockSyntax)node!, position);
+                            return node!;
+
+                        case SyntaxKind.ForEachStatement:
+                        case SyntaxKind.ForEachVariableStatement:
+                            Debug.Assert(!isBody);
+                            statementPart = (int)GetStatementPart((CommonForEachStatementSyntax)node!, position);
+                            return node!;
+
+                        case SyntaxKind.DoStatement:
+                            // The active statement of DoStatement node is the while condition,
+                            // which is lexically not the closest breakpoint span (the body is).
+                            // do { ... } [|while (condition);|]
+                            Debug.Assert(position == ((DoStatementSyntax)node).WhileKeyword.SpanStart);
+                            Debug.Assert(!isBody);
+                            goto default;
+
+                        case SyntaxKind.PropertyDeclaration:
+                            // The active span corresponding to a property declaration is the span corresponding to its initializer (if any),
+                            // not the span corresponding to the accessor.
+                            // int P { [|get;|] } = [|<initializer>|];
+                            Debug.Assert(position == ((PropertyDeclarationSyntax)node).Initializer!.SpanStart);
+                            goto default;
+
+                        case SyntaxKind.VariableDeclaration:
+                            // VariableDeclaration ::= TypeSyntax CommaSeparatedList(VariableDeclarator)
+                            // 
+                            // The compiler places sequence points after each local variable initialization.
+                            // The TypeSyntax is considered to be part of the first sequence span.
+                            Debug.Assert(!isBody);
+
+                            node = ((VariableDeclarationSyntax)node!).Variables.First();
+
+                            if (partner != null)
+                            {
+                                partner = ((VariableDeclarationSyntax)partner).Variables.First();
+                            }
+
+                            statementPart = DefaultStatementPart;
+                            return node!;
+
+                        case SyntaxKind.SwitchExpression:
+                            // An active statement that covers IL generated for the decision tree:
+                            //   <governing-expression> [|switch { <arm>, ..., <arm> }|]
+                            // This active statement is never a leaf active statement (does not correspond to a breakpoint span).
+
+                            var switchExpression = (SwitchExpressionSyntax)node;
+                            if (position == switchExpression.SwitchKeyword.SpanStart)
+                            {
+                                Debug.Assert(span.End == switchExpression.CloseBraceToken.Span.End);
+                                statementPart = (int)SwitchExpressionPart.SwitchBody;
+                                return node!;
+                            }
+
+                            // The switch expression itself can be (a part of) an active statement associated with the containing node
+                            // For example, when it is used as a switch arm expression like so: 
+                            //   <expr> switch { <pattern> [|when <expr> switch { ... }|] ... }
+                            Debug.Assert(position == switchExpression.Span.Start);
+                            if (isBody)
+                            {
+                                goto default;
+                            }
+
+                            // ascend to parent node:
+                            break;
+
+                        case SyntaxKind.SwitchExpressionArm:
+                            // An active statement may occur in the when clause and in the arm expression:
+                            //   <constant-pattern> [|when <condition>|] => [|<expression>|]
+                            // The former is covered by when-clause node - it's a labeled node.
+                            // The latter isn't enclosed in a distinct labeled syntax node and thus needs to be covered 
+                            // by the arm node itself.
+                            Debug.Assert(position == ((SwitchExpressionArmSyntax)node).Expression.SpanStart);
+                            Debug.Assert(!isBody);
+                            goto default;
+
+                        default:
+                            statementPart = DefaultStatementPart;
+                            return node!;
+                    }
+                }
+
                 node = node.Parent!;
                 if (partner != null)
                 {
                     partner = partner.Parent;
                 }
             }
-
-            switch (node.Kind())
-            {
-                case SyntaxKind.Block:
-                    statementPart = (int)GetStatementPart((BlockSyntax)node!, position);
-                    break;
-
-                case SyntaxKind.ForEachStatement:
-                case SyntaxKind.ForEachVariableStatement:
-                    statementPart = (int)GetStatementPart((CommonForEachStatementSyntax)node!, position);
-                    break;
-
-                case SyntaxKind.VariableDeclaration:
-                    // VariableDeclaration ::= TypeSyntax CommaSeparatedList(VariableDeclarator)
-                    // 
-                    // The compiler places sequence points after each local variable initialization.
-                    // The TypeSyntax is considered to be part of the first sequence span.
-                    node = ((VariableDeclarationSyntax)node!).Variables.First();
-
-                    if (partner != null)
-                    {
-                        partner = ((VariableDeclarationSyntax)partner).Variables.First();
-                    }
-
-                    statementPart = 0;
-                    break;
-
-                default:
-                    statementPart = 0;
-                    break;
-            }
-
-            return node!;
         }
 
         private static BlockPart GetStatementPart(BlockSyntax node, int position)
@@ -352,17 +411,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         private static TextSpan GetActiveSpan(BlockSyntax node, BlockPart part)
         {
-            switch (part)
+            return part switch
             {
-                case BlockPart.OpenBrace:
-                    return node.OpenBraceToken.Span;
-
-                case BlockPart.CloseBrace:
-                    return node.CloseBraceToken.Span;
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(part);
-            }
+                BlockPart.OpenBrace => node.OpenBraceToken.Span,
+                BlockPart.CloseBrace => node.CloseBraceToken.Span,
+                _ => throw ExceptionUtilities.UnexpectedValue(part),
+            };
         }
 
         private static ForEachPart GetStatementPart(CommonForEachStatementSyntax node, int position)
@@ -375,44 +429,36 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         private static TextSpan GetActiveSpan(ForEachStatementSyntax node, ForEachPart part)
         {
-            switch (part)
+            return part switch
             {
-                case ForEachPart.ForEach:
-                    return node.ForEachKeyword.Span;
-
-                case ForEachPart.VariableDeclaration:
-                    return TextSpan.FromBounds(node.Type.SpanStart, node.Identifier.Span.End);
-
-                case ForEachPart.In:
-                    return node.InKeyword.Span;
-
-                case ForEachPart.Expression:
-                    return node.Expression.Span;
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(part);
-            }
+                ForEachPart.ForEach => node.ForEachKeyword.Span,
+                ForEachPart.VariableDeclaration => TextSpan.FromBounds(node.Type.SpanStart, node.Identifier.Span.End),
+                ForEachPart.In => node.InKeyword.Span,
+                ForEachPart.Expression => node.Expression.Span,
+                _ => throw ExceptionUtilities.UnexpectedValue(part),
+            };
         }
 
         private static TextSpan GetActiveSpan(ForEachVariableStatementSyntax node, ForEachPart part)
         {
-            switch (part)
+            return part switch
             {
-                case ForEachPart.ForEach:
-                    return node.ForEachKeyword.Span;
+                ForEachPart.ForEach => node.ForEachKeyword.Span,
+                ForEachPart.VariableDeclaration => TextSpan.FromBounds(node.Variable.SpanStart, node.Variable.Span.End),
+                ForEachPart.In => node.InKeyword.Span,
+                ForEachPart.Expression => node.Expression.Span,
+                _ => throw ExceptionUtilities.UnexpectedValue(part),
+            };
+        }
 
-                case ForEachPart.VariableDeclaration:
-                    return TextSpan.FromBounds(node.Variable.SpanStart, node.Variable.Span.End);
-
-                case ForEachPart.In:
-                    return node.InKeyword.Span;
-
-                case ForEachPart.Expression:
-                    return node.Expression.Span;
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(part);
-            }
+        private static TextSpan GetActiveSpan(SwitchExpressionSyntax node, SwitchExpressionPart part)
+        {
+            return part switch
+            {
+                SwitchExpressionPart.WholeExpression => node.Span,
+                SwitchExpressionPart.SwitchBody => TextSpan.FromBounds(node.SwitchKeyword.SpanStart, node.CloseBraceToken.Span.End),
+                _ => throw ExceptionUtilities.UnexpectedValue(part),
+            };
         }
 
         protected override bool AreEquivalent(SyntaxNode left, SyntaxNode right)
@@ -657,6 +703,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     // The active statement of DoStatement node is the while condition,
                     // which is lexically not the closest breakpoint span (the body is).
                     // do { ... } [|while (condition);|]
+                    Debug.Assert(statementPart == DefaultStatementPart);
+
                     var doStatement = (DoStatementSyntax)node;
                     return BreakpointSpans.TryGetClosestBreakpointSpan(node, doStatement.WhileKeyword.SpanStart, out span);
 
@@ -664,6 +712,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     // The active span corresponding to a property declaration is the span corresponding to its initializer (if any),
                     // not the span corresponding to the accessor.
                     // int P { [|get;|] } = [|<initializer>|];
+                    Debug.Assert(statementPart == DefaultStatementPart);
+
                     var propertyDeclaration = (PropertyDeclarationSyntax)node;
 
                     if (propertyDeclaration.Initializer != null &&
@@ -671,18 +721,34 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     {
                         return true;
                     }
-                    else
-                    {
-                        span = default;
-                        return false;
-                    }
+
+                    span = default;
+                    return false;
+
+                case SyntaxKind.SwitchExpression:
+                    span = GetActiveSpan((SwitchExpressionSyntax)node, (SwitchExpressionPart)statementPart);
+                    return true;
+
+                case SyntaxKind.SwitchExpressionArm:
+                    // An active statement may occur in the when clause and in the arm expression:
+                    //   <constant-pattern> [|when <condition>|] => [|<expression>|]
+                    // The former is covered by when-clause node - it's a labeled node.
+                    // The latter isn't enclosed in a distinct labeled syntax node and thus needs to be covered 
+                    // by the arm node itself.
+                    Debug.Assert(statementPart == DefaultStatementPart);
+
+                    span = ((SwitchExpressionArmSyntax)node).Expression.Span;
+                    return true;
 
                 default:
+                    // make sure all nodes that use statement parts are handled above:
+                    Debug.Assert(statementPart == DefaultStatementPart);
+
                     return BreakpointSpans.TryGetClosestBreakpointSpan(node, node.SpanStart, out span);
             }
         }
 
-        protected override IEnumerable<KeyValuePair<SyntaxNode, int>> EnumerateNearStatements(SyntaxNode statement)
+        protected override IEnumerable<(SyntaxNode statement, int statementPart)> EnumerateNearStatements(SyntaxNode statement)
         {
             var direction = +1;
             SyntaxNodeOrToken nodeOrToken = statement;
@@ -700,13 +766,19 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         yield break;
                     }
 
-                    if (parent.IsKind(SyntaxKind.Block))
+                    switch (parent.Kind())
                     {
-                        yield return KeyValuePairUtil.Create(parent, (int)(direction > 0 ? BlockPart.CloseBrace : BlockPart.OpenBrace));
-                    }
-                    else if (parent.IsKind(SyntaxKind.ForEachStatement))
-                    {
-                        yield return KeyValuePairUtil.Create(parent, (int)ForEachPart.ForEach);
+                        case SyntaxKind.Block:
+                            // The next sequence point hit after the last statement of a block is the closing brace:
+                            yield return (parent, (int)(direction > 0 ? BlockPart.CloseBrace : BlockPart.OpenBrace));
+                            break;
+
+                        case SyntaxKind.ForEachStatement:
+                        case SyntaxKind.ForEachVariableStatement:
+                            // The next sequence point hit after the body is the in keyword:
+                            //   [|foreach|] ([|variable-declaration|] [|in|] [|expression|]) [|<body>|]
+                            yield return (parent, (int)ForEachPart.In);
+                            break;
                     }
 
                     if (direction > 0)
@@ -722,14 +794,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         // We don't have any better place where to place the span than the initial field.
                         // Consider: in non-partial classes we could find a single constructor. 
                         // Otherwise, it would be confusing to select one arbitrarily.
-                        yield return KeyValuePairUtil.Create(statement, -1);
+                        yield return (statement, -1);
                     }
 
                     nodeOrToken = statement = parent;
                     fieldOrPropertyModifiers = SyntaxUtilities.TryGetFieldOrPropertyModifiers(statement);
                     direction = +1;
 
-                    yield return KeyValuePairUtil.Create(nodeOrToken.AsNode()!, 0);
+                    yield return (nodeOrToken.AsNode()!, DefaultStatementPart);
                 }
                 else
                 {
@@ -750,16 +822,19 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         }
                     }
 
-                    if (node.IsKind(SyntaxKind.Block))
+                    switch (node.Kind())
                     {
-                        yield return KeyValuePairUtil.Create(node, (int)(direction > 0 ? BlockPart.OpenBrace : BlockPart.CloseBrace));
-                    }
-                    else if (node.IsKind(SyntaxKind.ForEachStatement))
-                    {
-                        yield return KeyValuePairUtil.Create(node, (int)ForEachPart.ForEach);
+                        case SyntaxKind.Block:
+                            yield return (node, (int)(direction > 0 ? BlockPart.OpenBrace : BlockPart.CloseBrace));
+                            break;
+
+                        case SyntaxKind.ForEachStatement:
+                        case SyntaxKind.ForEachVariableStatement:
+                            yield return (node, (int)ForEachPart.ForEach);
+                            break;
                     }
 
-                    yield return KeyValuePairUtil.Create(node, 0);
+                    yield return (node, DefaultStatementPart);
                 }
             }
         }
@@ -774,10 +849,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             switch (oldStatement.Kind())
             {
                 case SyntaxKind.Block:
-                    Debug.Assert(statementPart != 0);
-
                     // closing brace of a using statement or a block that contains using local declarations:
-                    if (statementPart == 2)
+                    if (statementPart == (int)BlockPart.CloseBrace)
                     {
                         if (oldStatement.Parent.IsKind(SyntaxKind.UsingStatement, out UsingStatementSyntax? oldUsing))
                         {
@@ -791,15 +864,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return true;
 
                 case SyntaxKind.ConstructorDeclaration:
-                    Debug.Assert(statementPart != 0);
-
                     // The call could only change if the base type of the containing class changed.
                     return true;
 
                 case SyntaxKind.ForEachStatement:
                 case SyntaxKind.ForEachVariableStatement:
-                    Debug.Assert(statementPart != 0);
-
                     // only check the expression, edits in the body and the variable declaration are allowed:
                     return AreEquivalentActiveStatements((CommonForEachStatementSyntax)oldStatement, (CommonForEachStatementSyntax)newStatement);
 
@@ -1411,6 +1480,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ReturnStatement:
                 case SyntaxKind.ThrowStatement:
                 case SyntaxKind.ExpressionStatement:
+                case SyntaxKind.EmptyStatement:
                 case SyntaxKind.GotoStatement:
                 case SyntaxKind.GotoCaseStatement:
                 case SyntaxKind.GotoDefaultStatement:
@@ -1490,6 +1560,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.SwitchExpression:
                     return ((SwitchExpressionSyntax)node).SwitchKeyword.Span;
+
+                case SyntaxKind.SwitchExpressionArm:
+                    return ((SwitchExpressionArmSyntax)node).EqualsGreaterThanToken.Span;
 
                 default:
                     return null;
@@ -2903,6 +2976,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                             return;
 
                         case SyntaxKind.SwitchExpression:
+                            // TODO: remove (https://github.com/dotnet/roslyn/issues/43099)
                             ReportError(RudeEditKind.SwitchExpressionUpdate, node, _newNode);
                             break;
                     }

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -314,14 +314,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     switch (node.Kind())
                     {
                         case SyntaxKind.Block:
-                            statementPart = (int)GetStatementPart((BlockSyntax)node!, position);
-                            return node!;
+                            statementPart = (int)GetStatementPart((BlockSyntax)node, position);
+                            return node;
 
                         case SyntaxKind.ForEachStatement:
                         case SyntaxKind.ForEachVariableStatement:
                             Debug.Assert(!isBody);
-                            statementPart = (int)GetStatementPart((CommonForEachStatementSyntax)node!, position);
-                            return node!;
+                            statementPart = (int)GetStatementPart((CommonForEachStatementSyntax)node, position);
+                            return node;
 
                         case SyntaxKind.DoStatement:
                             // The active statement of DoStatement node is the while condition,
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                             // The TypeSyntax is considered to be part of the first sequence span.
                             Debug.Assert(!isBody);
 
-                            node = ((VariableDeclarationSyntax)node!).Variables.First();
+                            node = ((VariableDeclarationSyntax)node).Variables.First();
 
                             if (partner != null)
                             {
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                             }
 
                             statementPart = DefaultStatementPart;
-                            return node!;
+                            return node;
 
                         case SyntaxKind.SwitchExpression:
                             // An active statement that covers IL generated for the decision tree:
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                             {
                                 Debug.Assert(span.End == switchExpression.CloseBraceToken.Span.End);
                                 statementPart = (int)SwitchExpressionPart.SwitchBody;
-                                return node!;
+                                return node;
                             }
 
                             // The switch expression itself can be (a part of) an active statement associated with the containing node
@@ -392,7 +392,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                         default:
                             statementPart = DefaultStatementPart;
-                            return node!;
+                            return node;
                     }
                 }
 
@@ -405,31 +405,24 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static BlockPart GetStatementPart(BlockSyntax node, int position)
-        {
-            return position < node.OpenBraceToken.Span.End ? BlockPart.OpenBrace : BlockPart.CloseBrace;
-        }
+            => position < node.OpenBraceToken.Span.End ? BlockPart.OpenBrace : BlockPart.CloseBrace;
 
         private static TextSpan GetActiveSpan(BlockSyntax node, BlockPart part)
-        {
-            return part switch
+            => part switch
             {
                 BlockPart.OpenBrace => node.OpenBraceToken.Span,
                 BlockPart.CloseBrace => node.CloseBraceToken.Span,
                 _ => throw ExceptionUtilities.UnexpectedValue(part),
             };
-        }
 
         private static ForEachPart GetStatementPart(CommonForEachStatementSyntax node, int position)
-        {
-            return position < node.OpenParenToken.SpanStart ? ForEachPart.ForEach :
-                   position < node.InKeyword.SpanStart ? ForEachPart.VariableDeclaration :
-                   position < node.Expression.SpanStart ? ForEachPart.In :
-                   ForEachPart.Expression;
-        }
+            => position < node.OpenParenToken.SpanStart ? ForEachPart.ForEach :
+               position < node.InKeyword.SpanStart ? ForEachPart.VariableDeclaration :
+               position < node.Expression.SpanStart ? ForEachPart.In :
+               ForEachPart.Expression;
 
         private static TextSpan GetActiveSpan(ForEachStatementSyntax node, ForEachPart part)
-        {
-            return part switch
+            => part switch
             {
                 ForEachPart.ForEach => node.ForEachKeyword.Span,
                 ForEachPart.VariableDeclaration => TextSpan.FromBounds(node.Type.SpanStart, node.Identifier.Span.End),
@@ -437,11 +430,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 ForEachPart.Expression => node.Expression.Span,
                 _ => throw ExceptionUtilities.UnexpectedValue(part),
             };
-        }
 
         private static TextSpan GetActiveSpan(ForEachVariableStatementSyntax node, ForEachPart part)
-        {
-            return part switch
+            => part switch
             {
                 ForEachPart.ForEach => node.ForEachKeyword.Span,
                 ForEachPart.VariableDeclaration => TextSpan.FromBounds(node.Variable.SpanStart, node.Variable.Span.End),
@@ -449,22 +440,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 ForEachPart.Expression => node.Expression.Span,
                 _ => throw ExceptionUtilities.UnexpectedValue(part),
             };
-        }
 
         private static TextSpan GetActiveSpan(SwitchExpressionSyntax node, SwitchExpressionPart part)
-        {
-            return part switch
+            => part switch
             {
                 SwitchExpressionPart.WholeExpression => node.Span,
                 SwitchExpressionPart.SwitchBody => TextSpan.FromBounds(node.SwitchKeyword.SpanStart, node.CloseBraceToken.Span.End),
                 _ => throw ExceptionUtilities.UnexpectedValue(part),
             };
-        }
 
         protected override bool AreEquivalent(SyntaxNode left, SyntaxNode right)
-        {
-            return SyntaxFactory.AreEquivalent(left, right);
-        }
+            => SyntaxFactory.AreEquivalent(left, right);
 
         private static bool AreEquivalentIgnoringLambdaBodies(SyntaxNode left, SyntaxNode right)
         {
@@ -478,9 +464,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         internal override SyntaxNode FindPartner(SyntaxNode leftRoot, SyntaxNode rightRoot, SyntaxNode leftNode)
-        {
-            return SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode);
-        }
+            => SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode);
 
         internal override SyntaxNode? FindPartnerInMemberInitializer(SemanticModel leftModel, INamedTypeSymbol leftType, SyntaxNode leftNode, INamedTypeSymbol rightType, CancellationToken cancellationToken)
         {
@@ -524,9 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         internal override bool IsClosureScope(SyntaxNode node)
-        {
-            return LambdaUtilities.IsClosureScope(node);
-        }
+            => LambdaUtilities.IsClosureScope(node);
 
         protected override SyntaxNode? FindEnclosingLambdaBody(SyntaxNode? container, SyntaxNode node)
         {
@@ -547,19 +529,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         protected override IEnumerable<SyntaxNode> GetLambdaBodyExpressionsAndStatements(SyntaxNode lambdaBody)
-        {
-            return SpecializedCollections.SingletonEnumerable(lambdaBody);
-        }
+            => SpecializedCollections.SingletonEnumerable(lambdaBody);
 
         protected override SyntaxNode TryGetPartnerLambdaBody(SyntaxNode oldBody, SyntaxNode newLambda)
-        {
-            return LambdaUtilities.TryGetCorrespondingLambdaBody(oldBody, newLambda);
-        }
+            => LambdaUtilities.TryGetCorrespondingLambdaBody(oldBody, newLambda);
 
         protected override Match<SyntaxNode> ComputeTopLevelMatch(SyntaxNode oldCompilationUnit, SyntaxNode newCompilationUnit)
-        {
-            return TopSyntaxComparer.Instance.ComputeMatch(oldCompilationUnit, newCompilationUnit);
-        }
+            => TopSyntaxComparer.Instance.ComputeMatch(oldCompilationUnit, newCompilationUnit);
 
         protected override Match<SyntaxNode> ComputeBodyMatch(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
         {
@@ -652,36 +628,23 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         #region Syntax and Semantic Utils
 
         protected override IEnumerable<SequenceEdit> GetSyntaxSequenceEdits(ImmutableArray<SyntaxNode> oldNodes, ImmutableArray<SyntaxNode> newNodes)
-        {
-            return SyntaxComparer.GetSequenceEdits(oldNodes, newNodes);
-        }
+            => SyntaxComparer.GetSequenceEdits(oldNodes, newNodes);
 
         internal override SyntaxNode EmptyCompilationUnit
-        {
-            get
-            {
-                return SyntaxFactory.CompilationUnit();
-            }
-        }
+            => SyntaxFactory.CompilationUnit();
 
+        // there are no experimental features at this time.
         internal override bool ExperimentalFeaturesEnabled(SyntaxTree tree)
-        {
-            // there are no experimental features at this time.
-            return false;
-        }
+            => false;
 
         protected override bool StateMachineSuspensionPointKindEquals(SyntaxNode suspensionPoint1, SyntaxNode suspensionPoint2)
             => (suspensionPoint1 is CommonForEachStatementSyntax) ? suspensionPoint2 is CommonForEachStatementSyntax : suspensionPoint1.RawKind == suspensionPoint2.RawKind;
 
         protected override bool StatementLabelEquals(SyntaxNode node1, SyntaxNode node2)
-        {
-            return StatementSyntaxComparer.GetLabelImpl(node1) == StatementSyntaxComparer.GetLabelImpl(node2);
-        }
+            => StatementSyntaxComparer.GetLabelImpl(node1) == StatementSyntaxComparer.GetLabelImpl(node2);
 
         protected override bool TryGetEnclosingBreakpointSpan(SyntaxNode root, int position, out TextSpan span)
-        {
-            return BreakpointSpans.TryGetClosestBreakpointSpan(root, position, out span);
-        }
+            => BreakpointSpans.TryGetClosestBreakpointSpan(root, position, out span);
 
         protected override bool TryGetActiveSpan(SyntaxNode node, int statementPart, int minLength, out TextSpan span)
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -188,7 +188,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             SwitchStatement,
             SwitchSection,
             CasePatternSwitchLabel,            // tied to parent
-            WhenClause,
+            SwitchExpression,
+            SwitchExpressionArm,               // tied to parent
+            WhenClause,                        // tied to parent
 
             YieldStatement,                    // tied to parent
             GotoStatement,
@@ -256,6 +258,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case Label.GroupClauseLambda:
                 case Label.QueryContinuation:
                 case Label.CasePatternSwitchLabel:
+                case Label.WhenClause:
+                case Label.SwitchExpressionArm:
                     return 1;
 
                 default:
@@ -312,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.EmptyStatement:
                     isLeaf = true;
-                    return Label.Ignored;
+                    return Label.ExpressionStatement;
 
                 case SyntaxKind.GotoStatement:
                     isLeaf = true;
@@ -392,6 +396,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.CasePatternSwitchLabel:
                     return Label.CasePatternSwitchLabel;
+
+                case SyntaxKind.SwitchExpression:
+                    return Label.SwitchExpression;
+
+                case SyntaxKind.SwitchExpressionArm:
+                    return Label.SwitchExpressionArm;
 
                 case SyntaxKind.TryStatement:
                     return Label.TryStatement;

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -133,6 +133,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.InsertIntoInterface, nameof(FeaturesResources.Adding_0_into_an_interface_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.InsertLocalFunctionIntoInterfaceMethod, nameof(FeaturesResources.Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.InternalError, nameof(FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error));
+            // TODO: remove (https://github.com/dotnet/roslyn/issues/43099)
             AddRudeEdit(RudeEditKind.SwitchExpressionUpdate, nameof(FeaturesResources.Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.ChangingFromAsynchronousToSynchronous, nameof(FeaturesResources.Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.ChangingStateMachineShape, nameof(FeaturesResources.Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine));

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -804,7 +804,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
 
                     If propertyOrFieldModifiers.HasValue Then
-                        Yield ValueTuple.Create(statement, -1)
+                        Yield (statement, -1)
                     End If
 
                     nodeOrToken = parent
@@ -827,7 +827,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
                 End If
 
-                Yield ValueTuple.Create(node, DefaultStatementPart)
+                Yield (node, DefaultStatementPart)
             End While
         End Function
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -759,7 +759,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return BreakpointSpans.TryGetEnclosingBreakpointSpan(node, node.SpanStart, minLength, span)
         End Function
 
-        Protected Overrides Iterator Function EnumerateNearStatements(statement As SyntaxNode) As IEnumerable(Of KeyValuePair(Of SyntaxNode, Integer))
+        Protected Overrides Iterator Function EnumerateNearStatements(statement As SyntaxNode) As IEnumerable(Of ValueTuple(Of SyntaxNode, Integer))
             Dim direction As Integer = +1
             Dim nodeOrToken As SyntaxNodeOrToken = statement
             Dim propertyOrFieldModifiers As SyntaxTokenList? = GetFieldOrPropertyModifiers(statement)
@@ -804,7 +804,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
 
                     If propertyOrFieldModifiers.HasValue Then
-                        Yield KeyValuePairUtil.Create(statement, -1)
+                        Yield ValueTuple.Create(statement, -1)
+                        Return
                     End If
 
                     nodeOrToken = parent
@@ -827,7 +828,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
                 End If
 
-                Yield KeyValuePairUtil.Create(node, 0)
+                Yield ValueTuple.Create(node, -1)
             End While
         End Function
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -805,7 +805,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                     If propertyOrFieldModifiers.HasValue Then
                         Yield ValueTuple.Create(statement, -1)
-                        Return
                     End If
 
                     nodeOrToken = parent
@@ -828,7 +827,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
                 End If
 
-                Yield ValueTuple.Create(node, -1)
+                Yield ValueTuple.Create(node, DefaultStatementPart)
             End While
         End Function
 


### PR DESCRIPTION
Implements mapping of active statements that can now occur in switch expressions. 

EnC is still disallowed in method with switch expressions due to https://github.com/dotnet/roslyn/issues/43099
