### PR TITLE
Clean up KeyValuePairUtil

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -236,8 +236,8 @@ my_option2 = my_val2");
             var comp = cmd.Compilation;
             var tree = comp.SyntaxTrees.Single();
             AssertEx.SetEqual(new[] {
-                KeyValuePairUtil.Create("cs0169", ReportDiagnostic.Suppress),
-                KeyValuePairUtil.Create("warning01", ReportDiagnostic.Suppress)
+                KeyValuePair.Create("cs0169", ReportDiagnostic.Suppress),
+                KeyValuePair.Create("warning01", ReportDiagnostic.Suppress)
             }, tree.DiagnosticOptions);
 
             var provider = cmd.AnalyzerOptions.AnalyzerConfigOptionsProvider;
@@ -10559,16 +10559,16 @@ class C {
 
             parsedArgs = DefaultParse(new[] { "/pathmap:K1=V1", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePairUtil.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:C:\\goo\\=/", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePairUtil.Create("C:\\goo\\", "/"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("C:\\goo\\", "/"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:K1=V1,K2=V2", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePairUtil.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePairUtil.Create("K2\\", "V2\\"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePair.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K2\\", "V2\\"), parsedArgs.PathMap[1]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:,,,", "a.cs" }, WorkingDirectory);
             Assert.Equal(4, parsedArgs.Errors.Count());
@@ -10588,17 +10588,17 @@ class C {
 
             parsedArgs = DefaultParse(new[] { "/pathmap:\"supporting spaces=is hard\"", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePairUtil.Create("supporting spaces\\", "is hard\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("supporting spaces\\", "is hard\\"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:\"K 1=V 1\",\"K 2=V 2\"", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePairUtil.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePairUtil.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePair.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:\"K 1\"=\"V 1\",\"K 2\"=\"V 2\"", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePairUtil.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePairUtil.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePair.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
         }
 
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
@@ -11093,7 +11093,7 @@ System.NotImplementedException: 28
                 cscCopy,
                 arguments + " /deterministic",
                 workingDirectory: dir.Path,
-                additionalEnvironmentVars: new[] { KeyValuePairUtil.Create("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", cscDir) });
+                additionalEnvironmentVars: new[] { KeyValuePair.Create("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", cscDir) });
 
             Assert.Equal("", result.Output.Trim());
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -1013,7 +1014,7 @@ A: goto B;";
 @"#load ""a.csx""
 goto B;
 B: goto A;";
-            var resolver = TestSourceReferenceResolver.Create(KeyValuePairUtil.Create("a.csx", sourceA));
+            var resolver = TestSourceReferenceResolver.Create(KeyValuePair.Create("a.csx", sourceA));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(sourceB, options: options, parseOptions: TestOptions.Script);
             compilation.GetDiagnostics().Verify(

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -137,7 +137,7 @@ public class C : NotFound
 }";
             // TODO: Compilation create doesn't accept analyzers anymore.
             var options = TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(
-                new[] { KeyValuePairUtil.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Suppress) });
+                new[] { KeyValuePair.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Suppress) });
 
             CreateCompilationWithMscorlib45(source, options: options/*, analyzers: new IDiagnosticAnalyzerFactory[] { new ComplainAboutX() }*/).VerifyDiagnostics(
                 // (2,18): error CS0246: The type or namespace name 'NotFound' could not be found (are you missing a using directive or an assembly reference?)
@@ -160,7 +160,7 @@ public class C : NotFound
 }";
             // TODO: Compilation create doesn't accept analyzers anymore.
             var options = TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(
-                new[] { KeyValuePairUtil.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Error) });
+                new[] { KeyValuePair.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Error) });
 
             CreateCompilationWithMscorlib45(source, options: options).VerifyDiagnostics(
                 // (2,18): error CS0246: The type or namespace name 'NotFound' could not be found (are you missing a using directive or an assembly reference?)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -23,7 +23,6 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
-using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 using System.Security.Cryptography;
 using static Roslyn.Test.Utilities.TestHelpers;
 
@@ -2946,7 +2945,7 @@ System.Func<object> f = delegate ()
         public void LoadedFileWithWrongReturnType()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "return \"Who returns a string?\";"));
+                KeyValuePair.Create("a.csx", "return \"Who returns a string?\";"));
             var script = CreateSubmission(@"
 #load ""a.csx""
 42", returnType: typeof(int), options: TestOptions.DebugDll.WithSourceReferenceResolver(resolver));

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -45,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 var code = "#load \"a.csx\"";
                 var resolver = TestSourceReferenceResolver.Create(
-                    KeyValuePairUtil.Create("a.csx", @"
+                    KeyValuePair.Create("a.csx", @"
                     #load ""b.csx""
                     asdf();"));
                 var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
@@ -71,8 +72,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var code = "#load \"b.csx\"";
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00, 0x00 }),
-                KeyValuePairUtil.Create<string, object>("b.csx", "#load \"a.csx\""));
+                KeyValuePair.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00, 0x00 }),
+                KeyValuePair.Create<string, object>("b.csx", "#load \"a.csx\""));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(code, sourceFileName: "external1.csx", options: options, parseOptions: TestOptions.Script);
             var external1 = compilation.SyntaxTrees.Last();
@@ -150,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void Cycles()
         {
             var code = "#load \"a.csx\"";
-            var resolver = TestSourceReferenceResolver.Create(KeyValuePairUtil.Create("a.csx", code));
+            var resolver = TestSourceReferenceResolver.Create(KeyValuePair.Create("a.csx", code));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 
@@ -169,8 +170,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             compilation.VerifyDiagnostics();
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "#load \"b.csx\""),
-                KeyValuePairUtil.Create("b.csx", code));
+                KeyValuePair.Create("a.csx", "#load \"b.csx\""),
+                KeyValuePair.Create("b.csx", code));
             options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTreeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTreeTests.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 using static Roslyn.Test.Utilities.TestHelpers;
-using KeyValuePair = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -11,7 +11,6 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.AnalyzerConfig;
 using static Roslyn.Test.Utilities.TestHelpers;
-using KeyValuePair = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
@@ -1099,7 +1098,7 @@ dotnet_diagnostic.cs000.severity = none", "Z:\\.editorconfig"));
                 else
                 {
                     AssertEx.SetEqual(
-                        expected[i].Select(KeyValuePair.ToKeyValuePair),
+                        expected[i].Select(KeyValuePairUtil.ToKeyValuePair),
                         options[i].AnalyzerOptions);
                 }
             }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
@@ -13,7 +13,6 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
-using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 {
@@ -37,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         {
             var c = CSharpCompilation.Create("c", options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).
                 WithSpecificDiagnosticOptions(
-                    new[] { KeyValuePairUtil.Create($"CS{(int)ErrorCode.WRN_AlwaysNull:D4}", ReportDiagnostic.Suppress) }));
+                    new[] { KeyValuePair.Create($"CS{(int)ErrorCode.WRN_AlwaysNull:D4}", ReportDiagnostic.Suppress) }));
 
             var d1 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlignmentMagnitude);
             var d2 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlwaysNull);

