### PR TITLE
Updating our code-inverting tools to support inverting patterns.

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     var nextPatternPart = GetPattern(switchLabels[i], out whenClauseUnused);
                     Debug.Assert(whenClauseUnused == null, "We should not have offered to convert multiple cases if any have a when clause");
 
-                    totalPattern = BinaryPattern(SyntaxKind.OrPattern, totalPattern, nextPatternPart);
+                    totalPattern = BinaryPattern(SyntaxKind.OrPattern, totalPattern.Parenthesize(), nextPatternPart.Parenthesize());
                 }
 
 #endif

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -1894,5 +1894,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     }
 }", parseOptions: CSharp9);
         }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestComplexIf_Precedence_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 0 || i is < 10 or > 20 && i is >= 30 or <= 40)
+        {
+            return;
+        }
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 0:
+            case (< 10 or > 20) and (>= 30 or <= 40):
+                return;
+        }
+    }
+}", parseOptions: CSharp9);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
 
         [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
-        public async Task InvertIsPattern1_CSharp8()
+        public async Task InvertIsTypePattern1_CSharp8()
         {
             await TestInRegularAndScriptAsync(
 @"class C
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
 
         [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
-        public async Task InvertIsPattern1_CSharp9()
+        public async Task InvertIsTypePattern1_CSharp9()
         {
             await TestInRegularAndScriptAsync(
 @"class C

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
     {
         var c = !(a <= 10 || b is false);
     }
-}", parseOptions: CSharp8);
+}", parseOptions: CSharp9);
         }
 
         [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
     {
         var c = !(a <= 10 || b is true);
     }
-}", parseOptions: CSharp8);
+}", parseOptions: CSharp9);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -334,5 +334,89 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
     }
 }", parseOptions: CSharp9);
         }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsNullPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is null;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is null));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsNullPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is null;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is not null);
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsNotNullPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is not null;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is not null));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsNotNullPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is not null;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is null);
+    }
+}", parseOptions: CSharp9);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -502,5 +502,89 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
     }
 }", parseOptions: CSharp9);
         }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsAndPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string and object;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string and object));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsAndPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string and object;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is not string or not object);
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsOrPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string or object;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string or object));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsOrPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string or object;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is not string and not object);
+    }
+}", parseOptions: CSharp9);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -302,14 +302,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
 {
     void M(bool x, int a, object b)
     {
-        var c = a > 10 [||]&& b is string s;
+        var c = a > 10 [||]&& b is string;
     }
 }",
 @"class C
 {
     void M(bool x, int a, object b)
     {
-        var c = !(a <= 10 || !(b is string s));
+        var c = !(a <= 10 || !(b is string));
     }
 }", parseOptions: CSharp8);
         }
@@ -323,14 +323,56 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
 {
     void M(bool x, int a, object b)
     {
-        var c = a > 10 [||]&& b is string s;
+        var c = a > 10 [||]&& b is string;
     }
 }",
 @"class C
 {
     void M(bool x, int a, object b)
     {
-        var c = !(a <= 10 || b is not string s);
+        var c = !(a <= 10 || b is not string);
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsNotTypePattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is not string;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is not string));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsNotTypePattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is not string;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is string);
     }
 }", parseOptions: CSharp9);
         }
@@ -583,6 +625,174 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
     void M(bool x, int a, object b)
     {
         var c = !(a <= 10 || b is not string and not object);
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsTypeWithDesignationPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string s;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string s));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsTypeWithDesignationPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string s;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string s));
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsVarPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is var s;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is var s));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsVarPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is var s;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is var s));
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsAndWithDesignationPattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string s and object;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string s and object));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsAndWithDesignationPattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string s and object;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string s and object));
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsAndWithDesignationPattern2_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string and object s;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string and object s));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsAndWithDesignationPattern2_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is string and object s;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is string and object s));
     }
 }", parseOptions: CSharp9);
         }

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -418,5 +418,89 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
     }
 }", parseOptions: CSharp9);
         }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsTruePattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is true;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is true));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsTruePattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is true;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is false);
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsFalsePattern1_CSharp8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is false;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || !(b is false));
+    }
+}", parseOptions: CSharp8);
+        }
+
+        [WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertLogical)]
+        public async Task InvertIsFalsePattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& b is false;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || b is true);
+    }
+}", parseOptions: CSharp8);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
                 var label = section.Labels[i];
                 Debug.Assert(label.Guards.Length == 0, "We shouldn't have guards when we're combining multiple cases into a single arm");
                 var nextPattern = AsPatternSyntax(label.Pattern);
-                pattern = BinaryPattern(SyntaxKind.OrPattern, pattern, nextPattern);
+                pattern = BinaryPattern(SyntaxKind.OrPattern, pattern.Parenthesize(), nextPattern.Parenthesize());
             }
 
             return SwitchExpressionArm(pattern, whenClause, AsExpressionSyntax(section.Body));
@@ -98,15 +98,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
         private static PatternSyntax AsPatternSyntax(AnalyzedPattern pattern)
             => pattern switch
             {
-                AnalyzedPattern.And p => BinaryPattern(SyntaxKind.AndPattern, AsPatternSyntax(p.LeftPattern), AsPatternSyntax(p.RightPattern)),
+                AnalyzedPattern.And p => BinaryPattern(SyntaxKind.AndPattern, AsPatternSyntax(p.LeftPattern).Parenthesize(), AsPatternSyntax(p.RightPattern).Parenthesize()),
                 AnalyzedPattern.Constant p => ConstantPattern(p.ExpressionSyntax),
                 AnalyzedPattern.Source p => p.PatternSyntax,
                 AnalyzedPattern.Type p => DeclarationPattern((TypeSyntax)p.IsExpressionSyntax.Right, DiscardDesignation()),
                 AnalyzedPattern.Relational p => RelationalPattern(Token(s_operatorMap[p.OperatorKind]), p.Value),
                 AnalyzedPattern.Range p => BinaryPattern(
                     SyntaxKind.AndPattern,
-                    RelationalPattern(Token(SyntaxKind.GreaterThanEqualsToken), p.LowerBound),
-                    RelationalPattern(Token(SyntaxKind.LessThanEqualsToken), p.HigherBound)),
+                    RelationalPattern(Token(SyntaxKind.GreaterThanEqualsToken), p.LowerBound).Parenthesize(),
+                    RelationalPattern(Token(SyntaxKind.LessThanEqualsToken), p.HigherBound).Parenthesize()),
                 var p => throw ExceptionUtilities.UnexpectedValue(p)
             };
 

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
             => ImmutableArray.Create<AbstractReducer>(
                 new CSharpNameReducer(),
                 new CSharpEscapingReducer(),
-                new CSharpParenthesesReducer(),
+                new CSharpParenthesizedExpressionReducer(),
                 new CSharpDefaultExpressionReducer());
 
         private class FormattingRule : AbstractMetadataFormattingRule

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -71,6 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
                 new CSharpNameReducer(),
                 new CSharpEscapingReducer(),
                 new CSharpParenthesizedExpressionReducer(),
