### PR TITLE
Gate the construction of the singleton RemoteWorkspace

### DIFF
--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
             var persistentService = previewWorkspace.Services.GetService<IPersistentStorageService>();
             Assert.NotNull(persistentService);
 
-            var storage = persistentService.GetStorage(previewWorkspace.CurrentSolution);
+            using var storage = persistentService.GetStorage(previewWorkspace.CurrentSolution);
             Assert.True(storage is NoOpPersistentStorage);
         }
 

--- a/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
@@ -57,7 +57,7 @@ namespace AnalyzerRunner
             if (usePersistentStorage)
             {
                 var persistentStorageService = workspace.Services.GetRequiredService<IPersistentStorageService>();
-                var persistentStorage = persistentStorageService.GetStorage(workspace.CurrentSolution);
+                using var persistentStorage = persistentStorageService.GetStorage(workspace.CurrentSolution);
                 if (persistentStorage is NoOpPersistentStorage)
                 {
                     throw new InvalidOperationException("Benchmark is not configured to use persistent storage.");

--- a/src/Workspaces/Remote/Core/Services/SolutionService.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionService.cs
@@ -22,6 +22,11 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal sealed class SolutionService
     {
+        /// <summary>
+        /// This object gates the construction of the singleton <see cref="RemoteWorkspace"/> instance.
+        /// </summary>
+        private static readonly object s_remoteWorkspaceGate = new object();
+
         private static readonly SemaphoreSlim s_gate = new SemaphoreSlim(initialCount: 1);
 
         // this simple cache hold onto the last and primary solution created
@@ -41,10 +46,16 @@ namespace Microsoft.CodeAnalysis.Remote
                 var primaryWorkspace = exportProvider.GetExports<PrimaryWorkspace>().Single().Value;
                 if (primaryWorkspace.Workspace == null)
                 {
-                    // The Roslyn OOP service assumes a singleton workspace exists, but doesn't initialize it anywhere.
-                    // If we get here, code is asking for a workspace before it exists, so we create one on the fly.
-                    // The RemoteWorkspace constructor assigns itself as the new singleton instance.
-                    _ = new RemoteWorkspace();
+                    lock (s_remoteWorkspaceGate)
+                    {
+                        if (primaryWorkspace.Workspace is null)
+                        {
+                            // The Roslyn OOP service assumes a singleton workspace exists, but doesn't initialize it anywhere.
+                            // If we get here, code is asking for a workspace before it exists, so we create one on the fly.
+                            // The RemoteWorkspace constructor assigns itself as the new singleton instance.
+                            _ = new RemoteWorkspace();
+                        }
+                    }
 
                     // the above call initialized the workspace:
                     Contract.ThrowIfNull(primaryWorkspace.Workspace);


### PR DESCRIPTION
`Workspace.Dispose()` doesn't dispose of all the workspace and language services it provides. For items that export `IWorkspaceService` or `ILanguageService` directly, this isn't a problem because those instances are serviced by the underlying MEF catalog and it will dispose of items. However, for items provided by `IWorkspaceServiceFactory`, only the factory is tracked by the underlying MEF catalog and the factory-created instances are part of each workspace. For unit tests, we're good about making sure both the workspace and the MEF catalog are disposed. However, for integration tests things are a bit more relaxed. In **devenv.exe**, we only have one Workspace and one MEF catalog and neither get disposed until VS is shutting down. For the OOP process, however, we have some paths by which more than one `RemoteWorkspace` can get created, and these are not disposed. If more than one `RemoteWorkspace` instance gets created, one of them will be discarded, which can lead to finalization of `SqlConnection` if the discarded workspace performed any database operations. This is an attempt to fix the issue by putting a lock around the `new RemoteWorkspace()` call in `SolutionService.PrimaryWorkspace`.

In addition, two cases in test code where `IPersistentStorage` was not disposed have been corrected.

Fixes #22302