### PR TITLE
Use the same analyzer version in the Code Style layer as elsewhere

### DIFF
--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -10,6 +10,7 @@
     <GeneratePerformanceSensitiveAttribute>true</GeneratePerformanceSensitiveAttribute>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonFixedVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAutomaticBraceCompletion.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAutomaticBraceCompletion.cs
@@ -640,7 +640,8 @@ class C
 assertCaretPosition: true);
         }
 
-        [WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        [WpfTheory(Skip = "https://github.com/dotnet/roslyn/issues/43627")]
+        [CombinatorialData, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         [Trait(Traits.Feature, Traits.Features.CompleteStatement)]
         [WorkItem(18104, "https://github.com/dotnet/roslyn/issues/18104")]
         public void CompleteStatementTriggersCompletion(bool showCompletionInArgumentLists)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
@@ -47,7 +47,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.Editor.Verify.CurrentLineText("using$$", assertCaretPosition: true);
         }
 
-        [WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory(Skip = "https://github.com/dotnet/roslyn/issues/43627")]
+        [CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
         public void SpeculativeTInList(bool showCompletionInArgumentLists)
         {
             SetUpEditor(@"
@@ -104,7 +105,8 @@ public static class NavigateTo
             VisualStudio.Editor.Verify.CurrentLineText("NavigateTo.Search$$", assertCaretPosition: true);
         }
 
-        [WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory(Skip = "https://github.com/dotnet/roslyn/issues/43627")]
+        [CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
         public void CtrlAltSpace(bool showCompletionInArgumentLists)
         {
             VisualStudio.Workspace.SetTriggerCompletionInArgumentLists(showCompletionInArgumentLists);
@@ -154,7 +156,8 @@ public static class NavigateTo
             VisualStudio.Editor.Verify.CurrentLineText("System.Console.writeline();$$", assertCaretPosition: true);
         }
 
-        [WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory(Skip = "https://github.com/dotnet/roslyn/issues/43627")]
+        [CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
         public void CtrlAltSpaceOption(bool showCompletionInArgumentLists)
         {
             VisualStudio.Workspace.SetTriggerCompletionInArgumentLists(showCompletionInArgumentLists);


### PR DESCRIPTION
Improves build performance by allowing VBCSCompiler.exe to service all build requests for Roslyn.sln.