+                new CSharpParenthesizedPatternReducer(),
                 new CSharpDefaultExpressionReducer());
 
         private class FormattingRule : AbstractMetadataFormattingRule

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3580,6 +3580,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override SyntaxNode ParenthesizedPattern(SyntaxNode pattern)
             => Parenthesize(pattern);
 
+        internal override SyntaxNode TypePattern(SyntaxNode type)
+            => SyntaxFactory.TypePattern((TypeSyntax)type);
+
         #endregion
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3558,7 +3558,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp7;
 
         internal override SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxToken isKeyword, SyntaxNode pattern)
-            => SyntaxFactory.IsPatternExpression((ExpressionSyntax)expression, isKeyword, (PatternSyntax)pattern);
+            => SyntaxFactory.IsPatternExpression(
+                (ExpressionSyntax)expression,
+                isKeyword == default ? SyntaxFactory.Token(SyntaxKind.IsKeyword) : isKeyword,
+                (PatternSyntax)pattern);
 
         internal override SyntaxNode ConstantPattern(SyntaxNode expression)
             => SyntaxFactory.ConstantPattern((ExpressionSyntax)expression);

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2984,10 +2984,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         #region Statements and Expressions
 
         public override SyntaxNode AddEventHandler(SyntaxNode @event, SyntaxNode handler)
-            => SyntaxFactory.AssignmentExpression(SyntaxKind.AddAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
+            => SyntaxFactory.AssignmentExpression(SyntaxKind.AddAssignmentExpression, (ExpressionSyntax)@event, (ExpressionSyntax)Parenthesize(handler));
 
         public override SyntaxNode RemoveEventHandler(SyntaxNode @event, SyntaxNode handler)
-            => SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
+            => SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, (ExpressionSyntax)@event, (ExpressionSyntax)Parenthesize(handler));
 
         public override SyntaxNode AwaitExpression(SyntaxNode expression)
             => SyntaxFactory.AwaitExpression((ExpressionSyntax)expression);
@@ -3081,7 +3081,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 return expression;
             }
 
-            return Parenthesize(expression);
+            return (ExpressionSyntax)Parenthesize(expression);
         }
 
         private static SeparatedSyntaxList<ExpressionSyntax> AsExpressionList(IEnumerable<SyntaxNode> expressions)
@@ -3159,29 +3159,29 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return DefaultExpression(type.GenerateTypeSyntax());
         }
 
-        private static ExpressionSyntax Parenthesize(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
+        private static SyntaxNode Parenthesize(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
             => CSharpSyntaxGeneratorInternal.Parenthesize(expression, includeElasticTrivia, addSimplifierAnnotation);
 
         public override SyntaxNode IsTypeExpression(SyntaxNode expression, SyntaxNode type)
-            => SyntaxFactory.BinaryExpression(SyntaxKind.IsExpression, Parenthesize(expression), (TypeSyntax)type);
+            => SyntaxFactory.BinaryExpression(SyntaxKind.IsExpression, (ExpressionSyntax)Parenthesize(expression), (TypeSyntax)type);
 
         public override SyntaxNode TypeOfExpression(SyntaxNode type)
             => SyntaxFactory.TypeOfExpression((TypeSyntax)type);
 
         public override SyntaxNode TryCastExpression(SyntaxNode expression, SyntaxNode type)
-            => SyntaxFactory.BinaryExpression(SyntaxKind.AsExpression, Parenthesize(expression), (TypeSyntax)type);
+            => SyntaxFactory.BinaryExpression(SyntaxKind.AsExpression, (ExpressionSyntax)Parenthesize(expression), (TypeSyntax)type);
 
         public override SyntaxNode CastExpression(SyntaxNode type, SyntaxNode expression)
-            => SyntaxFactory.CastExpression((TypeSyntax)type, Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
+            => SyntaxFactory.CastExpression((TypeSyntax)type, (ExpressionSyntax)Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
 
         public override SyntaxNode ConvertExpression(SyntaxNode type, SyntaxNode expression)
-            => SyntaxFactory.CastExpression((TypeSyntax)type, Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
+            => SyntaxFactory.CastExpression((TypeSyntax)type, (ExpressionSyntax)Parenthesize(expression)).WithAdditionalAnnotations(Simplifier.Annotation);
 
         public override SyntaxNode AssignmentStatement(SyntaxNode left, SyntaxNode right)
-            => SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, (ExpressionSyntax)left, Parenthesize(right));
+            => SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, (ExpressionSyntax)left, (ExpressionSyntax)Parenthesize(right));
 
         private static SyntaxNode CreateBinaryExpression(SyntaxKind syntaxKind, SyntaxNode left, SyntaxNode right)
-            => SyntaxFactory.BinaryExpression(syntaxKind, Parenthesize(left), Parenthesize(right));
+            => SyntaxFactory.BinaryExpression(syntaxKind, (ExpressionSyntax)Parenthesize(left), (ExpressionSyntax)Parenthesize(right));
 
         public override SyntaxNode ValueEqualsExpression(SyntaxNode left, SyntaxNode right)
             => CreateBinaryExpression(SyntaxKind.EqualsExpression, left, right);
@@ -3208,7 +3208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => CreateBinaryExpression(SyntaxKind.GreaterThanOrEqualExpression, left, right);
 
         public override SyntaxNode NegateExpression(SyntaxNode expression)
-            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.UnaryMinusExpression, Parenthesize(expression));
+            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.UnaryMinusExpression, (ExpressionSyntax)Parenthesize(expression));
 
         public override SyntaxNode AddExpression(SyntaxNode left, SyntaxNode right)
             => CreateBinaryExpression(SyntaxKind.AddExpression, left, right);
@@ -3232,7 +3232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => CreateBinaryExpression(SyntaxKind.BitwiseOrExpression, left, right);
 
         public override SyntaxNode BitwiseNotExpression(SyntaxNode operand)
-            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.BitwiseNotExpression, Parenthesize(operand));
+            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.BitwiseNotExpression, (ExpressionSyntax)Parenthesize(operand));
 
         public override SyntaxNode LogicalAndExpression(SyntaxNode left, SyntaxNode right)
             => CreateBinaryExpression(SyntaxKind.LogicalAndExpression, left, right);
@@ -3241,10 +3241,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => CreateBinaryExpression(SyntaxKind.LogicalOrExpression, left, right);
 
         public override SyntaxNode LogicalNotExpression(SyntaxNode expression)
-            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, Parenthesize(expression));
+            => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, (ExpressionSyntax)Parenthesize(expression));
 
         public override SyntaxNode ConditionalExpression(SyntaxNode condition, SyntaxNode whenTrue, SyntaxNode whenFalse)
-            => SyntaxFactory.ConditionalExpression(Parenthesize(condition), Parenthesize(whenTrue), Parenthesize(whenFalse));
+            => SyntaxFactory.ConditionalExpression((ExpressionSyntax)Parenthesize(condition), (ExpressionSyntax)Parenthesize(whenTrue), (ExpressionSyntax)Parenthesize(whenFalse));
 
         public override SyntaxNode CoalesceExpression(SyntaxNode left, SyntaxNode right)
             => CreateBinaryExpression(SyntaxKind.CoalesceExpression, left, right);
