### PR TITLE
Restrict whitespace collapse between methods to Metadata As Source

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/AccessorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/AccessorDeclarationStructureTests.cs
@@ -7,12 +7,11 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
 {
-    public class AccessorDeclarationTests : AbstractCSharpSyntaxNodeStructureTests<AccessorDeclarationSyntax>
+    public class AccessorDeclarationStructureTests : AbstractCSharpSyntaxNodeStructureTests<AccessorDeclarationSyntax>
     {
         internal override AbstractSyntaxStructureProvider CreateProvider() => new AccessorDeclarationStructureProvider();
 
@@ -159,8 +158,8 @@ class C
     {
         $${|hint:get{|textspan:
         {
-        }|}
-|}
+        }|}|}
+
         set
         {
         }
@@ -168,13 +167,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(56, 80),
-                    hintSpan: TextSpan.FromBounds(53, 78),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
@@ -189,8 +182,8 @@ class C
         // Getter|}
         $${|hint2:get{|textspan2:
         {
-        }|}
-|}
+        }|}|}
+
         set
         {
         }
@@ -200,13 +193,7 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("span1", "// My ...", autoCollapse: true),
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(90, 114),
-                    hintSpan: TextSpan.FromBounds(87, 112),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
@@ -221,8 +208,8 @@ class C
            Getter */|}
         $${|hint2:get{|textspan2:
         {
-        }|}
-|}
+        }|}|}
+
         set
         {
         }
