### PR TITLE
Remove Razor diagnostic URI conversion workaround.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
@@ -60,21 +59,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             { WellKnownTags.NuGet, LSP.CompletionItemKind.Text }
         };
 
-        /// <summary>
-        /// Workaround for razor file paths being provided with a preceding slash on windows.
-        /// Long term fix in razor here - https://github.com/dotnet/aspnetcore/issues/19948
-        /// </summary>
         public static Uri GetUriFromFilePath(string filePath)
         {
             if (filePath is null)
             {
                 throw new ArgumentNullException(nameof(filePath));
-            }
-
-            // Remove preceding slash if we're on Window as it's an invalid URI.
-            if (filePath.StartsWith("/") && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                filePath = filePath.Substring(1);
             }
 
             return new Uri(filePath, UriKind.Absolute);


### PR DESCRIPTION
- Razor has implemented and inserted the "proper" handling of diagnostic URIs. Prior to this they would prefix file paths with a `/`. That's no longer true.
- Did not remove the entire method because it still has value in converting file paths into Uris and looks to be used by more than just the `InProcLnaguageServer` diagnostic path.

FYI @jinujoseph 