### PR TITLE
Add tests for pattern brace completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -364,6 +364,100 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_Nested()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name: $$ }
+    }
+}";
+
+            var expectedBeforeReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name: { } }
+    }
+}";
+
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name:
+            {
+
+            } }
+    }
+}";
+            using var session = CreateSession(code);
+            Assert.NotNull(session);
+
+            CheckStart(session.Session);
+            CheckText(session.Session, expectedBeforeReturn);
+            CheckReturn(session.Session, 16, expectedAfterReturn);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_Parentheses1()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name: $$ }
+    }
+}";
+            var expected = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name: () }
+    }
+}";
+
+            using var session = CreateSession(TestWorkspace.CreateCSharp(code), '(', ')');
+            Assert.NotNull(session);
+
+            CheckStart(session.Session);
+            CheckText(session.Session, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_Parentheses2()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name: { Length: (> 3) and $$ } }
+    }
+}";
+            var expected = @"
+class C
+{
+    void M()
+    {
+        _ = this is { Name: { Length: (> 3) and () } }
+    }
+}";
+
+            using var session = CreateSession(TestWorkspace.CreateCSharp(code), '(', ')');
+            Assert.NotNull(session);
+
+            CheckStart(session.Session);
+            CheckText(session.Session, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void RecursivePattern_FollowedByInvocation()
         {
             var code = @"

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.BraceCompletion;
 using Microsoft.VisualStudio.Text.Operations;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 
             if (result != null)
             {
-                Assert.Equal(result, session.SubjectBuffer.CurrentSnapshot.GetText());
+                AssertEx.EqualOrDiff(result, session.SubjectBuffer.CurrentSnapshot.GetText());
             }
         }
 


### PR DESCRIPTION
The feature appears to already work correctly. This pull request adds tests.

Contributes to #42368