--- a/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
@@ -5,6 +5,7 @@
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using Xunit;
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new SourceFileResolver(
                     ImmutableArray.Create(""),
                     isABaseDirectory,
-                    ImmutableArray.Create(KeyValuePairUtil.Create<string, string>("key", null)));
+                    ImmutableArray.Create(KeyValuePair.Create("key", (string)null)));
                 AssertEx.Fail("Didn't throw");
             }
             catch (ArgumentException argException)
@@ -43,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             new SourceFileResolver(
                 ImmutableArray.Create(""),
                 isABaseDirectory,
-                ImmutableArray.Create(KeyValuePairUtil.Create<string, string>("key", "")));
+                ImmutableArray.Create(KeyValuePair.Create("key", "")));
         }
 
         [Fact]
@@ -54,7 +55,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new SourceFileResolver(
                     ImmutableArray.Create(""),
                     "not_a_root directory",
-                    ImmutableArray.Create(KeyValuePairUtil.Create<string, string>("key", "value")));
+                    ImmutableArray.Create(KeyValuePair.Create("key", "value")));
                 AssertEx.Fail("Didn't throw");
             }
             catch (ArgumentException argException)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1146,7 +1146,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            var tuples = nodeActionsByKind.Select(kvp => KeyValuePairUtil.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
+            var tuples = nodeActionsByKind.Select(kvp => KeyValuePair.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
             var map = ImmutableDictionary.CreateRange(tuples);
             nodeActionsByKind.Free();
             return map;
@@ -1292,7 +1292,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            var tuples = operationActionsByKind.Select(kvp => KeyValuePairUtil.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
+            var tuples = operationActionsByKind.Select(kvp => KeyValuePair.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
             var map = ImmutableDictionary.CreateRange(tuples);
             operationActionsByKind.Free();
             return map;

--- a/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
                 using (XmlReader reader = XmlReader.Create(stream, s_xmlSettings))
                 {
                     var document = XDocument.Load(reader, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
-                    return KeyValuePairUtil.Create(resolvedPath, document);
+                    return KeyValuePair.Create(resolvedPath, document);
                 }
             }
         }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.Emit
             for (int i = 0; i < lambdaDebugInfo.Length; i++)
             {
                 var lambdaInfo = lambdaDebugInfo[i];
-                lambdas[lambdaInfo.SyntaxOffset] = KeyValuePairUtil.Create(lambdaInfo.LambdaId, lambdaInfo.ClosureOrdinal);
+                lambdas[lambdaInfo.SyntaxOffset] = KeyValuePair.Create(lambdaInfo.LambdaId, lambdaInfo.ClosureOrdinal);
             }
 
             for (int i = 0; i < closureDebugInfo.Length; i++)

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis.Emit
                     foreach (var paramDef in this.GetParametersToEmit(methodDef))
                     {
                         _parameterDefs.Add(paramDef);
-                        _parameterDefList.Add(KeyValuePairUtil.Create(methodDef, paramDef));
+                        _parameterDefList.Add(KeyValuePair.Create(methodDef, paramDef));
                     }
 
                     if (methodDef.GenericParameterCount > 0)

--- a/src/Compilers/Core/Portable/InternalUtilities/KeyValuePairUtil.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/KeyValuePairUtil.cs
@@ -6,21 +6,33 @@
 
 using System.Collections.Generic;
 
-namespace Roslyn.Utilities
+namespace Microsoft.CodeAnalysis
 {
     internal static class KeyValuePairUtil
     {
-        public static KeyValuePair<K, V> Create<K, V>(K key, V value)
-        {
-            return new KeyValuePair<K, V>(key, value);
-        }
-
-        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> keyValuePair, out TKey key, out TValue value)
-        {
-            key = keyValuePair.Key;
-            value = keyValuePair.Value;
-        }
-
-        public static KeyValuePair<TKey, TValue> ToKeyValuePair<TKey, TValue>(this (TKey, TValue) tuple) => Create(tuple.Item1, tuple.Item2);
+        public static KeyValuePair<TKey, TValue> ToKeyValuePair<TKey, TValue>(this (TKey, TValue) tuple)
+            => KeyValuePair.Create(tuple.Item1, tuple.Item2);
     }
 }
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+namespace System.Collections.Generic
+{
+    // In netcoreapp3.1 non-generic KeyValuePair type is defined in System.Collections.Generic
+    internal static class KeyValuePair
+    {
+        public static KeyValuePair<K, V> Create<K, V>(K key, V value)
+            => new KeyValuePair<K, V>(key, value);
+    }
+}
+
+// In netcoreapp3.1 Deconstruct is defined on KeyValuePair<K, V>
+internal static class KeyValuePairExtensions
+{
+    public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> keyValuePair, out TKey key, out TValue value)
+    {
+        key = keyValuePair.Key;
+        value = keyValuePair.Value;
+    }
+}
+#endif

--- a/src/Compilers/Core/Portable/InternalUtilities/KeyValuePairUtil.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/KeyValuePairUtil.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis
     }
 }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NETCOREAPP
 namespace System.Collections.Generic
 {
     // In netcoreapp3.1 non-generic KeyValuePair type is defined in System.Collections.Generic

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis
                 bool argumentRefersToNoPia;
                 SignatureTypeCode typeCode;
                 ImmutableArray<ModifierInfo<TypeSymbol>> modifiers = DecodeModifiersOrThrow(ref ppSig, AllowedRequiredModifierType.None, out typeCode, out _);
-                argumentsBuilder.Add(KeyValuePairUtil.Create(DecodeTypeOrThrow(ref ppSig, typeCode, out argumentRefersToNoPia), modifiers));
+                argumentsBuilder.Add(KeyValuePair.Create(DecodeTypeOrThrow(ref ppSig, typeCode, out argumentRefersToNoPia), modifiers));
                 argumentRefersToNoPiaLocalTypeBuilder.Add(argumentRefersToNoPia);
             }
 

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -853,7 +853,7 @@ DoneWithSequence:
                         {
                             Debug.Assert(keyIndex < i);
                             var primaryPair = nestedNamespaces[keyIndex];
-                            nestedNamespaces[keyIndex] = KeyValuePairUtil.Create(primaryPair.Key, primaryPair.Value.Concat(pair.Value));
+                            nestedNamespaces[keyIndex] = KeyValuePair.Create(primaryPair.Key, primaryPair.Value.Concat(pair.Value));
                             nestedNamespaces[i] = default(KeyValuePair<string, IEnumerable<IGrouping<string, TypeDefinitionHandle>>>);
                         }
                     }

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis
 
         public void Add(AssemblyIdentity identity, TValue value)
         {
-            var pair = KeyValuePairUtil.Create(identity, value);
+            var pair = KeyValuePair.Create(identity, value);
 
             OneOrMany<KeyValuePair<AssemblyIdentity, TValue>> sameName;
             _map[identity.Name] = _map.TryGetValue(identity.Name, out sameName) ? sameName.Add(pair) : OneOrMany.Create(pair);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1165,7 +1165,7 @@ namespace Microsoft.Cci
 
             signatureBlob = builder.ToImmutableArray();
             result = metadata.GetOrAddBlob(signatureBlob);
-            _signatureIndex.Add(methodReference, KeyValuePairUtil.Create(result, signatureBlob));
+            _signatureIndex.Add(methodReference, KeyValuePair.Create(result, signatureBlob));
             builder.Free();
             return result;
         }
