### PR TITLE
Allow enum preselection in Enum.HasFlag

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -818,5 +818,22 @@ internal enum ProjectTreeWriterOptions
 }";
             await VerifyItemExistsAsync(markup, "ProjectTreeWriterOptions");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestInEnumHasFlag()
+        {
+            var markup =
+@"using System.IO;
+
+class C
+{
+    void M()
+    {
+        FileInfo f;
+        f.Attributes.HasFlag($$
+    }
+}";
+            await VerifyItemExistsAsync(markup, "FileAttributes");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -3077,5 +3077,23 @@ class Program
             await TestInMethodAsync(
 @"(int, string) x = (1, [||]);", "global::System.String", TestMode.Position);
         }
+
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        public async Task TestInferringInEnumHasFlags(TestMode mode)
+        {
+            var text =
+@"using System.IO;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        FileInfo f;
+        f.Attributes.HasFlag([|flag|]);
+    }
+}";
+
+            await TestAsync(text, "global::System.IO.FileAttributes", mode);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/EnumCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/EnumCompletionProviderTests.vb
@@ -538,5 +538,20 @@ End Class
 ]]></Text>.Value
             Await VerifyItemExistsAsync(markup, "DayOfWeek.Monday")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInEnumHasFlag() As Task
+            Dim markup = <Text><![CDATA[
+Imports System.IO
+
+Class C
+    Sub Main()
+        Dim f As FileInfo
+        f.Attributes.HasFlag($$
+    End Sub
+End Class
+]]></Text>.Value
+            Await VerifyItemExistsAsync(markup, "FileAttributes.Hidden")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -821,5 +821,20 @@ Class C
 End Class"
             Await TestAsync(text, "Global.System.Threading.Tasks.Task(Of System.Boolean)", TestMode.Position)
         End Function
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
+        Public Async Function TestInferringInEnumHasFlags(mode As TestMode) As Task
+            Dim text =
+"Imports System.IO
+
+Module Program
+    Sub Main(args As String())
+        Dim f As FileInfo
+        f.Attributes.HasFlag([|flag|])
+    End Sub
+End Module"
+
+            Await TestAsync(text, "Global.System.IO.FileAttributes", mode)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -33,6 +33,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TypeInferrer
             End If
 
             Dim typeSyntax = inferredType.GenerateTypeSyntax().NormalizeWhitespace()
+            Assert.Equal(expectedType, typeSyntax.ToString())
         End Function
 
         Private Async Function TestInClassAsync(text As String, expectedType As String, mode As TestMode) As Tasks.Task
@@ -701,17 +702,17 @@ End Class
         End Function
 
         <WorkItem(14277, "https://github.com/dotnet/roslyn/issues/14277")>
-        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
+        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/14277"), CombinatorialData, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
         Public Async Function TestValueInNestedTuple1(mode As TestMode) As Task
             Await TestInMethodAsync(
-"dim x as (integer, (string, boolean)) = ([|Goo()|], ("""", true));", "global::System.Int32", mode)
+"dim x as (integer, (string, boolean)) = ([|Goo()|], ("""", true));", "System.Int32", mode)
         End Function
 
         <WorkItem(14277, "https://github.com/dotnet/roslyn/issues/14277")>
-        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
+        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/14277"), CombinatorialData, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
         Public Async Function TestValueInNestedTuple2(mode As TestMode) As Task
             Await TestInMethodAsync(
-"dim x as (integer, (string, boolean)) = (1, ("""", [|Goo()|]))", "global::System.Boolean", mode)
+"dim x as (integer, (string, boolean)) = (1, ("""", [|Goo()|]))", "System.Boolean", mode)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
@@ -818,7 +819,7 @@ Class C
         Return Await [||]
     End Function
 End Class"
-            Await TestAsync(text, "Task.FromResult(False)", TestMode.Position)
+            Await TestAsync(text, "Global.System.Threading.Tasks.Task(Of System.Boolean)", TestMode.Position)
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
@@ -117,6 +117,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices.TypeInferenceService
 
                 return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
             }
+
+            protected static bool IsEnumHasFlag(ISymbol symbol)
+            {
+                return symbol.Name == nameof(Enum.HasFlag) &&
+                       symbol.ContainingType?.SpecialType == SpecialType.System_Enum;
+            }
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
@@ -235,6 +235,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' called with argument at this position.  Note: if they're calling an extension
                         ' method then it will need one more argument in order for us to call it.
                         Dim symbols = info.GetBestOrAllSymbols()
+
+                        ' Special case If this Is an Then argument In Enum.HasFlag, infer the Enum type that we're invoking into,
+                        ' as otherwise we infer "Enum" which isn't useful
+                        If symbols.Any(AddressOf IsEnumHasFlag) Then
+                            Dim memberAccess = TryCast(invocation.Expression, MemberAccessExpressionSyntax)
+                            If memberAccess IsNot Nothing Then
+                                Dim typeInfo = SemanticModel.GetTypeInfo(memberAccess.Expression, CancellationToken)
+                                If typeInfo.Type IsNot Nothing AndAlso typeInfo.Type.IsEnumType() Then
+                                    Return CreateResult(typeInfo.Type)
+                                End If
+                            End If
+                        End If
+
                         If symbols.Any() Then
                             Return InferTypeInArgument(argumentOpt, index, symbols)
                         Else


### PR DESCRIPTION
This enables preselection of the enum type if you're calling Enum.HasFlag:

![image](https://user-images.githubusercontent.com/201340/79801162-6e377680-8312-11ea-9c3b-a1d7b67afacb.png)

@dpoeschl Any idea where the completion-level tests are of this? It seems Completion just defers to the type inferrer for what to preselect but I wasn't where we do testing for this.