### PR TITLE
Allow msbuild to pass properties and metadata as analyzerconfig:

### DIFF
--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    public class GenerateMSBuildAnalyzerConfig : Task
+    {
+        [Output]
+        public string ConfigFileContents { get; set; }
+
+        [Required]
+        public ITaskItem[] MetadataItems { get; set; }
+
+        [Required]
+        public ITaskItem[] PropertyItems { get; set; }
+
+        public GenerateMSBuildAnalyzerConfig()
+        {
+            ConfigFileContents = string.Empty;
+            MetadataItems = new ITaskItem[0];
+            PropertyItems = new ITaskItem[0];
+        }
+
+        public override bool Execute()
+        {
+            StringBuilder builder = new StringBuilder();
+
+            // we always generate global configs
+            builder.AppendLine("is_global = true");
+
+            // collect the properties into a global section
+            foreach (var prop in PropertyItems)
+            {
+                builder.Append("msbuild_property.")
+                       .Append(prop.ItemSpec)
+                       .Append(" = ")
+                       .AppendLine(prop.GetMetadata("Value")); //TODO: do we need to encode/escape this?
+            }
+
+            // group the metadata items by their itemspec
+            var groupedItems = MetadataItems.GroupBy(i => i.ItemSpec);
+
+            foreach (var group in groupedItems)
+            {
+                // write the section for this item
+                builder.AppendLine()
+                       .Append("[")
+                       .Append(group.Key)
+                       .AppendLine("]");
+
+                foreach (var item in group)
+                {
+                    string metadataName = item.GetMetadata("MetadataName");
+                    builder.Append("msbuild_item.")
+                           .Append(item.GetMetadata("ItemType"))
+                           .Append(".")
+                           .Append(metadataName)
+                           .Append(" = ")
+                           .AppendLine(item.GetMetadata(metadataName));
+                }
+            }
+
+            ConfigFileContents = builder.ToString();
+            return true;
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
@@ -2,14 +2,41 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
 {
-    public class GenerateMSBuildAnalyzerConfig : Task
+    /// <summary>
+    /// Transforms a set of MSBuild Properties and Metadata into a global analyzer config.
+    /// </summary>
+    /// <remarks>
+    /// This task takes a set of items passed in via <see cref="MetadataItems"/> and <see cref="PropertyItems"/> and transforms
+    /// them into a global analyzer config. 
+    /// 
+    /// <see cref="PropertyItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> is the property name
+    /// and have a metadata value called <c>Value</c> that contains the evaluated value of the property. Each of the ]
+    /// <see cref="PropertyItems"/> will be transformed into an <c>msbuild_property.<em>ItemSpec</em> = <em>Value</em></c> entry in the
+    /// global section of the generated config file.
+    /// 
+    /// <see cref="MetadataItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> represents a file in the 
+    /// compilation source tree. It should have two metadata values: <c>ItemType</c> is the name of the MSBuild item that originally 
+    /// inlcuded the file (e.g. <c>Compile</c>, <c>AdditionalFile</c> etc.); <c>MetadataName</c> is expected to contain the name of
+    /// another piece of metadata that should be retreived and used as the output value in the file. It is expected that a given 
+    /// file can have multiple entries in the <see cref="MetadataItems" /> differing by its <c>ItemType</c>.
+    /// 
+    /// Each of the <see cref="MetadataItems"/> will be transformed into a new section in the generated config file. The section
+    /// header will be the full path of the item (generated via its<see cref="ITaskItem.ItemSpec"/>), and each section will have a 
+    /// set of <c>msbuild_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetreivedMetadataValue</em></c>, one per <c>ItemType</c>
+    /// 
+    /// The Microsoft.Managed.Core.targets calls this task with the collected results of the <c>AnalyzerProperty</c> and 
+    /// <c>AnalyzerItemMetadata</c> item groups. 
+    /// </remarks>
+    public sealed class GenerateMSBuildAnalyzerConfig : Task
     {
         [Output]
         public string ConfigFileContents { get; set; }
@@ -23,8 +50,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public GenerateMSBuildAnalyzerConfig()
         {
             ConfigFileContents = string.Empty;
-            MetadataItems = new ITaskItem[0];
-            PropertyItems = new ITaskItem[0];
+            MetadataItems = Array.Empty<ITaskItem>();
+            PropertyItems = Array.Empty<ITaskItem>();
         }
 
         public override bool Execute()
@@ -40,11 +67,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 builder.Append("msbuild_property.")
                        .Append(prop.ItemSpec)
                        .Append(" = ")
-                       .AppendLine(prop.GetMetadata("Value")); //TODO: do we need to encode/escape this?
+                       .AppendLine(prop.GetMetadata("Value"));
             }
 
             // group the metadata items by their full path
-            var groupedItems = MetadataItems.GroupBy(i => i.GetMetadata("FullPath"));
+            var groupedItems = MetadataItems.GroupBy(i => NormalizeWithForwardSlash(i.GetMetadata("FullPath")));
 
             foreach (var group in groupedItems)
             {
@@ -69,5 +96,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             ConfigFileContents = builder.ToString();
             return true;
         }
+
+        /// <remarks>
+        /// Equivalent to Roslyn.Utilities.PathUtilities.NormalizeWithForwardSlash
+        /// Both methods should be kept in sync.
+        /// </remarks>
+        private static string NormalizeWithForwardSlash(string p)
+            => PlatformInformation.IsUnix ? p : p.Replace('\\', '/');
     }
 }

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
@@ -26,12 +26,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// <see cref="MetadataItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> represents a file in the 
     /// compilation source tree. It should have two metadata values: <c>ItemType</c> is the name of the MSBuild item that originally 
     /// inlcuded the file (e.g. <c>Compile</c>, <c>AdditionalFile</c> etc.); <c>MetadataName</c> is expected to contain the name of
-    /// another piece of metadata that should be retreived and used as the output value in the file. It is expected that a given 
+    /// another piece of metadata that should be retrieved and used as the output value in the file. It is expected that a given 
     /// file can have multiple entries in the <see cref="MetadataItems" /> differing by its <c>ItemType</c>.
     /// 
     /// Each of the <see cref="MetadataItems"/> will be transformed into a new section in the generated config file. The section
     /// header will be the full path of the item (generated via its<see cref="ITaskItem.ItemSpec"/>), and each section will have a 
-    /// set of <c>msbuild_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetreivedMetadataValue</em></c>, one per <c>ItemType</c>
+    /// set of <c>msbuild_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetrievedMetadataValue</em></c>, one per <c>ItemType</c>
     /// 
     /// The Microsoft.Managed.Core.targets calls this task with the collected results of the <c>AnalyzerProperty</c> and 
     /// <c>AnalyzerItemMetadata</c> item groups. 

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
@@ -43,8 +43,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                        .AppendLine(prop.GetMetadata("Value")); //TODO: do we need to encode/escape this?
             }
 