@@ -1294,7 +1294,7 @@ namespace Microsoft.Cci
             var blob = builder.ToImmutableArray();
             var result = metadata.GetOrAddBlob(blob);
 
-            _signatureIndex.Add(propertyDef, KeyValuePairUtil.Create(result, blob));
+            _signatureIndex.Add(propertyDef, KeyValuePair.Create(result, blob));
             builder.Free();
             return result;
         }

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis
 
         internal sealed override IEnumerable<KeyValuePair<MetadataReference, IAssemblySymbolInternal>> GetReferencedAssemblies()
         {
-            return ReferencedAssembliesMap.Select(ra => KeyValuePairUtil.Create(ra.Key, (IAssemblySymbolInternal)ReferencedAssemblies[ra.Value]));
+            return ReferencedAssembliesMap.Select(ra => KeyValuePair.Create(ra.Key, (IAssemblySymbolInternal)ReferencedAssemblies[ra.Value]));
         }
 
         internal TAssemblySymbol? GetReferencedAssemblySymbol(MetadataReference reference)

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 #nullable enable
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -1874,7 +1874,7 @@ ProduceBoundNode:
                                                          callerInfoOpt:=callerInfoOpt,
                                                          representCandidateInDiagnosticsOpt:=Nothing)
 
-                diagnosticPerSymbol.Add(KeyValuePairUtil.Create(candidates(i).Candidate.UnderlyingSymbol, candidateDiagnostics.ToReadOnlyAndFree()))
+                diagnosticPerSymbol.Add(KeyValuePair.Create(candidates(i).Candidate.UnderlyingSymbol, candidateDiagnostics.ToReadOnlyAndFree()))
 
             Next
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -982,7 +982,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             If useOfLocalBeforeDeclaration AndAlso Not type.IsErrorType() Then
                                 conversion = New Conversion(Conversions.ClassifyConversion(type, convertedType, Nothing))
                             Else
