### PR TITLE
Implement SegmentedArray<T>

### DIFF
--- a/src/Workspaces/CoreTest/Collections/SegmentedArrayHelperTests.cs
+++ b/src/Workspaces/CoreTest/Collections/SegmentedArrayHelperTests.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    public class SegmentedArrayHelperTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(16)]
+        [InlineData(32)]
+        public void CalculateSegmentSize(int elementSize)
+        {
+            var expected = elementSize switch
+            {
+                1 => 65536,
+                2 => 32768,
+                3 => 16384,
+                4 => 16384,
+                5 => 16384,
+                6 => 8192,
+                7 => 8192,
+                8 => 8192,
+                9 => 8192,
+                10 => 8192,
+                16 => 4096,
+                32 => 2048,
+                _ => throw ExceptionUtilities.Unreachable,
+            };
+
+            Assert.Equal(expected, SegmentedArrayHelper.CalculateSegmentSize(elementSize));
+        }
+
+        [Theory]
+        [InlineData(1024)]
+        [InlineData(2048)]
+        [InlineData(4096)]
+        [InlineData(8192)]
+        [InlineData(16384)]
+        [InlineData(32768)]
+        [InlineData(65536)]
+        public void CalculateSegmentShift(int segmentSize)
+        {
+            var expected = segmentSize switch
+            {
+                1024 => 10,
+                2048 => 11,
+                4096 => 12,
+                8192 => 13,
+                16384 => 14,
+                32768 => 15,
+                65536 => 16,
+                _ => throw ExceptionUtilities.Unreachable,
+            };
+
+            Assert.Equal(expected, SegmentedArrayHelper.CalculateSegmentShift(segmentSize));
+        }
+
+        [Theory]
+        [InlineData(1024)]
+        [InlineData(2048)]
+        [InlineData(4096)]
+        [InlineData(8192)]
+        [InlineData(16384)]
+        [InlineData(32768)]
+        [InlineData(65536)]
+        public void CalculateOffsetMask(int segmentSize)
+        {
+            var expected = segmentSize switch
+            {
+                1024 => 0x3FF,
+                2048 => 0x7FF,
+                4096 => 0xFFF,
+                8192 => 0x1FFF,
+                16384 => 0x3FFF,
+                32768 => 0x7FFF,
+                65536 => 0xFFFF,
+                _ => throw ExceptionUtilities.Unreachable,
+            };
+
+            Assert.Equal(expected, SegmentedArrayHelper.CalculateOffsetMask(segmentSize));
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/Collections/SegmentedArrayTests.cs
+++ b/src/Workspaces/CoreTest/Collections/SegmentedArrayTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.False(data.IsReadOnly);
             Assert.False(data.IsSynchronized);
             Assert.Equal(0, data.Length);
-            Assert.Same(Array.Empty<IntPtr[]>().SyncRoot, data.SyncRoot);
+            Assert.Null(data.SyncRoot);
 
             Assert.Throws<NullReferenceException>(() => data[0]);
             Assert.Throws<NullReferenceException>(() => ((IReadOnlyList<IntPtr>)data)[0]);
@@ -178,6 +178,30 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 ((IList)data)[i] = IntPtr.Add(data[i], 1);
                 Assert.Equal((IntPtr)(i + 1), ((IList)data)[i]);
             }
+        }
+
+        /// <summary>
+        /// Verify that indexing and iteration match for an array with many segments.
+        /// </summary>
+        [Fact]
+        public void TestIterateLargeArray()
+        {
+            var data = new SegmentedArray<Guid>(1000000);
+            Assert.True(data.GetTestAccessor().Items.Length > 10);
+
+            for (var i = 0; i < data.Length; i++)
+            {
+                data[i] = Guid.NewGuid();
+                Assert.NotEqual(Guid.Empty, data[i]);
+            }
+
+            var index = 0;
+            foreach (var guid in data)
+            {
+                Assert.Equal(guid, data[index++]);
+            }
+
+            Assert.Equal(data.Length, index);
         }
     }
 }

