### PR TITLE
🐇 Avoid computing unnecessary semantic models

### DIFF
--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -41,9 +41,7 @@ namespace Microsoft.CodeAnalysis.Editing
         {
             options ??= await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
-            var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(model);
-            var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var addImportsService = document.GetRequiredLanguageService<IAddImportsService>();
             var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
 
@@ -51,14 +49,17 @@ namespace Microsoft.CodeAnalysis.Editing
             var spansTree = new SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>(new TextSpanIntervalIntrospector(), spans);
 
             var nodes = root.DescendantNodesAndSelf().Where(IsInSpan);
-            var (importDirectivesToAdd, namespaceSymbols, context) = strategy switch
+            var (importDirectivesToAdd, namespaceSymbols, context, model, newRoot) = strategy switch
             {
                 Strategy.AddImportsFromSymbolAnnotations
-                    => GetImportDirectivesFromAnnotatedNodes(nodes, root, model, addImportsService, generator, cancellationToken),
+                    => await GetImportDirectivesFromAnnotatedNodesAsync(document, nodes, root, addImportsService, generator, cancellationToken).ConfigureAwait(false),
                 Strategy.AddImportsFromSyntaxes
-                    => GetImportDirectivesFromSyntaxes(nodes, ref root, model, addImportsService, generator, cancellationToken),
+                    => await GetImportDirectivesFromSyntaxesAsync(document, nodes, root, addImportsService, generator, cancellationToken).ConfigureAwait(false),
                 _ => throw new InvalidEnumArgumentException(nameof(strategy), (int)strategy, typeof(Strategy)),
             };
+
+            // If the previous call provided a new root, use it.
+            root = newRoot ?? root;
 
             if (importDirectivesToAdd.Length == 0)
             {
@@ -88,6 +89,8 @@ namespace Microsoft.CodeAnalysis.Editing
                 // Find the context. It might be null if we have removed the context in the process of complexifying the tree.
                 context = root.DescendantNodesAndSelf().FirstOrDefault(x => x.HasAnnotation(annotation)) ?? root;
             }
+
+            model ??= await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var placeSystemNamespaceFirst = options.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);
 
@@ -142,16 +145,18 @@ namespace Microsoft.CodeAnalysis.Editing
         /// </summary>
         /// <param name="root">ref as we add simplifier annotations to nodes with explicit namespaces</param>
         /// <returns></returns>