-                                conversion = New Conversion(KeyValuePairUtil.Create(conversionNode.ConversionKind,
+                                conversion = New Conversion(KeyValuePair.Create(conversionNode.ConversionKind,
                                                                                 TryCast(conversionNode.ExpressionSymbol, MethodSymbol)))
                             End If
                         End If

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -601,9 +601,9 @@ Namespace Microsoft.CodeAnalysis.Operations
                 If conversionKind.HasFlag(VisualBasic.ConversionKind.UserDefined) AndAlso conversion.Operand.Kind = BoundKind.UserDefinedConversion Then
                     method = DirectCast(conversion.Operand, BoundUserDefinedConversion).Call.Method
                 End If
-                Return New Conversion(KeyValuePairUtil.Create(conversionKind, method))
+                Return New Conversion(KeyValuePair.Create(conversionKind, method))
             ElseIf expression.Kind = BoundKind.TryCast OrElse expression.Kind = BoundKind.DirectCast Then
-                Return New Conversion(KeyValuePairUtil.Create(Of ConversionKind, MethodSymbol)(DirectCast(expression, BoundConversionOrCast).ConversionKind, Nothing))
+                Return New Conversion(KeyValuePair.Create(Of ConversionKind, MethodSymbol)(DirectCast(expression, BoundConversionOrCast).ConversionKind, Nothing))
             End If
             Return New Conversion(Conversions.Identity)
         End Function

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared ReadOnly Property DefaultPreprocessorSymbols As ImmutableArray(Of KeyValuePair(Of String, Object))
             Get
                 If s_defaultPreprocessorSymbols.IsDefaultOrEmpty Then
-                    s_defaultPreprocessorSymbols = ImmutableArray.Create(KeyValuePairUtil.Create("_MYTYPE", CObj("Empty")))
+                    s_defaultPreprocessorSymbols = ImmutableArray.Create(KeyValuePair.Create("_MYTYPE", CObj("Empty")))
                 End If
 
                 Return s_defaultPreprocessorSymbols

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -128,9 +128,9 @@ my_option2 = my_val2")
             Dim comp = cmd.Compilation
             Dim tree = comp.SyntaxTrees.Single()
             AssertEx.SetEqual({
-                KeyValuePairUtil.Create("bc42024", ReportDiagnostic.Suppress),
-                KeyValuePairUtil.Create("warning01", ReportDiagnostic.Suppress),
-                KeyValuePairUtil.Create("warning03", ReportDiagnostic.Suppress)
+                KeyValuePair.Create("bc42024", ReportDiagnostic.Suppress),
+                KeyValuePair.Create("warning01", ReportDiagnostic.Suppress),
+                KeyValuePair.Create("warning03", ReportDiagnostic.Suppress)
                 }, tree.DiagnosticOptions)
 
             Dim provider = cmd.AnalyzerOptions.AnalyzerConfigOptionsProvider
@@ -3418,16 +3418,16 @@ print Goodbye, World"
 
             parsedArgs = DefaultParse({"/pathmap:K1=V1", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePairUtil.Create("K1\", "V1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePair.Create("K1\", "V1\"), parsedArgs.PathMap(0))
 
             parsedArgs = DefaultParse({"/pathmap:C:\goo\=/", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePairUtil.Create("C:\goo\", "/"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePair.Create("C:\goo\", "/"), parsedArgs.PathMap(0))
 
             parsedArgs = DefaultParse({"/pathmap:K1=V1,K2=V2", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePairUtil.Create("K1\", "V1\"), parsedArgs.PathMap(0))
-            Assert.Equal(KeyValuePairUtil.Create("K2\", "V2\"), parsedArgs.PathMap(1))
+            Assert.Equal(KeyValuePair.Create("K1\", "V1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePair.Create("K2\", "V2\"), parsedArgs.PathMap(1))
 
             parsedArgs = DefaultParse({"/pathmap:,,,", "a.vb"}, _baseDirectory)
             Assert.Equal(4, parsedArgs.Errors.Count())
@@ -3447,17 +3447,17 @@ print Goodbye, World"
 
             parsedArgs = DefaultParse({"/pathmap:""supporting spaces=is hard""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePairUtil.Create("supporting spaces\", "is hard\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePair.Create("supporting spaces\", "is hard\"), parsedArgs.PathMap(0))
 
             parsedArgs = DefaultParse({"/pathmap:""K 1=V 1"",""K 2=V 2""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePairUtil.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
-            Assert.Equal(KeyValuePairUtil.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
+            Assert.Equal(KeyValuePair.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePair.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
 
             parsedArgs = DefaultParse({"/pathmap:""K 1""=""V 1"",""K 2""=""V 2""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePairUtil.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
-            Assert.Equal(KeyValuePairUtil.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
+            Assert.Equal(KeyValuePair.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePair.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
         End Sub
 
         ' PathMapKeepsCrossPlatformRoot and PathMapInconsistentSlashes should be in an

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -191,7 +191,7 @@ End Class
 </compilation>
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
 
@@ -3984,7 +3984,7 @@ End Class
 </compilation>
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
 
@@ -4297,11 +4297,11 @@ End Class
 </compilation>
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(
                 OutputKind.WindowsApplication,
-                KeyValuePairUtil.Create(Of String, Object)("_MyType", "WindowsForms"),
-                KeyValuePairUtil.Create(Of String, Object)("Config", "Debug"),
-                KeyValuePairUtil.Create(Of String, Object)("DEBUG", -1),
-                KeyValuePairUtil.Create(Of String, Object)("TRACE", -1),
-                KeyValuePairUtil.Create(Of String, Object)("PLATFORM", "AnyCPU"))
+                KeyValuePair.Create(Of String, Object)("_MyType", "WindowsForms"),
+                KeyValuePair.Create(Of String, Object)("Config", "Debug"),
+                KeyValuePair.Create(Of String, Object)("DEBUG", -1),
+                KeyValuePair.Create(Of String, Object)("TRACE", -1),
+                KeyValuePair.Create(Of String, Object)("PLATFORM", "AnyCPU"))
 
             Dim parseOptions As VisualBasicParseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compOptions As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
@@ -130,7 +130,7 @@ End Module
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)
@@ -208,7 +208,7 @@ End Class
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.WindowsApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("WindowsForms")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("WindowsForms")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithOutputKind(OutputKind.WindowsApplication).WithParseOptions(parseOptions).WithMainTypeName("Form1")
@@ -239,7 +239,7 @@ End Module
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)
@@ -297,7 +297,7 @@ End Namespace
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/CompilationEventTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/CompilationEventTests.vb
@@ -138,7 +138,7 @@ End Module
     </compilation>
             Dim q = New AsyncQueue(Of CompilationEvent)()
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)
             Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, options:=compilationOptions).WithEventQueue(q)

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -1548,7 +1548,7 @@ End Namespace
                           </compilation>
 
             Dim defines = AddPredefinedPreprocessorSymbols(OutputKind.WindowsApplication)
-            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("WindowsForms")))
+            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("WindowsForms")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)

--- a/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/RegionAnalysisTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/RegionAnalysisTests.vb
@@ -934,7 +934,7 @@ End Namespace
             Dim comp = CompileAndGetModelAndSpan(program, startNodes, endNodes, Nothing, Nothing,
                                                  parseOptions:=
                                                     VisualBasicParseOptions.Default.WithPreprocessorSymbols(
-                                                        KeyValuePairUtil.Create("SQLITE_DEBUG", CObj(True))))
+                                                        KeyValuePair.Create("SQLITE_DEBUG", CObj(True))))
 
             Assert.Equal(4, startNodes.Count)
             Assert.Equal(SyntaxKind.DictionaryAccessExpression, startNodes(2).Kind)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDirectives.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDirectives.vb
@@ -1576,7 +1576,7 @@ BC30059: Constant expression is required.
     <Fact>
     Public Sub ParseProjConstsCaseInsensitivity()
 
-        Dim psymbols = ImmutableArray.Create({Roslyn.Utilities.KeyValuePairUtil.Create("Blah", CObj(False)), Roslyn.Utilities.KeyValuePairUtil.Create("blah", CObj(True))})
+        Dim psymbols = ImmutableArray.Create({KeyValuePair.Create("Blah", CObj(False)), KeyValuePair.Create("blah", CObj(True))})
 
         Dim options As VisualBasicParseOptions = VisualBasicParseOptions.Default.WithPreprocessorSymbols(psymbols)
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -578,7 +579,7 @@ class Class
                 {
                     var solution = workspace.CurrentSolution;
                     var compilationOptions = solution.Projects.Single().CompilationOptions;
-                    var specificDiagnosticOptions = new[] { KeyValuePairUtil.Create(IDEDiagnosticIds.FormattingDiagnosticId, ReportDiagnostic.Warn) };
+                    var specificDiagnosticOptions = new[] { KeyValuePair.Create(IDEDiagnosticIds.FormattingDiagnosticId, ReportDiagnostic.Warn) };
                     compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(specificDiagnosticOptions);
                     var updatedSolution = solution.WithProjectCompilationOptions(solution.ProjectIds.Single(), compilationOptions);
                     workspace.ChangeSolution(updatedSolution);
@@ -823,7 +824,7 @@ class Class
                 {
                     var solution = workspace.CurrentSolution;
                     var compilationOptions = solution.Projects.Single().CompilationOptions;
-                    var specificDiagnosticOptions = new[] { KeyValuePairUtil.Create(IDEDiagnosticIds.FormattingDiagnosticId, ReportDiagnostic.Warn) };
+                    var specificDiagnosticOptions = new[] { KeyValuePair.Create(IDEDiagnosticIds.FormattingDiagnosticId, ReportDiagnostic.Warn) };
                     compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(specificDiagnosticOptions);
                     var updatedSolution = solution.WithProjectCompilationOptions(solution.ProjectIds.Single(), compilationOptions);
                     workspace.ChangeSolution(updatedSolution);

--- a/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -504,7 +505,7 @@ class Program
                 CompilationName,
                 new[] { tree },
                 References,
-                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(new[] { KeyValuePairUtil.Create("CS0219", ReportDiagnostic.Suppress) }));
+                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(new[] { KeyValuePair.Create("CS0219", ReportDiagnostic.Suppress) }));
         }
 
         protected override bool CompilationSucceeded(Compilation compilation, Stream temporaryStream)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CodeFixVerifierHelper.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CodeFixVerifierHelper.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 var editorConfigStorageLocation = key.Option.StorageLocations.OfType<IEditorConfigStorageLocation2>().FirstOrDefault();
                 if (editorConfigStorageLocation is null)
                 {
-                    remainingOptions.Add(KeyValuePairUtil.Create<OptionKey2, object?>(key, value));
+                    remainingOptions.Add(KeyValuePair.Create<OptionKey2, object?>(key, value));
                     continue;
                 }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             if (scope == FixAllScope.Custom)
             {
                 // Bulk fixing diagnostics in selected scope.                    
-                var diagnosticsToFix = ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(document, diagnostics.ToImmutableArray())));
+                var diagnosticsToFix = ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(KeyValuePair.Create(document, diagnostics.ToImmutableArray())));
                 return FixAllState.Create(fixAllProvider, diagnosticsToFix, fixer, equivalenceKey);
             }
 

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/DeclaratorMapDescription.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/DeclaratorMapDescription.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             {
                 for (var j = 0; j < OldSpans[i].Length; j++)
                 {
-                    yield return KeyValuePairUtil.Create(OldSpans[i][j], NewSpans[i][j]);
+                    yield return KeyValuePair.Create(OldSpans[i][j], NewSpans[i][j]);
                 }
             }
         }

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             foreach (var pair in mapping)
             {
-                yield return KeyValuePairUtil.Create(pair.Value, pair.Key);
+                yield return KeyValuePair.Create(pair.Value, pair.Key);
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             else if (language == LanguageNames.VisualBasic)
             {
                 return new VisualBasicParseOptions(preprocessorSymbols: preprocessorSymbolsAttribute.Value
-                    .Split(',').Select(v => KeyValuePairUtil.Create(v.Split('=').ElementAt(0), (object)v.Split('=').ElementAt(1))).ToImmutableArray());
+                    .Split(',').Select(v => KeyValuePair.Create(v.Split('=').ElementAt(0), (object)v.Split('=').ElementAt(1))).ToImmutableArray());
             }
             else
             {

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
                                                source.IndexOf(s_endSpanMark, start, length, StringComparison.Ordinal))
                 End If
 
-                Yield KeyValuePairUtil.Create(position, span)
+                Yield KeyValuePair.Create(position, span)
                 i = [end] + 1
             End While
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
@@ -131,7 +131,7 @@ End Class
                 CompilationName,
                 {DirectCast(tree, VisualBasicSyntaxTree)},
                 References,
-                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions({KeyValuePairUtil.Create("BC0219", ReportDiagnostic.Suppress)}))
+                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions({KeyValuePair.Create("BC0219", ReportDiagnostic.Suppress)}))
         End Function
 
         Protected Overrides Function CompilationSucceeded(compilation As Compilation, temporaryStream As Stream) As Boolean

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var importStringGroups = CustomDebugInfoReader.GetCSharpGroupedImportStrings(
                 methodToken,
-                KeyValuePairUtil.Create(reader, methodVersion),
+                KeyValuePair.Create(reader, methodVersion),
                 getMethodCustomDebugInfo: (token, arg) => GetCustomDebugInfoBytes(arg.Key, token, arg.Value),
                 getMethodImportStrings: (token, arg) => GetImportStrings(arg.Key, token, arg.Value),
                 externAliasStrings: out externAliasStrings);
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var importStrings = CustomDebugInfoReader.GetVisualBasicImportStrings(
                 methodToken,
-                KeyValuePairUtil.Create(reader, methodVersion),
+                KeyValuePair.Create(reader, methodVersion),
                 (token, arg) => GetImportStrings(arg.Key, token, arg.Value));
 
             if (importStrings.IsDefault)

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 var builder = new List<KeyValuePair<ISymbol, ImmutableArray<Diagnostic>>>();
                 foreach (var kvp in diagnosticsMapBuilder)
                 {
-                    builder.Add(KeyValuePairUtil.Create(kvp.Key, GetUniqueDiagnostics(kvp.Value)));
+                    builder.Add(KeyValuePair.Create(kvp.Key, GetUniqueDiagnostics(kvp.Value)));
                 }
 
                 return builder.OrderBy(kvp => kvp.Key.GetDocumentationCommentId() ?? string.Empty);

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerTelemetry.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerTelemetry.cs
@@ -9,10 +9,6 @@ using System.Text;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.Internal.Log;
 
-#if NETSTANDARD2_0
-using Roslyn.Utilities;
-#endif
-
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal sealed class DiagnosticAnalyzerTelemetry

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -13,6 +14,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Execution;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -16,10 +16,6 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 
-#if NETSTANDARD2_0
-using Roslyn.Utilities;
-#endif
-
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1507,7 +1507,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 if (activeNode.NewTrackedNode != null)
                 {
                     lazyKnownMatches ??= new List<KeyValuePair<SyntaxNode, SyntaxNode>>();
-                    lazyKnownMatches.Add(KeyValuePairUtil.Create(activeNode.OldNode, activeNode.NewTrackedNode));
+                    lazyKnownMatches.Add(KeyValuePair.Create(activeNode.OldNode, activeNode.NewTrackedNode));
                 }
             }
         }
@@ -1532,7 +1532,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (StatementLabelEquals(oldNode, newNode))
                 {
-                    lazyKnownMatches.Add(KeyValuePairUtil.Create(oldNode, newNode));
+                    lazyKnownMatches.Add(KeyValuePair.Create(oldNode, newNode));
                 }
             }
 

--- a/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
@@ -9,10 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
 
-#if NETSTANDARD2_0
-using Roslyn.Utilities;
-#endif
-
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal class AggregateIncrementalAnalyzer : IIncrementalAnalyzer

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -4,6 +4,7 @@
 extern alias PortableTestUtils;
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Scripting;
@@ -88,7 +89,7 @@ Environment.Exit(0)
             var dir = Temp.CreateDirectory();
             dir.CreateFile("C.dll").WriteAllBytes(TestResources.General.C1);
 
-            var result = ProcessUtilities.Run(CsiPath, "/r:C.dll a.csx", workingDirectory: cwd.Path, additionalEnvironmentVars: new[] { KeyValuePairUtil.Create("LIB", dir.Path) });
+            var result = ProcessUtilities.Run(CsiPath, "/r:C.dll a.csx", workingDirectory: cwd.Path, additionalEnvironmentVars: new[] { KeyValuePair.Create("LIB", dir.Path) });
 
             // error CS0006: Metadata file 'C.dll' could not be found
             Assert.True(result.Errors.StartsWith("error CS0006", StringComparison.Ordinal));

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 {
@@ -622,7 +621,7 @@ if (true)
         public async Task ReturnInLoadedFile()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "return 42;"));
+                KeyValuePair.Create("a.csx", "return 42;"));
             var options = ScriptOptions.Default.WithSourceResolver(resolver);
 
             var script = CSharpScript.Create("#load \"a.csx\"", options);
@@ -640,7 +639,7 @@ if (true)
         public async Task ReturnInLoadedFileTrailingExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", @"
+                KeyValuePair.Create("a.csx", @"
 if (false)
 {
     return 42;
@@ -663,7 +662,7 @@ if (false)
         public void ReturnInLoadedFileTrailingVoidExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", @"
+                KeyValuePair.Create("a.csx", @"
 if (false)
 {
     return 1;
@@ -686,8 +685,8 @@ System.Console.WriteLine(42)"));
         public async Task MultipleLoadedFilesWithTrailingExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "1"),
-                KeyValuePairUtil.Create("b.csx", @"
+                KeyValuePair.Create("a.csx", "1"),
+                KeyValuePair.Create("b.csx", @"
 #load ""a.csx""
 2"));
             var options = ScriptOptions.Default.WithSourceResolver(resolver);
@@ -696,8 +695,8 @@ System.Console.WriteLine(42)"));
             Assert.Null(result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "1"),
-                KeyValuePairUtil.Create("b.csx", "2"));
+                KeyValuePair.Create("a.csx", "1"),
+                KeyValuePair.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -706,8 +705,8 @@ System.Console.WriteLine(42)"));
             Assert.Null(result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "1"),
-                KeyValuePairUtil.Create("b.csx", "2"));
+                KeyValuePair.Create("a.csx", "1"),
+                KeyValuePair.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -721,8 +720,8 @@ System.Console.WriteLine(42)"));
         public async Task MultipleLoadedFilesWithReturnAndTrailingExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "return 1;"),
-                KeyValuePairUtil.Create("b.csx", @"
+                KeyValuePair.Create("a.csx", "return 1;"),
+                KeyValuePair.Create("b.csx", @"
 #load ""a.csx""
 2"));
             var options = ScriptOptions.Default.WithSourceResolver(resolver);
@@ -731,8 +730,8 @@ System.Console.WriteLine(42)"));
             Assert.Equal(1, result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "return 1;"),
-                KeyValuePairUtil.Create("b.csx", "2"));
+                KeyValuePair.Create("a.csx", "return 1;"),
+                KeyValuePair.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -741,8 +740,8 @@ System.Console.WriteLine(42)"));
             Assert.Equal(1, result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", "return 1;"),
-                KeyValuePairUtil.Create("b.csx", "2"));
+                KeyValuePair.Create("a.csx", "return 1;"),
+                KeyValuePair.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -756,7 +755,7 @@ return 3;", options);
         public async Task LoadedFileWithReturnAndGoto()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", @"
+                KeyValuePair.Create("a.csx", @"
 goto EOF;
 NEXT:
 return 1;
@@ -805,7 +804,7 @@ b");
         public async Task LoadedFileWithVoidReturn()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePairUtil.Create("a.csx", @"
+                KeyValuePair.Create("a.csx", @"
 var i = 42;
 return;
 i = -1;"));

--- a/src/Test/Utilities/Portable/TestHelpers.cs
+++ b/src/Test/Utilities/Portable/TestHelpers.cs
@@ -14,7 +14,6 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using KeyValuePair = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Roslyn.Test.Utilities
 {
@@ -23,10 +22,10 @@ namespace Roslyn.Test.Utilities
         public static ImmutableDictionary<K, V> CreateImmutableDictionary<K, V>(
             IEqualityComparer<K> comparer,
             params (K, V)[] entries)
-            => ImmutableDictionary.CreateRange(comparer, entries.Select(KeyValuePair.ToKeyValuePair));
+            => ImmutableDictionary.CreateRange(comparer, entries.Select(KeyValuePairUtil.ToKeyValuePair));
 
         public static ImmutableDictionary<K, V> CreateImmutableDictionary<K, V>(params (K, V)[] entries)
-            => ImmutableDictionary.CreateRange(entries.Select(KeyValuePair.ToKeyValuePair));
+            => ImmutableDictionary.CreateRange(entries.Select(KeyValuePairUtil.ToKeyValuePair));
 
         public static IEnumerable<Type> GetAllTypesWithStaticFieldsImplementingType(Assembly assembly, Type type)
         {

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
@@ -220,7 +220,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
             Private Shared Function GetConditionalCompilationSymbols(kind As OutputKind, str As String) As ImmutableArray(Of KeyValuePair(Of String, Object))
                 Debug.Assert(str IsNot Nothing)
-                Dim key = KeyValuePairUtil.Create(str, kind)
+                Dim key = KeyValuePair.Create(str, kind)
 
                 Dim result As ImmutableArray(Of KeyValuePair(Of String, Object)) = Nothing
                 If s_conditionalCompilationSymbolsCache.TryGetValue(key, result) Then

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         {
                             case FixAllScope.Project:
                                 var diagnostics = await fixAllContext.GetProjectDiagnosticsAsync(project).ConfigureAwait(false);
-                                var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(project, diagnostics));
+                                var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePair.Create(project, diagnostics));
                                 return ImmutableDictionary.CreateRange(kvp);
 
                             case FixAllScope.Solution:

--- a/src/Workspaces/Core/Portable/Diagnostics/SkippedHostAnalyzersInfo.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/SkippedHostAnalyzersInfo.cs
@@ -8,10 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.PooledObjects;
 
-#if !NETCOREAPP
-using Roslyn.Utilities;
-#endif
-
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     /// <summary>

--- a/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Execution
                     var key = reader.ReadString();
                     var value = (ReportDiagnostic)reader.ReadInt32();
 
-                    specificDiagnosticOptionsList.Add(KeyValuePairUtil.Create(key, value));
+                    specificDiagnosticOptionsList.Add(KeyValuePair.Create(key, value));
                 }
             }
 
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Execution
                     var key = reader.ReadString();
                     var value = reader.ReadString();
 
-                    featuresList.Add(KeyValuePairUtil.Create(key, value));
+                    featuresList.Add(KeyValuePair.Create(key, value));
                 }
             }
 

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -484,7 +484,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                         var documentId = project.GetDocumentId(tree);
                         if (documentId != null)
                         {
-                            yield return KeyValuePairUtil.Create(documentId, tree);
+                            yield return KeyValuePair.Create(documentId, tree);
                         }
                     }
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis
             // We need to compute our AnalyerConfigDocumentStates first, since we use those to produce our DocumentStates
             _analyzerConfigDocumentStates = ImmutableSortedDictionary.CreateRange(DocumentIdComparer.Instance,
                 projectInfoFixed.AnalyzerConfigDocuments.Select(d =>
-                    KeyValuePairUtil.Create(d.Id, new AnalyzerConfigDocumentState(d, solutionServices))));
+                    KeyValuePair.Create(d.Id, new AnalyzerConfigDocumentState(d, solutionServices))));
             _lazyAnalyzerConfigSet = ComputeAnalyzerConfigSetValueSource(_analyzerConfigDocumentStates.Values);
 
             _documentIds = projectInfoFixed.Documents.Select(d => d.Id).ToImmutableList();
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
                 documentIds: _documentIds.AddRange(documents.Select(d => d.Id)),
-                documentStates: _documentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d))));
+                documentStates: _documentStates.AddRange(documents.Select(d => KeyValuePair.Create(d.Id, d))));
         }
 
         public ProjectState AddAdditionalDocuments(ImmutableArray<TextDocumentState> documents)
