### PR TITLE
Making name of script globals type hidden

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -57,6 +57,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly Lazy<AliasSymbol> _globalNamespaceAlias;  // alias symbol used to resolve "global::".
         private readonly Lazy<ImplicitNamedTypeSymbol?> _scriptClass;
 
+        // The type of host object model if available.
+        private TypeSymbol? _lazyHostObjectTypeSymbol;
+
         // All imports (using directives and extern aliases) in syntax trees in this compilation.
         // NOTE: We need to de-dup since the Imports objects that populate the list may be GC'd
         // and re-created.
@@ -1452,8 +1455,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             );
         }
 
-        // The type of host object model if available.
-        private TypeSymbol? _lazyHostObjectTypeSymbol;
+        protected override ITypeSymbol? CommonScriptGlobalsType
+            => GetHostObjectTypeSymbol()?.GetPublicSymbol();
 
         internal TypeSymbol? GetHostObjectTypeSymbol()
         {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -362,10 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         containingType = symbol.ContainingType;
 
-                        var hostType = ((CSharpCompilation)semanticModelOpt.Compilation).GetHostObjectTypeSymbol();
-                        var x = SymbolEqualityComparer.Default.Equals(containingType, hostType);
-
-                        if ((object)containingType != null && !x)
+                        if ((object)containingType != null)
                         {
                             includeType = IncludeNamedType(symbol.ContainingType);
                         }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -362,7 +362,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         containingType = symbol.ContainingType;
 
-                        if ((object)containingType != null)
+                        var hostType = ((CSharpCompilation)semanticModelOpt.Compilation).GetHostObjectTypeSymbol();
+                        var x = SymbolEqualityComparer.Default.Equals(containingType, hostType);
+
+                        if ((object)containingType != null && !x)
                         {
                             includeType = IncludeNamedType(symbol.ContainingType);
                         }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -367,9 +367,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool IncludeNamedType(INamedTypeSymbol namedType)
         {
-            return
-                namedType != null &&
-                (!namedType.IsScriptClass || format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeScriptType));
+            if (namedType is null)
+            {
+                return false;
+            }
+
+            if (namedType.IsScriptClass && format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeScriptType))
+            {
+                return false;
+            }
+
+            if (namedType == semanticModelOpt.Compilation.ScriptGlobalsType)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private static bool IsEnumMember(ISymbol symbol)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (namedType == semanticModelOpt.Compilation.ScriptGlobalsType)
+            if (namedType == semanticModelOpt?.Compilation.ScriptGlobalsType)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (namedType.IsScriptClass && format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeScriptType))
+            if (namedType.IsScriptClass && !format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeScriptType))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2530,6 +2530,33 @@ namespace N1 {
                 SymbolDisplayPartKind.NamespaceName);
         }
 
