### PR TITLE
Remove previous docker container

### DIFF
--- a/eng/docker/mono.sh
+++ b/eng/docker/mono.sh
@@ -15,6 +15,7 @@ dockerfile="$dir"/Mono
 
 # Ensure the container isn't already running. Can happened for cancelled jobs in CI
 docker kill $CONTAINER_NAME || true
+docker container rm $CONTAINER_NAME || true
 
 # Make container names CI-specific if we're running in CI
 #  Jenkins


### PR DESCRIPTION
In addition to killing the previous docker container, we should remove it so we can re-use the name.

Example failure if the container is not removed - https://dev.azure.com/dnceng/public/_build/results?buildId=596677&view=logs&j=0bb0e3da-a79e-5da9-5d54-e0768ef96e56&t=d5e17906-1333-5933-671b-e536ad5fb7e2