### PR TITLE
Remove public API on DocumentOptionSet

### DIFF
--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -29,9 +29,6 @@ namespace Microsoft.CodeAnalysis.Options
         private protected override object? GetOptionCore(OptionKey optionKey)
             => _backingOptionSet.GetOption(optionKey);
 
-        public new object? GetOption(OptionKey optionKey)
-            => base.GetOption(optionKey);
-
         public T GetOption<T>(PerLanguageOption<T> option)
             => _backingOptionSet.GetOption(option, _language);
 

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsVolatile.get -> bool
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsExtern(bool isExtern) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ElementBindingExpression(params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
-Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/42931 added this API as we thought converting the base type's `OptionSet.GetOption` method from an abstract to non-abstract method and removing the override on `DocumentOptionSet` would be a binary breaking change for callers. However, based on the public API review meeting, it was identified that it would indeed not be a breaking change as the compiler would have emitted a callvirt to `OptionSet.GetOption`.