@@ -232,13 +219,7 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("span1", "/* My ...", autoCollapse: true),
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(93, 117),
-                    hintSpan: TextSpan.FromBounds(90, 115),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/ConstructorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/ConstructorDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -162,9 +161,9 @@ class C
             const string code = @"
 class C
 {
-    $$public C()
+    {|hint:$$public C(){|textspan:
     {
-    }
+    }|}|}
 
     public C(int x)
     {
@@ -172,13 +171,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(28, 44),
-                    hintSpan: TextSpan.FromBounds(18, 42),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/ConversionOperatorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/ConversionOperatorDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -55,9 +54,9 @@ class C
             const string code = @"
 class C
 {
-    $$public static explicit operator C(byte i)
+    {|hint:$$public static explicit operator C(byte i){|textspan:
     {
-    }
+    }|}|}
 
     public static explicit operator C(short i)
     {
@@ -65,13 +64,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(59, 75),
-                    hintSpan: TextSpan.FromBounds(18, 73),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact,

--- a/src/EditorFeatures/CSharpTest/Structure/EnumDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/EnumDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -55,22 +54,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
         public async Task TestEnum3(string typeKind)
         {
             var code = $@"
-$$enum E
+{{|hint:$$enum E{{|textspan:
 {{
-}}
+}}|}}|}}
 
 {typeKind} Following
 {{
 }}";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(8, 16),
-                    hintSpan: TextSpan.FromBounds(2, 14),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: false));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/EventDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/EventDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -61,11 +60,11 @@ class C
             const string code = @"
 class C
 {
-    $$event EventHandler E
+    {|hint:$$event EventHandler E{|textspan:
     {
         add { }
         remove { }
-    }
+    }|}|}
 
     event EventHandler E2
     {
@@ -75,13 +74,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(38, 91),
-                    hintSpan: TextSpan.FromBounds(18, 89),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/IndexerDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/IndexerDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -55,22 +54,16 @@ class C
             const string code = @"
 class C
 {
-    $$public string this[int index]
+    {|hint:$$public string this[int index]{|textspan:
     {
         get { }
-    }
+    }|}|}
 
     int Value => 0;
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(47, 80),
-                    hintSpan: TextSpan.FromBounds(18, 78),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/AccessorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/AccessorDeclarationStructureTests.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Structure;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
+{
+    public class AccessorDeclarationStructureTests : AbstractCSharpSyntaxNodeStructureTests<AccessorDeclarationSyntax>
+    {
+        protected override string WorkspaceKind => CodeAnalysis.WorkspaceKind.MetadataAsSource;
+        internal override AbstractSyntaxStructureProvider CreateProvider() => new AccessorDeclarationStructureProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertyGetter3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        $${|hint:get{|textspan:
+        {
+        }|}
+|}
+        set
+        {
+        }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(56, 80),
+                    hintSpan: TextSpan.FromBounds(53, 78),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertyGetterWithSingleLineComments3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        {|span1:// My
+        // Getter|}
+        $${|hint2:get{|textspan2:
+        {
+        }|}
+|}
+        set
+        {
+        }
+    }
+}
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span1", "// My ...", autoCollapse: true),
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(90, 114),
+                    hintSpan: TextSpan.FromBounds(87, 112),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestPropertyGetterWithMultiLineComments3()
+        {
+            const string code = @"
+class C
+{
+    public string Text
+    {
+        {|span1:/* My
+           Getter */|}
+        $${|hint2:get{|textspan2:
+        {
+        }|}
+|}
+        set
+        {
+        }
+    }
+}
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span1", "/* My ...", autoCollapse: true),
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(93, 117),
+                    hintSpan: TextSpan.FromBounds(90, 115),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/ConstructorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/ConstructorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -72,6 +73,31 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestConstructor10()
+        {
+            const string code = @"
+class C
+{
+    $$public C()
+    {
+    }
+
+    public C(int x)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(28, 44),
+                    hintSpan: TextSpan.FromBounds(18, 42),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/ConversionOperatorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/ConversionOperatorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -56,6 +57,31 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator3()
+        {
+            const string code = @"
+class C
+{
+    $$public static explicit operator C(byte i)
+    {
+    }
+
+    public static explicit operator C(short i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(59, 75),
+                    hintSpan: TextSpan.FromBounds(18, 73),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/EnumDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/EnumDeclarationStructureTests.cs
@@ -100,5 +100,31 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSou
                     bannerText: CSharpStructureHelpers.Ellipsis,
                     autoCollapse: false));
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [InlineData("enum")]
+        [InlineData("struct")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        public async Task TestEnum3(string typeKind)
+        {
+            var code = $@"
+$$enum E
+{{
+}}
+
+{typeKind} Following
+{{
+}}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(8, 16),
+                    hintSpan: TextSpan.FromBounds(2, 14),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: false));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/EventDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/EventDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -76,6 +77,35 @@ class Goo
             await VerifyBlockSpansAsync(code,
                 Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
                 Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestEvent3()
+        {
+            const string code = @"
+class C
+{
+    $$event EventHandler E
+    {
+        add { }
+        remove { }
+    }
+
+    event EventHandler E2
+    {
+        add { }
+        remove { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(38, 91),
+                    hintSpan: TextSpan.FromBounds(18, 89),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/IndexerDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/IndexerDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -76,6 +77,30 @@ class Goo
             await VerifyBlockSpansAsync(code,
                 Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
                 Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestIndexer3()
+        {
+            const string code = @"
+class C
+{
+    $$public string this[int index]
+    {
+        get { }
+    }
+
+    int Value => 0;
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(47, 80),
+                    hintSpan: TextSpan.FromBounds(18, 78),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/MethodDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/MethodDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -72,6 +73,31 @@ class Goo
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestMethod3()
+        {
+            const string code = @"
+class C
+{
+    $$public string Goo()
+    {
+    }
+
+    public string Goo2()
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(37, 53),
+                    hintSpan: TextSpan.FromBounds(18, 51),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/OperatorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/OperatorDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -72,6 +73,31 @@ class Goo
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestOperator3()
+        {
+            const string code = @"
+class C
+{
+    $$public static int operator +(int i)
+    {
+    }
+
+    public static int operator -(int i)
+    {
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(53, 69),
+                    hintSpan: TextSpan.FromBounds(18, 67),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/PropertyDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/PropertyDeclarationStructureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSource
@@ -76,6 +77,64 @@ class Goo
             await VerifyBlockSpansAsync(code,
                 Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
                 Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty3()
+        {
+            const string code = @"
+class C
+{
+    $$public int Goo
+    {
+        get { }
+        set { }
+    }
+
+    public int Goo2
+    {
+        get { }
+        set { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(32, 82),
+                    hintSpan: TextSpan.FromBounds(18, 80),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestProperty4()
+        {
+            const string code = @"
+class C
+{
+    $$public int Goo
+    {
+        get { }
+        set { }
+    }
+
+    public int this[int value]
+    {
+        get { }
+        set { }
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: TextSpan.FromBounds(32, 82),
+                    hintSpan: TextSpan.FromBounds(18, 80),
+                    type: BlockTypes.Nonstructural,
+                    bannerText: CSharpStructureHelpers.Ellipsis,
+                    autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MethodDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MethodDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -55,9 +54,9 @@ class C
             const string code = @"
 class C
 {
-    $$public string Goo()
+    {|hint:$$public string Goo(){|textspan:
     {
-    }
+    }|}|}
 
     public string Goo2()
     {
@@ -65,13 +64,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(37, 53),
-                    hintSpan: TextSpan.FromBounds(18, 51),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/OperatorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/OperatorDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -55,9 +54,9 @@ class C
             const string code = @"
 class C
 {
-    $$public static int operator +(int i)
+    {|hint:$$public static int operator +(int i){|textspan:
     {
-    }
+    }|}|}
 
     public static int operator -(int i)
     {
@@ -65,13 +64,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(53, 69),
-                    hintSpan: TextSpan.FromBounds(18, 67),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/EditorFeatures/CSharpTest/Structure/PropertyDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/PropertyDeclarationStructureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -61,11 +60,11 @@ class C
             const string code = @"
 class C
 {
-    $$public int Goo
+    {|hint:$$public int Goo{|textspan:
     {
         get { }
         set { }
-    }
+    }|}|}
 
     public int Goo2
     {
@@ -75,13 +74,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(32, 82),
-                    hintSpan: TextSpan.FromBounds(18, 80),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
@@ -90,11 +83,11 @@ class C
             const string code = @"
 class C
 {
-    $$public int Goo
+    {|hint:$$public int Goo{|textspan:
     {
         get { }
         set { }
-    }
+    }|}|}
 
     public int this[int value]
     {
@@ -104,13 +97,7 @@ class C
 }";
 
             await VerifyBlockSpansAsync(code,
-                new BlockSpan(
-                    isCollapsible: true,
-                    textSpan: TextSpan.FromBounds(32, 82),
-                    hintSpan: TextSpan.FromBounds(18, 80),
-                    type: BlockTypes.Nonstructural,
-                    bannerText: CSharpStructureHelpers.Ellipsis,
-                    autoCollapse: true));
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]

--- a/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
@@ -34,8 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
             //
-            // All accessor kinds are grouped together.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.AsNode() is AccessorDeclarationSyntax;
+            // All accessor kinds are grouped together in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.AsNode() is AccessorDeclarationSyntax);
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 accessorDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
@@ -33,7 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var nextSibling = current.GetNextSibling();
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConstructorDeclaration);
+            //
+            // Whitespace between constructors is collapsed in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConstructorDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 constructorDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
@@ -33,7 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var nextSibling = current.GetNextSibling();
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConversionOperatorDeclaration);
+            //
+            // Whitespace between conversion operators is collapsed in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.ConversionOperatorDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 operatorDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
@@ -28,7 +28,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 var nextSibling = current.GetNextSibling();
 
                 // Check IsNode to compress blank lines after this node if it is the last child of the parent.
-                var compressEmptyLines = !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax;
+                //
+                // Whitespace between type declarations is collapsed in Metadata as Source.
+                var compressEmptyLines = isMetadataAsSource
+                    && (!nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax);
 
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     enumDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
@@ -35,8 +35,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
             //
-            // Full events are grouped together with event field definitions.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.EventDeclaration) || nextSibling.IsKind(SyntaxKind.EventFieldDeclaration);
+            // Full events are grouped together with event field definitions in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.EventDeclaration) || nextSibling.IsKind(SyntaxKind.EventFieldDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 eventDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
@@ -35,8 +35,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
             //
-            // Indexers are grouped together with properties.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.IndexerDeclaration) || nextSibling.IsKind(SyntaxKind.PropertyDeclaration);
+            // Indexers are grouped together with properties in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.IndexerDeclaration) || nextSibling.IsKind(SyntaxKind.PropertyDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 indexerDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
@@ -33,7 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var nextSibling = current.GetNextSibling();
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.MethodDeclaration);
+            //
+            // Whitespace between methods is collapsed in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.MethodDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 methodDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             }
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
-                externsAndUsings, compressEmptyLines: true, autoCollapse: true,
+                externsAndUsings, compressEmptyLines: false, autoCollapse: true,
                 type: BlockTypes.Imports, isCollapsible: true));
 
             // finally, add any leading comments before the end of the namespace block

--- a/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
@@ -33,7 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var nextSibling = current.GetNextSibling();
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.OperatorDeclaration);
+            //
+            // Whitespace between operators is collapsed in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.OperatorDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 operatorDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
@@ -34,8 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
 
             // Check IsNode to compress blank lines after this node if it is the last child of the parent.
             //
-            // Properties are grouped together with indexers.
-            var compressEmptyLines = !nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.PropertyDeclaration) || nextSibling.IsKind(SyntaxKind.IndexerDeclaration);
+            // Properties are grouped together with indexers in Metadata as Source.
+            var compressEmptyLines = isMetadataAsSource
+                && (!nextSibling.IsNode || nextSibling.IsKind(SyntaxKind.PropertyDeclaration) || nextSibling.IsKind(SyntaxKind.IndexerDeclaration));
 
             spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                 propertyDeclaration,

--- a/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
@@ -34,8 +34,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 // Check IsNode to compress blank lines after this node if it is the last child of the parent.
                 //
                 // Collapse to Definitions doesn't collapse type nodes, but a Toggle All Outlining would collapse groups
-                // of types to the compressed form of not showing blank lines. All kinds of types are grouped together.
-                var compressEmptyLines = !nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax;
+                // of types to the compressed form of not showing blank lines. All kinds of types are grouped together
+                // in Metadata as Source.
+                var compressEmptyLines = isMetadataAsSource
+                    && (!nextSibling.IsNode || nextSibling.AsNode() is BaseTypeDeclarationSyntax);
 
                 spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
                     typeDeclaration,

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOutlining.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOutlining.cs
@@ -59,8 +59,8 @@ namespace ClassLibrary1[|
 #if DEBUG
 {|Release:        void Goo(){|Debug:
         {
-        }
-        |}
+        }|}
+        
         void Goo2(){|Debug:
         {
         }|}|}


### PR DESCRIPTION
This enhancement was added in #42850 but generated some early negative feedback in normal source files. This change restricts the new behavior to Metadata As Source, which effectively restricts it to decompiled sources. We always have the option of expanding the feature to all sources in the future.