-            // group the metadata items by their itemspec
-            var groupedItems = MetadataItems.GroupBy(i => i.ItemSpec);
+            // group the metadata items by their full path
+            var groupedItems = MetadataItems.GroupBy(i => i.GetMetadata("FullPath"));
 
             foreach (var group in groupedItems)
             {

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -66,6 +66,73 @@
 
   <!--
     ========================
+    Property/metadata global .editorconfig Support
+    ========================
+    
+    Generates a global analyzer config that contains the evaluation of requested MSBuild properties and item metadata
+    
+    Requested properties/items are requested via item groups like:
+   
+      <AnalyzerProperty Include="PropertyNameToEval" />
+      <AnalyzerItemMetadata Include="ItemType" MetadataName="MetaDataToRetrieve" />
+    -->
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildAnalyzerConfig" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
+
+  <PropertyGroup>
+    <GeneratedMSBuildAnalyzerConfigFile Condition="'$(GeneratedMSBuildAnalyzerConfigFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).GeneratedMSBuildAnalyzerConfig.editorconfig</GeneratedMSBuildAnalyzerConfigFile>
+    <GenerateMSBuildAnalyzerConfigFile Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == ''">true</GenerateMSBuildAnalyzerConfigFile>
+  </PropertyGroup>
+
+  <Target Name="GenerateMSBuildAnalyzerConfigFileShouldRun"
+          BeforeTargets="GenerateMSBuildAnalyzerConfigFile"
+          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'">
+    <PropertyGroup>
+      <_GeneratedAnalyzerConfigHasItems Condition="'@(AnalyzerItemMetadata->Count())' != '0'">true</_GeneratedAnalyzerConfigHasItems>
+      <_GeneratedAnalyzerConfigShouldRun Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == 'true' and ('$(_GeneratedAnalyzerConfigHasItems)' == 'true' or '@(AnalyzerProperty->Count())' != '0')">true</_GeneratedAnalyzerConfigShouldRun>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GenerateMSBuildAnalyzerConfigFile"
+          BeforeTargets="BeforeCompile;CoreCompile"
+          DependsOnTargets="PrepareForBuild;CoreGenerateAssemblyInfo"
+          Condition="'$(_GeneratedAnalyzerConfigShouldRun)' == 'true'"
+          Outputs="$(GeneratedMSBuildAnalyzerConfigFile)">
+
+    <ItemGroup>
+      <!-- Collect requested properties, and eval their value -->
+      <_GeneratedAnalyzerConfigProperty Include="@(AnalyzerProperty)">
+        <Value>$(%(AnalyzerProperty.Identity))</Value>
+      </_GeneratedAnalyzerConfigProperty>
+
+      <!-- Collect the requested items and remember which metadata is wanted -->
+      <_GeneratedAnalyzerConfigItem Include="@(%(AnalyzerItemMetadata.Identity))" Condition="'$(_GeneratedAnalyzerConfigHasItems)' == 'true'">
+        <ItemType>%(Identity)</ItemType>
+        <MetadataName>%(MetadataName)</MetadataName>
+      </_GeneratedAnalyzerConfigItem>
+
+      <!-- Transform the collected items into their full path -->
+      <_GeneratedAnalyzerConfigMetadata Include="@(_GeneratedAnalyzerConfigItem->'%(FullPath)')" />
+
+      <!-- Record that we'll write a file, and add it to the editorconfig inputs -->
+      <FileWrites Include="$(GeneratedMSBuildAnalyzerConfigFile)" />
+      <EditorConfigFiles Include="$(GeneratedMSBuildAnalyzerConfigFile)"  />
+    </ItemGroup>
+
+    <!-- Transform the collected properties and items into an editor config file -->
+    <GenerateMSBuildAnalyzerConfig
+      PropertyItems="@(_GeneratedAnalyzerConfigProperty)"
+      MetadataItems="@(_GeneratedAnalyzerConfigMetadata)">
+
+      <Output TaskParameter="ConfigFileContents"
+          PropertyName="_GeneratedAnalyzerConfigFileContent" />
+    </GenerateMSBuildAnalyzerConfig>
+
+    <!-- Write the output to the generated file, if it's changed -->
+    <WriteLinesToFile Lines="$(_GeneratedAnalyzerConfigFileContent)" File="$(GeneratedMSBuildAnalyzerConfigFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
+  </Target>
+
+  <!--
+    ========================
     DeterministicSourcePaths
     ========================
     

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -94,7 +94,17 @@
 
   <Target Name="GenerateMSBuildAnalyzerConfigFile"
           BeforeTargets="BeforeCompile;CoreCompile"
-          DependsOnTargets="PrepareForBuild;CoreGenerateAssemblyInfo"
+          DependsOnTargets="PrepareForBuild;GenerateMSBuildAnalyzerConfigFileShouldRun;GenerateMSBuildAnalyzerConfigFileCore"
+          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'" />
+
+  <Target Name="GenerateMSBuildAnalyzerConfigFileShouldRun">
+    <PropertyGroup>
+      <_GeneratedAnalyzerConfigHasItems Condition="'@(AnalyzerItemMetadata->Count())' != '0'">true</_GeneratedAnalyzerConfigHasItems>
+      <_GeneratedAnalyzerConfigShouldRun Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == 'true' and ('$(_GeneratedAnalyzerConfigHasItems)' == 'true' or '@(AnalyzerProperty->Count())' != '0')">true</_GeneratedAnalyzerConfigShouldRun>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GenerateMSBuildAnalyzerConfigFileCore"
           Condition="'$(_GeneratedAnalyzerConfigShouldRun)' == 'true'"
           Outputs="$(GeneratedMSBuildAnalyzerConfigFile)">
 
@@ -105,13 +115,10 @@
       </_GeneratedAnalyzerConfigProperty>
 
       <!-- Collect the requested items and remember which metadata is wanted -->
-      <_GeneratedAnalyzerConfigItem Include="@(%(AnalyzerItemMetadata.Identity))" Condition="'$(_GeneratedAnalyzerConfigHasItems)' == 'true'">
+      <_GeneratedAnalyzerConfigMetadata Include="@(%(AnalyzerItemMetadata.Identity))" Condition="'$(_GeneratedAnalyzerConfigHasItems)' == 'true'">
         <ItemType>%(Identity)</ItemType>
         <MetadataName>%(MetadataName)</MetadataName>
-      </_GeneratedAnalyzerConfigItem>
-
-      <!-- Transform the collected items into their full path -->
-      <_GeneratedAnalyzerConfigMetadata Include="@(_GeneratedAnalyzerConfigItem->'%(FullPath)')" />
+      </_GeneratedAnalyzerConfigMetadata>
 
       <!-- Record that we'll write a file, and add it to the editorconfig inputs -->
       <FileWrites Include="$(GeneratedMSBuildAnalyzerConfigFile)" />

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -79,7 +79,7 @@
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildAnalyzerConfig" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
 
   <PropertyGroup>
-    <GeneratedMSBuildAnalyzerConfigFile Condition="'$(GeneratedMSBuildAnalyzerConfigFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).GeneratedMSBuildAnalyzerConfig.editorconfig</GeneratedMSBuildAnalyzerConfigFile>
+    <GeneratedMSBuildAnalyzerConfigFile Condition="'$(GeneratedMSBuildAnalyzerConfigFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).GeneratedMSBuildAnalyzerConfig.editorconfig</GeneratedMSBuildAnalyzerConfigFile>
     <GenerateMSBuildAnalyzerConfigFile Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == ''">true</GenerateMSBuildAnalyzerConfigFile>
   </PropertyGroup>
 

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -74,7 +74,7 @@
     Requested properties/items are requested via item groups like:
    
       <AnalyzerProperty Include="PropertyNameToEval" />
-      <AnalyzerItemMetadata Include="ItemType" MetadataName="MetaDataToRetrieve" />
+      <AnalyzerItemMetadata Include="ItemType" MetadataName="MetadataToRetrieve" />
     -->
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildAnalyzerConfig" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
 
@@ -83,19 +83,9 @@
     <GenerateMSBuildAnalyzerConfigFile Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == ''">true</GenerateMSBuildAnalyzerConfigFile>
   </PropertyGroup>
 
-  <Target Name="GenerateMSBuildAnalyzerConfigFileShouldRun"
-          BeforeTargets="GenerateMSBuildAnalyzerConfigFile"
-          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'">
-    <PropertyGroup>
-      <_GeneratedAnalyzerConfigHasItems Condition="'@(AnalyzerItemMetadata->Count())' != '0'">true</_GeneratedAnalyzerConfigHasItems>
-      <_GeneratedAnalyzerConfigShouldRun Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == 'true' and ('$(_GeneratedAnalyzerConfigHasItems)' == 'true' or '@(AnalyzerProperty->Count())' != '0')">true</_GeneratedAnalyzerConfigShouldRun>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="GenerateMSBuildAnalyzerConfigFile"
           BeforeTargets="BeforeCompile;CoreCompile"
-          DependsOnTargets="PrepareForBuild;GenerateMSBuildAnalyzerConfigFileShouldRun;GenerateMSBuildAnalyzerConfigFileCore"
-          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'" />
+          DependsOnTargets="PrepareForBuild;GenerateMSBuildAnalyzerConfigFileShouldRun;GenerateMSBuildAnalyzerConfigFileCore" />
 
   <Target Name="GenerateMSBuildAnalyzerConfigFileShouldRun">
     <PropertyGroup>
@@ -122,7 +112,7 @@
 
       <!-- Record that we'll write a file, and add it to the editorconfig inputs -->
       <FileWrites Include="$(GeneratedMSBuildAnalyzerConfigFile)" />
-      <EditorConfigFiles Include="$(GeneratedMSBuildAnalyzerConfigFile)"  />
+      <EditorConfigFiles Include="$(GeneratedMSBuildAnalyzerConfigFile)" />
     </ItemGroup>
 
     <!-- Transform the collected properties and items into an editor config file -->

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildAnalyzerConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildAnalyzerConfigTests.cs
@@ -1,0 +1,202 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
+{
+    public class GenerateMSBuildAnalyzerConfigTests
+    {
+        [Fact]
+        public void GlobalPropertyIsGeneratedIfEmpty()
+        {
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig();
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+            Assert.Equal(@"is_global = true
+", result);
+        }
+
+        [Fact]
+        public void PropertiesAreGeneratedInGlobalSection()
+        {
+            TaskItem property1 = new TaskItem("Property1", new Dictionary<string, string> { { "Value", "abc123" } });
+            TaskItem property2 = new TaskItem("Property2", new Dictionary<string, string> { { "Value", "def456" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                PropertyItems = new[] { property1, property2 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+msbuild_property.Property1 = abc123
+msbuild_property.Property2 = def456
+", result);
+        }
+
+        [Fact]
+        public void ItemMetaDataCreatesSection()
+        {
+            TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                MetadataItems = new[] { item1 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+
+[c:\file1.cs]
+msbuild_item.Compile.ToRetrieve = abc123
+", result);
+        }
+
+        [Fact]
+        public void MutlipleItemMetaDataCreatesSections()
+        {
+            TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
+            TaskItem item2 = new TaskItem("c:\\file2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
+            TaskItem item3 = new TaskItem("c:\\file3.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFiles" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "ghi789" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                MetadataItems = new[] { item1, item2, item3 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+
+[c:\file1.cs]
+msbuild_item.Compile.ToRetrieve = abc123
+
+[c:\file2.cs]
+msbuild_item.Compile.ToRetrieve = def456
+
+[c:\file3.cs]
+msbuild_item.AdditionalFiles.ToRetrieve = ghi789
+", result);
+        }
+
+        [Fact]
+        public void DuplicateItemSpecsAreCombinedInSections()
+        {
+            TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
+            TaskItem item2 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                MetadataItems = new[] { item1, item2 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+
+[c:\file1.cs]
+msbuild_item.Compile.ToRetrieve = abc123
+msbuild_item.AdditionalFile.ToRetrieve = def456
+", result);
+        }
+
+        [Fact]
+        public void ItemIsMissingRequestedMetadata()
+        {
+            TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                MetadataItems = new[] { item1 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+
+[c:\file1.cs]
+msbuild_item.Compile.ToRetrieve = 
+", result);
+        }
+
+        [Fact]
+        public void ItemIsMissingRequiredMetadata()
+        {
+            TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { });
+            TaskItem item2 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" } });
+            TaskItem item3 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "MetadataName", "ToRetrieve" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                MetadataItems = new[] { item1, item2, item3 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+
+[c:\file1.cs]
+msbuild_item.. = 
+msbuild_item.Compile. = 
+msbuild_item..ToRetrieve = 
+", result);
+        }
+
+        [Fact]
+        public void PropertiesAreGeneratedBeforeItems()
+        {
+            TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
+            TaskItem item2 = new TaskItem("c:\\file2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
+            TaskItem item3 = new TaskItem("c:\\file3.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFiles" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "ghi789" } });
+            TaskItem item4 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFiles" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "jkl012" } });
+
+            TaskItem property1 = new TaskItem("Property1", new Dictionary<string, string> { { "Value", "abc123" } });
+            TaskItem property2 = new TaskItem("Property2", new Dictionary<string, string> { { "Value", "def456" } });
+
+            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            {
+                MetadataItems = new[] { item1, item2, item3, item4 },
+                PropertyItems = new[] { property1, property2 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+msbuild_property.Property1 = abc123
+msbuild_property.Property2 = def456
+
+[c:\file1.cs]
+msbuild_item.Compile.ToRetrieve = abc123
+msbuild_item.AdditionalFiles.ToRetrieve = jkl012
+
+[c:\file2.cs]
+msbuild_item.Compile.ToRetrieve = def456
+
+[c:\file3.cs]
+msbuild_item.AdditionalFiles.ToRetrieve = ghi789
+", result);
+        }
+
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -732,6 +732,10 @@ namespace Roslyn.Utilities
         /// If the current environment uses the '\' directory separator, replaces all uses of '\'
         /// in the given string with '/'. Otherwise, returns the string.
         /// </summary>
+        /// <remarks>
+        /// This method is equivalent to Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildAnalyzerConfig.NormalizeWithForwardSlash
+        /// Both methods should be kept in sync.
+        /// </remarks>
         public static string NormalizeWithForwardSlash(string p)
             => DirectorySeparatorChar == '/' ? p : p.Replace(DirectorySeparatorChar, '/');
 


### PR DESCRIPTION
- Add new target to evaluate requested properties and metadata
- Add new task to turn collected evaluations into a global analyzer config
- Add tests

This PR aims to answer the question of how analyzers / generators get information from MSBuild. 

This implements the MSBuild -> Editorconfig portion. Consuming the generated editorconfig will be done in a different PR.

The basic idea is that an analyzer/generator can declare the properties and metadata it is interested in via an item group in a targets file (added via the usual nuget mechanism):

```xml
<ItemGroup> 
  <!-- Properties -->
  <AnalyzerProperty Include="PropertyName" />
 
  <!-- Metadata -->
  <AnalyzerItemMetadata Include="ItemType" MetadataName="MetadataName" />
</ItemGroup>
```

For instance, to access the `TargetFramework` and `LangVersion` properties:

```xml
<ItemGroup> 
  <AnalyzerProperty Include="TargetFramework" />
  <AnalyzerProperty Include="LangVersion" />
</ItemGroup>
```

Or to access the `%(AccessedTime)` of `@(Compile)` items:

```xml
<ItemGroup> 
  <AnalyzerItemMetadata Include="Compile" MetadataName="AccessedTime" />
</ItemGroup>
```

`AnalyzerProperty` items end up the in the global section of the generated config. Metadata items are placed in merged sections based on the full path of the `ItemSpec`, with a combination of the ItemType that produced it and the name of the metadata.

Eg:

```xml
<ItemGroup> 
  <AnalyzerProperty Include="TargetFramework" />
  <AnalyzerItemMetadata Include="Compile" MetadataName="AccessedTime" />
  <AnalyzerItemMetadata Include="AdditionalFiles" MetadataName="ModifiedTime" />
</ItemGroup>
```
For a project like:

```xml
<Project Sdk='Microsoft.NET.Sdk'>
  <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
  </PropertyGroup>
  
  <ItemGroup>
    <Compile Include="file1.cs" />
    <Compile Include="file2.cs" />
    <AdditionalFiles Include="file1.cs" />
  </ItemGroup>
</Project>

```
Would produce an editor config like:

```
is_global = true
msbuild_property.TargetFramework = netstandard2.0

[c:\full\path\to\file1.cs]
msbuild_item.Compile.AccessedTime = 2004-08-14 16:52:36.3168743
msbuild_item.AdditionalFiles.ModifiedTime = 2004-08-14 16:52:36.3168743

[c:\full\path\to\file2.cs]
msbuild_item.Compile.AccessedTime = 2004-08-14 16:52:36.3168743
```
