### PR TITLE
Update inline rename code following completion of TypeScript external access work

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
@@ -33,11 +34,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public Glyph Glyph => Glyph.None;
 
+            public ImmutableArray<DocumentSpan> DefinitionLocations => default;
+
             public string GetFinalSymbolName(string replacementText) => null;
 
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken) => default;
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken) => default;
 
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken) => null;
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken) => null;
 
             public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => null;
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Rename;
@@ -26,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         /// <summary>
         /// Represents information about the ability to rename a particular location.
         /// </summary>
-        private partial class SymbolInlineRenameInfo : IInlineRenameInfoWithFileRename
+        private partial class SymbolInlineRenameInfo : IInlineRenameInfo
         {
             private const string AttributeSuffix = "Attribute";
 
@@ -60,6 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 IEnumerable<IRefactorNotifyService> refactorNotifyServices,
                 Document document,
                 TextSpan triggerSpan,
+                string triggerText,
                 ISymbol renameSymbol,
                 bool forceRenameOverloads,
                 ImmutableArray<DocumentSpan> definitionLocations,
@@ -74,13 +74,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.HasOverloads = RenameLocations.GetOverloadedSymbols(this.RenameSymbol).Any();
                 this.ForceRenameOverloads = forceRenameOverloads;
 
-                _isRenamingAttributePrefix = CanRenameAttributePrefix(document, triggerSpan, cancellationToken);
-                this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), cancellationToken);
+                _isRenamingAttributePrefix = CanRenameAttributePrefix(document, triggerSpan, triggerText, cancellationToken);
+                this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), triggerText, cancellationToken);
 
                 this.DefinitionLocations = definitionLocations;
             }
 
-            private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
+            private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, string triggerText, CancellationToken cancellationToken)
             {
                 // if this isn't an attribute, or it doesn't have the 'Attribute' suffix, then clearly
                 // we can't rename just the attribute prefix.
@@ -94,7 +94,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // we need to rename the entire attribute).
                 var nameWithoutAttribute = GetWithoutAttributeSuffix(this.RenameSymbol.Name);
 
-                var triggerText = GetSpanText(document, triggerSpan, cancellationToken);
                 return triggerText.StartsWith(triggerText); // TODO: Always true? What was it supposed to do?
             }
 
@@ -111,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             ///     - Compiler-generated EventHandler suffix       XEventHandler => X
             ///     - Compiler-generated get_ and set_ prefixes    get_X => X
             /// </summary>
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
             {
                 var searchName = this.RenameSymbol.Name;
                 if (_isRenamingAttributePrefix)
@@ -121,9 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     searchName = GetWithoutAttributeSuffix(this.RenameSymbol.Name);
                 }
 
-                var spanText = GetSpanText(location.Document, location.TextSpan, cancellationToken);
-                var index = spanText.LastIndexOf(searchName, StringComparison.Ordinal);
-
+                var index = triggerText.LastIndexOf(searchName, StringComparison.Ordinal);
                 if (index < 0)
                 {
                     // Couldn't even find the search text at this reference location.  This might happen
@@ -135,16 +132,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return new TextSpan(location.TextSpan.Start + index, searchName.Length);
             }
 
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
             {
-                var spanText = GetSpanText(location.Document, location.TextSpan, cancellationToken);
-                var position = spanText.LastIndexOf(replacementText, StringComparison.Ordinal);
+                var position = triggerText.LastIndexOf(replacementText, StringComparison.Ordinal);
 
                 if (_isRenamingAttributePrefix)
                 {
                     // We're only renaming the attribute prefix part.  We want to adjust the span of 
                     // the reference we've found to only update the prefix portion.
-                    var index = spanText.LastIndexOf(replacementText + AttributeSuffix, StringComparison.Ordinal);
+                    var index = triggerText.LastIndexOf(replacementText + AttributeSuffix, StringComparison.Ordinal);
                     position = index >= 0 ? index : position;
                 }
 
@@ -161,15 +157,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             private bool HasAttributeSuffix(string value)
                 => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _document.GetLanguageService<ISyntaxFactsService>().IsCaseSensitive, result: out var _);