--- a/src/Workspaces/CoreTest/Collections/SegmentedArrayTests.cs
+++ b/src/Workspaces/CoreTest/Collections/SegmentedArrayTests.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    public class SegmentedArrayTests
+    {
+        public static IEnumerable<object[]> TestLengths
+        {
+            get
+            {
+                yield return new object[] { 1 };
+                yield return new object[] { 10 };
+                yield return new object[] { 100 };
+                yield return new object[] { 100000 };
+            }
+        }
+
+        private static void ResetToSequence(SegmentedArray<IntPtr> array)
+        {
+            for (var i = 0; i < array.Length; i++)
+            {
+                array[i] = (IntPtr)i;
+            }
+        }
+
+        [Fact]
+        public void TestDefaultInstance()
+        {
+            var data = default(SegmentedArray<IntPtr>);
+            Assert.Null(data.GetTestAccessor().Items);
+
+            Assert.True(data.IsFixedSize);
+            Assert.False(data.IsReadOnly);
+            Assert.False(data.IsSynchronized);
+            Assert.Equal(0, data.Length);
+            Assert.Same(Array.Empty<IntPtr[]>().SyncRoot, data.SyncRoot);
+
+            Assert.Throws<NullReferenceException>(() => data[0]);
+            Assert.Throws<NullReferenceException>(() => ((IReadOnlyList<IntPtr>)data)[0]);
+            Assert.Throws<NullReferenceException>(() => ((IList<IntPtr>)data)[0]);
+            Assert.Throws<NullReferenceException>(() => ((IList<IntPtr>)data)[0] = IntPtr.Zero);
+            Assert.Throws<NullReferenceException>(() => ((IList)data)[0]);
+            Assert.Throws<NullReferenceException>(() => ((IList)data)[0] = IntPtr.Zero);
+
+            Assert.Equal(0, ((ICollection)data).Count);
+            Assert.Equal(0, ((ICollection<IntPtr>)data).Count);
+            Assert.Equal(0, ((IReadOnlyCollection<IntPtr>)data).Count);
+
+            Assert.Throws<NullReferenceException>(() => data.Clone());
+            Assert.Throws<NullReferenceException>(() => data.CopyTo(Array.Empty<IntPtr>(), 0));
+            Assert.Throws<NullReferenceException>(() => ((ICollection<IntPtr>)data).CopyTo(Array.Empty<IntPtr>(), 0));
+
+            var enumerator1 = data.GetEnumerator();
+            Assert.Throws<NullReferenceException>(() => enumerator1.MoveNext());
+
+            var enumerator2 = ((IEnumerable)data).GetEnumerator();
+            Assert.Throws<NullReferenceException>(() => enumerator1.MoveNext());
+
+            var enumerator3 = ((IEnumerable<IntPtr>)data).GetEnumerator();
+            Assert.Throws<NullReferenceException>(() => enumerator1.MoveNext());
+
+            Assert.Throws<NotSupportedException>(() => ((IList)data).Add(IntPtr.Zero));
+            Assert.Throws<NotSupportedException>(() => ((ICollection<IntPtr>)data).Add(IntPtr.Zero));
+            Assert.Throws<NotSupportedException>(() => ((ICollection<IntPtr>)data).Clear());
+            Assert.Throws<NotSupportedException>(() => ((IList)data).Insert(0, IntPtr.Zero));
+            Assert.Throws<NotSupportedException>(() => ((IList<IntPtr>)data).Insert(0, IntPtr.Zero));
+            Assert.Throws<NotSupportedException>(() => ((IList)data).Remove(IntPtr.Zero));
+            Assert.Throws<NotSupportedException>(() => ((ICollection<IntPtr>)data).Remove(IntPtr.Zero));
+            Assert.Throws<NotSupportedException>(() => ((IList)data).RemoveAt(0));
+            Assert.Throws<NotSupportedException>(() => ((IList<IntPtr>)data).RemoveAt(0));
+
+            Assert.Throws<NullReferenceException>(() => ((IList)data).Clear());
+            Assert.Throws<NullReferenceException>(() => ((IList)data).Contains(IntPtr.Zero));
+            Assert.Throws<NullReferenceException>(() => ((ICollection<IntPtr>)data).Contains(IntPtr.Zero));
+            Assert.Throws<NullReferenceException>(() => ((IList)data).IndexOf(IntPtr.Zero));
+            Assert.Throws<NullReferenceException>(() => ((IList<IntPtr>)data).IndexOf(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void TestConstructor1()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => new SegmentedArray<byte>(-1));
+
+            Assert.Empty(new SegmentedArray<byte>(0));
+            Assert.Same(Array.Empty<byte[]>(), new SegmentedArray<byte>(0).GetTestAccessor().Items);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestLengths))]
+        public void TestConstructor2(int length)
+        {
+            var data = new SegmentedArray<IntPtr>(length);
+            Assert.Equal(length, data.Length);
+
+            var items = data.GetTestAccessor().Items;
+            Assert.Equal(length, items.Sum(item => item.Length));
+
+            for (var i = 0; i < items.Length - 1; i++)
+            {
+                Assert.Equal(SegmentedArray<IntPtr>.TestAccessor.SegmentSize, items[i].Length);
+                Assert.True(items[i].Length <= SegmentedArray<IntPtr>.TestAccessor.SegmentSize);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestLengths))]
+        public void TestBasicProperties(int length)
+        {
+            var data = new SegmentedArray<IntPtr>(length);
+
+            Assert.True(data.IsFixedSize);
+            Assert.False(data.IsReadOnly);
+            Assert.False(data.IsSynchronized);
+            Assert.Equal(length, data.Length);
+            Assert.Same(data.GetTestAccessor().Items, data.SyncRoot);
+
+            Assert.Equal(length, ((ICollection)data).Count);
+            Assert.Equal(length, ((ICollection<IntPtr>)data).Count);
+            Assert.Equal(length, ((IReadOnlyCollection<IntPtr>)data).Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestLengths))]
+        public void TestIndexer(int length)
+        {
+            var data = new SegmentedArray<IntPtr>(length);
+            ResetToSequence(data);
+
+            for (var i = 0; i < length; i++)
+            {
+                data[i] = (IntPtr)i;
+            }
+
+            for (var i = 0; i < length; i++)
+            {
+                Assert.Equal((IntPtr)i, data[i]);
+            }
+
+            for (var i = 0; i < length; i++)
+            {
+                ref var value = ref data[i];
+                Assert.Equal((IntPtr)i, data[i]);
+                value = IntPtr.Add(value, 1);
+
+                Assert.Equal((IntPtr)(i + 1), value);
+                Assert.Equal((IntPtr)(i + 1), data[i]);
+            }
+
+            ResetToSequence(data);
+            for (var i = 0; i < length; i++)
+            {
+                Assert.Equal((IntPtr)i, ((IReadOnlyList<IntPtr>)data)[i]);
+                data[i] = IntPtr.Add(data[i], 1);
+                Assert.Equal((IntPtr)(i + 1), ((IReadOnlyList<IntPtr>)data)[i]);
+            }
+
+            ResetToSequence(data);
+            for (var i = 0; i < length; i++)
+            {
+                Assert.Equal((IntPtr)i, ((IList<IntPtr>)data)[i]);
+                ((IList<IntPtr>)data)[i] = IntPtr.Add(data[i], 1);
+                Assert.Equal((IntPtr)(i + 1), ((IList<IntPtr>)data)[i]);
+            }
+
+            ResetToSequence(data);
+            for (var i = 0; i < length; i++)
+            {
+                Assert.Equal((IntPtr)i, ((IList)data)[i]);
+                ((IList)data)[i] = IntPtr.Add(data[i], 1);
+                Assert.Equal((IntPtr)(i + 1), ((IList)data)[i]);
+            }
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/Collections/SegmentedArrayTests.cs
+++ b/src/Workspaces/CoreTest/Collections/SegmentedArrayTests.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 yield return new object[] { 1 };
                 yield return new object[] { 10 };
                 yield return new object[] { 100 };
+                yield return new object[] { SegmentedArray<IntPtr>.TestAccessor.SegmentSize / 2 };
+                yield return new object[] { SegmentedArray<IntPtr>.TestAccessor.SegmentSize };
+                yield return new object[] { SegmentedArray<IntPtr>.TestAccessor.SegmentSize * 2 };
                 yield return new object[] { 100000 };
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
 
         internal static int CalculateOffsetMask(int segmentSize)
         {
-            Debug.Assert(segmentSize <= 1 || (segmentSize & (segmentSize - 1)) != 0);
+            Debug.Assert(segmentSize <= 1 || (segmentSize & (segmentSize - 1)) == 0);
             return segmentSize - 1;
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
         /// <returns>The segment size to use for small object heap segmented arrays.</returns>
         internal static int CalculateSegmentSize(int elementSize)
         {
+            // Default Large Object Heap size threshold
+            // https://github.com/dotnet/runtime/blob/c9d69e38d0e54bea5d188593ef6c3b30139f3ab1/src/coreclr/src/gc/gc.h#L111
             const int Threshold = 85000;
 
             var segmentSize = 2;
@@ -38,6 +40,11 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             }
         }
 
+        /// <summary>
+        /// Calculates a shift which can be applied to an absolute index to get the page index within a segmented array.
+        /// </summary>
+        /// <param name="segmentSize">The number of elements in each page of the segmented array. Must be a power of 2.</param>
+        /// <returns>The shift to apply to the absolute index to get the page index within a segmented array.</returns>
         internal static int CalculateSegmentShift(int segmentSize)
         {
             var segmentShift = 0;
@@ -49,9 +56,15 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return segmentShift;
         }
 
+        /// <summary>
+        /// Calculates a mask, which can be applied to an absolute index to get the index within a page of a segmented
+        /// array.
+        /// </summary>
+        /// <param name="segmentSize">The number of elements in each page of the segmented array. Must be a power of 2.</param>
+        /// <returns>The bit mask to obtain the index within a page from an absolute index within a segmented array.</returns>
         internal static int CalculateOffsetMask(int segmentSize)
         {
-            Debug.Assert(segmentSize <= 1 || (segmentSize & (segmentSize - 1)) == 0);
+            Debug.Assert(segmentSize == 1 || (segmentSize & (segmentSize - 1)) == 0, "Expected size of 1, or a power of 2");
             return segmentSize - 1;
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArrayHelper.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Shared.Collections
+{
+    internal static class SegmentedArrayHelper
+    {
+        /// <summary>
+        /// Calculates the maximum number of elements of size <paramref name="elementSize"/> which can fit into an array
+        /// which has the following characteristics:
+        /// <list type="bullet">
+        /// <item><description>The array can be allocated in the small object heap.</description></item>
+        /// <item><description>The array length is a power of 2.</description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="elementSize">The size of the elements in the array.</param>
+        /// <returns>The segment size to use for small object heap segmented arrays.</returns>
+        internal static int CalculateSegmentSize(int elementSize)
+        {
+            const int Threshold = 85000;
+
+            var segmentSize = 2;
+            while (ArraySize(elementSize, segmentSize << 1) < Threshold)
+            {
+                segmentSize <<= 1;
+            }
+
+            return segmentSize;
+
+            static int ArraySize(int elementSize, int segmentSize)
+            {
+                // Array object header, plus space for the elements
+                return (2 * IntPtr.Size) + (elementSize * segmentSize);
+            }
+        }
+
+        internal static int CalculateSegmentShift(int segmentSize)
+        {
+            var segmentShift = 0;
+            while (0 != (segmentSize >>= 1))
+            {
+                segmentShift++;
+            }
+
+            return segmentShift;
+        }
+
+        internal static int CalculateOffsetMask(int segmentSize)
+        {
+            Debug.Assert(segmentSize <= 1 || (segmentSize & (segmentSize - 1)) != 0);
+            return segmentSize - 1;
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
@@ -121,16 +121,12 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
 
         int IList.Add(object value)
         {
-            IList list = Array.Empty<T>();
-            _ = list.Add(value);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         void ICollection<T>.Add(T value)
         {
-            ICollection<T> list = Array.Empty<T>();
-            list.Add(value);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         void IList.Clear()
@@ -143,9 +139,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
 
         void ICollection<T>.Clear()
         {
-            ICollection<T> list = Array.Empty<T>();
-            list.Clear();
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         bool IList.Contains(object value)
@@ -202,44 +196,32 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
 
         void IList.Insert(int index, object value)
         {
-            IList list = Array.Empty<T>();
-            list.Insert(0, value);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         void IList<T>.Insert(int index, T value)
         {
-            IList<T> list = Array.Empty<T>();
-            list.Insert(0, value);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         void IList.Remove(object value)
         {
-            IList list = Array.Empty<T>();
-            list.Remove(value);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         bool ICollection<T>.Remove(T value)
         {
-            ICollection<T> collection = Array.Empty<T>();
-            _ = collection.Remove(value);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         void IList.RemoveAt(int index)
         {
-            IList list = Array.Empty<T>();
-            list.RemoveAt(0);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         void IList<T>.RemoveAt(int index)
         {
-            IList<T> list = Array.Empty<T>();
-            list.RemoveAt(0);
-            throw ExceptionUtilities.Unreachable;
+            throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
@@ -253,20 +235,10 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             if (other is null)
                 return 1;
 
-            if (!(other is SegmentedArray<T> o))
+            if (!(other is SegmentedArray<T> o)
+                || Length != o.Length)
             {
-                // Delegate to T[] so the correct exception is thrown
-                IStructuralComparable comparable = Array.Empty<T>();
-                comparable.CompareTo(new object(), comparer);
-                throw ExceptionUtilities.Unreachable;
-            }
-
-            if (Length != o.Length)
-            {
-                // Delegate to T[] so the correct exception is thrown
-                IStructuralComparable comparable = Array.Empty<T>();
-                comparable.CompareTo(new T[1], comparer);
-                throw ExceptionUtilities.Unreachable;
+                throw new ArgumentException(CompilerExtensionsResources.ArgumentException_OtherNotArrayOfCorrectLength, nameof(other));
             }
 
             for (var i = 0; i < Length; i++)
@@ -314,6 +286,9 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
 
             return ret;
         }
+
+        internal TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
 
         public struct Enumerator : IEnumerator<T>
         {
@@ -364,6 +339,20 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
                 _nextItemIndex = 0;
                 _current = default;
             }
+        }
+
+        internal readonly struct TestAccessor
+        {
+            private readonly SegmentedArray<T> _array;
+
+            public TestAccessor(SegmentedArray<T> array)
+            {
+                _array = array;
+            }
+
+            public static int SegmentSize => s_segmentSize;
+
+            public T[][] Items => _array._items;
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
@@ -1,0 +1,385 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Shared.Collections
+{
+    internal readonly struct SegmentedArray<T> : ICloneable, IList, IStructuralComparable, IStructuralEquatable, IList<T>, IReadOnlyList<T>
+    {
+        private readonly int _segmentSize;
+        private readonly int _segmentShift;
+        private readonly int _offsetMask;
+
+        private readonly int _length;
+        private readonly T[][] _items;
+
+        public SegmentedArray(int segmentSize, int length)
+        {
+            if (segmentSize <= 1 || (segmentSize & (segmentSize - 1)) != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(segmentSize), CompilerExtensionsResources.Segment_size_must_be_power_of_2_greater_than_1);
+            }
+
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            _segmentSize = segmentSize;
+            _offsetMask = segmentSize - 1;
+            _segmentShift = 0;
+
+            while (0 != (segmentSize >>= 1))
+            {
+                _segmentShift++;
+            }
+
+            if (length == 0)
+            {
+                _items = Array.Empty<T[]>();
+                _length = 0;
+            }
+            else
+            {
+                _items = new T[(length + _segmentSize - 1) >> _segmentShift][];
+                for (var i = 0; i < _items.Length - 1; i++)
+                {
+                    _items[i] = new T[_segmentSize];
+                }
+
+                _items[^1] = new T[length & _offsetMask];
+                _length = length;
+            }
+        }
+
+        private SegmentedArray(int segmentSize, int segmentShift, int offsetMask, int length, T[][] items)
+        {
+            _segmentSize = segmentSize;
+            _segmentShift = segmentShift;
+            _offsetMask = offsetMask;
+            _length = length;
+            _items = items;
+        }
+
+        public bool IsFixedSize => true;
+
+        public bool IsReadOnly => false;
+
+        public bool IsSynchronized => false;
+
+        public int Length => _length;
+
+        public object SyncRoot => _items ?? Array.Empty<T[]>().SyncRoot;
+
+        public ref T this[int index]
+        {
+            get
+            {
+                return ref _items[index >> _segmentShift][index & _offsetMask];
+            }
+        }
+
+        int ICollection.Count => _length;
+
+        int ICollection<T>.Count => _length;
+
+        int IReadOnlyCollection<T>.Count => _length;
+
+        T IReadOnlyList<T>.this[int index] => this[index];
+
+        T IList<T>.this[int index]
+        {
+            get => this[index];
+            set => this[index] = value;
+        }
+
+        object IList.this[int index]
+        {
+            get => this[index];
+            set => this[index] = (T)value;
+        }
+
+        public object Clone()
+        {
+            var items = (T[][])_items.Clone();
+            for (var i = 0; i < items.Length; i++)
+            {
+                items[i] = (T[])items[i].Clone();
+            }
+
+            return new SegmentedArray<T>(_segmentSize, _segmentShift, _offsetMask, _length, items);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            for (var i = 0; i < _items.Length; i++)
+            {
+                _items[i].CopyTo(array, index + (i * _segmentSize));
+            }
+        }
+
+        void ICollection<T>.CopyTo(T[] array, int arrayIndex)
+        {
+            for (var i = 0; i < _items.Length; i++)
+            {
+                ICollection<T> collection = _items[i];
+                collection.CopyTo(array, arrayIndex + (i * _segmentSize));
+            }
+        }
+
+        public Enumerator GetEnumerator()
+            => new Enumerator(this);
+
+        int IList.Add(object value)
+        {
+            IList list = Array.Empty<T>();
+            _ = list.Add(value);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        void ICollection<T>.Add(T value)
+        {
+            ICollection<T> list = Array.Empty<T>();
+            list.Add(value);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        void IList.Clear()
+        {
+            foreach (IList list in _items)
+            {
+                list.Clear();
+            }
+        }
+
+        void ICollection<T>.Clear()
+        {
+            ICollection<T> list = Array.Empty<T>();
+            list.Clear();
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        bool IList.Contains(object value)
+        {
+            foreach (IList list in _items)
+            {
+                if (list.Contains(value))
+                    return true;
+            }
+
+            return false;
+        }
+
+        bool ICollection<T>.Contains(T value)
+        {
+            foreach (ICollection<T> collection in _items)
+            {
+                if (collection.Contains(value))
+                    return true;
+            }
+
+            return false;
+        }
+
+        int IList.IndexOf(object value)
+        {
+            for (var i = 0; i < _items.Length; i++)
+            {
+                IList list = _items[i];
+                var index = list.IndexOf(value);
+                if (index >= 0)
+                {
+                    return index + i * _segmentSize;
+                }
+            }
+
+            return -1;
+        }
+
+        int IList<T>.IndexOf(T value)
+        {
+            for (var i = 0; i < _items.Length; i++)
+            {
+                IList<T> list = _items[i];
+                var index = list.IndexOf(value);
+                if (index >= 0)
+                {
+                    return index + i * _segmentSize;
+                }
+            }
+
+            return -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            IList list = Array.Empty<T>();
+            list.Insert(0, value);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        void IList<T>.Insert(int index, T value)
+        {
+            IList<T> list = Array.Empty<T>();
+            list.Insert(0, value);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        void IList.Remove(object value)
+        {
+            IList list = Array.Empty<T>();
+            list.Remove(value);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        bool ICollection<T>.Remove(T value)
+        {
+            ICollection<T> collection = Array.Empty<T>();
+            _ = collection.Remove(value);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            IList list = Array.Empty<T>();
+            list.RemoveAt(0);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        void IList<T>.RemoveAt(int index)
+        {
+            IList<T> list = Array.Empty<T>();
+            list.RemoveAt(0);
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other is null)
+                return 1;
+
+            if (!(other is SegmentedArray<T> o))
+            {
+                // Delegate to T[] so the correct exception is thrown
+                IStructuralComparable comparable = Array.Empty<T>();
+                comparable.CompareTo(new object(), comparer);
+                throw ExceptionUtilities.Unreachable;
+            }
+
+            if (Length != o.Length)
+            {
+                // Delegate to T[] so the correct exception is thrown
+                IStructuralComparable comparable = Array.Empty<T>();
+                comparable.CompareTo(new T[1], comparer);
+                throw ExceptionUtilities.Unreachable;
+            }
+
+            for (var i = 0; i < Length; i++)
+            {
+                var result = comparer.Compare(this[i], o[i]);
+                if (result != 0)
+                    return result;
+            }
+
+            return 0;
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other is null)
+                return false;
+
+            if (!(other is SegmentedArray<T> o))
+                return false;
+
+            if ((object)_items == o._items)
+                return true;
+
+            if (Length != o.Length)
+                return false;
+
+            for (var i = 0; i < Length; i++)
+            {
+                if (!comparer.Equals(this[i], o[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            _ = comparer ?? throw new ArgumentNullException(nameof(comparer));
+
+            var ret = 0;
+            for (var i = Length >= 8 ? Length - 8 : 0; i < Length; i++)
+            {
+                ret = Hash.Combine(comparer.GetHashCode(this[i]), ret);
+            }
+
+            return ret;
+        }
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private readonly T[][] _items;
+            private int _nextItemSegment;
+            private int _nextItemIndex;
+            private T _current;
+
+            public Enumerator(SegmentedArray<T> array)
+            {
+                _items = array._items;
+                _nextItemSegment = 0;
+                _nextItemIndex = 0;
+                _current = default;
+            }
+
+            public T Current => _current;
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                if (_items.Length == 0)
+                    return false;
+
+                if (_nextItemIndex == _items[_nextItemSegment].Length)
+                {
+                    if (_nextItemSegment == _items.Length - 1)
+                    {
+                        return false;
+                    }
+
+                    _nextItemSegment++;
+                    _nextItemIndex = 0;
+                }
+
+                _current = _items[_nextItemSegment][_nextItemIndex];
+                _nextItemIndex++;
+                return true;
+            }
+
+            public void Reset()
+            {
+                _nextItemSegment = 0;
+                _nextItemIndex = 0;
+                _current = default;
+            }
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
@@ -69,7 +69,11 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
 
                 // Make sure the last page only contains the number of elements required for the desired length. This
                 // collection is not resizeable so any additional padding would be a waste of space.
-                _items[^1] = new T[length & s_offsetMask];
+                //
+                // Avoid using (length & s_offsetMask) because it doesn't handle a last page size of s_segmentSize.
+                var lastPageSize = length - ((_items.Length - 1) << s_segmentShift);
+
+                _items[^1] = new T[lastPageSize];
                 _length = length;
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SegmentedArray`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -110,10 +112,10 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             set => this[index] = value;
         }
 
-        object IList.this[int index]
+        object? IList.this[int index]
         {
             get => this[index];
-            set => this[index] = (T)value;
+            set => this[index] = (T)value!;
         }
 
         public object Clone()
@@ -147,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
         public Enumerator GetEnumerator()
             => new Enumerator(this);
 
-        int IList.Add(object value)
+        int IList.Add(object? value)
         {
             throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
@@ -173,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
-        bool IList.Contains(object value)
+        bool IList.Contains(object? value)
         {
             foreach (IList list in _items)
             {
@@ -195,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return false;
         }
 
-        int IList.IndexOf(object value)
+        int IList.IndexOf(object? value)
         {
             for (var i = 0; i < _items.Length; i++)
             {
@@ -225,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return -1;
         }
 
-        void IList.Insert(int index, object value)
+        void IList.Insert(int index, object? value)
         {
             throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
@@ -235,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
 
-        void IList.Remove(object value)
+        void IList.Remove(object? value)
         {
             throw new NotSupportedException(CompilerExtensionsResources.NotSupported_FixedSizeCollection);
         }
@@ -261,7 +263,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
-        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is null)
                 return 1;
@@ -284,7 +286,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return 0;
         }
 
-        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
         {
             if (other is null)
                 return false;
@@ -316,7 +318,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             var ret = 0;
             for (var i = Length >= 8 ? Length - 8 : 0; i < Length; i++)
             {
-                ret = Hash.Combine(comparer.GetHashCode(this[i]), ret);
+                ret = Hash.Combine(comparer.GetHashCode(this[i]!), ret);
             }
 
             return ret;
@@ -337,11 +339,11 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
                 _items = array._items;
                 _nextItemSegment = 0;
                 _nextItemIndex = 0;
-                _current = default;
+                _current = default!;
             }
 
             public T Current => _current;
-            object IEnumerator.Current => Current;
+            object? IEnumerator.Current => Current;
 
             public void Dispose()
             {
@@ -372,7 +374,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             {
                 _nextItemSegment = 0;
                 _nextItemIndex = 0;
-                _current = default;
+                _current = default!;
             }
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -173,6 +173,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\NotificationOption2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\OperatorPlacementWhenWrappingPreference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\ParenthesesPreference.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Collections\SegmentedArray`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedDiagnostic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedSyntaxHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedSyntaxNode.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -173,6 +173,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\NotificationOption2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\OperatorPlacementWhenWrappingPreference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\ParenthesesPreference.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Collections\SegmentedArrayHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\SegmentedArray`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedDiagnostic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedSyntaxHelpers.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
@@ -273,4 +273,10 @@
   <data name="Segment_size_must_be_power_of_2_greater_than_1" xml:space="preserve">
     <value>Segment size must be power of 2 greater than 1</value>
   </data>
+  <data name="ArgumentException_OtherNotArrayOfCorrectLength" xml:space="preserve">
+    <value>Object is not a array with the same number of elements as the array to compare it to.</value>
+  </data>
+  <data name="NotSupported_FixedSizeCollection" xml:space="preserve">
+    <value>Collection was of a fixed size.</value>
+  </data>
 </root>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
@@ -270,4 +270,7 @@
   <data name="Specified_sequence_has_duplicate_items" xml:space="preserve">
     <value>Specified sequence has duplicate items</value>
   </data>
+  <data name="Segment_size_must_be_power_of_2_greater_than_1" xml:space="preserve">
+    <value>Segment size must be power of 2 greater than 1</value>
+  </data>
 </root>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
@@ -157,6 +157,11 @@
         <target state="new">Public or Protected Field</target>
         <note>{locked: public}{locked: protected}{locked:field}</note>
       </trans-unit>
+      <trans-unit id="Segment_size_must_be_power_of_2_greater_than_1">
+        <source>Segment size must be power of 2 greater than 1</source>
+        <target state="new">Segment size must be power of 2 greater than 1</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Specified_sequence_has_duplicate_items">
         <source>Specified sequence has duplicate items</source>
         <target state="new">Specified sequence has duplicate items</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">An element with the same key but a different value already exists.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ArgumentException_OtherNotArrayOfCorrectLength">
+        <source>Object is not a array with the same number of elements as the array to compare it to.</source>
+        <target state="new">Object is not a array with the same number of elements as the array to compare it to.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Begins_with_I">
         <source>Begins with I</source>
         <target state="new">Begins with I</target>
@@ -101,6 +106,11 @@
         <source>Non-Field Members</source>
         <target state="new">Non-Field Members</target>
         <note>{locked:field}</note>
+      </trans-unit>
+      <trans-unit id="NotSupported_FixedSizeCollection">
+        <source>Collection was of a fixed size.</source>
+        <target state="new">Collection was of a fixed size.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Organize_usings">
         <source>Organize usings</source>


### PR DESCRIPTION
Implements `SegmentedArray<T>`, which is intended to serve as a replacement for `T[]` that does not place objects in the Large Object Heap. More complex data types (e.g. a replacement for `List<T>` or `Dictionary<TKey, TValue>`) could be implemented on top of this type.