### PR TITLE
Enable ngen for codelens

### DIFF
--- a/src/VisualStudio/CodeLens/Microsoft.VisualStudio.LanguageServices.CodeLens.csproj
+++ b/src/VisualStudio/CodeLens/Microsoft.VisualStudio.LanguageServices.CodeLens.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.VisualStudio.LanguageServices.CodeLens</RootNamespace>
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
+    <ApplyNgenOptimization>partial</ApplyNgenOptimization>
     <!-- NuGet -->
     <IsPackable>false</IsPackable>
     <PackageDescription>


### PR DESCRIPTION
I think ngen should be enabled for this assembly, since we are [profiling it](https://devdiv.visualstudio.com/_apps/hub/ms-vscs-artifact.build-tasks.drop-hub-group-explorer-hub?name=OptimizationData/dotnet/roslyn/master-vs-deps/20200415.11/645509/1). Also, not sure if this is somehow related to [this issue](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_queries/edit/1077670/?triage=true)

@chsienki @tmat 