### PR TITLE
Fix sorting of 'wrapping' items.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Wrapping/SortingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/SortingTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Wrapping;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
+{
+    public class SortingTests
+    {
+        [Fact]
+        public void FirstNotInMruSecondNotInMru()
+        {
+            var items = ImmutableArray.Create("Action1", "Action2");
+
+            var sorted = WrapItemsAction.SortByMostRecentlyUsed(
+                items, ImmutableArray<string>.Empty, a => a);
+
+            // Shouldn't change order
+            Assert.Equal((IEnumerable<string>)items, sorted);
+        }
+
+        [Fact]
+        public void FirstInMruSecondNotInMru()
+        {
+            var items = ImmutableArray.Create("Action1", "Action2");
+
+            var sorted = WrapItemsAction.SortByMostRecentlyUsed(
+                items, ImmutableArray.Create("Action1"), a => a);
+
+            // Shouldn't change order
+            Assert.Equal((IEnumerable<string>)items, sorted);
+        }
+
+        [Fact]
+        public void FirstNotInMruSecondInMru()
+        {
+            var items = ImmutableArray.Create("Action1", "Action2");
+
+            var sorted = WrapItemsAction.SortByMostRecentlyUsed(
+                items, ImmutableArray.Create("Action2"), a => a);
+
+            // Should swap order.
+            Assert.Equal((IEnumerable<string>)ImmutableArray.Create("Action2", "Action1"), sorted);
+        }
+
+        [Fact]
+        public void FirstInMruSecondInMru1()
+        {
+            var items = ImmutableArray.Create("Action1", "Action2");
+
+            var sorted = WrapItemsAction.SortByMostRecentlyUsed(
+                items, ImmutableArray.Create("Action1", "Action2"), a => a);
+
+            // Shouldn't change order
+            Assert.Equal((IEnumerable<string>)items, sorted);
+        }
+
+        [Fact]
+        public void FirstInMruSecondInMru2()
+        {
+            var items = ImmutableArray.Create("Action1", "Action2");
+
+            var sorted = WrapItemsAction.SortByMostRecentlyUsed(
+                items, ImmutableArray.Create("Action2", "Action1"), a => a);
+
+            // Should swap order.
+            Assert.Equal((IEnumerable<string>)ImmutableArray.Create("Action2", "Action1"), sorted);
+        }
+    }
+}

--- a/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
+++ b/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
-using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
 
 namespace Microsoft.CodeAnalysis.Wrapping
@@ -64,22 +63,35 @@ namespace Microsoft.CodeAnalysis.Wrapping
         }
 
         public static ImmutableArray<CodeAction> SortActionsByMostRecentlyUsed(ImmutableArray<CodeAction> codeActions)
-        {
-            // make a local so this array can't change out from under us.
-            var mruTitles = s_mruTitles;
-            return codeActions.Sort((d1, d2) => ComparerWithState.CompareTo(d1, d2, (mruTitles, codeActions), s_comparers));
-        }
+            => SortActionsByMostRecentlyUsed(codeActions, s_mruTitles);
 
-        private static readonly ImmutableArray<Func<CodeAction, (ImmutableArray<string>, ImmutableArray<CodeAction>), IComparable>> s_comparers =
-            ImmutableArray.Create<Func<CodeAction, (ImmutableArray<string>, ImmutableArray<CodeAction>), IComparable>>(
-                // one of these has never been invoked.  It's always after an item that has been
-                // invoked.
-                // we've invoked both of these before.  Order by how recently it was invoked.
-                (ca, tuple) => tuple.Item1.IndexOf(GetSortTitle(ca)),
-                // Neither of these has been invoked.   Keep it in the same order we found it in the
-                // array.  Note: we cannot return 0 here as ImmutableArray/Array are not guaranteed
-                // to sort stably.
-                (ca, tuple) => tuple.Item2.IndexOf(ca));
+        public static ImmutableArray<CodeAction> SortActionsByMostRecentlyUsed(
+            ImmutableArray<CodeAction> codeActions, ImmutableArray<string> mruTitles)
+        {
+            return codeActions.Sort((d1, d2) =>
+            {
+                var mruIndex1 = mruTitles.IndexOf(GetSortTitle(d1));
+                var mruIndex2 = mruTitles.IndexOf(GetSortTitle(d2));
+
+                // If both are in the mru, prefer the one earlier on.
+                if (mruIndex1 >= 0 && mruIndex2 >= 0)
+                    return mruIndex1 - mruIndex2;
+
+                // if either is in the mru, and the other is not, then the mru item is preferred.
+                if (mruIndex1 >= 0)
+                    return -1;
+
+                if (mruIndex2 >= 0)
+                    return 1;
+
+                // Neither are in the mru.  Sort them based on their original locations.
+                var index1 = codeActions.IndexOf(d1);
+                var index2 = codeActions.IndexOf(d2);
+
+                // Note: we don't return 0 here as ImmutableArray.Sort is not stable.
+                return index1 - index2;
+            });
+        }
 
         private static string GetSortTitle(CodeAction codeAction)
             => (codeAction as WrapItemsAction)?.SortTitle ?? codeAction.Title;

--- a/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
+++ b/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
@@ -63,15 +63,15 @@ namespace Microsoft.CodeAnalysis.Wrapping
         }
 
         public static ImmutableArray<CodeAction> SortActionsByMostRecentlyUsed(ImmutableArray<CodeAction> codeActions)
-            => SortActionsByMostRecentlyUsed(codeActions, s_mruTitles);
+            => SortByMostRecentlyUsed(codeActions, s_mruTitles, a => GetSortTitle(a));
 
-        public static ImmutableArray<CodeAction> SortActionsByMostRecentlyUsed(
-            ImmutableArray<CodeAction> codeActions, ImmutableArray<string> mruTitles)
+        public static ImmutableArray<T> SortByMostRecentlyUsed<T>(
+            ImmutableArray<T> items, ImmutableArray<string> mostRecentlyUsedKeys, Func<T, string> getKey)
         {
-            return codeActions.Sort((d1, d2) =>
+            return items.Sort((d1, d2) =>
             {
-                var mruIndex1 = mruTitles.IndexOf(GetSortTitle(d1));
-                var mruIndex2 = mruTitles.IndexOf(GetSortTitle(d2));
+                var mruIndex1 = mostRecentlyUsedKeys.IndexOf(getKey(d1));
+                var mruIndex2 = mostRecentlyUsedKeys.IndexOf(getKey(d2));
 
                 // If both are in the mru, prefer the one earlier on.
                 if (mruIndex1 >= 0 && mruIndex2 >= 0)
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.Wrapping
                     return 1;
 
                 // Neither are in the mru.  Sort them based on their original locations.
-                var index1 = codeActions.IndexOf(d1);
-                var index2 = codeActions.IndexOf(d2);
+                var index1 = items.IndexOf(d1);
+                var index2 = items.IndexOf(d2);
 
                 // Note: we don't return 0 here as ImmutableArray.Sort is not stable.
                 return index1 - index2;


### PR DESCRIPTION
This regressed with https://github.com/dotnet/roslyn/pull/37894

The problem there is that you could have a wrapping item that was never invoke compared against one that was invoked.  The non-invoked wrapping item would then show up with a negative index (because it wasn't in hte MRU list), but the invoked one would have a positive index.  Negatie is less than positive.  So the non-inokved one would now have priority!

We odn't have tests here.  And that's on me.  Will def add a test here to validate that this approach works.