+        public class ScriptGlobals
+        {
+            public void Print(object obj) { }
+        }
+
+        [Fact]
+        public void TestMinimalNamespace__()
+        {
+            var text = @"Print()";
+            var tree = SyntaxFactory.ParseSyntaxTree(text, TestOptions.Script);
+
+            var comp = CSharpCompilation.CreateScriptCompilation(
+                "submission1",
+                tree,
+                TargetFrameworkUtil.GetReferences(TargetFramework.Standard),
+                returnType: typeof(object),
+                globalsType: typeof(ScriptGlobals));
+
+            var model = comp.GetSemanticModel(tree);
+            var hostTypeSymbol = comp.GetHostObjectTypeSymbol();
+
+            var format = new SymbolDisplayFormat();
+            var displayParts = hostTypeSymbol.ToMinimalDisplayParts(model, position: 0, format);
+
+            //Verify(description, expectedText, expectedKinds);
+        }
+
         [Fact]
         public void TestRemoveAttributeSuffix1()
         {

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2540,22 +2540,53 @@ namespace N1 {
         {
             var text = @"Print()";
             var tree = SyntaxFactory.ParseSyntaxTree(text, TestOptions.Script);
+            var hostReference = MetadataReference.CreateFromFile(typeof(ScriptGlobals).Assembly.Location);
 
             var comp = CSharpCompilation.CreateScriptCompilation(
                 "submission1",
                 tree,
-                TargetFrameworkUtil.GetReferences(TargetFramework.Standard),
+                TargetFrameworkUtil.GetReferences(TargetFramework.Standard).Concat(hostReference),
                 returnType: typeof(object),
                 globalsType: typeof(ScriptGlobals));
 
             var model = comp.GetSemanticModel(tree);
             var hostTypeSymbol = comp.GetHostObjectTypeSymbol();
+            var printSymbol = hostTypeSymbol.GetMember("Print");
 
-            var format = new SymbolDisplayFormat();
-            var displayParts = hostTypeSymbol.ToMinimalDisplayParts(model, position: 0, format);
+            var displayParts = printSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat);
 
             //Verify(description, expectedText, expectedKinds);
         }
+
+        private static readonly SymbolDisplayFormat s_memberSignatureDisplayFormat =
+                new SymbolDisplayFormat(
+                    globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+                    genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
+                    memberOptions:
+                        SymbolDisplayMemberOptions.IncludeRef |
+                        SymbolDisplayMemberOptions.IncludeType |
+                        SymbolDisplayMemberOptions.IncludeParameters |
+                        SymbolDisplayMemberOptions.IncludeContainingType,
+                    kindOptions:
+                        SymbolDisplayKindOptions.IncludeMemberKeyword,
+                    propertyStyle:
+                        SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+                    parameterOptions:
+                        SymbolDisplayParameterOptions.IncludeName |
+                        SymbolDisplayParameterOptions.IncludeType |
+                        SymbolDisplayParameterOptions.IncludeParamsRefOut |
+                        SymbolDisplayParameterOptions.IncludeExtensionThis |
+                        SymbolDisplayParameterOptions.IncludeDefaultValue |
+                        SymbolDisplayParameterOptions.IncludeOptionalBrackets,
+                    localOptions:
+                        SymbolDisplayLocalOptions.IncludeRef |
+                        SymbolDisplayLocalOptions.IncludeType,
+                    miscellaneousOptions:
+                        SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
+                        SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+                        SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName |
+                        SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                        SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral);
 
         [Fact]
         public void TestRemoveAttributeSuffix1()

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2572,61 +2572,127 @@ namespace N1 {
             var eventSymbol = hostTypeSymbol.GetMember("Event");
 
             // ...
-            /*var nestedTypeSymbol = (ITypeSymbol)hostTypeSymbol.GetMember("NestedType");
+            //name type symbol 
+            var nestedTypeSymbol = (TypeSymbol)hostTypeSymbol.GetMember("NestedType");
             var nestedMethodSymbol = nestedTypeSymbol.GetMember("Method");
             var nestedDelegateSymbol = nestedTypeSymbol.GetMember("MyDelegate");
             var nestedFieldSymbol = nestedTypeSymbol.GetMember("Field");
             var nestedPropertySymbol = nestedTypeSymbol.GetMember("Property");
             var nestedEventSymbol = nestedTypeSymbol.GetMember("Event");
-            // ...*/
+            // ...
 
             Verify(methodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "void Method(int p)",
-                SymbolDisplayPartKind.Keyword);
+
+                 SymbolDisplayPartKind.Keyword,
+                 SymbolDisplayPartKind.Space,
+                 SymbolDisplayPartKind.MethodName,
+                 SymbolDisplayPartKind.Punctuation,
+                 SymbolDisplayPartKind.Keyword,
+                 SymbolDisplayPartKind.Space,
+                 SymbolDisplayPartKind.ParameterName,
+                 SymbolDisplayPartKind.Punctuation);
 
             Verify(delegateSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "delegate void MyDelegate(int x)",
-                SymbolDisplayPartKind.Keyword);
+                "MyDelegate(int x)",
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
 
             Verify(fieldSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "int Field",
-                SymbolDisplayPartKind.Keyword);
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.FieldName);
 
             Verify(propertySymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "int Property {get;}",
-                SymbolDisplayPartKind.Keyword);
+                "int Property { get; }",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.PropertyName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation);
 
             Verify(eventSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "Action Event",
-                SymbolDisplayPartKind.Keyword);
+                "event System.Action Event",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NamespaceName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EventName);
 
