### PR TITLE
Mark RichCodeNav.EnvVarDump as private asset

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -136,7 +136,7 @@
      Code indexing targets to help generating LSIF from indexing builds.
   -->
   <ItemGroup>
-    <PackageReference Include="RichCodeNav.EnvVarDump" Version="$(RichCodeNavEnvVarDumpVersion)" />
+    <PackageReference Include="RichCodeNav.EnvVarDump" Version="$(RichCodeNavEnvVarDumpVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- 


### PR DESCRIPTION
Otherwise this package becomes a dependency of all our NuGet packages.