### PR TITLE
Support symbol retargeting for function pointers.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -729,6 +729,56 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 return new PointerTypeSymbol(newPointed);
             }
 
+            public FunctionPointerTypeSymbol Retarget(FunctionPointerTypeSymbol type)
+            {
+                var signature = type.Signature;
+                var newReturn = Retarget(signature.ReturnTypeWithAnnotations, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
+                var newRefModifiers = RetargetModifiers(signature.RefCustomModifiers, out bool symbolModified);
+                symbolModified = symbolModified || !signature.ReturnTypeWithAnnotations.IsSameAs(newReturn);
+
+                var newParameterTypes = ImmutableArray<TypeWithAnnotations>.Empty;
+                ImmutableArray<ImmutableArray<CustomModifier>> newParamModifiers = default;
+
+                var paramCount = signature.ParameterCount;
+                if (paramCount > 0)
+                {
+                    var newParameterTypesBuilder = ArrayBuilder<TypeWithAnnotations>.GetInstance(paramCount);
+                    var newParameterCustomModifiersBuilder = ArrayBuilder<ImmutableArray<CustomModifier>>.GetInstance(paramCount);
+                    bool parametersModified = false;
+
+                    foreach (var parameter in signature.Parameters)
+                    {
+                        var newParameterType = Retarget(parameter.TypeWithAnnotations, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
+                        var newModifiers = RetargetModifiers(parameter.RefCustomModifiers, out bool customModifiersChanged);
+                        newParameterTypesBuilder.Add(newParameterType);
+                        newParameterCustomModifiersBuilder.Add(newModifiers);
+                        parametersModified = parametersModified || !parameter.TypeWithAnnotations.IsSameAs(newParameterType) || customModifiersChanged;
+                    }
+
+                    if (parametersModified)
+                    {
+                        newParameterTypes = newParameterTypesBuilder.ToImmutableAndFree();
+                        newParamModifiers = newParameterCustomModifiersBuilder.ToImmutableAndFree();
+                        symbolModified = true;
+                    }
+                    else
+                    {
+                        newParameterTypesBuilder.Free();
+                        newParameterCustomModifiersBuilder.Free();
+                        newParameterTypes = signature.ParameterTypesWithAnnotations;
+                    }
+                }
+
+                if (symbolModified)
+                {
+                    return type.SubstituteTypeSymbol(newReturn, newParameterTypes, newRefModifiers, newParamModifiers);
+                }
+                else
+                {
+                    return type;
+                }
+            }
+
             public static ErrorTypeSymbol Retarget(ErrorTypeSymbol type)
             {
                 // TODO: if it is a missing symbol error but no longer missing in the target assembly, then we can resolve it here.
@@ -1254,6 +1304,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
 
             public override Symbol VisitPointerType(PointerTypeSymbol symbol, RetargetOptions options)
+            {
+                return Retarget(symbol);
+            }
+
+            public override Symbol VisitFunctionPointerType(FunctionPointerTypeSymbol symbol, RetargetOptions argument)
             {
                 return Retarget(symbol);
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomModifiers.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomModifiers.cs
@@ -202,11 +202,12 @@ public class Modifiers
             Assert.False(p1.HasExplicitDefaultValue, "Parameter has default value");
             Assert.Equal(0, p1.Ordinal);
 
-            //PointerTypeSymbol p1Type = (PointerTypeSymbol)p1.Type;
+            PointerTypeSymbol p1Type = (PointerTypeSymbol)p1.Type;
 
-            //Assert.Same(mscorlibAssembly, p1Type.ContainingAssembly);
-            //Assert.Equal(SpecialType.System_DateTime, p1Type.PointedAtType.SpecialType);
-            //Assert.Equal(0, p1Type.CustomModifiers.Count);
+            Assert.Null(p1Type.ContainingAssembly);
+            Assert.Same(mscorlibAssembly, p1Type.PointedAtType.ContainingAssembly);
+            Assert.Equal(SpecialType.System_DateTime, p1Type.PointedAtType.SpecialType);
+            Assert.Equal(0, p1.TypeWithAnnotations.CustomModifiers.Length);
         }
     }
 }


### PR DESCRIPTION
@AlekseyTs @dotnet/roslyn-compiler for review.