### PR TITLE
always partition tests assemblies

### DIFF
--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -6,16 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using RunTests.Cache;
-using Newtonsoft.Json.Linq;
 using RestSharp;
 using System.Collections.Immutable;
 using Newtonsoft.Json;
-using System.Reflection;
 using System.Diagnostics;
 
 namespace RunTests
@@ -296,23 +292,7 @@ namespace RunTests
 
             foreach (var assemblyPath in options.Assemblies.OrderByDescending(x => new FileInfo(x).Length))
             {
-                var name = Path.GetFileName(assemblyPath);
-
-                // As a starting point we will just schedule the items we know to be a performance
-                // bottleneck.  Can adjust as we get real data.
-                if (name == "Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll" ||
-                    name == "Microsoft.CodeAnalysis.EditorFeatures.UnitTests.dll" ||
-                    name == "Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" ||
-                    name == "Microsoft.VisualStudio.LanguageServices.UnitTests.dll" ||
-                    name == "Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll" ||
-                    name == "Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.dll")
-                {
-                    list.AddRange(scheduler.Schedule(assemblyPath));
-                }
-                else
-                {
-                    list.Add(scheduler.CreateAssemblyInfo(assemblyPath));
-                }
+                list.AddRange(scheduler.Schedule(assemblyPath));
             }
 
             return list;


### PR DESCRIPTION
back in the day there were only a few IDE tests that were worth partitioning. Then came nullable.

Now assemblies like Semantic unit tests are taking 28 minutes in a 52 minute test run.

(Tests that take over 5 mins)

| Assemble  Name | State | Execution Time |
|:---------------|------:|---------------:|
| Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.dll               |  PASSED | 00:05:03.3564739  |
| Microsoft.CodeAnalysis.Workspaces.UnitTests.dll                            |  PASSED | 00:05:04.6994768  |
| InteractiveHost.UnitTests.dll                                              |  PASSED | 00:05:12.7279281  |
| Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll.1                         |  PASSED | 00:05:33.0601148  |
| Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.dll                      |  PASSED | 00:06:13.1561937  |
| Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll.7               |  PASSED | 00:06:19.2043116  |
| Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll.5               |  PASSED | 00:06:41.8132374  |
| Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll.4               |  PASSED | 00:07:03.5482936  |
| Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll.2               |  PASSED | 00:07:14.0802639  |
| Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.dll.1          |  PASSED | 00:07:41.8327451  |
| Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.dll.3          |  PASSED | 00:07:44.4432539  |
| Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll.6               |  PASSED | 00:07:48.4731964  |
| Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.dll                  |  PASSED | 00:10:52.6523791  |
| Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll.3               |  PASSED | 00:12:24.2802953  |
| Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.dll                      |  PASSED | 00:13:35.3311507  |
| Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll.1                     |  PASSED | 00:15:39.8984603  |
| Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll.2                         |  PASSED | 00:22:19.3518864  |
| Microsoft.VisualStudio.LanguageServices.UnitTests.dll.1                    |  PASSED | 00:22:32.9940231  |
| Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.dll                       |  PASSED | 00:28:35.9769910  |

With this this change I see a noticeable improvement on my machine

| branch | Test execution time |
|:---------------|------:|
| master | 00:13:38.9999106 |
| this PR    | 00:10:36.2635440 |

I'll now verify if this makes a difference on the CI machines