### PR TITLE
Add vscode tasks to run tests in current file/project

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,20 +5,40 @@
   "tasks": [
     {
         "label": "build",
-        "command": "./build.cmd",
-        "type": "shell",
+        "command": "dotnet",
         "args": [
+          "msbuild",
+          "-p:GenerateFullPaths=true",
+          "Compilers.sln"
         ],
+        "windows": {
+          "args": [
+            "msbuild",
+            "-p:GenerateFullPaths=true",
+            "Roslyn.sln"
+          ]
+        },
         "problemMatcher": "$msCompile",
         "group": "build"
     },
     {
         "label": "build skip analyzers",
-        "command": "./build.cmd",
-        "type": "shell",
+        "command": "dotnet",
         "args": [
-          "-skipAnalyzers"
+          "msbuild",
+          "-p:UseRoslynAnalyzers=false",
+          "-p:GenerateFullPaths=true",
+          "Compilers.sln"
         ],
+        "windows": {
+          "args": [
+            "msbuild",
+            "-p:UseRoslynAnalyzers=false",
+            "-p:GenerateFullPaths=true",
+            "Roslyn.sln"
+          ]
+        },
+        "type": "shell",
         "problemMatcher": "$msCompile",
         "group": "build"
     },
@@ -44,6 +64,17 @@
           "-p:UseRoslynAnalyzers=false",
           "-p:GenerateFullPaths=true",
           "${fileDirname}"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "build"
+    },
+    {
+        "label": "generate compiler code",
+        "command": "dotnet",
+        "type": "process",
+        "args": [
+          "pwsh",
+          "${workspaceRoot}/eng/generate-compiler-code.ps1"
         ],
         "problemMatcher": "$msCompile",
         "group": "build"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,7 +33,7 @@
     },
     {
         "label": "build csc skip analyzers",
-        "command": "dotnet",
+        "command": "./.dotnet/dotnet",
         "type": "shell",
         "args": [
           "msbuild",
@@ -46,8 +46,8 @@
     },
     {
         "label": "build current project skip analyzers",
-        "command": "dotnet",
-        "type": "process",
+        "command": "./.dotnet/dotnet",
+        "type": "shell",
         "args": [
           "pwsh",
           "${workspaceRoot}/scripts/vscode-build.ps1",
@@ -59,8 +59,8 @@
     },
     {
         "label": "generate compiler code",
-        "command": "dotnet",
-        "type": "process",
+        "command": "./.dotnet/dotnet",
+        "type": "shell",
         "args": [
           "pwsh",
           "${workspaceRoot}/eng/generate-compiler-code.ps1"
@@ -70,8 +70,8 @@
     },
     {
         "label": "run tests in current file (netcoreapp3.1)",
-        "command": "dotnet",
-        "type": "process",
+        "command": "./.dotnet/dotnet",
+        "type": "shell",
         "args": [
           "pwsh",
           "${workspaceRoot}/scripts/vscode-run-tests.ps1",
@@ -87,8 +87,8 @@
     },
     {
         "label": "run tests in current project (netcoreapp3.1)",
-        "command": "dotnet",
-        "type": "process",
+        "command": "./.dotnet/dotnet",
+        "type": "shell",
         "args": [
           "pwsh",
           "${workspaceRoot}/scripts/vscode-run-tests.ps1",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,9 @@
         ],
         "windows": {
           "command": "./build.cmd",
+          "args": [
+            "-skipAnalyzers"
+          ],
         },
         "problemMatcher": "$msCompile",
         "group": "build"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,40 +5,26 @@
   "tasks": [
     {
         "label": "build",
-        "command": "dotnet",
+        "command": "./build.sh",
+        "type": "shell",
         "args": [
-          "msbuild",
-          "-p:GenerateFullPaths=true",
-          "Compilers.sln"
         ],
         "windows": {
-          "args": [
-            "msbuild",
-            "-p:GenerateFullPaths=true",
-            "Roslyn.sln"
-          ]
+          "command": "./build.cmd",
         },
         "problemMatcher": "$msCompile",
         "group": "build"
     },
     {
         "label": "build skip analyzers",
-        "command": "dotnet",
+        "command": "./build.sh",
+        "type": "shell",
         "args": [
-          "msbuild",
-          "-p:UseRoslynAnalyzers=false",
-          "-p:GenerateFullPaths=true",
-          "Compilers.sln"
+          "--skipAnalyzers"
         ],
         "windows": {
-          "args": [
-            "msbuild",
-            "-p:UseRoslynAnalyzers=false",
-            "-p:GenerateFullPaths=true",
-            "Roslyn.sln"
-          ]
+          "command": "./build.cmd",
         },
-        "type": "shell",
         "problemMatcher": "$msCompile",
         "group": "build"
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,12 +50,13 @@
     },
     {
         "label": "run tests in current file (netcoreapp3.1)",
-        "command": "powershell",
-        "type": "shell",
+        "command": "dotnet",
+        "type": "process",
         "args": [
+          "pwsh",
           "${workspaceRoot}/scripts/vscode-run-tests.ps1",
           "-filePath",
-          "${relativeFile}",
+          "${file}",
           "-framework",
           "netcoreapp3.1",
           "-filter",
@@ -66,12 +67,13 @@
     },
     {
         "label": "run tests in current project (netcoreapp3.1)",
-        "command": "powershell",
-        "type": "shell",
+        "command": "dotnet",
+        "type": "process",
         "args": [
+          "pwsh",
           "${workspaceRoot}/scripts/vscode-run-tests.ps1",
           "-filePath",
-          "${relativeFile}",
+          "${file}",
           "-framework",
           "netcoreapp3.1"
         ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,6 +47,36 @@
         ],
         "problemMatcher": "$msCompile",
         "group": "build"
+    },
+    {
+        "label": "run tests in current file (netcoreapp3.1)",
+        "command": "powershell",
+        "type": "shell",
+        "args": [
+          "${workspaceRoot}/scripts/vscode-run-tests.ps1",
+          "-filePath",
+          "${relativeFile}",
+          "-framework",
+          "netcoreapp3.1",
+          "-filter",
+          "${fileBasenameNoExtension}"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "test"
+    },
+    {
+        "label": "run tests in current project (netcoreapp3.1)",
+        "command": "powershell",
+        "type": "shell",
+        "args": [
+          "${workspaceRoot}/scripts/vscode-run-tests.ps1",
+          "-filePath",
+          "${relativeFile}",
+          "-framework",
+          "netcoreapp3.1"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "test"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -45,14 +45,14 @@
         "group": "build"
     },
     {
-        "label": "build directory skip analyzers",
+        "label": "build current project skip analyzers",
         "command": "dotnet",
-        "type": "shell",
+        "type": "process",
         "args": [
-          "msbuild",
-          "-p:UseRoslynAnalyzers=false",
-          "-p:GenerateFullPaths=true",
-          "${fileDirname}"
+          "pwsh",
+          "${workspaceRoot}/scripts/vscode-build.ps1",
+          "-filePath",
+          "${file}"
         ],
         "problemMatcher": "$msCompile",
         "group": "build"

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -2,9 +2,15 @@
   "isRoot": true,
   "tools": {
     "dotnet-format": {
-      "version": "3.2.107801",
+      "version": "3.3.111304",
       "commands": [
         "dotnet-format"
+      ]
+    },
+    "powershell": {
+      "version": "6.2.4",
+      "commands": [
+        "pwsh"
       ]
     }
   }

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,7 +8,7 @@
       ]
     },
     "powershell": {
-      "version": "6.2.4",
+      "version": "7.0.0",
       "commands": [
         "pwsh"
       ]

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -25,7 +25,7 @@ function GetProjectOutputBinary([string]$fileName, [string]$projectName = "", [s
 
 function GetPublishData() {
   if (Test-Path variable:global:_PublishData) {
-  return $global:_PublishData
+    return $global:_PublishData
   }
 
   Write-Host "Downloading $PublishDataUrl"
@@ -38,9 +38,9 @@ function GetBranchPublishData([string]$branchName) {
   $data = GetPublishData
 
   if (Get-Member -InputObject $data.branches -Name $branchName) {
-  return $data.branches.$branchName
+    return $data.branches.$branchName
   } else {
-  return $null
+    return $null
   }
 }
 
@@ -48,9 +48,9 @@ function GetReleasePublishData([string]$releaseName) {
   $data = GetPublishData
 
   if (Get-Member -InputObject $data.releases -Name $releaseName) {
-  return $data.releases.$releaseName
+    return $data.releases.$releaseName
   } else {
-  return $null
+    return $null
   }
 }
 
@@ -171,6 +171,33 @@ function Ensure-DotnetSdk() {
   }
 
   throw "Could not find dotnet executable in $dotnetInstallDir"
+}
+
+# Walks up the source tree, starting at the given file's directory, and returns a FileInfo object for the first .csproj file it finds, if any.
+function Get-ProjectFile([object]$fileInfo) {
+  Push-Location
+
+  Set-Location $fileInfo.Directory
+  try {
+    while ($true) {
+      # search up from the current file for a folder containing a csproj
+      $files = Get-ChildItem *.csproj
+      if ($files) {
+        return $files[0]
+      }
+      else {
+        $location = Get-Location
+        Set-Location ..
+        if ((Get-Location).Path -eq $location.Path) {
+          # our location didn't change. We must be at the drive root, so give up
+          return $null
+        }
+      }
+    }
+  }
+  finally {
+    Pop-Location
+  }
 }
 
 function Get-VersionCore([string]$name, [string]$versionFile) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -634,6 +634,10 @@ try {
     InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
   }
 
+  if ($restore) {
+    &(Ensure-DotNetSdk) tool restore
+  }
+
   try
   {
     if ($bootstrap) {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -286,6 +286,9 @@ function BuildSolution {
 }
 
 InitializeDotNetCli $restore
+if [[ "$restore" == true ]]; then
+  dotnet tool restore
+fi
 
 bootstrap_dir=""
 if [[ "$bootstrap" == true ]]; then

--- a/scripts/vscode-build.ps1
+++ b/scripts/vscode-build.ps1
@@ -1,0 +1,26 @@
+param (
+  [Parameter(Mandatory = $true)][string]$filePath
+)
+
+Set-StrictMode -version 3.0
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "../eng/build-utils.ps1")
+
+$fileInfo = Get-ItemProperty $filePath
+$projectFileInfo = Get-ProjectFile $fileInfo
+if ($projectFileInfo) {
+  $dotnetPath = Resolve-Path (Ensure-DotNetSdk) -Relative
+  $projectDir = Resolve-Path $projectFileInfo.Directory -Relative
+
+  $invocation = "$dotnetPath msbuild $projectDir -p:UseRoslynAnalyzers=false -p:GenerateFullPaths=true"
+  Write-Output "> $invocation"
+  Invoke-Expression $invocation
+
+  exit 0
+}
+else {
+  Write-Host "Failed to build project. $fileInfo is not part of a C# project."
+
+  exit 1
+}

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -7,6 +7,8 @@ param (
 Set-StrictMode -version 3.0
 $ErrorActionPreference="Stop"
 
+. (Join-Path $PSScriptRoot "../eng/build-utils.ps1")
+
 Push-Location
 
 $fileInfo = Get-ItemProperty $filePath
@@ -21,7 +23,7 @@ try
         if ($files)
         {
             Pop-Location
-            $dotnetPath = Resolve-Path "$PSScriptRoot/../.dotnet/dotnet.exe" -Relative
+            $dotnetPath = Resolve-Path (Ensure-DotNetSdk) -Relative
 
             $projectFileInfo = $files[0]
             $projectDir = Resolve-Path $projectFileInfo.Directory -Relative
@@ -29,7 +31,8 @@ try
             $filterArg = if ($filter) {" --filter $filter"} else {""}
             $logFileName = if ($filter) {$fileInfo.Name} else {$projectFileInfo.Name}
 
-            $resultsPath = Resolve-Path "$PSScriptRoot/../artifacts/TestResults" -Relative
+            $resultsPath = Join-Path (Resolve-Path "$PSScriptRoot/.." -Relative) "/artifacts/TestResults"
+            New-Item -ItemType Directory -Force -Path $resultsPath | Out-Null
 
             $invocation = "$dotnetPath test $projectDir$filterArg --framework $framework --logger `"html;LogFileName=$logfileName.html`" --results-directory $resultsPath"
             Write-Output "> $invocation"

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -1,0 +1,56 @@
+param (
+    [Parameter(Mandatory=$true)][string]$filePath,
+    [Parameter(Mandatory=$true)][string]$framework,
+    [Parameter(Mandatory=$false)][string]$filter
+)
+
+Set-StrictMode -version 3.0
+$ErrorActionPreference="Stop"
+
+Push-Location
+
+$fileInfo = Get-ItemProperty $filePath
+Set-Location $fileInfo.Directory
+
+try
+{
+    while ($true)
+    {
+        # search up from the current file for a folder containing a csproj
+        $files = Get-ChildItem *.csproj
+        if ($files)
+        {
+            Pop-Location
+            $dotnetPath = Resolve-Path "$PSScriptRoot/../.dotnet/dotnet.exe" -Relative
+
+            $projectFileInfo = $files[0]
+            $projectDir = Resolve-Path $projectFileInfo.Directory -Relative
+
+            $filterArg = if ($filter) {" --filter $filter"} else {""}
+            $logFileName = if ($filter) {$fileInfo.Name} else {$projectFileInfo.Name}
+
+            $resultsPath = Resolve-Path "$PSScriptRoot/../artifacts/TestResults" -Relative
+
+            $invocation = "$dotnetPath test $projectDir$filterArg --framework $framework --logger `"html;LogFileName=$logfileName.html`" --results-directory $resultsPath"
+            Write-Output "> $invocation"
+            Invoke-Expression $invocation
+
+            break
+        }
+        else
+        {
+            $location = Get-Location
+            Set-Location ..
+            if ((Get-Location).Path -eq $location.Path)
+            {
+                # our location didn't change. We must be at the drive root, so give up
+                Write-Host "Failed to run tests. $fileInfo is not part of a C# project."
+                break
+            }
+        }
+    }
+}
+finally
+{
+    Pop-Location
+}

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -1,55 +1,34 @@
 param (
-    [Parameter(Mandatory=$true)][string]$filePath,
-    [Parameter(Mandatory=$true)][string]$framework,
-    [Parameter(Mandatory=$false)][string]$filter
+  [Parameter(Mandatory = $true)][string]$filePath,
+  [Parameter(Mandatory = $true)][string]$framework,
+  [Parameter(Mandatory = $false)][string]$filter
 )
 
 Set-StrictMode -version 3.0
-$ErrorActionPreference="Stop"
+$ErrorActionPreference = "Stop"
 
 . (Join-Path $PSScriptRoot "../eng/build-utils.ps1")
 
-Push-Location
-
-$originalCwd = Get-Location
 $fileInfo = Get-ItemProperty $filePath
-Set-Location $fileInfo.Directory
+$projectFileInfo = Get-ProjectFile $fileInfo
+if ($projectFileInfo) {
+  $dotnetPath = Resolve-Path (Ensure-DotNetSdk) -Relative
+  $projectDir = Resolve-Path $projectFileInfo.Directory -Relative
 
-try {
-    while ($true) {
-        # search up from the current file for a folder containing a csproj
-        $files = Get-ChildItem *.csproj
-        if ($files) {
-            Set-Location $originalCwd
-            $dotnetPath = Resolve-Path (Ensure-DotNetSdk) -Relative
+  $filterArg = if ($filter) { " --filter $filter" } else { "" }
+  $logFileName = if ($filter) { $fileInfo.Name } else { $projectFileInfo.Name }
 
-            $projectFileInfo = $files[0]
-            $projectDir = Resolve-Path $projectFileInfo.Directory -Relative
+  $resultsPath = Join-Path $PSScriptRoot ".." "artifacts/TestResults"
+  $resultsPath = Resolve-Path (New-Item -ItemType Directory -Force -Path $resultsPath) -Relative
 
-            $filterArg = if ($filter) {" --filter $filter"} else {""}
-            $logFileName = if ($filter) {$fileInfo.Name} else {$projectFileInfo.Name}
+  $invocation = "$dotnetPath test $projectDir$filterArg --framework $framework --logger `"html;LogFileName=$logfileName.html`" --results-directory $resultsPath"
+  Write-Output "> $invocation"
+  Invoke-Expression $invocation
 
-            $resultsPath = Join-Path (Resolve-Path "$PSScriptRoot/.." -Relative) "/artifacts/TestResults"
-            New-Item -ItemType Directory -Force -Path $resultsPath | Out-Null
-
-            $invocation = "$dotnetPath test $projectDir$filterArg --framework $framework --logger `"html;LogFileName=$logfileName.html`" --results-directory $resultsPath"
-            Write-Output "> $invocation"
-            Invoke-Expression $invocation
-
-            exit 0
-        }
-        else {
-            $location = Get-Location
-            Set-Location ..
-            if ((Get-Location).Path -eq $location.Path) {
-                # our location didn't change. We must be at the drive root, so give up
-                Write-Host "Failed to run tests. $fileInfo is not part of a C# project."
-
-                exit 1
-            }
-        }
-    }
+  exit 0
 }
-finally {
-    Pop-Location
+else {
+  Write-Host "Failed to run tests. $fileInfo is not part of a C# project."
+
+  exit 1
 }

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -14,14 +14,11 @@ Push-Location
 $fileInfo = Get-ItemProperty $filePath
 Set-Location $fileInfo.Directory
 
-try
-{
-    while ($true)
-    {
+try {
+    while ($true) {
         # search up from the current file for a folder containing a csproj
         $files = Get-ChildItem *.csproj
-        if ($files)
-        {
+        if ($files) {
             Pop-Location
             $dotnetPath = Resolve-Path (Ensure-DotNetSdk) -Relative
 
@@ -40,12 +37,10 @@ try
 
             break
         }
-        else
-        {
+        else {
             $location = Get-Location
             Set-Location ..
-            if ((Get-Location).Path -eq $location.Path)
-            {
+            if ((Get-Location).Path -eq $location.Path) {
                 # our location didn't change. We must be at the drive root, so give up
                 Write-Host "Failed to run tests. $fileInfo is not part of a C# project."
                 break
@@ -53,7 +48,6 @@ try
         }
     }
 }
-finally
-{
+finally {
     Pop-Location
 }

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -11,6 +11,7 @@ $ErrorActionPreference="Stop"
 
 Push-Location
 
+$originalCwd = Get-Location
 $fileInfo = Get-ItemProperty $filePath
 Set-Location $fileInfo.Directory
 
@@ -19,7 +20,7 @@ try {
         # search up from the current file for a folder containing a csproj
         $files = Get-ChildItem *.csproj
         if ($files) {
-            Pop-Location
+            Set-Location $originalCwd
             $dotnetPath = Resolve-Path (Ensure-DotNetSdk) -Relative
 
             $projectFileInfo = $files[0]
@@ -35,7 +36,7 @@ try {
             Write-Output "> $invocation"
             Invoke-Expression $invocation
 
-            break
+            exit 0
         }
         else {
             $location = Get-Location
@@ -43,7 +44,8 @@ try {
             if ((Get-Location).Path -eq $location.Path) {
                 # our location didn't change. We must be at the drive root, so give up
                 Write-Host "Failed to run tests. $fileInfo is not part of a C# project."
-                break
+
+                exit 1
             }
         }
     }


### PR DESCRIPTION
This PR adds a couple of vscode tasks to improve developer productivity.

- run tests in current file
- run tests in current project

(running all tests is still best handled by Test.cmd)

The task will also write the test results to an html file in TestResults. This should be useful for keeping track of which tests were failing or sifting through test runs with many failures.

I didn't make the task try to search for .vbproj files because VB doesn't work that well in vscode. You are better off going to full VS if you need to work in VB.

Here's a demo:
![demo-test-task-3](https://user-images.githubusercontent.com/5833655/79518143-2b6d5a00-8005-11ea-88e9-f43189ea13b5.gif)