-            /*Verify(nestedTypeSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "class NestedType",
-                SymbolDisplayPartKind.Keyword);
+            Verify(nestedTypeSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "NestedType",
+                SymbolDisplayPartKind.ClassName);
 
             Verify(nestedMethodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "void NestedType.Method(int p)",
-                SymbolDisplayPartKind.Keyword);
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
 
             Verify(nestedDelegateSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "delegate void NestedType.MyDelegate(int x)",
-                SymbolDisplayPartKind.Keyword);
+                "NestedType.MyDelegate(int x)",
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
 
             Verify(nestedFieldSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "int NestedType.Field",
-                SymbolDisplayPartKind.Keyword);
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.FieldName);
 
             Verify(nestedPropertySymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "int NestedType.Property {get;} ",
-                SymbolDisplayPartKind.Keyword);
+                "int NestedType.Property { get; }",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.PropertyName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation);
 
             Verify(nestedEventSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-                "Action NestedType.Event",
-                SymbolDisplayPartKind.Keyword);*/
-
-            // Verify(methodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
-            // "",
-            //    expectedKinds);
+                "event System.Action NestedType.Event",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NamespaceName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.EventName);
         }
 
         private static readonly SymbolDisplayFormat s_memberSignatureDisplayFormat =
@@ -2638,6 +2704,8 @@ namespace N1 {
                         SymbolDisplayMemberOptions.IncludeType |
                         SymbolDisplayMemberOptions.IncludeParameters |
                         SymbolDisplayMemberOptions.IncludeContainingType,
+                    delegateStyle:
+                        SymbolDisplayDelegateStyle.NameAndSignature,
                     kindOptions:
                         SymbolDisplayKindOptions.IncludeMemberKeyword,
                     propertyStyle:

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2532,13 +2532,26 @@ namespace N1 {
 
         public class ScriptGlobals
         {
-            public void Print(object obj) { }
+            public void Method(int p) { }
+            public delegate void MyDelegate(int x);
+            public int Field;
+            public int Property => 1;
+            public event Action Event;
+
+            public class NestedType
+            {
+                public void Method(int p) { }
+                public delegate void MyDelegate(int x);
+                public int Field;
+                public int Property => 1;
+                public event Action Event;
+            }
         }
 
         [Fact]
         public void TestMinimalNamespace__()
         {
-            var text = @"Print()";
+            var text = @"1";
             var tree = SyntaxFactory.ParseSyntaxTree(text, TestOptions.Script);
             var hostReference = MetadataReference.CreateFromFile(typeof(ScriptGlobals).Assembly.Location);
 
@@ -2551,11 +2564,69 @@ namespace N1 {
 
             var model = comp.GetSemanticModel(tree);
             var hostTypeSymbol = comp.GetHostObjectTypeSymbol();
-            var printSymbol = hostTypeSymbol.GetMember("Print");
 
-            var displayParts = printSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat);
+            var methodSymbol = hostTypeSymbol.GetMember("Method");
+            var delegateSymbol = hostTypeSymbol.GetMember("MyDelegate");
+            var fieldSymbol = hostTypeSymbol.GetMember("Field");
+            var propertySymbol = hostTypeSymbol.GetMember("Property");
+            var eventSymbol = hostTypeSymbol.GetMember("Event");
 
-            //Verify(description, expectedText, expectedKinds);
+            // ...
+            /*var nestedTypeSymbol = (ITypeSymbol)hostTypeSymbol.GetMember("NestedType");
+            var nestedMethodSymbol = nestedTypeSymbol.GetMember("Method");
+            var nestedDelegateSymbol = nestedTypeSymbol.GetMember("MyDelegate");
+            var nestedFieldSymbol = nestedTypeSymbol.GetMember("Field");
+            var nestedPropertySymbol = nestedTypeSymbol.GetMember("Property");
+            var nestedEventSymbol = nestedTypeSymbol.GetMember("Event");
+            // ...*/
+
+            Verify(methodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "void Method(int p)",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(delegateSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "delegate void MyDelegate(int x)",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(fieldSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "int Field",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(propertySymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "int Property {get;}",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(eventSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "Action Event",
+                SymbolDisplayPartKind.Keyword);
+
+            /*Verify(nestedTypeSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "class NestedType",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(nestedMethodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "void NestedType.Method(int p)",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(nestedDelegateSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "delegate void NestedType.MyDelegate(int x)",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(nestedFieldSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "int NestedType.Field",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(nestedPropertySymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "int NestedType.Property {get;} ",
+                SymbolDisplayPartKind.Keyword);
+
+            Verify(nestedEventSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+                "Action NestedType.Event",
+                SymbolDisplayPartKind.Keyword);*/
+
+            // Verify(methodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
+            // "",
+            //    expectedKinds);
         }
 
         private static readonly SymbolDisplayFormat s_memberSignatureDisplayFormat =

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2580,14 +2580,14 @@ namespace N1 {
 
             Verify(methodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "void Method(int p)",
-                 SymbolDisplayPartKind.Keyword,
-                 SymbolDisplayPartKind.Space,
-                 SymbolDisplayPartKind.MethodName,
-                 SymbolDisplayPartKind.Punctuation,
-                 SymbolDisplayPartKind.Keyword,
-                 SymbolDisplayPartKind.Space,
-                 SymbolDisplayPartKind.ParameterName,
-                 SymbolDisplayPartKind.Punctuation);
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
 
             Verify(delegateSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "MyDelegate(int x)",

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2549,7 +2549,7 @@ namespace N1 {
         }
 
         [Fact]
-        public void TestMinimalNamespace__()
+        public void TestMembersInScriptGlobals()
         {
             var text = @"1";
             var tree = SyntaxFactory.ParseSyntaxTree(text, TestOptions.Script);
@@ -2571,19 +2571,15 @@ namespace N1 {
             var propertySymbol = hostTypeSymbol.GetMember("Property");
             var eventSymbol = hostTypeSymbol.GetMember("Event");
 
-            // ...
-            //name type symbol 
             var nestedTypeSymbol = (TypeSymbol)hostTypeSymbol.GetMember("NestedType");
             var nestedMethodSymbol = nestedTypeSymbol.GetMember("Method");
             var nestedDelegateSymbol = nestedTypeSymbol.GetMember("MyDelegate");
             var nestedFieldSymbol = nestedTypeSymbol.GetMember("Field");
             var nestedPropertySymbol = nestedTypeSymbol.GetMember("Property");
             var nestedEventSymbol = nestedTypeSymbol.GetMember("Event");
-            // ...
 
             Verify(methodSymbol.ToMinimalDisplayParts(model, position: 0, s_memberSignatureDisplayFormat),
                 "void Method(int p)",
-
                  SymbolDisplayPartKind.Keyword,
                  SymbolDisplayPartKind.Space,
                  SymbolDisplayPartKind.MethodName,
@@ -2696,36 +2692,36 @@ namespace N1 {
         }
 
         private static readonly SymbolDisplayFormat s_memberSignatureDisplayFormat =
-                new SymbolDisplayFormat(
-                    globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
-                    genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
-                    memberOptions:
-                        SymbolDisplayMemberOptions.IncludeRef |
-                        SymbolDisplayMemberOptions.IncludeType |
-                        SymbolDisplayMemberOptions.IncludeParameters |
-                        SymbolDisplayMemberOptions.IncludeContainingType,
-                    delegateStyle:
-                        SymbolDisplayDelegateStyle.NameAndSignature,
-                    kindOptions:
-                        SymbolDisplayKindOptions.IncludeMemberKeyword,
-                    propertyStyle:
-                        SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
-                    parameterOptions:
-                        SymbolDisplayParameterOptions.IncludeName |
-                        SymbolDisplayParameterOptions.IncludeType |
-                        SymbolDisplayParameterOptions.IncludeParamsRefOut |
-                        SymbolDisplayParameterOptions.IncludeExtensionThis |
-                        SymbolDisplayParameterOptions.IncludeDefaultValue |
-                        SymbolDisplayParameterOptions.IncludeOptionalBrackets,
-                    localOptions:
-                        SymbolDisplayLocalOptions.IncludeRef |
-                        SymbolDisplayLocalOptions.IncludeType,
-                    miscellaneousOptions:
-                        SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
-                        SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
-                        SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName |
-                        SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
-                        SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral);
+            new SymbolDisplayFormat(
+                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
+                memberOptions:
+                    SymbolDisplayMemberOptions.IncludeRef |
+                    SymbolDisplayMemberOptions.IncludeType |
+                    SymbolDisplayMemberOptions.IncludeParameters |
+                    SymbolDisplayMemberOptions.IncludeContainingType,
+                delegateStyle:
+                    SymbolDisplayDelegateStyle.NameAndSignature,
+                kindOptions:
+                    SymbolDisplayKindOptions.IncludeMemberKeyword,
+                propertyStyle:
+                    SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+                parameterOptions:
+                    SymbolDisplayParameterOptions.IncludeName |
+                    SymbolDisplayParameterOptions.IncludeType |
+                    SymbolDisplayParameterOptions.IncludeParamsRefOut |
+                    SymbolDisplayParameterOptions.IncludeExtensionThis |
+                    SymbolDisplayParameterOptions.IncludeDefaultValue |
+                    SymbolDisplayParameterOptions.IncludeOptionalBrackets,
+                localOptions:
+                    SymbolDisplayLocalOptions.IncludeRef |
+                    SymbolDisplayLocalOptions.IncludeType,
+                miscellaneousOptions:
+                    SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
+                    SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+                    SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName |
+                    SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                    SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral);
 
         [Fact]
         public void TestRemoveAttributeSuffix1()

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2532,7 +2532,7 @@ namespace N1 {
 
         public class ScriptGlobals
         {
-            public void Method(int p) { }
+            public void Method(int p) { Event.Invoke(); }
             public delegate void MyDelegate(int x);
             public int Field;
             public int Property => 1;
@@ -2540,7 +2540,7 @@ namespace N1 {
 
             public class NestedType
             {
-                public void Method(int p) { }
+                public void Method(int p) { Event.Invoke(); }
                 public delegate void MyDelegate(int x);
                 public int Field;
                 public int Property => 1;

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -855,6 +855,12 @@ namespace Microsoft.CodeAnalysis
         protected abstract ITypeSymbol CommonDynamicType { get; }
 
         /// <summary>
+        /// A symbol representing the script globals type.
+        /// </summary>
+        internal ITypeSymbol? ScriptGlobalsType => CommonScriptGlobalsType;
+        protected abstract ITypeSymbol? CommonScriptGlobalsType { get; }
+
+        /// <summary>
         /// A symbol representing the implicit Script class. This is null if the class is not
         /// defined in the compilation.
         /// </summary>

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -771,6 +771,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Nothing)
         End Function
 
+        Protected Overrides ReadOnly Property CommonScriptGlobalsType As ITypeSymbol
+            Get
+                Throw New NotImplementedException()
+            End Get
+        End Property
+
 #End Region
 
 #Region "Syntax Trees"

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -773,7 +773,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Overrides ReadOnly Property CommonScriptGlobalsType As ITypeSymbol
             Get
-                Throw New NotImplementedException()
+                Return Nothing
             End Get
         End Property
 


### PR DESCRIPTION
Exposes global types symbol from compilation and changed symbol display so that the name of global type is now shown when hovering over a method, field, property, etc.

Fixes https://github.com/dotnet/roslyn/issues/5983