### PR TITLE
Reuse previous lambda body binding if possible

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -52,6 +53,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             protected override UnboundLambdaState WithCachingCore(bool includeCache)
             {
                 return new QueryUnboundLambdaState(Binder, _rangeVariableMap, _parameters, _bodyFactory, includeCache);
+            }
+
+            protected override BoundExpression GetReusableLambdaExpressionBody(BoundBlock body)
+            {
+                return null;
+            }
+
+            protected override BoundBlock CreateBlockFromExpression(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, BoundExpression expression, DiagnosticBag diagnostics)
+            {
+                throw ExceptionUtilities.Unreachable;
             }
 
             protected override BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -55,12 +55,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new QueryUnboundLambdaState(Binder, _rangeVariableMap, _parameters, _bodyFactory, includeCache);
             }
 
-            protected override BoundExpression GetReusableLambdaExpressionBody(BoundBlock body)
+            protected override BoundExpression GetLambdaExpressionBody(BoundBlock body)
             {
                 return null;
             }
 
-            protected override BoundBlock CreateBlockFromExpression(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, BoundExpression expression, DiagnosticBag diagnostics)
+            protected override BoundBlock CreateBlockFromLambdaExpressionBody(Binder lambdaBodyBinder, BoundExpression expression, DiagnosticBag diagnostics)
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3193,7 +3193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return bodyBinder.CreateBlockFromExpression(body, bodyBinder.GetDeclaredLocalsForScope(body), refKind, expression, expressionSyntax, diagnostics);
         }
 
-        public BoundBlock BindLambdaExpressionAsBlockContinued(ExpressionSyntax body, BoundExpression expression, DiagnosticBag diagnostics)
+        public BoundBlock CreateBlockFromExpression(ExpressionSyntax body, BoundExpression expression, DiagnosticBag diagnostics)
         {
             Binder bodyBinder = this.GetBinder(body);
             Debug.Assert(bodyBinder != null);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Transactions;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -3155,7 +3153,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Binds an expression-bodied member with expression e as either { return e;} or { e; }.
+        /// Binds an expression-bodied member with expression e as either { return e; } or { e; }.
         /// </summary>
         internal virtual BoundBlock BindExpressionBodyAsBlock(ArrowExpressionClauseSyntax expressionBody,
                                                       DiagnosticBag diagnostics)
@@ -3179,7 +3177,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Binds a lambda with expression e as either { return e;} or { e; }.
+        /// Binds a lambda with expression e as either { return e; } or { e; }.
         /// </summary>
         public BoundBlock BindLambdaExpressionAsBlock(ExpressionSyntax body, DiagnosticBag diagnostics)
         {
@@ -3193,6 +3191,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             expression = ValidateEscape(expression, Binder.ExternalScope, refKind != RefKind.None, diagnostics);
 
             return bodyBinder.CreateBlockFromExpression(body, bodyBinder.GetDeclaredLocalsForScope(body), refKind, expression, expressionSyntax, diagnostics);
+        }
+
+        public BoundBlock BindLambdaExpressionAsBlockContinued(ExpressionSyntax body, BoundExpression expression, DiagnosticBag diagnostics)
+        {
+            Binder bodyBinder = this.GetBinder(body);
+            Debug.Assert(bodyBinder != null);
+
+            Debug.Assert(body.Kind() != SyntaxKind.RefExpression);
+            return bodyBinder.CreateBlockFromExpression(body, bodyBinder.GetDeclaredLocalsForScope(body), RefKind.None, expression, body, diagnostics);
         }
 
         private BindValueKind GetRequiredReturnValueKind(RefKind refKind)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -285,7 +285,7 @@ static class Ext
 
         [ConditionalFactAttribute(typeof(IsRelease))]
         [WorkItem(40495, "https://github.com/dotnet/roslyn/issues/40495")]
-        public void NestedLambdas()
+        public void NestedLambdas_01()
         {
             var source =
 @"#nullable enable
@@ -301,6 +301,43 @@ class Program
             Enumerable.Range(0, 1).Sum(e =>
             Enumerable.Range(0, 1).Sum(f =>
             Enumerable.Range(0, 1).Count(g => true)))))));
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [ConditionalFactAttribute(typeof(IsRelease))]
+        [WorkItem(1083969, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1083969")]
+        public void NestedLambdas_02()
+        {
+            var source =
+@"using System.Collections.Generic;
+using System.Linq;
+class Program
+{
+    static void F(IEnumerable<int[]> x)
+    {
+        x.GroupBy(y => y[1]).SelectMany(x =>
+        x.GroupBy(y => y[2]).SelectMany(x =>
+        x.GroupBy(y => y[3]).SelectMany(x =>
+        x.GroupBy(y => y[4]).SelectMany(x =>
+        x.GroupBy(y => y[5]).SelectMany(x =>
+        x.GroupBy(y => y[6]).SelectMany(x =>
+        x.GroupBy(y => y[7]).SelectMany(x =>
+        x.GroupBy(y => y[8]).SelectMany(x =>
+        x.GroupBy(y => y[9]).SelectMany(x =>
+        x.GroupBy(y => y[0]).SelectMany(x =>
+        x.GroupBy(y => y[1]).SelectMany(x =>
+        x.GroupBy(y => y[2]).SelectMany(x =>
+        x.GroupBy(y => y[3]).SelectMany(x =>
+        x.GroupBy(y => y[4]).SelectMany(x =>
+        x.GroupBy(y => y[5]).SelectMany(x =>
+        x.GroupBy(y => y[6]).SelectMany(x =>
+        x.GroupBy(y => y[7]).SelectMany(x =>
+        x.GroupBy(y => y[8]).SelectMany(x =>
+        x.GroupBy(y => y[9]).SelectMany(x =>
+        x.GroupBy(y => y[0]).Select(x => x.Average(z => z[0])))))))))))))))))))));
     }
 }";
             var comp = CreateCompilation(source);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -307,6 +307,8 @@ class Program
             comp.VerifyDiagnostics();
         }
 
+        // Test should complete in several seconds if UnboundLambda.ReallyBind
+        // uses results from _returnInferenceCache.
         [ConditionalFactAttribute(typeof(IsRelease))]
         [WorkItem(1083969, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1083969")]
         public void NestedLambdas_02()


### PR DESCRIPTION
Allow re-use of expression-bodied lambda bodies bound during return type inference. (Re-use was disabled in https://github.com/dotnet/roslyn/pull/37052.)