### PR TITLE
🐇 Avoid making two copies of SyntaxToken at each step of the formatting operations chain

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
         }
 
         public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
-            SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (IsQuestionOrColonOfNewConditional(currentToken))
             {
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
                 return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines);
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
         public override void AddIndentBlockOperations(

--- a/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.vb
@@ -38,14 +38,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
         End Function
 
         Public Overrides Function GetAdjustNewLinesOperationSlow(
-                previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
+                ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If IsCommaOfNewConditional(previousToken) Then
                 ' We want to force the expressions after the commas to be put on the 
                 ' next line.
                 Return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines)
             End If
 
-            Return nextOperation.Invoke()
+            Return nextOperation.Invoke(previousToken, currentToken)
         End Function
 
         Public Overrides Sub AddIndentBlockOperationsSlow(

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/CurlyBraceCompletionSession.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
                 return new BraceCompletionFormattingRule(_indentStyle, cachedOptions);
             }
 
-            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // Eg Cases -
                 // new MyObject {
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
                     }
                 }
 
-                return base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+                return base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
             }
 
             public override void AddAlignTokensOperations(List<AlignTokensOperation> list, SyntaxNode node, in NextAlignTokensOperationAction nextOperation)

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceFormattingRule.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceFormattingRule.cs
@@ -19,10 +19,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
         }
 
         public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(
-            SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             var operation = GetAdjustNewLinesOperation(previousToken, currentToken);
-            return operation ?? nextOperation.Invoke();
+            return operation ?? nextOperation.Invoke(in previousToken, in currentToken);
         }
 
         private AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.PasteFormattingRule.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.PasteFormattingRule.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
     {
         internal class PasteFormattingRule : AbstractFormattingRule
         {
-            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (currentToken.Parent != null)
                 {
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
                     }
                 }
 
-                return nextOperation.Invoke();
+                return nextOperation.Invoke(in previousToken, in currentToken);
             }
         }
     }

--- a/src/EditorFeatures/VisualBasic/Utilities/LineAdjustmentFormattingRule.vb
+++ b/src/EditorFeatures/VisualBasic/Utilities/LineAdjustmentFormattingRule.vb
@@ -16,9 +16,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
         Private Sub New()
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
-                Return nextOperation.Invoke()
+                Return nextOperation.Invoke(previousToken, currentToken)
             End If
 
             Dim previous = CType(previousToken, SyntaxToken)
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
                 Return FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines)
             End If
 
-            Return nextOperation.Invoke()
+            Return nextOperation.Invoke(previousToken, currentToken)
         End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/ChangeSignature/ChangeSignatureFormattingRule.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/ChangeSignatureFormattingRule.cs
@@ -45,14 +45,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             }
         }
 
-        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (previousToken.Kind() == SyntaxKind.CommaToken && s_allowableKinds.Contains(previousToken.Parent.Kind()))
             {
                 return FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
             }
 
-            return base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+            return base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.FormattingProvider.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.FormattingProvider.cs
@@ -16,10 +16,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
             }
 
-            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // for extract method case, for a hybrid case, don't force rule, but preserve user style
-                var operation = base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+                var operation = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
                 if (operation == null)
                 {
                     return null;

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -103,24 +103,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
                 return false;
             }
 
-            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (ForceSingleSpace(previousToken, currentToken))
                 {
                     return null;
                 }
 
-                return base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+                return base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
             }
 
-            public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
                 if (ForceSingleSpace(previousToken, currentToken))
                 {
                     return new AdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
                 }
 
-                return base.GetAdjustSpacesOperation(previousToken, currentToken, in nextOperation);
+                return base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
             }
         }
 

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             public CleanUpNewLinesFormatter(SourceText text)
                 => _text = text;
 
-            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // Since we know the general shape of these new import statements, we simply look for where
                 // tokens are not on the same line and force them to only be separated by a single newline.

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
@@ -25,14 +25,14 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             /// Wrap the large &amp;&amp; expression after every &amp;&amp; token.
             /// </summary>
             public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