@@ -3557,8 +3557,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override bool SupportsPatterns(ParseOptions options)
             => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp7;
 
-        internal override SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxNode pattern)
-            => SyntaxFactory.IsPatternExpression((ExpressionSyntax)expression, (PatternSyntax)pattern);
+        internal override SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxToken isKeyword, SyntaxNode pattern)
+            => SyntaxFactory.IsPatternExpression((ExpressionSyntax)expression, isKeyword, (PatternSyntax)pattern);
 
         internal override SyntaxNode ConstantPattern(SyntaxNode expression)
             => SyntaxFactory.ConstantPattern((ExpressionSyntax)expression);
@@ -3567,6 +3567,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             => SyntaxFactory.DeclarationPattern(
                 type.GenerateTypeSyntax(),
                 SyntaxFactory.SingleVariableDesignation(name.ToIdentifierToken()));
+
+        internal override SyntaxNode AndPattern(SyntaxNode left, SyntaxNode right)
+            => SyntaxFactory.BinaryPattern(SyntaxKind.AndPattern, (PatternSyntax)Parenthesize(left), (PatternSyntax)Parenthesize(right));
+
+        internal override SyntaxNode NotPattern(SyntaxNode pattern)
+            => SyntaxFactory.UnaryPattern(SyntaxFactory.Token(SyntaxKind.NotKeyword), (PatternSyntax)Parenthesize(pattern));
+
+        internal override SyntaxNode OrPattern(SyntaxNode left, SyntaxNode right)
+            => SyntaxFactory.BinaryPattern(SyntaxKind.OrPattern, (PatternSyntax)Parenthesize(left), (PatternSyntax)Parenthesize(right));
+
+        internal override SyntaxNode ParenthesizedPattern(SyntaxNode pattern)
+            => Parenthesize(pattern);
 
         #endregion
     }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 new CSharpCastReducer(),
                 new CSharpExtensionMethodReducer(),
                 new CSharpParenthesizedExpressionReducer(),
+                new CSharpParenthesizedPatternReducer(),
                 new CSharpEscapingReducer(),
                 new CSharpMiscellaneousReducer(),
                 new CSharpInferredMemberNameReducer(),

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 new CSharpNullableAnnotationReducer(),
                 new CSharpCastReducer(),
                 new CSharpExtensionMethodReducer(),
-                new CSharpParenthesesReducer(),
+                new CSharpParenthesizedExpressionReducer(),
                 new CSharpEscapingReducer(),
                 new CSharpMiscellaneousReducer(),
                 new CSharpInferredMemberNameReducer(),

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/AbstractCSharpReducer.AbstractReductionRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/AbstractCSharpReducer.AbstractReductionRewriter.cs
@@ -59,14 +59,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             private static SyntaxNode GetParentNode(SyntaxNode node)
             {
                 if (node is ExpressionSyntax expression)
-                {
                     return GetParentNode(expression);
-                }
+
+                if (node is PatternSyntax pattern)
+                    return GetParentNode(pattern);
 
                 if (node is CrefSyntax cref)
-                {
                     return GetParentNode(cref);
-                }
 
                 return null;
             }
@@ -83,6 +82,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 }
 
                 return lastExpression.Parent;
+            }
+
+            private static SyntaxNode GetParentNode(PatternSyntax pattern)
+            {
+                var lastPattern = pattern;
+                for (SyntaxNode current = pattern; current != null; current = current.Parent)
+                {
+                    if (current is PatternSyntax currentPattern)
+                    {
+                        lastPattern = currentPattern;
+                    }
+                }
+
+                return lastPattern.Parent;
             }
 
             private static SyntaxNode GetParentNode(CrefSyntax cref)
