### PR TITLE
Document new conversions in general test plan

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -308,6 +308,8 @@ __makeref( x )
 - Interpolated string
 - Tuple literal
 - Tuple
+- Default literal
+- Implicit object creation
 
 ## Types 
 

--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -309,7 +309,7 @@ __makeref( x )
 - Tuple literal
 - Tuple
 - Default literal
-- Implicit object creation
+- Implicit object creation (target-typed new)
 
 ## Types 
 


### PR DESCRIPTION
We forgot to add some recently added conversions to the test plan.