-                SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+                in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (_syntaxFacts.IsLogicalAndExpression(previousToken.Parent))
                 {
                     return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                 }
 
-                return nextOperation.Invoke();
+                return nextOperation.Invoke(in previousToken, in currentToken);
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
@@ -48,18 +48,22 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override sealed AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
+                var previousTokenCopy = previousToken;
+                var currentTokenCopy = currentToken;
                 var nextOperationCopy = nextOperation;
-                return GetAdjustNewLinesOperationSlow(previousToken, currentToken, ref nextOperationCopy);
+                return GetAdjustNewLinesOperationSlow(ref previousTokenCopy, ref currentTokenCopy, ref nextOperationCopy);
             }
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public override sealed AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
+                var previousTokenCopy = previousToken;
+                var currentTokenCopy = currentToken;
                 var nextOperationCopy = nextOperation;
-                return GetAdjustSpacesOperationSlow(previousToken, currentToken, ref nextOperationCopy);
+                return GetAdjustSpacesOperationSlow(ref previousTokenCopy, ref currentTokenCopy, ref nextOperationCopy);
             }
 #pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
 
@@ -91,14 +95,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             /// <summary>
             /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
             /// </summary>
-            public virtual AdjustNewLinesOperation GetAdjustNewLinesOperationSlow(SyntaxToken previousToken, SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
-                => base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+            public virtual AdjustNewLinesOperation GetAdjustNewLinesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
+                => base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
 
             /// <summary>
             /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
             /// </summary>
-            public virtual AdjustSpacesOperation GetAdjustSpacesOperationSlow(SyntaxToken previousToken, SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
-                => base.GetAdjustSpacesOperation(previousToken, currentToken, in nextOperation);
+            public virtual AdjustSpacesOperation GetAdjustSpacesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
+                => base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractMetadataFormattingRule.cs
@@ -17,11 +17,11 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             protected abstract bool IsNewLine(char c);
 
             public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
-                    SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+                    in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (previousToken.RawKind == 0 || currentToken.RawKind == 0)
                 {
-                    nextOperation.Invoke();
+                    nextOperation.Invoke(in previousToken, in currentToken);
                 }
 
                 var betweenMembersAndUsingsOperation = GetAdjustNewLinesOperationBetweenMembersAndUsings(previousToken, currentToken);
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                     return betweenMembersAndUsingsOperation;
                 }
 
-                return nextOperation.Invoke();
+                return nextOperation.Invoke(in previousToken, in currentToken);
             }
 
             protected int GetNumberOfLines(IEnumerable<SyntaxTrivia> triviaList)

--- a/src/Features/VisualBasic/Portable/ChangeSignature/ChangeSignatureFormattingRule.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/ChangeSignatureFormattingRule.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
             End If
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If previousToken.IsKind(SyntaxKind.CommaToken) AndAlso
                (previousToken.Parent.IsKind(SyntaxKind.ParameterList) OrElse previousToken.Parent.IsKind(SyntaxKind.ArgumentList)) Then
                 Return FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
@@ -118,14 +118,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
         Private Class FormattingRule
             Inherits CompatAbstractFormattingRule
 
-            Public Overrides Function GetAdjustNewLinesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
+            Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
                 If Not previousToken.IsLastTokenOfStatement() Then
-                    Return nextOperation.Invoke()
+                    Return nextOperation.Invoke(previousToken, currentToken)
                 End If
 
                 ' between [generated code] and [existing code]
                 If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
-                    Return nextOperation.Invoke()
+                    Return nextOperation.Invoke(previousToken, currentToken)
                 End If
 
                 ' make sure attribute and previous statement has at least 1 blank lines between them
@@ -139,7 +139,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return FormattingOperations.CreateAdjustNewLinesOperation(2, AdjustNewLinesOption.ForceLines)
                 End If
 
-                Return nextOperation.Invoke()
+                Return nextOperation.Invoke(previousToken, currentToken)
             End Function
 
             Private Function IsLessThanInAttribute(token As SyntaxToken) As Boolean

--- a/src/VisualStudio/CSharp/Impl/CodeModel/EndRegionFormattingRule.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/EndRegionFormattingRule.cs
@@ -27,14 +27,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             return false;
         }
 
