### PR TITLE
document that TaskMethodBuilder cannot be a nested type

### DIFF
--- a/docs/features/task-types.md
+++ b/docs/features/task-types.md
@@ -26,7 +26,7 @@ class Awaiter<T> : INotifyCompletion
 ```
 ## Builder Type
 The _builder type_ is a `class` or `struct` that corresponds to the specific _task type_.
-The _builder type_ must not be a nested type.
+The _builder type_ must not be nested in a generic type.
 The _builder type_ has the following `public` methods.
 For non-generic _builder types_, `SetResult()` has no parameters.
 ```cs

--- a/docs/features/task-types.md
+++ b/docs/features/task-types.md
@@ -26,7 +26,7 @@ class Awaiter<T> : INotifyCompletion
 ```
 ## Builder Type
 The _builder type_ is a `class` or `struct` that corresponds to the specific _task type_.
-The _builder type_ must not be nested in a generic type.
+The _builder type_ can have at most 1 type parameter and must not be nested in a generic type.
 The _builder type_ has the following `public` methods.
 For non-generic _builder types_, `SetResult()` has no parameters.
 ```cs

--- a/docs/features/task-types.md
+++ b/docs/features/task-types.md
@@ -26,6 +26,7 @@ class Awaiter<T> : INotifyCompletion
 ```
 ## Builder Type
 The _builder type_ is a `class` or `struct` that corresponds to the specific _task type_.
+The _builder type_ must not be a nested type.
 The _builder type_ has the following `public` methods.
 For non-generic _builder types_, `SetResult()` has no parameters.
 ```cs


### PR DESCRIPTION
The compiler gives you no help when you don't get the TaskMethodBuilder right, so it's really important all the conditions are well documented.