@@ -620,14 +620,14 @@ namespace Microsoft.CodeAnalysis
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
                 additionalDocumentIds: _additionalDocumentIds.AddRange(documents.Select(d => d.Id)),
-                additionalDocumentStates: _additionalDocumentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d))));
+                additionalDocumentStates: _additionalDocumentStates.AddRange(documents.Select(d => KeyValuePair.Create(d.Id, d))));
         }
 
         public ProjectState AddAnalyzerConfigDocuments(ImmutableArray<AnalyzerConfigDocumentState> documents)
         {
             Debug.Assert(!documents.Any(d => this._analyzerConfigDocumentStates.ContainsKey(d.Id)));
 
-            var newAnalyzerConfigDocumentStates = _analyzerConfigDocumentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d)));
+            var newAnalyzerConfigDocumentStates = _analyzerConfigDocumentStates.AddRange(documents.Select(d => KeyValuePair.Create(d.Id, d)));
 
             return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
         }

--- a/src/Workspaces/CoreTest/Differencing/MatchTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/MatchTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Roslyn.Utilities;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Differencing.UnitTests
@@ -22,13 +22,13 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
                 x2 = new TestNode(1, 2));
 
             var m = TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot,
-                new[] { KeyValuePairUtil.Create(x1, x2), KeyValuePairUtil.Create(x1, x2) });
+                new[] { KeyValuePair.Create(x1, x2), KeyValuePair.Create(x1, x2) });
             Assert.True(m.TryGetNewNode(x1, out var n));
             Assert.Equal(n, x2);
 