-        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (IsAfterEndRegionBeforeMethodDeclaration(previousToken))
             {
                 return FormattingOperations.CreateAdjustNewLinesOperation(2, AdjustNewLinesOption.ForceLines);
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Utilities/BlankLineInGeneratedMethodFormattingRule.cs
+++ b/src/VisualStudio/CSharp/Impl/Utilities/BlankLineInGeneratedMethodFormattingRule.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Utilities
         {
         }
 
-        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             // case: insert blank line in empty method body.
             if (previousToken.Kind() == SyntaxKind.OpenBraceToken &&
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Utilities
                 }
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocumentPreserveFormattingRule.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocumentPreserveFormattingRule.cs
@@ -14,9 +14,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private static readonly AdjustSpacesOperation s_preserveSpace = FormattingOperations.CreateAdjustSpacesOperation(0, AdjustSpacesOption.PreserveSpaces);
         private static readonly AdjustNewLinesOperation s_preserveLine = FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
 
-        public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
-            var operation = base.GetAdjustSpacesOperation(previousToken, currentToken, in nextOperation);
+            var operation = base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
             if (operation != null)
             {
                 return s_preserveSpace;
@@ -25,9 +25,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return operation;
         }
 
-        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
-            var operation = base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+            var operation = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
             if (operation != null)
             {
                 return s_preserveLine;

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
@@ -119,10 +119,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
 
         private class NoLineChangeFormattingRule : AbstractFormattingRule
         {
-            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // no line operation. no line changes what so ever
-                var lineOperation = base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+                var lineOperation = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
                 if (lineOperation != null)
                 {
                     // ignore force if same line option
@@ -147,9 +147,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 // don't suppress anything
             }
 
-            public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
-                var spaceOperation = base.GetAdjustSpacesOperation(previousToken, currentToken, in nextOperation);
+                var spaceOperation = base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
 
                 // if there is force space operation, convert it to ForceSpaceIfSingleLine operation.
                 // (force space basically means remove all line breaks)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
@@ -37,11 +37,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             => null;
 
         // return 1 space for every token pairs as a default operation
-        public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             var space = currentToken.Kind() == SyntaxKind.EndOfFileToken ? 0 : 1;
             return FormattingOperations.CreateAdjustSpacesOperation(space, AdjustSpacesOption.DefaultSpacesIfOnSingleLine);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -94,9 +94,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return null;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
-            var operation = nextOperation.Invoke();
+            var operation = nextOperation.Invoke(in previousToken, in currentToken);
             if (operation == null)
             {
                 // If there are more than one Type Parameter Constraint Clause then each go in separate line
@@ -218,9 +218,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return FormattingOperations.CreateAdjustNewLinesOperation(2 /* +1 for member itself and +1 for a blank line*/, AdjustNewLinesOption.ForceLines);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
-            var operation = nextOperation.Invoke();
+            var operation = nextOperation.Invoke(in previousToken, in currentToken);
             if (operation == null)
             {
                 return null;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/EndOfFileTokenFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/EndOfFileTokenFormattingRule.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp End Of File Token Formatting Rule";
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             // * <End Of File> case for C#, make sure we don't insert new line between * and <End of
             // File> tokens.
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             // * <End Of File) case
             // for C#, make sure we have nothing between these two tokens
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -75,11 +75,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             RoslynDebug.AssertNotNull(currentToken.Parent);
 
-            var operation = nextOperation.Invoke();
+            var operation = nextOperation.Invoke(in previousToken, in currentToken);
 
             // } else in the if else context
             if (previousToken.IsKind(SyntaxKind.CloseBraceToken)
@@ -200,11 +200,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return operation;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             RoslynDebug.AssertNotNull(currentToken.Parent);
 
-            var operation = nextOperation.Invoke();
+            var operation = nextOperation.Invoke(in previousToken, in currentToken);
 
             // else condition is actually handled in the GetAdjustSpacesOperation()
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/QueryExpressionFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/QueryExpressionFormattingRule.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (previousToken.IsNestedQueryExpression())
             {
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // skip the very first from keyword
             if (currentToken.IsFirstFromKeywordInExpression())
             {
-                return nextOperation.Invoke();
+                return nextOperation.Invoke(in previousToken, in currentToken);
             }
 
             switch (currentToken.Kind())
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     break;
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
         private readonly struct CachedOptions : IEquatable<CachedOptions>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return new SpacingFormattingRule(cachedOptions);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             RoslynDebug.Assert(previousToken.Parent != null && currentToken.Parent != null);
 
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
         public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
@@ -13,17 +13,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp Structured Trivia Formatting Rule";
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (previousToken.Parent is StructuredTriviaSyntax || currentToken.Parent is StructuredTriviaSyntax)
             {
                 return null;
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             if (previousToken.Parent is StructuredTriviaSyntax || currentToken.Parent is StructuredTriviaSyntax)
             {
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return new TokenBasedFormattingRule(cachedOptions);
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             ////////////////////////////////////////////////////
             // brace related operations
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // for (int i = 10; i < 10; i++) case
             if (previousToken.IsSemicolonInForStatement())
             {
-                return nextOperation.Invoke();
+                return nextOperation.Invoke(in previousToken, in currentToken);
             }
 
             // ; case in the switch case statement and else condition
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
         private AdjustNewLinesOperation AdjustNewLinesAfterSemicolonToken(
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 _ => throw ExceptionUtilities.UnexpectedValue(node.Kind()),
             };
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             //////////////////////////////////////////////////////
             // ";" related operations
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
-            return nextOperation.Invoke();
+            return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
         private readonly struct CachedOptions : IEquatable<CachedOptions>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
@@ -72,14 +72,14 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
         {
-            var action = new NextGetAdjustNewLinesOperation(_getAdjustNewLinesOperationRules, index: 0, previousToken, currentToken);
-            return action.Invoke();
+            var action = new NextGetAdjustNewLinesOperation(_getAdjustNewLinesOperationRules, index: 0);
+            return action.Invoke(in previousToken, in currentToken);
         }
 
         public AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
         {
-            var action = new NextGetAdjustSpacesOperation(_getAdjustSpacesOperationRules, index: 0, previousToken, currentToken);
-            return action.Invoke();
+            var action = new NextGetAdjustSpacesOperation(_getAdjustSpacesOperationRules, index: 0);
+            return action.Invoke(in previousToken, in currentToken);
         }
 
         private static ImmutableArray<AbstractFormattingRule> FilterToRulesImplementingMethod(ImmutableArray<AbstractFormattingRule> rules, string name)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
@@ -46,13 +46,13 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
-            => nextOperation.Invoke();
+        public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            => nextOperation.Invoke(in previousToken, in currentToken);
 
         /// <summary>
         /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
-            => nextOperation.Invoke();
+        public virtual AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            => nextOperation.Invoke(in previousToken, in currentToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
@@ -47,18 +47,22 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override sealed AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
+            var previousTokenCopy = previousToken;
+            var currentTokenCopy = currentToken;
             var nextOperationCopy = nextOperation;
-            return GetAdjustNewLinesOperationSlow(previousToken, currentToken, ref nextOperationCopy);
+            return GetAdjustNewLinesOperationSlow(ref previousTokenCopy, ref currentTokenCopy, ref nextOperationCopy);
         }
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override sealed AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
+            var previousTokenCopy = previousToken;
+            var currentTokenCopy = currentToken;
             var nextOperationCopy = nextOperation;
-            return GetAdjustSpacesOperationSlow(previousToken, currentToken, ref nextOperationCopy);
+            return GetAdjustSpacesOperationSlow(ref previousTokenCopy, ref currentTokenCopy, ref nextOperationCopy);
         }
 #pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
 
@@ -90,13 +94,13 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperationSlow(SyntaxToken previousToken, SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
-            => base.GetAdjustNewLinesOperation(previousToken, currentToken, in nextOperation);
+        public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
+            => base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
 
         /// <summary>
         /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustSpacesOperation? GetAdjustSpacesOperationSlow(SyntaxToken previousToken, SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
-            => base.GetAdjustSpacesOperation(previousToken, currentToken, in nextOperation);
+        public virtual AdjustSpacesOperation? GetAdjustSpacesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
+            => base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustNewLinesOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustNewLinesOperation.cs
@@ -14,25 +14,19 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     {
         private readonly ImmutableArray<AbstractFormattingRule> _formattingRules;
         private readonly int _index;
-        private readonly SyntaxToken _previousToken;
-        private readonly SyntaxToken _currentToken;
 
         public NextGetAdjustNewLinesOperation(
             ImmutableArray<AbstractFormattingRule> formattingRules,
-            int index,
-            SyntaxToken previousToken,
-            SyntaxToken currentToken)
+            int index)
         {
             _formattingRules = formattingRules;
             _index = index;
-            _previousToken = previousToken;
-            _currentToken = currentToken;
         }
 
         private NextGetAdjustNewLinesOperation NextOperation
-            => new NextGetAdjustNewLinesOperation(_formattingRules, _index + 1, _previousToken, _currentToken);
+            => new NextGetAdjustNewLinesOperation(_formattingRules, _index + 1);
 
-        public AdjustNewLinesOperation? Invoke()
+        public AdjustNewLinesOperation? Invoke(in SyntaxToken previousToken, in SyntaxToken currentToken)
         {
             // If we have no remaining handlers to execute, then we'll execute our last handler
             if (_index >= _formattingRules.Length)
@@ -42,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             else
             {
                 // Call the handler at the index, passing a continuation that will come back to here with index + 1
-                return _formattingRules[_index].GetAdjustNewLinesOperation(_previousToken, _currentToken, NextOperation);
+                return _formattingRules[_index].GetAdjustNewLinesOperation(in previousToken, in currentToken, NextOperation);
             }
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustSpacesOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustSpacesOperation.cs
@@ -14,25 +14,19 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     {
         private readonly ImmutableArray<AbstractFormattingRule> _formattingRules;
         private readonly int _index;
-        private readonly SyntaxToken _previousToken;
-        private readonly SyntaxToken _currentToken;
 
         public NextGetAdjustSpacesOperation(
             ImmutableArray<AbstractFormattingRule> formattingRules,
-            int index,
-            SyntaxToken previousToken,
-            SyntaxToken currentToken)
+            int index)
         {
             _formattingRules = formattingRules;
             _index = index;
-            _previousToken = previousToken;
-            _currentToken = currentToken;
         }
 
         private NextGetAdjustSpacesOperation NextOperation
-            => new NextGetAdjustSpacesOperation(_formattingRules, _index + 1, _previousToken, _currentToken);
+            => new NextGetAdjustSpacesOperation(_formattingRules, _index + 1);
 
-        public AdjustSpacesOperation? Invoke()
+        public AdjustSpacesOperation? Invoke(in SyntaxToken previousToken, in SyntaxToken currentToken)
         {
             // If we have no remaining handlers to execute, then we'll execute our last handler
             if (_index >= _formattingRules.Length)
@@ -42,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
             else
             {
                 // Call the handler at the index, passing a continuation that will come back to here with index + 1
-                return _formattingRules[_index].GetAdjustSpacesOperation(_previousToken, _currentToken, NextOperation);
+                return _formattingRules[_index].GetAdjustSpacesOperation(in previousToken, in currentToken, NextOperation);
             }
         }
     }

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -54,8 +54,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         <PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowCaptures:=False, AllowImplicitBoxing:=False)>
         Public Overrides Function GetAdjustNewLinesOperationSlow(
-                previousToken As SyntaxToken,
-                currentToken As SyntaxToken,
+                ByRef previousToken As SyntaxToken,
+                ByRef currentToken As SyntaxToken,
                 ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If previousToken.Parent Is Nothing Then
                 Return Nothing
@@ -209,7 +209,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         End Function
 
         ' return 1 space for every token pairs as a default operation
-        Public Overrides Function GetAdjustSpacesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             If previousToken.Kind = SyntaxKind.ColonToken AndAlso
                TypeOf previousToken.Parent Is LabelStatementSyntax AndAlso
                currentToken.Kind <> SyntaxKind.EndOfFileToken Then

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextFunc As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextFunc As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             ' * <end of file token>
             If currentToken.Kind = SyntaxKind.EndOfFileToken Then
                 Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
@@ -356,7 +356,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 
-            Return nextFunc.Invoke()
+            Return nextFunc.Invoke(previousToken, currentToken)
         End Function
 
         Private Function PrecedingTriviaContainsLineBreak(previousToken As SyntaxToken) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
@@ -84,14 +84,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             End If
         End Sub
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             ' if it doesn't have elastic trivia, pass it through
             If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
-                Return nextOperation.Invoke()
+                Return nextOperation.Invoke(previousToken, currentToken)
             End If
 
             ' if it has one, check whether there is a forced one
-            Dim operation = nextOperation.Invoke()
+            Dim operation = nextOperation.Invoke(previousToken, currentToken)
 
             If operation IsNot Nothing AndAlso operation.Option = AdjustSpacesOption.ForceSpaces Then
                 Return operation
@@ -121,17 +121,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         End Function
 
         Public Overrides Function GetAdjustNewLinesOperationSlow(
-                previousToken As SyntaxToken,
-                currentToken As SyntaxToken,
+                ByRef previousToken As SyntaxToken,
+                ByRef currentToken As SyntaxToken,
                 ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
 
             ' if it doesn't have elastic trivia, pass it through
             If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
-                Return nextOperation.Invoke()
+                Return nextOperation.Invoke(previousToken, currentToken)
             End If
 
             ' if it has one, check whether there is a forced one
-            Dim operation = nextOperation.Invoke()
+            Dim operation = nextOperation.Invoke(previousToken, currentToken)
 
             If operation IsNot Nothing AndAlso operation.Option = AdjustNewLinesOption.ForceLines Then
                 Return operation

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/StructuredTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/StructuredTriviaFormattingRule.vb
@@ -13,23 +13,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If UnderStructuredTrivia(previousToken, currentToken) Then
                 Return Nothing
             End If
 
-            Return nextOperation.Invoke()
+            Return nextOperation.Invoke(previousToken, currentToken)
         End Function
 
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             If UnderStructuredTrivia(previousToken, currentToken) Then
                 If previousToken.Kind = SyntaxKind.HashToken AndAlso SyntaxFacts.IsPreprocessorKeyword(CType(currentToken.Kind, SyntaxKind)) Then
                     Return CreateAdjustSpacesOperation(space:=0, option:=AdjustSpacesOption.ForceSpacesIfOnSingleLine)
                 End If
             End If
 
-            Return nextOperation.Invoke()
+            Return nextOperation.Invoke(previousToken, currentToken)
         End Function
 
         Private Function UnderStructuredTrivia(previousToken As SyntaxToken, currentToken As SyntaxToken) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Indentation/SpecialFormattingOperation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/SpecialFormattingOperation.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             ' don't suppress anything
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
 
             ' unlike regular one. force position of attribute
             Dim attributeNode = TryCast(previousToken.Parent, AttributeListSyntax)
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             Return Nothing
         End Function
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(previousToken As SyntaxToken, currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             Dim spaceOperation = MyBase.GetAdjustSpacesOperationSlow(previousToken, currentToken, nextOperation)
 
             ' if there is force space operation, convert it to ForceSpaceIfSingleLine operation.


### PR DESCRIPTION
### Summary

This appears to provide a 3% improvement.

### Before

```
BenchmarkDotNet=v0.11.4, OS=Windows 10.0.18363
AMD Ryzen Threadripper 2990WX, 1 CPU, 64 logical and 32 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4150.0
  Job-OKQBPV : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4150.0

Server=True  InvocationCount=1  UnrollFactor=1
```

|            Method |             Document |         Mean |      Error |     StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------ |--------------------- |-------------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|      FormatCSharp | Bound(...)rated [24] |   902.107 ms |  9.0826 ms |  7.5843 ms |           - |           - |           - |         28790.46 KB |
| FormatVisualBasic | Bound(...)rated [24] |   509.950 ms |  4.0274 ms |  3.3631 ms |   1000.0000 |           - |           - |         27405.64 KB |
|      FormatCSharp | ErrorFacts.Generated |    20.870 ms |  0.6553 ms |  1.8908 ms |           - |           - |           - |          1274.77 KB |
| FormatVisualBasic | ErrorFacts.Generated |     9.422 ms |  0.1848 ms |  0.2767 ms |           - |           - |           - |           818.09 KB |
|      FormatCSharp | Synta(...)rated [29] | 2,050.614 ms | 17.4836 ms | 15.4987 ms |   3000.0000 |   2000.0000 |   2000.0000 |         76187.18 KB |
| FormatVisualBasic | Synta(...)rated [29] | 2,047.467 ms | 29.7898 ms | 24.8759 ms |  10000.0000 |   5000.0000 |   3000.0000 |        107066.14 KB |
|      FormatCSharp | Synta(...)rated [25] |   401.977 ms |  7.7503 ms |  6.8704 ms |   4000.0000 |   1000.0000 |           - |         18084.18 KB |
| FormatVisualBasic | Synta(...)rated [25] | 1,198.173 ms | 15.2435 ms | 13.5130 ms |   2000.0000 |   1000.0000 |   1000.0000 |         68622.22 KB |
|      FormatCSharp | Synta(...)rated [27] |   706.526 ms | 12.5824 ms | 11.1540 ms |           - |           - |           - |         27453.25 KB |
| FormatVisualBasic | Synta(...)rated [27] | 1,044.804 ms | 21.0915 ms | 21.6595 ms |   4000.0000 |   2000.0000 |   1000.0000 |         58106.18 KB |

### After

```
BenchmarkDotNet=v0.11.4, OS=Windows 10.0.18363
AMD Ryzen Threadripper 2990WX, 1 CPU, 64 logical and 32 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4150.0
  Job-OKQBPV : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4150.0

Server=True  InvocationCount=1  UnrollFactor=1
```

|            Method |             Document |         Mean |      Error |     StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------ |--------------------- |-------------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|      FormatCSharp | Bound(...)rated [24] |   851.546 ms |  6.6579 ms |  6.2278 ms |           - |           - |           - |         28776.26 KB |
| FormatVisualBasic | Bound(...)rated [24] |   512.190 ms | 10.1590 ms | 17.2507 ms |   1000.0000 |           - |           - |         27402.09 KB |
|      FormatCSharp | ErrorFacts.Generated |    21.224 ms |  0.6719 ms |  1.9599 ms |           - |           - |           - |          1290.78 KB |
| FormatVisualBasic | ErrorFacts.Generated |     9.483 ms |  0.1850 ms |  0.3141 ms |           - |           - |           - |           810.09 KB |
|      FormatCSharp | Synta(...)rated [29] | 1,975.754 ms | 29.8634 ms | 27.9343 ms |   3000.0000 |   2000.0000 |   2000.0000 |         76203.13 KB |
| FormatVisualBasic | Synta(...)rated [29] | 1,987.659 ms | 38.6107 ms | 37.9209 ms |   3000.0000 |   2000.0000 |   1000.0000 |        107024.45 KB |
|      FormatCSharp | Synta(...)rated [25] |   382.028 ms |  7.6219 ms |  7.1295 ms |           - |           - |           - |         18086.93 KB |
| FormatVisualBasic | Synta(...)rated [25] | 1,199.007 ms | 23.7543 ms | 36.2753 ms |   4000.0000 |   2000.0000 |   1000.0000 |         68594.77 KB |
|      FormatCSharp | Synta(...)rated [27] |   674.774 ms |  6.1743 ms |  5.4733 ms |           - |           - |           - |         27475.86 KB |
| FormatVisualBasic | Synta(...)rated [27] | 1,025.651 ms | 19.9862 ms | 29.2956 ms |   4000.0000 |   2000.0000 |   1000.0000 |         58130.52 KB |
