### PR TITLE
Underscores in using declarations are discards

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -121,3 +121,9 @@ public class Derived : Base<string?>
 }
 ```
 
+20. https://github.com/dotnet/roslyn/issues/43292 In *Visual Studio 2019 version 16.3* and onwards, the compiler considered `using` declarations using an underscore identifier to declare a local named `_`. In *Visual Studio 2019 version 16.7*, those no longer declare locals, they are instead discards. The following becomes an error:
+``` csharp
+using var _ = (IDisposable)null;
+_.ToString(); // the name '_' doesn't exist in this context
+```
+

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 kind = LocalDeclarationKind.Constant;
                             }
-                            else if (decl.UsingKeyword != default(SyntaxToken))
+                            else if (decl.UsingKeyword != default)
                             {
                                 kind = LocalDeclarationKind.UsingVariable;
                             }
@@ -231,11 +231,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 kind = LocalDeclarationKind.RegularVariable;
                             }
+
                             foreach (var vdecl in decl.Declaration.Variables)
                             {
-                                var localSymbol = MakeLocal(decl.Declaration, vdecl, kind, localDeclarationBinder);
-                                locals.Add(localSymbol);
+                                bool isDiscard = kind == LocalDeclarationKind.UsingVariable && vdecl.Identifier.IsUnderscoreToken();
 
+                                if (!isDiscard)
+                                {
+                                    var localSymbol = MakeLocal(decl.Declaration, vdecl, kind, localDeclarationBinder);
+                                    locals.Add(localSymbol);
+                                }
                                 // also gather expression-declared variables from the bracketed argument lists and the initializers
                                 ExpressionVariableFinder.FindExpressionVariables(this, locals, vdecl, localDeclarationBinder);
                             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/43292

Will inform the compat council of the small break.