### PR TITLE
Ensure that TS can report todo comments even prior to us having connected to the OOP server.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -213,12 +213,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
             using var _ = ArrayBuilder<TodoCommentData>.GetInstance(out var converted);
 
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var tree = document.SupportsSyntaxTree
-                ? await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false)
-                : null;
 
+            // TS doesn't have syntax trees, so just explicitly pass along null when converting the data.
             foreach (var comment in todoComments)
-                converted.Add(comment.CreateSerializableData(document, text, tree));
+                converted.Add(comment.CreateSerializableData(document, text, tree: null));
 
             await ReportTodoCommentDataAsync(
                 document.Id, converted.ToImmutable(), cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -52,7 +52,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
         /// <summary>
         /// Queue where we enqueue the information we get from OOP to process in batch in the future.
         /// </summary>
-        private AsyncBatchingWorkQueue<DocumentAndComments>? _workQueue;
+        private readonly TaskCompletionSource<AsyncBatchingWorkQueue<DocumentAndComments>> _workQueueSource
+            = new TaskCompletionSource<AsyncBatchingWorkQueue<DocumentAndComments>>();
 
         public event EventHandler<TodoItemsUpdatedArgs>? TodoListUpdated;
 
@@ -92,10 +93,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
 
         private async Task StartWorkerAsync(CancellationToken cancellationToken)
         {
-            _workQueue = new AsyncBatchingWorkQueue<DocumentAndComments>(
-                TimeSpan.FromSeconds(1),
-                ProcessTodoCommentInfosAsync,
-                cancellationToken);
+            _workQueueSource.SetResult(
+                new AsyncBatchingWorkQueue<DocumentAndComments>(
+                    TimeSpan.FromSeconds(1),
+                    ProcessTodoCommentInfosAsync,
+                    cancellationToken));
 
             var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
             if (client == null)
@@ -198,11 +200,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
         /// <summary>
         /// Callback from the OOP service back into us.
         /// </summary>
-        public Task ReportTodoCommentDataAsync(DocumentId documentId, ImmutableArray<TodoCommentData> infos, CancellationToken cancellationToken)
+        public async Task ReportTodoCommentDataAsync(DocumentId documentId, ImmutableArray<TodoCommentData> infos, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfNull(_workQueue);
-            _workQueue.AddWork(new DocumentAndComments(documentId, infos));
-            return Task.CompletedTask;
+            var workQueue = await _workQueueSource.Task.ConfigureAwait(false);
+            workQueue.AddWork(new DocumentAndComments(documentId, infos));
         }
 
         /// <inheritdoc cref="IVsTypeScriptTodoCommentService.ReportTodoCommentsAsync(Document, ImmutableArray{TodoComment}, CancellationToken)"/>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/43320#event-3241083748

TS is going to be reporting these comments using their own mechanism for scheduling.  Technically, nothing ensures that they will be runnign after we "start" (i.e. hook up to OOP) our TODO service.  This is esp. the case since we launch this in a Fire-And-Forget manner in async-package-load.

This PR just makes us resilient to the TS calling into us before that.  In that case, all we do is just have their call await us actually getting started and then from that point on everything is hooked up properly and messages are processed normally.