-
-            private static string GetSpanText(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
-            {
-                // TO-DO: Add new 'triggerText' parameter to the callers of this method via IVT so that we can get the text asynchronously instead.
-                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1080161
-                var sourceText = document.GetTextSynchronously(cancellationToken);
-                var triggerText = sourceText.ToString(triggerSpan);
-                return triggerText;
-            }
 
             internal bool IsRenamingAttributeTypeWithAttributeSuffix()
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         /// <summary>
         /// Represents information about the ability to rename a particular location.
         /// </summary>
-        private partial class SymbolInlineRenameInfo : IInlineRenameInfo
+        private partial class SymbolInlineRenameInfo : IInlineRenameInfoWithFileRename
         {
             private const string AttributeSuffix = "Attribute";
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
@@ -197,8 +197,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var triggerText = sourceText.ToString(triggerToken.Span);
+
             return new SymbolInlineRenameInfo(
-                refactorNotifyServices, document, triggerToken.Span,
+                refactorNotifyServices, document, triggerToken.Span, triggerText,
                 symbol, forceRenameOverloads, documentSpans.ToImmutableAndFree(), cancellationToken);
         }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
@@ -97,11 +97,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             static InlineRenameSessionInfo? IsReadOnlyOrCannotNavigateToSpan(IInlineRenameInfo renameInfo, Document document, CancellationToken cancellationToken)
             {
-                if (renameInfo is IInlineRenameInfoWithFileRename renameInfoWithFileRename)
+                if (renameInfo is IInlineRenameInfo inlineRenameInfo)
                 {
                     var workspace = document.Project.Solution.Workspace;
                     var navigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
-                    foreach (var documentSpan in renameInfoWithFileRename.DefinitionLocations)
+                    foreach (var documentSpan in inlineRenameInfo.DefinitionLocations)
                     {
                         var sourceText = documentSpan.Document.GetTextSynchronously(cancellationToken);
                         var textSnapshot = sourceText.FindCorrespondingEditorTextSnapshot();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
@@ -97,10 +97,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             static InlineRenameSessionInfo? IsReadOnlyOrCannotNavigateToSpan(IInlineRenameInfo renameInfo, Document document, CancellationToken cancellationToken)
             {
-                if (renameInfo is IInlineRenameInfo inlineRenameInfo)
+                if (renameInfo is IInlineRenameInfo inlineRenameInfo && inlineRenameInfo.DefinitionLocations != default)
                 {
                     var workspace = document.Project.Solution.Workspace;
                     var navigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
+
                     foreach (var documentSpan in inlineRenameInfo.DefinitionLocations)
                     {
                         var sourceText = documentSpan.Document.GetTextSynchronously(cancellationToken);

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -184,11 +184,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     _referenceSpanToLinkedRenameSpanMap.Clear();
                     foreach (var span in spans)
                     {
-                        var sourceText = _baseDocuments.First().GetTextSynchronously(CancellationToken.None);
-                        var triggerText = sourceText.ToString(span);
-
+                        var document = _baseDocuments.First();
                         var renameableSpan = _session._renameInfo.GetReferenceEditSpan(
-                            new InlineRenameLocation(_baseDocuments.First(), span), triggerText, CancellationToken.None);
+                            new InlineRenameLocation(document, span), GetTriggerText(document, span), CancellationToken.None);
                         var trackingSpan = new RenameTrackingSpan(
                                 _subjectBuffer.CurrentSnapshot.CreateTrackingSpan(renameableSpan.ToSpan(), SpanTrackingMode.EdgeInclusive, TrackingFidelityMode.Forward),
                                 RenameSpanKind.Reference);
@@ -209,6 +207,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
 
                 RaiseSpansChanged();
+            }
+
+            private static string GetTriggerText(Document document, TextSpan span)
+            {
+                var sourceText = document.GetTextSynchronously(CancellationToken.None);
+                return sourceText.ToString(span);
             }
 
             private void OnTextBufferChanged(object sender, TextContentChangedEventArgs args)
@@ -467,11 +471,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                             if (_referenceSpanToLinkedRenameSpanMap.ContainsKey(replacement.OriginalSpan) && kind != RenameSpanKind.Complexified)
                             {
-                                var sourceText = newDocument.GetTextSynchronously(cancellationToken);
-                                var triggerText = sourceText.ToString(replacement.NewSpan);
-
                                 var linkedRenameSpan = _session._renameInfo.GetConflictEditSpan(
-                                    new InlineRenameLocation(newDocument, replacement.NewSpan), triggerText,
+                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetTriggerText(newDocument, replacement.NewSpan),
                                     GetWithoutAttributeSuffix(_session.ReplacementText,
                                         document.GetLanguageService<LanguageServices.ISyntaxFactsService>().IsCaseSensitive), cancellationToken);
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -248,8 +248,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             this.UndoManager.CreateInitialState(this.ReplacementText, _triggerView.Selection, new SnapshotSpan(triggerSpan.Snapshot, startingSpan));
-            _openTextBuffers[triggerSpan.Snapshot.TextBuffer].SetReferenceSpans(
-                SpecializedCollections.SingletonEnumerable((startingSpan.ToTextSpan(), triggerSpan.GetText())));
+            _openTextBuffers[triggerSpan.Snapshot.TextBuffer].SetReferenceSpans(SpecializedCollections.SingletonEnumerable(startingSpan.ToTextSpan()));
 
             UpdateReferenceLocationsTask(ThreadingContext.JoinableTaskFactory.RunAsync(
                 () => _renameInfo.FindRenameLocationsAsync(_optionSet, _cancellationTokenSource.Token)));
@@ -445,16 +444,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 if (!documents.Any(d => locationsByDocument.Contains(d.Id)))
                 {
-                    _openTextBuffers[textBuffer].SetReferenceSpans(SpecializedCollections.EmptyEnumerable<(TextSpan, string)>());
+                    _openTextBuffers[textBuffer].SetReferenceSpans(SpecializedCollections.EmptyEnumerable<TextSpan>());
                 }
                 else
                 {
-                    IEnumerable<(TextSpan span, string text)> triggerSpansAndTexts =
-                        documents.SelectMany(d => locationsByDocument[d.Id]).Select(
-                        l => (l.TextSpan, l.Document.GetTextSynchronously(CancellationToken.None).ToString(l.TextSpan)));
-                    triggerSpansAndTexts = triggerSpansAndTexts.GroupBy(t => t.span).Select(t => t.First());
-
-                    _openTextBuffers[textBuffer].SetReferenceSpans(triggerSpansAndTexts);
+                    var spans = documents.SelectMany(d => locationsByDocument[d.Id]).Select(l => l.TextSpan).Distinct();
+                    _openTextBuffers[textBuffer].SetReferenceSpans(spans);
                 }
             }
 
@@ -814,7 +809,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
                 else
                 {
-                    var newText = newDocument.GetTextSynchronously(waitContext.CancellationToken);
+                    var newText = newDocument.GetTextAsync(waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
                     finalSolution = finalSolution.WithDocumentText(id, newText);
                 }
 

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             }
         }
 
-        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
+        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
         {
             return _info.GetConflictEditSpan(new VSTypeScriptInlineRenameLocationWrapper(
                 new InlineRenameLocation(location.Document, location.TextSpan)), replacementText, cancellationToken);
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public string GetFinalSymbolName(string replacementText)
             => _info.GetFinalSymbolName(replacementText);
 
-        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
+        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
         {
             return _info.GetReferenceEditSpan(new VSTypeScriptInlineRenameLocationWrapper(
                 new InlineRenameLocation(location.Document, location.TextSpan)), cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
@@ -194,6 +194,11 @@ namespace Microsoft.CodeAnalysis.Editor
         Glyph Glyph { get; }
 
         /// <summary>
+        /// The locations of the potential rename candidates for the symbol.
+        /// </summary>
+        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
+
+        /// <summary>
         /// Gets the final name of the symbol if the user has typed the provided replacement text
         /// in the editor.  Normally, the final name will be same as the replacement text.  However,
         /// that may not always be the same.  For example, when renaming an attribute the replacement
@@ -205,13 +210,13 @@ namespace Microsoft.CodeAnalysis.Editor
         /// Returns the actual span that should be edited in the buffer for a given rename reference
         /// location.
         /// </summary>
-        TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken);
+        TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the actual span that should be edited in the buffer for a given rename conflict
         /// location.
         /// </summary>
-        TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken);
+        TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determine the set of locations to rename given the provided options. May be called 
@@ -240,10 +245,6 @@ namespace Microsoft.CodeAnalysis.Editor
         /// an inline rename
         /// </summary>
         InlineRenameFileRenameInfo GetFileRenameInfo();
-
-        // TO-DO: Move property to IInlineRenameInfo once Typescript moves to the correct IVT layering
-        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1077984
-        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
     }
 
     /// <summary>

--- a/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorInlineRenameService.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
@@ -129,6 +129,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
         /// The glyph for the symbol being renamed, for use in displaying information to the user.
         /// </summary>
         FSharpGlyph Glyph { get; }
+
+        /// <summary>
+        /// The locations of the potential rename candidates for the symbol.
+        /// </summary>
+        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
 
         /// <summary>
         /// Gets the final name of the symbol if the user has typed the provided replacement text

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
@@ -130,6 +131,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 
         public Glyph Glyph => FSharpGlyphHelpers.ConvertTo(_info.Glyph);
 
+        public ImmutableArray<DocumentSpan> DefinitionLocations => _info.DefinitionLocations;
+
         public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken)
         {
             var set = await _info.FindRenameLocationsAsync(optionSet, cancellationToken).ConfigureAwait(false);
@@ -143,7 +146,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             }
         }
 
-        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
+        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
         {
             return _info.GetConflictEditSpan(new FSharpInlineRenameLocation(location.Document, location.TextSpan), replacementText, cancellationToken);
         }
@@ -153,7 +156,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             return _info.GetFinalSymbolName(replacementText);
         }
 
-        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
+        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
         {
             return _info.GetReferenceEditSpan(new FSharpInlineRenameLocation(location.Document, location.TextSpan), cancellationToken);
         }

--- a/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -31,6 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Rename
             public string DisplayName => null;
             public string FullDisplayName => null;
             public Glyph Glyph => Glyph.None;
+            public ImmutableArray<DocumentSpan> DefinitionLocations => default;
             public string GetFinalSymbolName(string replacementText) => null;
             public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken) => default;
             public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken) => null;