-        private (ImmutableArray<SyntaxNode> imports, IEnumerable<INamespaceSymbol> namespaceSymbols, SyntaxNode? context) GetImportDirectivesFromSyntaxes(
+        private async ValueTask<(ImmutableArray<SyntaxNode> imports, IEnumerable<INamespaceSymbol> namespaceSymbols, SyntaxNode? context, SemanticModel model, SyntaxNode? newRoot)> GetImportDirectivesFromSyntaxesAsync(
+            Document document,
                 IEnumerable<SyntaxNode> syntaxNodes,
-                ref SyntaxNode root,
-                SemanticModel model,
+                SyntaxNode root,
                 IAddImportsService addImportsService,
                 SyntaxGenerator generator,
                 CancellationToken cancellationToken
             )
         {
             var importsToAdd = ArrayBuilder<SyntaxNode>.GetInstance();
+
+            var model = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var nodesWithExplicitNamespaces = syntaxNodes
                 .Select(n => (syntaxnode: n, namespaceSymbol: GetExplicitNamespaceSymbol(n, model)))
@@ -190,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
             if (nodesToSimplify.Count == 0)
             {
-                return (importsToAdd.ToImmutableAndFree(), addedSymbols, null);
+                return (importsToAdd.ToImmutableAndFree(), addedSymbols, null, model, root);
             }
 
             var annotation = new SyntaxAnnotation();
@@ -202,19 +207,21 @@ namespace Microsoft.CodeAnalysis.Editing
             var first = root.DescendantNodesAndSelf().First(x => x.HasAnnotation(annotation));
             var last = root.DescendantNodesAndSelf().Last(x => x.HasAnnotation(annotation));
 
-            return (importsToAdd.ToImmutableAndFree(), addedSymbols, first.GetCommonRoot(last));
+            return (importsToAdd.ToImmutableAndFree(), addedSymbols, first.GetCommonRoot(last), model, root);
         }
 
-        private (ImmutableArray<SyntaxNode> imports, IEnumerable<INamespaceSymbol> namespaceSymbols, SyntaxNode? context) GetImportDirectivesFromAnnotatedNodes(
+        private async ValueTask<(ImmutableArray<SyntaxNode> imports, IEnumerable<INamespaceSymbol> namespaceSymbols, SyntaxNode? context, SemanticModel? model, SyntaxNode? newRoot)> GetImportDirectivesFromAnnotatedNodesAsync(
+            Document document,
             IEnumerable<SyntaxNode> syntaxNodes,
             SyntaxNode root,
-            SemanticModel model,
             IAddImportsService addImportsService,
             SyntaxGenerator generator,
             CancellationToken cancellationToken)
         {
             (SyntaxNode first, SyntaxNode last)? nodes = null;
             var importsToAdd = ArrayBuilder<SyntaxNode>.GetInstance();
+
+            SemanticModel? model = null;
 
             var annotatedNodes = syntaxNodes.Where(x => x.HasAnnotations(SymbolAnnotation.Kind));
             var addedSymbols = new HashSet<INamespaceSymbol>();
@@ -231,6 +238,8 @@ namespace Microsoft.CodeAnalysis.Editing
                 foreach (var annotation in annotations)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    model ??= await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                     foreach (var namedType in SymbolAnnotation.GetSymbols(annotation, model.Compilation).OfType<INamedTypeSymbol>())
                     {
@@ -275,7 +284,7 @@ namespace Microsoft.CodeAnalysis.Editing
             // since whatever added the symbol annotation probably also added simplifier annotations,
             // and if not they probably didn't for a reason
 
-            return (importsToAdd.ToImmutableAndFree(), addedSymbols, nodes is var (first, last) ? first.GetCommonRoot(last) : null);
+            return (importsToAdd.ToImmutableAndFree(), addedSymbols, nodes is var (first, last) ? first.GetCommonRoot(last) : null, model, root);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editing
         /// </summary>
         /// <param name="root">ref as we add simplifier annotations to nodes with explicit namespaces</param>
         /// <returns></returns>
-        private async ValueTask<(ImmutableArray<SyntaxNode> imports, IEnumerable<INamespaceSymbol> namespaceSymbols, SyntaxNode? context, SemanticModel model, SyntaxNode? newRoot)> GetImportDirectivesFromSyntaxesAsync(
+        private async ValueTask<(ImmutableArray<SyntaxNode> imports, HashSet<INamespaceSymbol> namespaceSymbols, SyntaxNode? context, SemanticModel model, SyntaxNode? newRoot)> GetImportDirectivesFromSyntaxesAsync(
             Document document,
                 IEnumerable<SyntaxNode> syntaxNodes,
                 SyntaxNode root,
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Editing
             return (importsToAdd.ToImmutableAndFree(), addedSymbols, first.GetCommonRoot(last), model, root);
         }
 
-        private async ValueTask<(ImmutableArray<SyntaxNode> imports, IEnumerable<INamespaceSymbol> namespaceSymbols, SyntaxNode? context, SemanticModel? model, SyntaxNode? newRoot)> GetImportDirectivesFromAnnotatedNodesAsync(
+        private async ValueTask<(ImmutableArray<SyntaxNode> imports, HashSet<INamespaceSymbol> namespaceSymbols, SyntaxNode? context, SemanticModel? model, SyntaxNode? newRoot)> GetImportDirectivesFromAnnotatedNodesAsync(
             Document document,
             IEnumerable<SyntaxNode> syntaxNodes,
             SyntaxNode root,


### PR DESCRIPTION
Significantly improves the performance BatchFixAllProvider when imports do not need to be added.

For one sample project, the Fix All in Solution performance for Roslyn.sln dropped from over one hour (cancelled before completion) to less than 30 seconds.