@@ -147,9 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             {
                 var parentNode = GetParentNode(expression);
                 if (parentNode == null)
-                {
                     return newNode;
-                }
 
                 return SimplifyNode(expression, newNode, parentNode, simplifier);
             }

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedExpressionReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedExpressionReducer.Rewriter.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Simplification
 {
-    internal partial class CSharpParenthesesReducer
+    internal partial class CSharpParenthesizedExpressionReducer
     {
         private class Rewriter : AbstractReductionRewriter
         {

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedExpressionReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedExpressionReducer.cs
@@ -14,12 +14,12 @@ using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.CodeAnalysis.CSharp.Simplification
 {
-    internal partial class CSharpParenthesesReducer : AbstractCSharpReducer
+    internal partial class CSharpParenthesizedExpressionReducer : AbstractCSharpReducer
     {
         private static readonly ObjectPool<IReductionRewriter> s_pool = new ObjectPool<IReductionRewriter>(
             () => new Rewriter(s_pool));
 
-        public CSharpParenthesesReducer() : base(s_pool)
+        public CSharpParenthesizedExpressionReducer() : base(s_pool)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedPatternReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedPatternReducer.Rewriter.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Simplification
+{
+    internal partial class CSharpParenthesizedPatternReducer
+    {
+        private class Rewriter : AbstractReductionRewriter
+        {
+            public Rewriter(ObjectPool<IReductionRewriter> pool)
+                : base(pool)
+            {
+            }
+
+            public override SyntaxNode VisitParenthesizedPattern(ParenthesizedPatternSyntax node)
+            {
+                return SimplifyExpression(
+                    node,
+                    newNode: base.VisitParenthesizedPattern(node),
+                    simplifier: s_simplifyParentheses);
+            }
+        }
+    }
+}

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedPatternReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpParenthesizedPatternReducer.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Microsoft.CodeAnalysis.CSharp.Simplification
+{
+    internal partial class CSharpParenthesizedPatternReducer : AbstractCSharpReducer
+    {
+        private static readonly ObjectPool<IReductionRewriter> s_pool = new ObjectPool<IReductionRewriter>(
+            () => new Rewriter(s_pool));
+
+        public CSharpParenthesizedPatternReducer() : base(s_pool)
+        {
+        }
+
+        private static readonly Func<ParenthesizedPatternSyntax, SemanticModel, OptionSet, CancellationToken, SyntaxNode> s_simplifyParentheses = SimplifyParentheses;
+
+        private static SyntaxNode SimplifyParentheses(
+            ParenthesizedPatternSyntax node,
+            SemanticModel semanticModel,
+            OptionSet optionSet,
+            CancellationToken cancellationToken)
+        {
+            if (node.CanRemoveParentheses(semanticModel))
+            {
+                // TODO(DustinCa): We should not be skipping elastic trivia below.
+                // However, the formatter seems to mess up trailing trivia in some
+                // cases if elastic trivia is there -- and it's not clear why.
+                // Specifically remove the elastic trivia formatting rule doesn't
+                // have any effect.
+                var resultNode = CSharpSyntaxFacts.Instance.Unparenthesize(node);
+                return SimplificationHelpers.CopyAnnotations(from: node, to: resultNode);
+            }
+
+            // We don't know how to simplify this.
+            return node;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -2191,9 +2191,14 @@ namespace Microsoft.CodeAnalysis.Editing
         #region Patterns
 
         internal abstract bool SupportsPatterns(ParseOptions options);
-        internal abstract SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxNode pattern);
+        internal abstract SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxToken isToken, SyntaxNode pattern);
+
+        internal abstract SyntaxNode AndPattern(SyntaxNode left, SyntaxNode right);
         internal abstract SyntaxNode DeclarationPattern(INamedTypeSymbol type, string name);
         internal abstract SyntaxNode ConstantPattern(SyntaxNode expression);
+        internal abstract SyntaxNode NotPattern(SyntaxNode pattern);
+        internal abstract SyntaxNode OrPattern(SyntaxNode left, SyntaxNode right);
+        internal abstract SyntaxNode ParenthesizedPattern(SyntaxNode pattern);
 
         #endregion
     }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -2199,6 +2199,7 @@ namespace Microsoft.CodeAnalysis.Editing
         internal abstract SyntaxNode NotPattern(SyntaxNode pattern);
         internal abstract SyntaxNode OrPattern(SyntaxNode left, SyntaxNode right);
         internal abstract SyntaxNode ParenthesizedPattern(SyntaxNode pattern);
+        internal abstract SyntaxNode TypePattern(SyntaxNode type);
 
         #endregion
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -3,12 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
+
+#if !CODE_STYLE
+using System.Diagnostics;
+#endif
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1548,7 +1548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
 
             var initializersExpressions = node.Declaration.Variables
                 .Where(v => v.Initializer != null)
-                .SelectAsArray<VariableDeclaratorSyntax, ExpressionSyntax>(initializedV => initializedV.Initializer.Value);
+                .SelectAsArray(initializedV => initializedV.Initializer.Value);
             return IsOnHeader(root, position, node, node, holes: initializersExpressions);
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1420,6 +1420,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsBinaryExpression(SyntaxNode node)
             => node is BinaryExpressionSyntax;
 
+        public bool IsIsExpression(SyntaxNode node)
+            => node.IsKind(SyntaxKind.IsExpression);
+
         public void GetPartsOfBinaryExpression(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right)
         {
             var binaryExpression = (BinaryExpressionSyntax)node;
@@ -1991,6 +1994,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         internal static bool ParentIsLocalDeclarationStatement(SyntaxNode node)
             => node?.Parent.IsKind(SyntaxKind.LocalDeclarationStatement) ?? false;
 
+        public bool IsIsPatternExpression(SyntaxNode node)
+            => node.IsKind(SyntaxKind.IsPatternExpression);
+
         public void GetPartsOfIsPatternExpression(SyntaxNode node, out SyntaxNode left, out SyntaxToken isToken, out SyntaxNode right)
         {
             var isPatternExpression = (IsPatternExpressionSyntax)node;
@@ -1998,12 +2004,6 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             isToken = isPatternExpression.IsKeyword;
             right = isPatternExpression.Pattern;
         }
-
-        public bool IsIsExpression(SyntaxNode node)
-            => node.IsKind(SyntaxKind.IsExpression);
-
-        public bool IsIsPatternExpression(SyntaxNode node)
-            => node.IsKind(SyntaxKind.IsPatternExpression);
 
         public bool IsAnyPattern(SyntaxNode node)
             => node is PatternSyntax;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -18,12 +18,12 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 
 #if CODE_STYLE
 using Microsoft.CodeAnalysis.Internal.Editing;
 #else
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 #endif
 
 namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
@@ -1999,6 +1999,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             right = isPatternExpression.Pattern;
         }
 
+        public bool IsIsExpression(SyntaxNode node)
+            => node.IsKind(SyntaxKind.IsExpression);
+
         public bool IsIsPatternExpression(SyntaxNode node)
             => node.IsKind(SyntaxKind.IsPatternExpression);
 
@@ -2008,8 +2011,33 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsConstantPattern(SyntaxNode node)
             => node.IsKind(SyntaxKind.ConstantPattern);
 
+        public bool IsDeclarationPattern(SyntaxNode node)
+            => node.IsKind(SyntaxKind.DeclarationPattern);
+
+        public bool IsRecursivePattern(SyntaxNode node)
+            => node.IsKind(SyntaxKind.RecursivePattern);
+
+        public bool IsVarPattern(SyntaxNode node)
+            => node.IsKind(SyntaxKind.VarPattern);
+
         public SyntaxNode GetExpressionOfConstantPattern(SyntaxNode node)
             => ((ConstantPatternSyntax)node).Expression;
+
+        public void GetPartsOfDeclarationPattern(SyntaxNode node, out SyntaxNode type, out SyntaxNode designation)
+        {
+            var declarationPattern = (DeclarationPatternSyntax)node;
+            type = declarationPattern.Type;
+            designation = declarationPattern.Designation;
+        }
+
+        public void GetPartsOfRecursivePattern(SyntaxNode node, out SyntaxNode type, out SyntaxNode positionalPart, out SyntaxNode propertyPart, out SyntaxNode designation)
+        {
+            var recursivePattern = (RecursivePatternSyntax)node;
+            type = recursivePattern.Type;
+            positionalPart = recursivePattern.PositionalPatternClause;
+            propertyPart = recursivePattern.PropertyPatternClause;
+            designation = recursivePattern.Designation;
+        }
 
 #if CODE_STYLE
 
@@ -2019,15 +2047,19 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsNotPattern(SyntaxNode node) => false;
         public bool IsOrPattern(SyntaxNode node) => false;
         public bool IsParenthesizedPattern(SyntaxNode node) => false;
+        public bool IsTypePattern(SyntaxNode node) => false;
         public bool IsUnaryPattern(SyntaxNode node) => false;
 
-        public void GetPartsOfParenthesizedPattern(SyntaxNode node, out SyntaxToken openParen, out SyntaxNode pattern, out SyntaxToken closeParen);
+        public void GetPartsOfParenthesizedPattern(SyntaxNode node, out SyntaxToken openParen, out SyntaxNode pattern, out SyntaxToken closeParen)
             => throw ExceptionUtilities.Unreachable;
 
         public void GetPartsOfBinaryPattern(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right)
             => throw ExceptionUtilities.Unreachable;
 
         public void GetPartsOfUnaryPattern(SyntaxNode node, out SyntaxToken operatorToken, out SyntaxNode pattern)
+            => throw ExceptionUtilities.Unreachable;
+
+        public SyntaxNode GetTypeOfTypePattern(SyntaxNode node)
             => throw ExceptionUtilities.Unreachable;
 
 #else
@@ -2049,6 +2081,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
 
         public bool IsParenthesizedPattern(SyntaxNode node)
             => node.IsKind(SyntaxKind.ParenthesizedPattern);
+
+        public bool IsTypePattern(SyntaxNode node)
+            => node.IsKind(SyntaxKind.TypePattern);
 
         public bool IsUnaryPattern(SyntaxNode node)
             => node is UnaryPatternSyntax;
@@ -2075,6 +2110,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             operatorToken = unaryPattern.PatternOperator;
             pattern = unaryPattern.Pattern;
         }
+
+        public SyntaxNode GetTypeOfTypePattern(SyntaxNode node)
+            => ((TypePatternSyntax)node).Type;
 
 #endif
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -2021,7 +2021,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsParenthesizedPattern(SyntaxNode node) => false;
         public bool IsUnaryPattern(SyntaxNode node) => false;
 
-        public SyntaxNode GetPatternOfParenthesizedPattern(SyntaxNode node)
+        public void GetPartsOfParenthesizedPattern(SyntaxNode node, out SyntaxToken openParen, out SyntaxNode pattern, out SyntaxToken closeParen);
             => throw ExceptionUtilities.Unreachable;
 
         public void GetPartsOfBinaryPattern(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right)
@@ -2053,8 +2053,13 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsUnaryPattern(SyntaxNode node)
             => node is UnaryPatternSyntax;
 
-        public SyntaxNode GetPatternOfParenthesizedPattern(SyntaxNode node)
-            => ((ParenthesizedPatternSyntax)node).Pattern;
+        public void GetPartsOfParenthesizedPattern(SyntaxNode node, out SyntaxToken openParen, out SyntaxNode pattern, out SyntaxToken closeParen)
+        {
+            var parenthesizedPattern = (ParenthesizedPatternSyntax)node;
+            openParen = parenthesizedPattern.OpenParenToken;
+            pattern = parenthesizedPattern.Pattern;
+            closeParen = parenthesizedPattern.CloseParenToken;
+        }
 
         public void GetPartsOfBinaryPattern(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/OperationExtensions.cs
@@ -53,6 +53,15 @@ namespace Microsoft.CodeAnalysis
             }
             else if (operation is IDeclarationPatternOperation)
             {
+#if !CODE_STYLE
+                while (operation.Parent is IBinaryPatternOperation ||
+                       operation.Parent is INegatedPatternOperation ||
+                       operation.Parent is IRelationalPatternOperation)
+                {
+                    operation = operation.Parent;
+                }
+#endif
+
                 switch (operation.Parent)
                 {
                     case IPatternCaseClauseOperation _:

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -28,8 +28,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         ISyntaxKinds SyntaxKinds { get; }
 
         bool SupportsIndexingInitializer(ParseOptions options);
+        bool SupportsNotPattern(ParseOptions options);
         bool SupportsThrowExpression(ParseOptions options);
-
         bool SupportsLocalFunctionDeclaration(ParseOptions options);
 
         SyntaxToken ParseToken(string text);
@@ -117,6 +117,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         bool IsBinaryExpression(SyntaxNode node);
         void GetPartsOfBinaryExpression(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right);
+        void GetPartsOfIsPatternExpression(SyntaxNode node, out SyntaxNode left, out SyntaxToken isToken, out SyntaxNode right);
 
         void GetPartsOfConditionalExpression(SyntaxNode node, out SyntaxNode condition, out SyntaxNode whenTrue, out SyntaxNode whenFalse);
 
@@ -390,8 +391,26 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// </summary>
         string GetNameForArgument(SyntaxNode argument);
 
+        bool IsIsPatternExpression(SyntaxNode node);
+
         bool IsNameOfSubpattern(SyntaxNode node);
         bool IsPropertyPatternClause(SyntaxNode node);
+
+        bool IsAnyPattern(SyntaxNode node);
+
+        bool IsAndPattern(SyntaxNode node);
+        bool IsBinaryPattern(SyntaxNode node);
+        bool IsConstantPattern(SyntaxNode node);
+        bool IsNotPattern(SyntaxNode node);
+        bool IsOrPattern(SyntaxNode node);
+        bool IsParenthesizedPattern(SyntaxNode node);
+        bool IsUnaryPattern(SyntaxNode node);
+
+        SyntaxNode GetExpressionOfConstantPattern(SyntaxNode node);
+        SyntaxNode GetPatternOfParenthesizedPattern(SyntaxNode node);
+
+        void GetPartsOfBinaryPattern(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right);
+        void GetPartsOfUnaryPattern(SyntaxNode node, out SyntaxToken operatorToken, out SyntaxNode pattern);
 
         /// <summary>
         /// <paramref name="fullHeader"/> controls how much of the type header should be considered. If <see

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsUnaryPattern(SyntaxNode node);
 
         SyntaxNode GetExpressionOfConstantPattern(SyntaxNode node);
-        SyntaxNode GetPatternOfParenthesizedPattern(SyntaxNode node);
+        void GetPartsOfParenthesizedPattern(SyntaxNode node, out SyntaxToken openParen, out SyntaxNode pattern, out SyntaxToken closeParen);
 
         void GetPartsOfBinaryPattern(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right);
         void GetPartsOfUnaryPattern(SyntaxNode node, out SyntaxToken operatorToken, out SyntaxNode pattern);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -116,7 +116,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         SyntaxNode GetObjectCreationType(SyntaxNode node);
 
         bool IsBinaryExpression(SyntaxNode node);
+        bool IsIsExpression(SyntaxNode node);
         void GetPartsOfBinaryExpression(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right);
+
+        bool IsIsPatternExpression(SyntaxNode node);
         void GetPartsOfIsPatternExpression(SyntaxNode node, out SyntaxNode left, out SyntaxToken isToken, out SyntaxNode right);
 
         void GetPartsOfConditionalExpression(SyntaxNode node, out SyntaxNode condition, out SyntaxNode whenTrue, out SyntaxNode whenFalse);
@@ -391,8 +394,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// </summary>
         string GetNameForArgument(SyntaxNode argument);
 
-        bool IsIsPatternExpression(SyntaxNode node);
-
         bool IsNameOfSubpattern(SyntaxNode node);
         bool IsPropertyPatternClause(SyntaxNode node);
 
@@ -401,16 +402,24 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsAndPattern(SyntaxNode node);
         bool IsBinaryPattern(SyntaxNode node);
         bool IsConstantPattern(SyntaxNode node);
+        bool IsDeclarationPattern(SyntaxNode node);
         bool IsNotPattern(SyntaxNode node);
         bool IsOrPattern(SyntaxNode node);
         bool IsParenthesizedPattern(SyntaxNode node);
+        bool IsRecursivePattern(SyntaxNode node);
+        bool IsTypePattern(SyntaxNode node);
         bool IsUnaryPattern(SyntaxNode node);
+        bool IsVarPattern(SyntaxNode node);
 
         SyntaxNode GetExpressionOfConstantPattern(SyntaxNode node);
         void GetPartsOfParenthesizedPattern(SyntaxNode node, out SyntaxToken openParen, out SyntaxNode pattern, out SyntaxToken closeParen);
 
         void GetPartsOfBinaryPattern(SyntaxNode node, out SyntaxNode left, out SyntaxToken operatorToken, out SyntaxNode right);
+        void GetPartsOfDeclarationPattern(SyntaxNode node, out SyntaxNode type, out SyntaxNode designation);
+        void GetPartsOfRecursivePattern(SyntaxNode node, out SyntaxNode type, out SyntaxNode positionalPart, out SyntaxNode propertyPart, out SyntaxNode designation);
         void GetPartsOfUnaryPattern(SyntaxNode node, out SyntaxToken operatorToken, out SyntaxNode pattern);
+
+        SyntaxNode GetTypeOfTypePattern(SyntaxNode node);
 
         /// <summary>
         /// <paramref name="fullHeader"/> controls how much of the type header should be considered. If <see

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
@@ -82,20 +82,32 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         public static SyntaxNode Unparenthesize(
             this ISyntaxFacts syntaxFacts, SyntaxNode node)
         {
-            syntaxFacts.GetPartsOfParenthesizedExpression(node,
-                out var openParenToken, out var expression, out var closeParenToken);
+            SyntaxToken openParenToken;
+            SyntaxNode operand;
+            SyntaxToken closeParenToken;
+
+            if (syntaxFacts.IsParenthesizedPattern(node))
+            {
+                syntaxFacts.GetPartsOfParenthesizedPattern(node,
+                    out openParenToken, out operand, out closeParenToken);
+            }
+            else
+            {
+                syntaxFacts.GetPartsOfParenthesizedExpression(node,
+                    out openParenToken, out operand, out closeParenToken);
+            }
 
             var leadingTrivia = openParenToken.LeadingTrivia
                 .Concat(openParenToken.TrailingTrivia)
                 .Where(t => !syntaxFacts.IsElastic(t))
-                .Concat(expression.GetLeadingTrivia());
+                .Concat(operand.GetLeadingTrivia());
 
-            var trailingTrivia = expression.GetTrailingTrivia()
+            var trailingTrivia = operand.GetTrailingTrivia()
                 .Concat(closeParenToken.LeadingTrivia)
                 .Where(t => !syntaxFacts.IsElastic(t))
                 .Concat(closeParenToken.TrailingTrivia);
 
-            var resultNode = expression
+            var resultNode = operand
                 .WithLeadingTrivia(leadingTrivia)
                 .WithTrailingTrivia(trailingTrivia);
 
@@ -141,6 +153,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         public static void GetPartsOfBinaryExpression(this ISyntaxFacts syntaxFacts, SyntaxNode node, out SyntaxNode left, out SyntaxNode right)
             => syntaxFacts.GetPartsOfBinaryExpression(node, out left, out _, out right);
+
+        public static SyntaxNode GetPatternOfParenthesizedPattern(this ISyntaxFacts syntaxFacts, SyntaxNode node)
+        {
+            syntaxFacts.GetPartsOfParenthesizedPattern(node, out _, out var pattern, out _);
+            return pattern;
+        }
 
         public static SyntaxNode GetExpressionOfParenthesizedExpression(this ISyntaxFacts syntaxFacts, SyntaxNode node)
         {
@@ -219,7 +237,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// </summary>
         public static bool IsOnTypeHeader(this ISyntaxFacts syntaxFacts, SyntaxNode root, int position, out SyntaxNode typeDeclaration)
             => syntaxFacts.IsOnTypeHeader(root, position, fullHeader: false, out typeDeclaration);
-
 
         #region ISyntaxKinds forwarding methods
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -2299,9 +2299,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Public Function GetPatternOfParenthesizedPattern(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetPatternOfParenthesizedPattern
+        Public Sub GetPartsOfParenthesizedPattern(node As SyntaxNode, ByRef openParen As SyntaxToken, ByRef pattern As SyntaxNode, ByRef closeParen As SyntaxToken) Implements ISyntaxFacts.GetPartsOfParenthesizedPattern
             Throw ExceptionUtilities.Unreachable
-        End Function
+        End Sub
 
         Public Sub GetPartsOfBinaryPattern(node As SyntaxNode, ByRef left As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef right As SyntaxNode) Implements ISyntaxFacts.GetPartsOfBinaryPattern
             Throw ExceptionUtilities.Unreachable

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1483,6 +1483,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return TypeOf node Is BinaryExpressionSyntax
         End Function
 
+        Public Function IsIsExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsIsExpression
+            Return node.IsKind(SyntaxKind.TypeOfIsExpression)
+        End Function
+
         Public Sub GetPartsOfBinaryExpression(node As SyntaxNode, ByRef left As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef right As SyntaxNode) Implements ISyntaxFacts.GetPartsOfBinaryExpression
             Dim binaryExpression = DirectCast(node, BinaryExpressionSyntax)
             left = binaryExpression.Left
@@ -2253,10 +2257,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
         Public Function SupportsNotPattern(options As ParseOptions) As Boolean Implements ISyntaxFacts.SupportsNotPattern
             Return False
-        End Function
-
-        Public Function IsIsExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsIsExpression
-            Return node.IsKind(SyntaxKind.TypeOfIsExpression)
         End Function
 
         Public Function IsIsPatternExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsIsPatternExpression

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -2255,6 +2255,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return False
         End Function
 
+        Public Function IsIsExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsIsExpression
+            Return node.IsKind(SyntaxKind.TypeOfIsExpression)
+        End Function
+
         Public Function IsIsPatternExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsIsPatternExpression
             Return False
         End Function
@@ -2275,6 +2279,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return False
         End Function
 
+        Public Function IsDeclarationPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsDeclarationPattern
+            Return False
+        End Function
+
         Public Function IsNotPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsNotPattern
             Return False
         End Function
@@ -2287,7 +2295,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return False
         End Function
 
+        Public Function IsRecursivePattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsRecursivePattern
+            Return False
+        End Function
+
         Public Function IsUnaryPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsUnaryPattern
+            Return False
+        End Function
+
+        Public Function IsTypePattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsTypePattern
+            Return False
+        End Function
+
+        Public Function IsVarPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsVarPattern
             Return False
         End Function
 
@@ -2310,5 +2330,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
         Public Sub GetPartsOfUnaryPattern(node As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef pattern As SyntaxNode) Implements ISyntaxFacts.GetPartsOfUnaryPattern
             Throw ExceptionUtilities.Unreachable
         End Sub
+
+        Public Sub GetPartsOfDeclarationPattern(node As SyntaxNode, ByRef type As SyntaxNode, ByRef designation As SyntaxNode) Implements ISyntaxFacts.GetPartsOfDeclarationPattern
+            Throw New NotImplementedException()
+        End Sub
+
+        Public Sub GetPartsOfRecursivePattern(node As SyntaxNode, ByRef type As SyntaxNode, ByRef positionalPart As SyntaxNode, ByRef propertyPart As SyntaxNode, ByRef designation As SyntaxNode) Implements ISyntaxFacts.GetPartsOfRecursivePattern
+            Throw New NotImplementedException()
+        End Sub
+
+        Public Function GetTypeOfTypePattern(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetTypeOfTypePattern
+            Throw New NotImplementedException()
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -2250,5 +2250,65 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             End Select
             Return False
         End Function
+
+        Public Function SupportsNotPattern(options As ParseOptions) As Boolean Implements ISyntaxFacts.SupportsNotPattern
+            Return False
+        End Function
+
+        Public Function IsIsPatternExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsIsPatternExpression
+            Return False
+        End Function
+
+        Public Function IsAnyPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsAnyPattern
+            Return False
+        End Function
+
+        Public Function IsAndPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsAndPattern
+            Return False
+        End Function
+
+        Public Function IsBinaryPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsBinaryPattern
+            Return False
+        End Function
+
+        Public Function IsConstantPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsConstantPattern
+            Return False
+        End Function
+
+        Public Function IsNotPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsNotPattern
+            Return False
+        End Function
+
+        Public Function IsOrPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsOrPattern
+            Return False
+        End Function
+
+        Public Function IsParenthesizedPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsParenthesizedPattern
+            Return False
+        End Function
+
+        Public Function IsUnaryPattern(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsUnaryPattern
+            Return False
+        End Function
+
+        Public Sub GetPartsOfIsPatternExpression(node As SyntaxNode, ByRef left As SyntaxNode, ByRef isToken As SyntaxToken, ByRef right As SyntaxNode) Implements ISyntaxFacts.GetPartsOfIsPatternExpression
+            Throw ExceptionUtilities.Unreachable
+        End Sub
+
+        Public Function GetExpressionOfConstantPattern(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetExpressionOfConstantPattern
+            Throw ExceptionUtilities.Unreachable
+        End Function
+
+        Public Function GetPatternOfParenthesizedPattern(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetPatternOfParenthesizedPattern
+            Throw ExceptionUtilities.Unreachable
+        End Function
+
+        Public Sub GetPartsOfBinaryPattern(node As SyntaxNode, ByRef left As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef right As SyntaxNode) Implements ISyntaxFacts.GetPartsOfBinaryPattern
+            Throw ExceptionUtilities.Unreachable
+        End Sub
+
+        Public Sub GetPartsOfUnaryPattern(node As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef pattern As SyntaxNode) Implements ISyntaxFacts.GetPartsOfUnaryPattern
+            Throw ExceptionUtilities.Unreachable
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -50,6 +50,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return parenthesized.WithTriviaFrom(expression);
         }
 
+#if !CODE_STYLE
+
+        public static PatternSyntax Parenthesize(
+            this PatternSyntax pattern, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
+        {
+            var withoutTrivia = pattern.WithoutTrivia();
+            var parenthesized = includeElasticTrivia
+                ? SyntaxFactory.ParenthesizedPattern(withoutTrivia)
+                : SyntaxFactory.ParenthesizedPattern(
+                    SyntaxFactory.Token(SyntaxTriviaList.Empty, SyntaxKind.OpenParenToken, SyntaxTriviaList.Empty),
+                    withoutTrivia,
+                    SyntaxFactory.Token(SyntaxTriviaList.Empty, SyntaxKind.CloseParenToken, SyntaxTriviaList.Empty));
+
+            var result = parenthesized.WithTriviaFrom(pattern);
+            return addSimplifierAnnotation
+                ? result.WithAdditionalAnnotations(Simplifier.Annotation)
+                : result;
+        }
+
+#endif
+
         public static CastExpressionSyntax Cast(
             this ExpressionSyntax expression,
             ITypeSymbol targetType)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -63,15 +63,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override SyntaxNode RefExpression(SyntaxNode expression)
             => SyntaxFactory.RefExpression((ExpressionSyntax)expression);
 
-        internal override SyntaxNode AddParentheses(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
-        {
-            return Parenthesize(expression, includeElasticTrivia, addSimplifierAnnotation);
-        }
+        internal override SyntaxNode AddParentheses(SyntaxNode expressionOrPattern, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
+            => Parenthesize(expressionOrPattern, includeElasticTrivia, addSimplifierAnnotation);
 
-        internal static ExpressionSyntax Parenthesize(SyntaxNode expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
-        {
-            return ((ExpressionSyntax)expression).Parenthesize(includeElasticTrivia, addSimplifierAnnotation);
-        }
+        internal static SyntaxNode Parenthesize(SyntaxNode expressionOrPattern, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
+            => expressionOrPattern switch
+            {
+                ExpressionSyntax expression => expression.Parenthesize(includeElasticTrivia, addSimplifierAnnotation),
+#if !CODE_STYLE
+                PatternSyntax pattern => pattern.Parenthesize(includeElasticTrivia, addSimplifierAnnotation),
+#endif
+                var other => other,
+            };
 
         internal override SyntaxNode YieldReturnStatement(SyntaxNode expressionOpt = null)
             => SyntaxFactory.YieldStatement(SyntaxKind.YieldReturnStatement, (ExpressionSyntax)expressionOpt);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
@@ -71,5 +71,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 IPropertySymbol property => property.Type,
                 _ => compilation.GetSpecialType(SpecialType.System_Object),
             };
+
+        public static SyntaxNode IsPatternExpression(this SyntaxGenerator generator, SyntaxNode expression, SyntaxNode pattern)
+            => generator.IsPatternExpression(expression, isToken: default, pattern);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
@@ -72,7 +72,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 _ => compilation.GetSpecialType(SpecialType.System_Object),
             };
 
+#if !CODE_STYLE
+
         public static SyntaxNode IsPatternExpression(this SyntaxGenerator generator, SyntaxNode expression, SyntaxNode pattern)
             => generator.IsPatternExpression(expression, isToken: default, pattern);
+
+#endif
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -11,6 +11,10 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
+#if !CODE_STYLE
+using Microsoft.CodeAnalysis.Shared.Extensions;
+#endif
+
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static partial class SyntaxGeneratorExtensions

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -222,6 +222,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     }
                     else
                     {
+                        // Keep this as a normal `is-pattern`, just with the pattern portion negated.
                         return generator.IsPatternExpression(left, isToken, negated);
                     }
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -9,7 +9,10 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
+
+#if !CODE_STYLE
 using Roslyn.Utilities;
+#endif
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                         semanticModel,
                         negateBinary,
                         cancellationToken))
-                    .WithTriviaFrom<SyntaxNode>(expressionOrPattern);
+                    .WithTriviaFrom(expressionOrPattern);
             }
 
             if (negateBinary && syntaxFacts.IsBinaryExpression(expressionOrPattern))
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                         semanticModel,
                         negateBinary,
                         cancellationToken))
-                    .WithTriviaFrom<SyntaxNode>(expressionOrPattern);
+                    .WithTriviaFrom(expressionOrPattern);
             }
 
             if (negateBinary && syntaxFacts.IsBinaryPattern(expressionOrPattern))
@@ -166,11 +166,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 }
 
                 var newBinaryExpressionSyntax = NewBinaryOperation(binaryOperation, newLeftOperand, negatedKind, newRightOperand, generator, cancellationToken)
-                    .WithTriviaFrom<SyntaxNode>(expressionNode);
+                    .WithTriviaFrom(expressionNode);
 
                 var newToken = syntaxFacts.GetOperatorTokenOfBinaryExpression(newBinaryExpressionSyntax);
                 var newTokenWithTrivia = newToken.WithTriviaFrom(operatorToken);
-                return newBinaryExpressionSyntax.ReplaceToken<SyntaxNode>(newToken, newTokenWithTrivia);
+                return newBinaryExpressionSyntax.ReplaceToken(newToken, newTokenWithTrivia);
             }
         }
 
@@ -194,11 +194,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 syntaxFacts.IsOrPattern(pattern) ? generator.AndPattern(newLeft, newRight) :
                 throw ExceptionUtilities.UnexpectedValue(pattern.RawKind);
 
-            newPattern = newPattern.WithTriviaFrom<SyntaxNode>(pattern);
+            newPattern = newPattern.WithTriviaFrom(pattern);
 
             syntaxFacts.GetPartsOfBinaryPattern(newPattern, out _, out var newToken, out _);
             var newTokenWithTrivia = newToken.WithTriviaFrom(operatorToken);
-            return newPattern.ReplaceToken<SyntaxNode>(newToken, newTokenWithTrivia);
+            return newPattern.ReplaceToken(newToken, newTokenWithTrivia);
         }
 
         private static SyntaxNode GetNegationOfIsPatternExpression(SyntaxNode isExpression, SyntaxGenerator generator, SyntaxGeneratorInternal generatorInternal, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -408,10 +408,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
             else
             {
-                newLiteralExpression = generator.LogicalNotExpression(expression.WithoutTrivia<SyntaxNode>());
+                newLiteralExpression = generator.LogicalNotExpression(expression.WithoutTrivia());
             }
 
-            return newLiteralExpression.WithTriviaFrom<SyntaxNode>(expression);
+            return newLiteralExpression.WithTriviaFrom(expression);
         }
 
 #if !CODE_STYLE
@@ -444,8 +444,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var operatorToken = syntaxFacts.GetOperatorTokenOfPrefixUnaryExpression(expression);
             var operand = syntaxFacts.GetOperandOfPrefixUnaryExpression(expression);
 
-            return operand.WithPrependedLeadingTrivia<SyntaxNode>(operatorToken.LeadingTrivia)
-                          .WithAdditionalAnnotations<SyntaxNode>(Simplifier.Annotation);
+            return operand.WithPrependedLeadingTrivia(operatorToken.LeadingTrivia)
+                          .WithAdditionalAnnotations(Simplifier.Annotation);
         }
 
 #if !CODE_STYLE
@@ -459,8 +459,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             if (syntaxFacts.IsNotPattern(pattern))
             {
-                return subPattern.WithPrependedLeadingTrivia<SyntaxNode>(opToken.LeadingTrivia)
-                                 .WithAdditionalAnnotations<SyntaxNode>(Simplifier.Annotation);
+                return subPattern.WithPrependedLeadingTrivia(opToken.LeadingTrivia)
+                                 .WithAdditionalAnnotations(Simplifier.Annotation);
             }
 
             // TODO: add support for more unary patterns.  for example, `< 0` can be negated to `>= 0`

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return GetNegationOfUnaryPattern(expressionOrPattern, generator, syntaxFacts);
 
             return syntaxFacts.IsAnyPattern(expressionOrPattern)
-                ? generator.NotPattern(generator.ParenthesizedPattern(expressionOrPattern))
+                ? generator.NotPattern(expressionOrPattern)
                 : generator.LogicalNotExpression(expressionOrPattern);
 
 #endif
@@ -367,9 +367,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var syntaxFacts = generatorInternal.SyntaxFacts;
 
             var expression = syntaxFacts.GetExpressionOfConstantPattern(pattern);
-            var negated = generator.Negate(generatorInternal, expression, semanticModel, cancellationToken);
+            if (syntaxFacts.IsTrueLiteralExpression(expression))
+                return generator.ConstantPattern(generator.FalseLiteralExpression());
 
-            return generator.ConstantPattern(negated);
+            if (syntaxFacts.IsFalseLiteralExpression(expression))
+                return generator.ConstantPattern(generator.TrueLiteralExpression());
+
+            return generator.NotPattern(pattern);
         }
 
 #endif

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -66,9 +66,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (negateBinary && syntaxFacts.IsBinaryExpression(expressionOrPattern))
                 return GetNegationOfBinaryExpression(expressionOrPattern, generator, generatorInternal, semanticModel, cancellationToken);
 
-            if (negateBinary && syntaxFacts.IsIsPatternExpression(expressionOrPattern))
-                return GetNegationOfIsPatternExpression(expressionOrPattern, generator, generatorInternal, semanticModel, cancellationToken);
-
             if (syntaxFacts.IsLiteralExpression(expressionOrPattern))
                 return GetNegationOfLiteralExpression(expressionOrPattern, generator, semanticModel);
 
@@ -78,6 +75,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 #if CODE_STYLE
             return generator.LogicalNotExpression(expressionOrPattern);
 #else
+            if (negateBinary && syntaxFacts.IsIsPatternExpression(expressionOrPattern))
+                return GetNegationOfIsPatternExpression(expressionOrPattern, generator, generatorInternal, semanticModel, cancellationToken);
 
             if (syntaxFacts.IsParenthesizedPattern(expressionOrPattern))
             {
@@ -175,6 +174,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
         }
 
+#if !CODE_STYLE
+
         private static SyntaxNode GetNegationOfBinaryPattern(
             SyntaxNode pattern,
             SyntaxGenerator generator,
@@ -268,6 +269,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             return true;
         }
+
+#endif
 
         private static SyntaxNode NewBinaryOperation(
             IBinaryOperation binaryOperation,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -216,6 +216,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 {
                     if (syntaxFacts.IsTypePattern(negated))
                     {
+                        // We started with `x is not t`.  Unwrap the type pattern for 't' and create a simple `is` binary expr `x is t`.
                         var type = syntaxFacts.GetTypeOfTypePattern(negated);
                         return generator.IsTypeExpression(left, type);
                     }

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -3850,6 +3850,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Throw New NotImplementedException()
         End Function
 
+        Friend Overrides Function TypePattern(type As SyntaxNode) As SyntaxNode
+            Throw New NotImplementedException()
+        End Function
+
 #End Region
 
     End Class

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -3822,7 +3822,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return False
         End Function
 
-        Friend Overrides Function IsPatternExpression(expression As SyntaxNode, pattern As SyntaxNode) As SyntaxNode
+        Friend Overrides Function IsPatternExpression(expression As SyntaxNode, isToken As SyntaxToken, pattern As SyntaxNode) As SyntaxNode
             Throw New NotImplementedException()
         End Function
 
@@ -3831,6 +3831,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Friend Overrides Function DeclarationPattern(type As INamedTypeSymbol, name As String) As SyntaxNode
+            Throw New NotImplementedException()
+        End Function
+
+        Friend Overrides Function AndPattern(left As SyntaxNode, right As SyntaxNode) As SyntaxNode
+            Throw New NotImplementedException()
+        End Function
+
+        Friend Overrides Function NotPattern(pattern As SyntaxNode) As SyntaxNode
+            Throw New NotImplementedException()
+        End Function
+
+        Friend Overrides Function OrPattern(left As SyntaxNode, right As SyntaxNode) As SyntaxNode
+            Throw New NotImplementedException()
+        End Function
+
+        Friend Overrides Function ParenthesizedPattern(pattern As SyntaxNode) As SyntaxNode
             Throw New NotImplementedException()
         End Function
 


### PR DESCRIPTION
part of https://github.com/dotnet/roslyn/issues/42368

i.e.  `!(x is not a or not b)` -> `x is a and b`