### PR TITLE
Do not apply analyzer bulk configuration to non-configurable diagnostics

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -501,6 +502,53 @@ class C
                 diagnostics.Verify(expected);
 
                 var diagnostic = diagnostics.Single();
+                Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+                Assert.False(diagnostic.IsSuppressed);
+            }
+        }
+
+        [Fact]
+        [WorkItem(43305, "https://github.com/dotnet/roslyn/issues/43305")]
+        public async Task TestAnalyzerConfigurationDoesNotAffectNonConfigurableDiagnostics()
+        {
+            var source = @"class C { }";
+
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics();
+
+            // Verify 'NonConfigurable' analyzer diagnostic without any analyzer config options.
+            var analyzer = new NamedTypeAnalyzer(NamedTypeAnalyzer.AnalysisKind.Symbol, configurable: false);
+            await verifyDiagnosticsAsync(compilation, analyzer, options: null);
+
+            // Verify 'NonConfigurable' analyzer diagnostic is not affected by category based configuration.
+            await verifyDiagnosticsAsync(compilation, analyzer, options: ($"dotnet_analyzer_diagnostic.category-{NamedTypeAnalyzer.RuleCategory}.severity", "none"));
+
+            // Verify 'NonConfigurable' analyzer diagnostic is not affected by all analyzers bulk configuration.
+            await verifyDiagnosticsAsync(compilation, analyzer, options: ("dotnet_analyzer_diagnostic.severity", "none"));
+
+            return;
+
+            static async Task verifyDiagnosticsAsync(Compilation compilation, DiagnosticAnalyzer analyzer, (string key, string value)? options)
+            {
+                AnalyzerOptions analyzerOptions;
+                if (options.HasValue)
+                {
+                    var analyzerConfigOptions = new CompilerAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add(options.Value.key, options.Value.value));
+                    var analyzerConfigOptionsProvider = new CompilerAnalyzerConfigOptionsProvider(
+                        ImmutableDictionary<object, AnalyzerConfigOptions>.Empty.Add(compilation.SyntaxTrees.Single(), analyzerConfigOptions));
+                    analyzerOptions = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, analyzerConfigOptionsProvider);
+                }
+                else
+                {
+                    analyzerOptions = null;
+                }
+
+                var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer), analyzerOptions);
+                var analyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+                var expected = Diagnostic(NamedTypeAnalyzer.RuleId, "C").WithArguments("C").WithLocation(1, 7);
+                analyzerDiagnostics.Verify(expected);
+
+                var diagnostic = analyzerDiagnostics.Single();
                 Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
                 Assert.False(diagnostic.IsSuppressed);
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1684,7 +1684,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // Apply bulk configuration from analyzer options for analyzer diagnostics, if applicable.
             var tree = diagnostic?.Location.SourceTree;
-            if (tree == null || analyzerOptions == null || diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Compiler))
+            if (tree == null || analyzerOptions == null || diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Compiler) || diagnostic.IsNotConfigurable())
             {
                 return diagnostic;
             }

--- a/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -1989,6 +1989,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             public const string RuleId = "ID1";
+            public const string RuleCategory = "Category1";
             private readonly DiagnosticDescriptor _rule;
             private readonly AnalysisKind _analysisKind;
             private readonly GeneratedCodeAnalysisFlags _analysisFlags;
@@ -2005,7 +2006,7 @@ namespace Microsoft.CodeAnalysis
                     RuleId,
                     "Title1",
                     "Symbol: {0}",
-                    "Category1",
+                    RuleCategory,
                     defaultSeverity: DiagnosticSeverity.Warning,
                     isEnabledByDefault: true,
                     customTags: customTags);


### PR DESCRIPTION
Fixes #43305

Verified that the added unit test fails prior to the fix.