### PR TITLE
Add vscode tasks to run tests in all frameworks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -99,6 +99,34 @@
         ],
         "problemMatcher": "$msCompile",
         "group": "test"
+    },
+    {
+        "label": "run tests in current file (all frameworks)",
+        "command": "./.dotnet/dotnet",
+        "type": "shell",
+        "args": [
+          "pwsh",
+          "${workspaceRoot}/scripts/vscode-run-tests.ps1",
+          "-filePath",
+          "${file}",
+          "-filter",
+          "${fileBasenameNoExtension}"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "test"
+    },
+    {
+        "label": "run tests in current project (all frameworks)",
+        "command": "./.dotnet/dotnet",
+        "type": "shell",
+        "args": [
+          "pwsh",
+          "${workspaceRoot}/scripts/vscode-run-tests.ps1",
+          "-filePath",
+          "${file}"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "test"
     }
   ]
 }

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -1,6 +1,6 @@
 param (
   [Parameter(Mandatory = $true)][string]$filePath,
-  [Parameter(Mandatory = $true)][string]$framework,
+  [Parameter(Mandatory = $false)][string]$framework,
   [Parameter(Mandatory = $false)][string]$filter
 )
 
@@ -16,12 +16,16 @@ if ($projectFileInfo) {
   $projectDir = Resolve-Path $projectFileInfo.Directory -Relative
 
   $filterArg = if ($filter) { " --filter $filter" } else { "" }
-  $logFileName = if ($filter) { $fileInfo.Name } else { $projectFileInfo.Name }
+  $logFilePrefix = if ($filter) { $fileInfo.Name } else { $projectFileInfo.Name }
+  $frameworkArg = if ($framework) { " --framework $framework" } else { "" }
 
   $resultsPath = Join-Path $PSScriptRoot ".." "artifacts/TestResults"
   $resultsPath = Resolve-Path (New-Item -ItemType Directory -Force -Path $resultsPath) -Relative
 
-  $invocation = "$dotnetPath test $projectDir$filterArg --framework $framework --logger `"html;LogFileName=$logfileName.html`" --results-directory $resultsPath"
+  # Remove old run logs with the same prefix
+  Remove-Item (Join-Path $resultsPath "$logFilePrefix*.html")
+
+  $invocation = "$dotnetPath test $projectDir" + $filterArg + $frameworkArg + " --logger `"html;LogFilePrefix=$logfilePrefix`" --results-directory $resultsPath"
   Write-Output "> $invocation"
   Invoke-Expression $invocation
 


### PR DESCRIPTION
Follow up to #43434

The new tasks will run tests in all the frameworks available in the environment.

So that you can look at the log files for either framework, we use a LogFilePrefix instead of a LogFileName. Test log files now look like this: `.\roslyn\artifacts\TestResults\CodeGenConstructorInitTests.cs_net472_20200422132235.html`.

The script will automatically clean out the log files for the previous run of a given file or project so that we don't indefinitely write more and more and more HTML files to disk every time you run tests with this task.