### PR TITLE
Import Microsoft.VsSDK.targets conditionally

### DIFF
--- a/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
@@ -66,7 +66,7 @@
     <NuGetPackageToIncludeInVsix Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
-  <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets"/>
+  <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets')"/>
 
   <Target Name="VsixSourceItemsOutputGroup"
           Returns="@(VSIXSourceItem)"

--- a/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
@@ -66,7 +66,8 @@
     <NuGetPackageToIncludeInVsix Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
-  <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets')"/>
+  <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets" 
+          Condition="Exists('$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets') and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'"/>
 
   <Target Name="VsixSourceItemsOutputGroup"
           Returns="@(VSIXSourceItem)"


### PR DESCRIPTION
VSToolsPath might not be initialized during restore.