-            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePairUtil.Create(x1, x1) }));
+            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePair.Create(x1, x1) }));
 
-            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePairUtil.Create(x1, x2), KeyValuePairUtil.Create(x1, new TestNode(0, 0)) }));
+            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePair.Create(x1, x2), KeyValuePair.Create(x1, new TestNode(0, 0)) }));
         }
 
         [Fact]
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             var m = TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[]
             {
-                KeyValuePairUtil.Create(x1, x2),
-                KeyValuePairUtil.Create(y1, x2),
+                KeyValuePair.Create(x1, x2),
+                KeyValuePair.Create(y1, x2),
             });
 
             // the first one wins:
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             var m = TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[]
             {
-                KeyValuePairUtil.Create(x1, newRoot),
+                KeyValuePair.Create(x1, newRoot),
             });
 
             // the root wins:

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Roslyn.Utilities;
@@ -31,44 +32,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         private static readonly BidirectionalMap<string, SpacingWithinParenthesesOption> s_spacingWithinParenthesisOptionsEditorConfigMap =
             new BidirectionalMap<string, SpacingWithinParenthesesOption>(new[]
             {
-                KeyValuePairUtil.Create("expressions", SpacingWithinParenthesesOption.Expressions),
-                KeyValuePairUtil.Create("type_casts", SpacingWithinParenthesesOption.TypeCasts),
-                KeyValuePairUtil.Create("control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements),
+                KeyValuePair.Create("expressions", SpacingWithinParenthesesOption.Expressions),
+                KeyValuePair.Create("type_casts", SpacingWithinParenthesesOption.TypeCasts),
+                KeyValuePair.Create("control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements),
             });
         private static readonly BidirectionalMap<string, BinaryOperatorSpacingOptions> s_binaryOperatorSpacingOptionsEditorConfigMap =
             new BidirectionalMap<string, BinaryOperatorSpacingOptions>(new[]
             {
-                KeyValuePairUtil.Create("ignore", BinaryOperatorSpacingOptions.Ignore),
-                KeyValuePairUtil.Create("none", BinaryOperatorSpacingOptions.Remove),
-                KeyValuePairUtil.Create("before_and_after", BinaryOperatorSpacingOptions.Single),
+                KeyValuePair.Create("ignore", BinaryOperatorSpacingOptions.Ignore),
+                KeyValuePair.Create("none", BinaryOperatorSpacingOptions.Remove),
+                KeyValuePair.Create("before_and_after", BinaryOperatorSpacingOptions.Single),
             });
         private static readonly BidirectionalMap<string, LabelPositionOptions> s_labelPositionOptionsEditorConfigMap =
             new BidirectionalMap<string, LabelPositionOptions>(new[]
             {
-                KeyValuePairUtil.Create("flush_left", LabelPositionOptions.LeftMost),
-                KeyValuePairUtil.Create("no_change", LabelPositionOptions.NoIndent),
-                KeyValuePairUtil.Create("one_less_than_current", LabelPositionOptions.OneLess),
+                KeyValuePair.Create("flush_left", LabelPositionOptions.LeftMost),
+                KeyValuePair.Create("no_change", LabelPositionOptions.NoIndent),
+                KeyValuePair.Create("one_less_than_current", LabelPositionOptions.OneLess),
             });
         private static readonly BidirectionalMap<string, NewLineOption> s_legacyNewLineOptionsEditorConfigMap =
             new BidirectionalMap<string, NewLineOption>(new[]
             {
-                KeyValuePairUtil.Create("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
+                KeyValuePair.Create("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
             });
         private static readonly BidirectionalMap<string, NewLineOption> s_newLineOptionsEditorConfigMap =
             new BidirectionalMap<string, NewLineOption>(new[]
             {
-                KeyValuePairUtil.Create("accessors", NewLineOption.Accessors),
-                KeyValuePairUtil.Create("types", NewLineOption.Types),
-                KeyValuePairUtil.Create("methods", NewLineOption.Methods),
-                KeyValuePairUtil.Create("properties", NewLineOption.Properties),
-                KeyValuePairUtil.Create("indexers", NewLineOption.Indexers),
-                KeyValuePairUtil.Create("events", NewLineOption.Events),
-                KeyValuePairUtil.Create("anonymous_methods", NewLineOption.AnonymousMethods),
-                KeyValuePairUtil.Create("control_blocks", NewLineOption.ControlBlocks),
-                KeyValuePairUtil.Create("anonymous_types", NewLineOption.AnonymousTypes),
-                KeyValuePairUtil.Create("object_collection_array_initializers", NewLineOption.ObjectCollectionsArrayInitializers),
-                KeyValuePairUtil.Create("lambdas", NewLineOption.Lambdas),
-                KeyValuePairUtil.Create("local_functions", NewLineOption.LocalFunction),
+                KeyValuePair.Create("accessors", NewLineOption.Accessors),
+                KeyValuePair.Create("types", NewLineOption.Types),
+                KeyValuePair.Create("methods", NewLineOption.Methods),
+                KeyValuePair.Create("properties", NewLineOption.Properties),
+                KeyValuePair.Create("indexers", NewLineOption.Indexers),
+                KeyValuePair.Create("events", NewLineOption.Events),
+                KeyValuePair.Create("anonymous_methods", NewLineOption.AnonymousMethods),
+                KeyValuePair.Create("control_blocks", NewLineOption.ControlBlocks),
+                KeyValuePair.Create("anonymous_types", NewLineOption.AnonymousTypes),
+                KeyValuePair.Create("object_collection_array_initializers", NewLineOption.ObjectCollectionsArrayInitializers),
+                KeyValuePair.Create("lambdas", NewLineOption.Lambdas),
+                KeyValuePair.Create("local_functions", NewLineOption.LocalFunction),
             });
         #endregion
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
@@ -135,8 +136,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         private static readonly BidirectionalMap<string, UnusedValuePreference> s_unusedExpressionAssignmentPreferenceMap =
             new BidirectionalMap<string, UnusedValuePreference>(new[]
             {
-                KeyValuePairUtil.Create("discard_variable", UnusedValuePreference.DiscardVariable),
-                KeyValuePairUtil.Create("unused_local_variable", UnusedValuePreference.UnusedLocalVariable),
+                KeyValuePair.Create("discard_variable", UnusedValuePreference.DiscardVariable),
+                KeyValuePair.Create("unused_local_variable", UnusedValuePreference.UnusedLocalVariable),
             });
 
         public static Option2<CodeStyleOption2<UnusedValuePreference>> CreateUnusedExpressionAssignmentOption(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
@@ -270,10 +271,10 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         private static readonly BidirectionalMap<string, AccessibilityModifiersRequired> s_accessibilityModifiersRequiredMap =
             new BidirectionalMap<string, AccessibilityModifiersRequired>(new[]
             {
-                KeyValuePairUtil.Create("never", AccessibilityModifiersRequired.Never),
-                KeyValuePairUtil.Create("always", AccessibilityModifiersRequired.Always),
-                KeyValuePairUtil.Create("for_non_interface_members", AccessibilityModifiersRequired.ForNonInterfaceMembers),
-                KeyValuePairUtil.Create("omit_if_default", AccessibilityModifiersRequired.OmitIfDefault),
+                KeyValuePair.Create("never", AccessibilityModifiersRequired.Never),
+                KeyValuePair.Create("always", AccessibilityModifiersRequired.Always),
+                KeyValuePair.Create("for_non_interface_members", AccessibilityModifiersRequired.ForNonInterfaceMembers),
+                KeyValuePair.Create("omit_if_default", AccessibilityModifiersRequired.OmitIfDefault),
             });
 
         private static CodeStyleOption2<AccessibilityModifiersRequired> ParseAccessibilityModifiersRequired(string optionString)
@@ -357,15 +358,15 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         private static readonly BidirectionalMap<string, ParenthesesPreference> s_parenthesesPreferenceMap =
             new BidirectionalMap<string, ParenthesesPreference>(new[]
             {
-                KeyValuePairUtil.Create("always_for_clarity", ParenthesesPreference.AlwaysForClarity),
-                KeyValuePairUtil.Create("never_if_unnecessary", ParenthesesPreference.NeverIfUnnecessary),
+                KeyValuePair.Create("always_for_clarity", ParenthesesPreference.AlwaysForClarity),
+                KeyValuePair.Create("never_if_unnecessary", ParenthesesPreference.NeverIfUnnecessary),
             });
 
         private static readonly BidirectionalMap<string, UnusedParametersPreference> s_unusedParametersPreferenceMap =
             new BidirectionalMap<string, UnusedParametersPreference>(new[]
             {
-                KeyValuePairUtil.Create("non_public", UnusedParametersPreference.NonPublicMethods),
-                KeyValuePairUtil.Create("all", UnusedParametersPreference.AllMethods),
+                KeyValuePair.Create("non_public", UnusedParametersPreference.NonPublicMethods),
+                KeyValuePair.Create("all", UnusedParametersPreference.AllMethods),
             });
 
         internal static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferSystemHashCode = CreateOption(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Immutable;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Options;
+using System.Collections.Generic;
 
 #if CODE_STYLE
 using WorkspacesResources = Microsoft.CodeAnalysis.CodeStyleResources;
@@ -90,9 +91,9 @@ namespace Microsoft.CodeAnalysis.Formatting
         private static readonly BidirectionalMap<string, string> s_parenthesesPreferenceMap =
             new BidirectionalMap<string, string>(new[]
             {
-                KeyValuePairUtil.Create("lf", "\n"),
-                KeyValuePairUtil.Create("cr", "\r"),
-                KeyValuePairUtil.Create("crlf", "\r\n"),
+                KeyValuePair.Create("lf", "\n"),
+                KeyValuePair.Create("cr", "\r"),
+                KeyValuePair.Create("crlf", "\r\n"),
             });
 
         private static Optional<string> ParseEditorConfigEndOfLine(string endOfLineValue)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BidirectionalMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BidirectionalMap.cs
@@ -20,7 +20,7 @@ namespace Roslyn.Utilities
         public BidirectionalMap(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
             _forwardMap = ImmutableDictionary.CreateRange<TKey, TValue>(pairs);
-            _backwardMap = ImmutableDictionary.CreateRange<TValue, TKey>(pairs.Select(p => KeyValuePairUtil.Create(p.Value, p.Key)));
+            _backwardMap = ImmutableDictionary.CreateRange<TValue, TKey>(pairs.Select(p => KeyValuePair.Create(p.Value, p.Key)));
         }
 
         private BidirectionalMap(ImmutableDictionary<TKey, TValue> forwardMap, ImmutableDictionary<TValue, TKey> backwardMap)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/DocumentBasedFixAllProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/DocumentBasedFixAllProvider.cs
@@ -10,10 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.PooledObjects;
 
-#if NETSTANDARD2_0
-using Roslyn.Utilities;
-#endif
-
 #pragma warning disable RS0005 // Do not use generic CodeAction.Create to create CodeAction
 
 namespace Microsoft.CodeAnalysis.CodeFixes

--- a/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
@@ -119,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
             For i = 0 To count - 1
                 Dim key = reader.ReadString()
                 Dim value = reader.ReadValue()
-                builder.Add(KeyValuePairUtil.Create(key, value))
+                builder.Add(KeyValuePair.Create(key, value))
             Next
             Dim options = New VisualBasicParseOptions(languageVersion, documentationMode, kind, builder.MoveToImmutable())
             Return options.WithFeatures(features)


### PR DESCRIPTION
Removes the need to add conditional directive  

```
#if !NETCOREAPP
using Roslyn.Utilities
#endif
```

in code that uses KeyValuePair deconstructor.

`KeyValuePair` is a type in `System.Collections.Generic` in `netcoreapp3.1`, but is not available in `netstandard2.0` or `net472`. Define the type in the same namespace if it's not defined already.

`KeyValuePair<K,V>.Deconstruct` is also available in `netcoreapp3.1`, but is not available in `netstandard2.0` or `net472`. Define it as an extension method in global namespace (to be available in all our code without TFM-conditional using) if it's not defined already.

The core of the change is in [KeyValuePairUtil.cs](https://github.com/dotnet/roslyn/pull/43579/files#diff-ee3dd515898db6c107adb85ae5e78f7e), the rest is mechanical.