### PR TITLE
🐇 Implement AsyncQueue<T>.TryDequeueAsync

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AsyncQueueTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AsyncQueueTests.cs
@@ -158,13 +158,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void DequeueAsyncWithCancellation()
+        public async Task DequeueAsyncWithCancellation()
         {
             var queue = new AsyncQueue<int>();
             var cts = new CancellationTokenSource();
             var task = queue.DequeueAsync(cts.Token);
             Assert.False(task.IsCanceled);
             cts.Cancel();
+            await Assert.ThrowsAsync<TaskCanceledException>(() => task);
             Assert.Equal(TaskStatus.Canceled, task.Status);
         }
 


### PR DESCRIPTION
This method uses `Optional<T>` instead of `T` for the return value of TryDequeueAsync, allowing the method to support normal termination of the queue without throwing cancellation exceptions.