--- a/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
@@ -34,8 +34,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Rename
             public Glyph Glyph => Glyph.None;
             public ImmutableArray<DocumentSpan> DefinitionLocations => default;
             public string GetFinalSymbolName(string replacementText) => null;
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken) => default;
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken) => null;
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken) => default;
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken) => null;
             public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => null;
             public bool TryOnAfterGlobalSymbolRenamed(CodeAnalysis.Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;
             public bool TryOnBeforeGlobalSymbolRenamed(CodeAnalysis.Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;

--- a/src/VisualStudio/Xaml/Impl/Features/InlineRename/IXamlRenameInfo.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/InlineRename/IXamlRenameInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
@@ -41,6 +42,11 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
         /// The kind of symbol being renamed, for use in displaying information to the user.
         /// </summary>
         SymbolKind Kind { get; }
+
+        /// <summary>
+        /// The locations of the potential rename candidates for the symbol.
+        /// </summary>
+        ImmutableArray<CodeAnalysis.DocumentSpan> DefinitionLocations { get; }
 
         /// <summary>
         /// Find all locations to be renamed.

--- a/src/VisualStudio/Xaml/Impl/Features/InlineRename/XamlEditorInlineRenameService.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/InlineRename/XamlEditorInlineRenameService.cs
@@ -67,6 +67,8 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
 
             public TextSpan TriggerSpan => _renameInfo.TriggerSpan;
 
+            public ImmutableArray<CodeAnalysis.DocumentSpan> DefinitionLocations => _renameInfo.DefinitionLocations;
+
             public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken)
             {
                 var references = new List<InlineRenameLocation>();
@@ -84,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
                     references.ToImmutableArray());
             }
 
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
             {
                 return location.TextSpan;
             }
@@ -94,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
                 return replacementText;
             }
 
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
             {
                 return location.TextSpan;
             }


### PR DESCRIPTION
TypeScript recently [moved inline rename](https://devdiv.visualstudio.com/DevDiv/_git/TypeScript-VS/pullrequest/237752) to the external access API.
This PR is a follow-up that accomplishes the following:
1) Moves DefinitionLocations property from IInlineRenameInfoWithFileRename to IInlineRenameInfo: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1077984/
2) Adds a new parameter "triggerText" to GetConflictEditSpan() and GetReferenceEditSpan() so that we can do more work asynchronously: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1080161/