### PR TITLE
Add documentation remarks for derived syntax types

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -11,15 +11,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
     /// <summary>Provides the base class from which the classes that represent name syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
-    /// <item><description><see cref="SimpleNameSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <item><description><see cref="SimpleNameSyntax"/>
     /// <list type="bullet">
     /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
-    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
     /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
+    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
     /// <item><description><see cref="AliasQualifiedNameSyntax"/></description></item>
     /// </list>
     /// </remarks>
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent simple name syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
     /// <item><description><see cref="GenericNameSyntax"/></description></item>
@@ -294,17 +294,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent type syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
-    /// <item><description><see cref="NameSyntax"/></description></item>
-    /// <item><description><see cref="SimpleNameSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <item><description><see cref="NameSyntax"/>
+    /// <list type="bullet">
+    /// <item><description><see cref="SimpleNameSyntax"/>
     /// <list type="bullet">
     /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
-    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
     /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
+    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
     /// <item><description><see cref="AliasQualifiedNameSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="PredefinedTypeSyntax"/></description></item>
     /// <item><description><see cref="ArrayTypeSyntax"/></description></item>
     /// <item><description><see cref="PointerTypeSyntax"/></description></item>
@@ -715,22 +718,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent expression syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
-    /// <item><description><see cref="NameSyntax"/></description></item>
-    /// <item><description><see cref="SimpleNameSyntax"/></description></item>
-    /// <item><description><see cref="TypeSyntax"/></description></item>
-    /// <item><description><see cref="InstanceExpressionSyntax"/></description></item>
-    /// <item><description><see cref="AnonymousFunctionExpressionSyntax"/></description></item>
-    /// <item><description><see cref="LambdaExpressionSyntax"/></description></item>
-    /// <item><description><see cref="BaseObjectCreationExpressionSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <item><description><see cref="TypeSyntax"/>
+    /// <list type="bullet">
+    /// <item><description><see cref="NameSyntax"/>
+    /// <list type="bullet">
+    /// <item><description><see cref="SimpleNameSyntax"/>
     /// <list type="bullet">
     /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
-    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
     /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
+    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
     /// <item><description><see cref="AliasQualifiedNameSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="PredefinedTypeSyntax"/></description></item>
     /// <item><description><see cref="ArrayTypeSyntax"/></description></item>
     /// <item><description><see cref="PointerTypeSyntax"/></description></item>
@@ -738,6 +741,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// <item><description><see cref="TupleTypeSyntax"/></description></item>
     /// <item><description><see cref="OmittedTypeArgumentSyntax"/></description></item>
     /// <item><description><see cref="RefTypeSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="ParenthesizedExpressionSyntax"/></description></item>
     /// <item><description><see cref="TupleExpressionSyntax"/></description></item>
     /// <item><description><see cref="PrefixUnaryExpressionSyntax"/></description></item>
@@ -752,8 +757,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// <item><description><see cref="BinaryExpressionSyntax"/></description></item>
     /// <item><description><see cref="AssignmentExpressionSyntax"/></description></item>
     /// <item><description><see cref="ConditionalExpressionSyntax"/></description></item>
+    /// <item><description><see cref="InstanceExpressionSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="ThisExpressionSyntax"/></description></item>
     /// <item><description><see cref="BaseExpressionSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="LiteralExpressionSyntax"/></description></item>
     /// <item><description><see cref="MakeRefExpressionSyntax"/></description></item>
     /// <item><description><see cref="RefTypeExpressionSyntax"/></description></item>
@@ -766,13 +775,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// <item><description><see cref="ElementAccessExpressionSyntax"/></description></item>
     /// <item><description><see cref="DeclarationExpressionSyntax"/></description></item>
     /// <item><description><see cref="CastExpressionSyntax"/></description></item>
+    /// <item><description><see cref="AnonymousFunctionExpressionSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="AnonymousMethodExpressionSyntax"/></description></item>
+    /// <item><description><see cref="LambdaExpressionSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="SimpleLambdaExpressionSyntax"/></description></item>
-    /// <item><description><see cref="RefExpressionSyntax"/></description></item>
     /// <item><description><see cref="ParenthesizedLambdaExpressionSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
+    /// </list>
+    /// </description></item>
+    /// <item><description><see cref="RefExpressionSyntax"/></description></item>
     /// <item><description><see cref="InitializerExpressionSyntax"/></description></item>
+    /// <item><description><see cref="BaseObjectCreationExpressionSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="ImplicitObjectCreationExpressionSyntax"/></description></item>
     /// <item><description><see cref="ObjectCreationExpressionSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="AnonymousObjectCreationExpressionSyntax"/></description></item>
     /// <item><description><see cref="ArrayCreationExpressionSyntax"/></description></item>
     /// <item><description><see cref="ImplicitArrayCreationExpressionSyntax"/></description></item>
@@ -1468,7 +1489,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent instance expression syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ThisExpressionSyntax"/></description></item>
     /// <item><description><see cref="BaseExpressionSyntax"/></description></item>
@@ -2041,7 +2062,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent argument list syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ArgumentListSyntax"/></description></item>
     /// <item><description><see cref="BracketedArgumentListSyntax"/></description></item>
@@ -2386,15 +2407,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent anonymous function expressions are derived.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
-    /// <list type="bullet">
-    /// <item><description><see cref="LambdaExpressionSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="AnonymousMethodExpressionSyntax"/></description></item>
+    /// <item><description><see cref="LambdaExpressionSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="SimpleLambdaExpressionSyntax"/></description></item>
     /// <item><description><see cref="ParenthesizedLambdaExpressionSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// </list>
     /// </remarks>
     public abstract partial class AnonymousFunctionExpressionSyntax : ExpressionSyntax
@@ -2527,7 +2548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent lambda expressions are derived.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="SimpleLambdaExpressionSyntax"/></description></item>
     /// <item><description><see cref="ParenthesizedLambdaExpressionSyntax"/></description></item>
@@ -2840,7 +2861,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ImplicitObjectCreationExpressionSyntax"/></description></item>
     /// <item><description><see cref="ObjectCreationExpressionSyntax"/></description></item>
@@ -3339,7 +3360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="FromClauseSyntax"/></description></item>
     /// <item><description><see cref="LetClauseSyntax"/></description></item>
@@ -3357,7 +3378,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="SelectClauseSyntax"/></description></item>
     /// <item><description><see cref="GroupClauseSyntax"/></description></item>
@@ -4161,7 +4182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="DiscardPatternSyntax"/></description></item>
     /// <item><description><see cref="DeclarationPatternSyntax"/></description></item>
@@ -4546,7 +4567,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="InterpolatedStringTextSyntax"/></description></item>
     /// <item><description><see cref="InterpolationSyntax"/></description></item>
@@ -4792,11 +4813,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Represents the base class for all statements syntax classes.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
-    /// <list type="bullet">
-    /// <item><description><see cref="CommonForEachStatementSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="BlockSyntax"/></description></item>
     /// <item><description><see cref="LocalFunctionStatementSyntax"/></description></item>
@@ -4813,8 +4830,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// <item><description><see cref="WhileStatementSyntax"/></description></item>
     /// <item><description><see cref="DoStatementSyntax"/></description></item>
     /// <item><description><see cref="ForStatementSyntax"/></description></item>
+    /// <item><description><see cref="CommonForEachStatementSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="ForEachStatementSyntax"/></description></item>
     /// <item><description><see cref="ForEachVariableStatementSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="UsingStatementSyntax"/></description></item>
     /// <item><description><see cref="FixedStatementSyntax"/></description></item>
     /// <item><description><see cref="CheckedStatementSyntax"/></description></item>
@@ -5269,7 +5290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="SingleVariableDesignationSyntax"/></description></item>
     /// <item><description><see cref="DiscardDesignationSyntax"/></description></item>
@@ -6153,7 +6174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ForEachStatementSyntax"/></description></item>
     /// <item><description><see cref="ForEachVariableStatementSyntax"/></description></item>
@@ -7041,7 +7062,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Represents a switch label within a switch statement.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="CasePatternSwitchLabelSyntax"/></description></item>
     /// <item><description><see cref="CaseSwitchLabelSyntax"/></description></item>
@@ -7787,34 +7808,46 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Member declaration syntax.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
-    /// <list type="bullet">
-    /// <item><description><see cref="BaseTypeDeclarationSyntax"/></description></item>
-    /// <item><description><see cref="TypeDeclarationSyntax"/></description></item>
-    /// <item><description><see cref="BaseFieldDeclarationSyntax"/></description></item>
-    /// <item><description><see cref="BaseMethodDeclarationSyntax"/></description></item>
-    /// <item><description><see cref="BasePropertyDeclarationSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="GlobalStatementSyntax"/></description></item>
     /// <item><description><see cref="NamespaceDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="BaseTypeDeclarationSyntax"/>
+    /// <list type="bullet">
+    /// <item><description><see cref="TypeDeclarationSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="ClassDeclarationSyntax"/></description></item>
     /// <item><description><see cref="StructDeclarationSyntax"/></description></item>
     /// <item><description><see cref="InterfaceDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="EnumDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="DelegateDeclarationSyntax"/></description></item>
     /// <item><description><see cref="EnumMemberDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="BaseFieldDeclarationSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="FieldDeclarationSyntax"/></description></item>
     /// <item><description><see cref="EventFieldDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
+    /// <item><description><see cref="BaseMethodDeclarationSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="MethodDeclarationSyntax"/></description></item>
     /// <item><description><see cref="OperatorDeclarationSyntax"/></description></item>
     /// <item><description><see cref="ConversionOperatorDeclarationSyntax"/></description></item>
     /// <item><description><see cref="ConstructorDeclarationSyntax"/></description></item>
     /// <item><description><see cref="DestructorDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
+    /// <item><description><see cref="BasePropertyDeclarationSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="PropertyDeclarationSyntax"/></description></item>
     /// <item><description><see cref="EventDeclarationSyntax"/></description></item>
     /// <item><description><see cref="IndexerDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="IncompleteMemberSyntax"/></description></item>
     /// </list>
     /// </remarks>
@@ -8364,15 +8397,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Base class for type declaration syntax.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
-    /// <item><description><see cref="TypeDeclarationSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <item><description><see cref="TypeDeclarationSyntax"/>
     /// <list type="bullet">
     /// <item><description><see cref="ClassDeclarationSyntax"/></description></item>
     /// <item><description><see cref="StructDeclarationSyntax"/></description></item>
     /// <item><description><see cref="InterfaceDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="EnumDeclarationSyntax"/></description></item>
     /// </list>
     /// </remarks>
@@ -8421,7 +8454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Base class for type declaration syntax (class, struct, interface).</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ClassDeclarationSyntax"/></description></item>
     /// <item><description><see cref="StructDeclarationSyntax"/></description></item>
@@ -9215,7 +9248,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Provides the base class from which the classes that represent base type syntax nodes are derived. This is an abstract class.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="SimpleBaseTypeSyntax"/></description></item>
     /// </list>
@@ -9336,7 +9369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Base type for type parameter constraint syntax.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ConstructorConstraintSyntax"/></description></item>
     /// <item><description><see cref="ClassOrStructConstraintSyntax"/></description></item>
@@ -9472,7 +9505,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="FieldDeclarationSyntax"/></description></item>
     /// <item><description><see cref="EventFieldDeclarationSyntax"/></description></item>
@@ -9691,7 +9724,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Base type for method declaration syntax.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="MethodDeclarationSyntax"/></description></item>
     /// <item><description><see cref="OperatorDeclarationSyntax"/></description></item>
@@ -10412,7 +10445,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Base type for property declaration syntax.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="PropertyDeclarationSyntax"/></description></item>
     /// <item><description><see cref="EventDeclarationSyntax"/></description></item>
@@ -10959,7 +10992,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>Base type for parameter list syntax.</summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="ParameterListSyntax"/></description></item>
     /// <item><description><see cref="BracketedParameterListSyntax"/></description></item>
@@ -11311,18 +11344,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// For example, the M in &lt;see cref="M" /&gt;.
     /// </summary>
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
-    /// <list type="bullet">
-    /// <item><description><see cref="MemberCrefSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="TypeCrefSyntax"/></description></item>
     /// <item><description><see cref="QualifiedCrefSyntax"/></description></item>
+    /// <item><description><see cref="MemberCrefSyntax"/>
+    /// <list type="bullet">
     /// <item><description><see cref="NameMemberCrefSyntax"/></description></item>
     /// <item><description><see cref="IndexerMemberCrefSyntax"/></description></item>
     /// <item><description><see cref="OperatorMemberCrefSyntax"/></description></item>
     /// <item><description><see cref="ConversionOperatorMemberCrefSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// </list>
     /// </remarks>
     public abstract partial class CrefSyntax : CSharpSyntaxNode
@@ -11440,7 +11473,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// might be a non-type member.
     /// </summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="NameMemberCrefSyntax"/></description></item>
     /// <item><description><see cref="IndexerMemberCrefSyntax"/></description></item>
@@ -11684,7 +11717,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// Unlike regular parameters, cref parameters do not have names.
     /// </summary>
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="CrefParameterListSyntax"/></description></item>
     /// <item><description><see cref="CrefBracketedParameterListSyntax"/></description></item>
@@ -11865,7 +11898,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="XmlElementSyntax"/></description></item>
     /// <item><description><see cref="XmlEmptyElementSyntax"/></description></item>
@@ -12165,7 +12198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="XmlTextAttributeSyntax"/></description></item>
     /// <item><description><see cref="XmlCrefAttributeSyntax"/></description></item>
@@ -12562,16 +12595,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
-    /// <item><description><see cref="BranchingDirectiveTriviaSyntax"/></description></item>
-    /// <item><description><see cref="ConditionalDirectiveTriviaSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <item><description><see cref="BranchingDirectiveTriviaSyntax"/>
+    /// <list type="bullet">
+    /// <item><description><see cref="ConditionalDirectiveTriviaSyntax"/>
     /// <list type="bullet">
     /// <item><description><see cref="IfDirectiveTriviaSyntax"/></description></item>
     /// <item><description><see cref="ElifDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="ElseDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="EndIfDirectiveTriviaSyntax"/></description></item>
     /// <item><description><see cref="RegionDirectiveTriviaSyntax"/></description></item>
     /// <item><description><see cref="EndRegionDirectiveTriviaSyntax"/></description></item>
@@ -12608,14 +12644,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
-    /// <item><description><see cref="ConditionalDirectiveTriviaSyntax"/></description></item>
-    /// </list>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <item><description><see cref="ConditionalDirectiveTriviaSyntax"/>
     /// <list type="bullet">
     /// <item><description><see cref="IfDirectiveTriviaSyntax"/></description></item>
     /// <item><description><see cref="ElifDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// </description></item>
     /// <item><description><see cref="ElseDirectiveTriviaSyntax"/></description></item>
     /// </list>
     /// </remarks>
@@ -12633,7 +12669,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <remarks>
-    /// <para>This node is associated with the following syntax nodes:</para>
+    /// This node has the following derived hierarchy:
     /// <list type="bullet">
     /// <item><description><see cref="IfDirectiveTriviaSyntax"/></description></item>
     /// <item><description><see cref="ElifDirectiveTriviaSyntax"/></description></item>

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -10,6 +10,19 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
     /// <summary>Provides the base class from which the classes that represent name syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SimpleNameSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
+    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
+    /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// <item><description><see cref="AliasQualifiedNameSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class NameSyntax : TypeSyntax
     {
         internal NameSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -19,6 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent simple name syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
+    /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class SimpleNameSyntax : NameSyntax
     {
         internal SimpleNameSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -273,6 +293,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent type syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="NameSyntax"/></description></item>
+    /// <item><description><see cref="SimpleNameSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
+    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
+    /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// <item><description><see cref="AliasQualifiedNameSyntax"/></description></item>
+    /// <item><description><see cref="PredefinedTypeSyntax"/></description></item>
+    /// <item><description><see cref="ArrayTypeSyntax"/></description></item>
+    /// <item><description><see cref="PointerTypeSyntax"/></description></item>
+    /// <item><description><see cref="NullableTypeSyntax"/></description></item>
+    /// <item><description><see cref="TupleTypeSyntax"/></description></item>
+    /// <item><description><see cref="OmittedTypeArgumentSyntax"/></description></item>
+    /// <item><description><see cref="RefTypeSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class TypeSyntax : ExpressionSyntax
     {
         internal TypeSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -673,6 +714,78 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent expression syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="NameSyntax"/></description></item>
+    /// <item><description><see cref="SimpleNameSyntax"/></description></item>
+    /// <item><description><see cref="TypeSyntax"/></description></item>
+    /// <item><description><see cref="InstanceExpressionSyntax"/></description></item>
+    /// <item><description><see cref="AnonymousFunctionExpressionSyntax"/></description></item>
+    /// <item><description><see cref="LambdaExpressionSyntax"/></description></item>
+    /// <item><description><see cref="BaseObjectCreationExpressionSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IdentifierNameSyntax"/></description></item>
+    /// <item><description><see cref="QualifiedNameSyntax"/></description></item>
+    /// <item><description><see cref="GenericNameSyntax"/></description></item>
+    /// <item><description><see cref="AliasQualifiedNameSyntax"/></description></item>
+    /// <item><description><see cref="PredefinedTypeSyntax"/></description></item>
+    /// <item><description><see cref="ArrayTypeSyntax"/></description></item>
+    /// <item><description><see cref="PointerTypeSyntax"/></description></item>
+    /// <item><description><see cref="NullableTypeSyntax"/></description></item>
+    /// <item><description><see cref="TupleTypeSyntax"/></description></item>
+    /// <item><description><see cref="OmittedTypeArgumentSyntax"/></description></item>
+    /// <item><description><see cref="RefTypeSyntax"/></description></item>
+    /// <item><description><see cref="ParenthesizedExpressionSyntax"/></description></item>
+    /// <item><description><see cref="TupleExpressionSyntax"/></description></item>
+    /// <item><description><see cref="PrefixUnaryExpressionSyntax"/></description></item>
+    /// <item><description><see cref="AwaitExpressionSyntax"/></description></item>
+    /// <item><description><see cref="PostfixUnaryExpressionSyntax"/></description></item>
+    /// <item><description><see cref="MemberAccessExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ConditionalAccessExpressionSyntax"/></description></item>
+    /// <item><description><see cref="MemberBindingExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ElementBindingExpressionSyntax"/></description></item>
+    /// <item><description><see cref="RangeExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ImplicitElementAccessSyntax"/></description></item>
+    /// <item><description><see cref="BinaryExpressionSyntax"/></description></item>
+    /// <item><description><see cref="AssignmentExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ConditionalExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ThisExpressionSyntax"/></description></item>
+    /// <item><description><see cref="BaseExpressionSyntax"/></description></item>
+    /// <item><description><see cref="LiteralExpressionSyntax"/></description></item>
+    /// <item><description><see cref="MakeRefExpressionSyntax"/></description></item>
+    /// <item><description><see cref="RefTypeExpressionSyntax"/></description></item>
+    /// <item><description><see cref="RefValueExpressionSyntax"/></description></item>
+    /// <item><description><see cref="CheckedExpressionSyntax"/></description></item>
+    /// <item><description><see cref="DefaultExpressionSyntax"/></description></item>
+    /// <item><description><see cref="TypeOfExpressionSyntax"/></description></item>
+    /// <item><description><see cref="SizeOfExpressionSyntax"/></description></item>
+    /// <item><description><see cref="InvocationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ElementAccessExpressionSyntax"/></description></item>
+    /// <item><description><see cref="DeclarationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="CastExpressionSyntax"/></description></item>
+    /// <item><description><see cref="AnonymousMethodExpressionSyntax"/></description></item>
+    /// <item><description><see cref="SimpleLambdaExpressionSyntax"/></description></item>
+    /// <item><description><see cref="RefExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ParenthesizedLambdaExpressionSyntax"/></description></item>
+    /// <item><description><see cref="InitializerExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ImplicitObjectCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ObjectCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="AnonymousObjectCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ArrayCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ImplicitArrayCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="StackAllocArrayCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ImplicitStackAllocArrayCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="QueryExpressionSyntax"/></description></item>
+    /// <item><description><see cref="OmittedArraySizeExpressionSyntax"/></description></item>
+    /// <item><description><see cref="InterpolatedStringExpressionSyntax"/></description></item>
+    /// <item><description><see cref="IsPatternExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ThrowExpressionSyntax"/></description></item>
+    /// <item><description><see cref="SwitchExpressionSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class ExpressionSyntax : CSharpSyntaxNode
     {
         internal ExpressionSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -1354,6 +1467,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent instance expression syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ThisExpressionSyntax"/></description></item>
+    /// <item><description><see cref="BaseExpressionSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class InstanceExpressionSyntax : ExpressionSyntax
     {
         internal InstanceExpressionSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -1920,6 +2040,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent argument list syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ArgumentListSyntax"/></description></item>
+    /// <item><description><see cref="BracketedArgumentListSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseArgumentListSyntax : CSharpSyntaxNode
     {
         internal BaseArgumentListSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -2258,6 +2385,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent anonymous function expressions are derived.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="LambdaExpressionSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="AnonymousMethodExpressionSyntax"/></description></item>
+    /// <item><description><see cref="SimpleLambdaExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ParenthesizedLambdaExpressionSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class AnonymousFunctionExpressionSyntax : ExpressionSyntax
     {
         internal AnonymousFunctionExpressionSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -2387,6 +2526,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent lambda expressions are derived.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SimpleLambdaExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ParenthesizedLambdaExpressionSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class LambdaExpressionSyntax : AnonymousFunctionExpressionSyntax
     {
         internal LambdaExpressionSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -2693,6 +2839,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public InitializerExpressionSyntax AddExpressions(params ExpressionSyntax[] items) => WithExpressions(this.Expressions.AddRange(items));
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ImplicitObjectCreationExpressionSyntax"/></description></item>
+    /// <item><description><see cref="ObjectCreationExpressionSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseObjectCreationExpressionSyntax : ExpressionSyntax
     {
         internal BaseObjectCreationExpressionSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -3185,6 +3338,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public ImplicitStackAllocArrayCreationExpressionSyntax AddInitializerExpressions(params ExpressionSyntax[] items) => WithInitializer(this.Initializer.WithExpressions(this.Initializer.Expressions.AddRange(items)));
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="FromClauseSyntax"/></description></item>
+    /// <item><description><see cref="LetClauseSyntax"/></description></item>
+    /// <item><description><see cref="JoinClauseSyntax"/></description></item>
+    /// <item><description><see cref="WhereClauseSyntax"/></description></item>
+    /// <item><description><see cref="OrderByClauseSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class QueryClauseSyntax : CSharpSyntaxNode
     {
         internal QueryClauseSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -3193,6 +3356,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         }
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SelectClauseSyntax"/></description></item>
+    /// <item><description><see cref="GroupClauseSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class SelectOrGroupClauseSyntax : CSharpSyntaxNode
     {
         internal SelectOrGroupClauseSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -3990,6 +4160,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public WhenClauseSyntax WithCondition(ExpressionSyntax condition) => Update(this.WhenKeyword, condition);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="DiscardPatternSyntax"/></description></item>
+    /// <item><description><see cref="DeclarationPatternSyntax"/></description></item>
+    /// <item><description><see cref="VarPatternSyntax"/></description></item>
+    /// <item><description><see cref="RecursivePatternSyntax"/></description></item>
+    /// <item><description><see cref="ConstantPatternSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class PatternSyntax : CSharpSyntaxNode
     {
         internal PatternSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -4365,6 +4545,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public ConstantPatternSyntax WithExpression(ExpressionSyntax expression) => Update(expression);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="InterpolatedStringTextSyntax"/></description></item>
+    /// <item><description><see cref="InterpolationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class InterpolatedStringContentSyntax : CSharpSyntaxNode
     {
         internal InterpolatedStringContentSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -4604,6 +4791,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Represents the base class for all statements syntax classes.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="CommonForEachStatementSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="BlockSyntax"/></description></item>
+    /// <item><description><see cref="LocalFunctionStatementSyntax"/></description></item>
+    /// <item><description><see cref="LocalDeclarationStatementSyntax"/></description></item>
+    /// <item><description><see cref="ExpressionStatementSyntax"/></description></item>
+    /// <item><description><see cref="EmptyStatementSyntax"/></description></item>
+    /// <item><description><see cref="LabeledStatementSyntax"/></description></item>
+    /// <item><description><see cref="GotoStatementSyntax"/></description></item>
+    /// <item><description><see cref="BreakStatementSyntax"/></description></item>
+    /// <item><description><see cref="ContinueStatementSyntax"/></description></item>
+    /// <item><description><see cref="ReturnStatementSyntax"/></description></item>
+    /// <item><description><see cref="ThrowStatementSyntax"/></description></item>
+    /// <item><description><see cref="YieldStatementSyntax"/></description></item>
+    /// <item><description><see cref="WhileStatementSyntax"/></description></item>
+    /// <item><description><see cref="DoStatementSyntax"/></description></item>
+    /// <item><description><see cref="ForStatementSyntax"/></description></item>
+    /// <item><description><see cref="ForEachStatementSyntax"/></description></item>
+    /// <item><description><see cref="ForEachVariableStatementSyntax"/></description></item>
+    /// <item><description><see cref="UsingStatementSyntax"/></description></item>
+    /// <item><description><see cref="FixedStatementSyntax"/></description></item>
+    /// <item><description><see cref="CheckedStatementSyntax"/></description></item>
+    /// <item><description><see cref="UnsafeStatementSyntax"/></description></item>
+    /// <item><description><see cref="LockStatementSyntax"/></description></item>
+    /// <item><description><see cref="IfStatementSyntax"/></description></item>
+    /// <item><description><see cref="SwitchStatementSyntax"/></description></item>
+    /// <item><description><see cref="TryStatementSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class StatementSyntax : CSharpSyntaxNode
     {
         internal StatementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -5047,6 +5268,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public EqualsValueClauseSyntax WithValue(ExpressionSyntax value) => Update(this.EqualsToken, value);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SingleVariableDesignationSyntax"/></description></item>
+    /// <item><description><see cref="DiscardDesignationSyntax"/></description></item>
+    /// <item><description><see cref="ParenthesizedVariableDesignationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class VariableDesignationSyntax : CSharpSyntaxNode
     {
         internal VariableDesignationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -5923,6 +6152,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public ForStatementSyntax AddIncrementors(params ExpressionSyntax[] items) => WithIncrementors(this.Incrementors.AddRange(items));
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ForEachStatementSyntax"/></description></item>
+    /// <item><description><see cref="ForEachVariableStatementSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class CommonForEachStatementSyntax : StatementSyntax
     {
         internal CommonForEachStatementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -6804,6 +7040,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Represents a switch label within a switch statement.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="CasePatternSwitchLabelSyntax"/></description></item>
+    /// <item><description><see cref="CaseSwitchLabelSyntax"/></description></item>
+    /// <item><description><see cref="DefaultSwitchLabelSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class SwitchLabelSyntax : CSharpSyntaxNode
     {
         internal SwitchLabelSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -7542,6 +7786,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Member declaration syntax.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="BaseTypeDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="TypeDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="BaseFieldDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="BaseMethodDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="BasePropertyDeclarationSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="GlobalStatementSyntax"/></description></item>
+    /// <item><description><see cref="NamespaceDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="ClassDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="StructDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="InterfaceDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EnumDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="DelegateDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EnumMemberDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="FieldDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EventFieldDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="MethodDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="OperatorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="ConversionOperatorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="ConstructorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="DestructorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="PropertyDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EventDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="IndexerDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="IncompleteMemberSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class MemberDeclarationSyntax : CSharpSyntaxNode
     {
         internal MemberDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -8087,6 +8363,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Base class for type declaration syntax.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="TypeDeclarationSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ClassDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="StructDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="InterfaceDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EnumDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseTypeDeclarationSyntax : MemberDeclarationSyntax
     {
         internal BaseTypeDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -8131,6 +8420,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Base class for type declaration syntax (class, struct, interface).</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ClassDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="StructDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="InterfaceDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class TypeDeclarationSyntax : BaseTypeDeclarationSyntax
     {
         internal TypeDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -8917,6 +9214,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Provides the base class from which the classes that represent base type syntax nodes are derived. This is an abstract class.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SimpleBaseTypeSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseTypeSyntax : CSharpSyntaxNode
     {
         internal BaseTypeSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -9032,6 +9335,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Base type for type parameter constraint syntax.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ConstructorConstraintSyntax"/></description></item>
+    /// <item><description><see cref="ClassOrStructConstraintSyntax"/></description></item>
+    /// <item><description><see cref="TypeConstraintSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class TypeParameterConstraintSyntax : CSharpSyntaxNode
     {
         internal TypeParameterConstraintSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -9160,6 +9471,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public TypeConstraintSyntax WithType(TypeSyntax type) => Update(type);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="FieldDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EventFieldDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseFieldDeclarationSyntax : MemberDeclarationSyntax
     {
         internal BaseFieldDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -9372,6 +9690,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Base type for method declaration syntax.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="MethodDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="OperatorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="ConversionOperatorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="ConstructorDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="DestructorDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseMethodDeclarationSyntax : MemberDeclarationSyntax
     {
         internal BaseMethodDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -10083,6 +10411,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Base type for property declaration syntax.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="PropertyDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="EventDeclarationSyntax"/></description></item>
+    /// <item><description><see cref="IndexerDeclarationSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BasePropertyDeclarationSyntax : MemberDeclarationSyntax
     {
         internal BasePropertyDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -10622,6 +10958,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
 
     /// <summary>Base type for parameter list syntax.</summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ParameterListSyntax"/></description></item>
+    /// <item><description><see cref="BracketedParameterListSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseParameterListSyntax : CSharpSyntaxNode
     {
         internal BaseParameterListSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -10967,6 +11310,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// A symbol referenced by a cref attribute (e.g. in a &lt;see&gt; or &lt;seealso&gt; documentation comment tag).
     /// For example, the M in &lt;see cref="M" /&gt;.
     /// </summary>
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="MemberCrefSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="TypeCrefSyntax"/></description></item>
+    /// <item><description><see cref="QualifiedCrefSyntax"/></description></item>
+    /// <item><description><see cref="NameMemberCrefSyntax"/></description></item>
+    /// <item><description><see cref="IndexerMemberCrefSyntax"/></description></item>
+    /// <item><description><see cref="OperatorMemberCrefSyntax"/></description></item>
+    /// <item><description><see cref="ConversionOperatorMemberCrefSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class CrefSyntax : CSharpSyntaxNode
     {
         internal CrefSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -11081,6 +11439,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// will always be bound as type, so it's safer to use QualifiedCrefSyntax or MemberCrefSyntax if the symbol
     /// might be a non-type member.
     /// </summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="NameMemberCrefSyntax"/></description></item>
+    /// <item><description><see cref="IndexerMemberCrefSyntax"/></description></item>
+    /// <item><description><see cref="OperatorMemberCrefSyntax"/></description></item>
+    /// <item><description><see cref="ConversionOperatorMemberCrefSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class MemberCrefSyntax : CrefSyntax
     {
         internal MemberCrefSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -11316,6 +11683,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// A list of cref parameters with surrounding punctuation.
     /// Unlike regular parameters, cref parameters do not have names.
     /// </summary>
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="CrefParameterListSyntax"/></description></item>
+    /// <item><description><see cref="CrefBracketedParameterListSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BaseCrefParameterListSyntax : CSharpSyntaxNode
     {
         internal BaseCrefParameterListSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -11490,6 +11864,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public CrefParameterSyntax WithType(TypeSyntax type) => Update(this.RefKindKeyword, type);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="XmlElementSyntax"/></description></item>
+    /// <item><description><see cref="XmlEmptyElementSyntax"/></description></item>
+    /// <item><description><see cref="XmlTextSyntax"/></description></item>
+    /// <item><description><see cref="XmlCDataSectionSyntax"/></description></item>
+    /// <item><description><see cref="XmlProcessingInstructionSyntax"/></description></item>
+    /// <item><description><see cref="XmlCommentSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class XmlNodeSyntax : CSharpSyntaxNode
     {
         internal XmlNodeSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -11779,6 +12164,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public XmlPrefixSyntax WithColonToken(SyntaxToken colonToken) => Update(this.Prefix, colonToken);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="XmlTextAttributeSyntax"/></description></item>
+    /// <item><description><see cref="XmlCrefAttributeSyntax"/></description></item>
+    /// <item><description><see cref="XmlNameAttributeSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class XmlAttributeSyntax : CSharpSyntaxNode
     {
         internal XmlAttributeSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -12168,6 +12561,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public XmlCommentSyntax AddTextTokens(params SyntaxToken[] items) => WithTextTokens(this.TextTokens.AddRange(items));
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="BranchingDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ConditionalDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IfDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ElifDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ElseDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="EndIfDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="RegionDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="EndRegionDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ErrorDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="WarningDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="BadDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="DefineDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="UndefDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="LineDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="PragmaWarningDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="PragmaChecksumDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ReferenceDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="LoadDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ShebangDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="NullableDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class DirectiveTriviaSyntax : StructuredTriviaSyntax
     {
         internal DirectiveTriviaSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -12186,6 +12607,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public abstract bool IsActive { get; }
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following abstract syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ConditionalDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IfDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ElifDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ElseDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class BranchingDirectiveTriviaSyntax : DirectiveTriviaSyntax
     {
         internal BranchingDirectiveTriviaSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -12199,6 +12632,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public new BranchingDirectiveTriviaSyntax WithEndOfDirectiveToken(SyntaxToken endOfDirectiveToken) => (BranchingDirectiveTriviaSyntax)WithEndOfDirectiveTokenCore(endOfDirectiveToken);
     }
 
+    /// <remarks>
+    /// <para>This node is associated with the following syntax nodes:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IfDirectiveTriviaSyntax"/></description></item>
+    /// <item><description><see cref="ElifDirectiveTriviaSyntax"/></description></item>
+    /// </list>
+    /// </remarks>
     public abstract partial class ConditionalDirectiveTriviaSyntax : BranchingDirectiveTriviaSyntax
     {
         internal ConditionalDirectiveTriviaSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -808,26 +808,32 @@ namespace CSharpSyntaxGenerator
                 var nd = (AbstractNode)node;
                 WriteComment($"<remarks>");
 
-                var descendantAbstractNodes = GetDescendantAbstractNodes(nd).Where(d => d != nd).ToList();
-                if (descendantAbstractNodes.Any())
-                {
-                    WriteComment($"<para>This node is associated with the following abstract syntax nodes:</para>");
-                    WriteComment($"<list type=\"bullet\">");
-
-                    foreach (var descendant in descendantAbstractNodes)
-                    {
-                        WriteComment($"<item><description><see cref=\"{descendant.Name}\"/></description></item>");
-                    }
-
-                    WriteComment($"</list>");
-                }
-
-                WriteComment($"<para>This node is associated with the following syntax nodes:</para>");
+                WriteComment($"This node has the following derived hierarchy:");
                 WriteComment($"<list type=\"bullet\">");
 
-                foreach (var descendant in GetDescendantNodes(nd))
+                void writeTypeHierarchy(TreeType node)
                 {
-                    WriteComment($"<item><description><see cref=\"{descendant.Name}\"/></description></item>");
+                    if (node is AbstractNode abstractNode)
+                    {
+                        WriteComment($"<item><description><see cref=\"{node.Name}\"/>");
+                        WriteComment($"<list type=\"bullet\">");
+                        foreach (var derived in GetImmediatelyDerivedNodes(abstractNode))
+                        {
+                            writeTypeHierarchy(derived);
+                        }
+
+                        WriteComment($"</list>");
+                        WriteComment($"</description></item>");
+                    }
+                    else
+                    {
+                        WriteComment($"<item><description><see cref=\"{node.Name}\"/></description></item>");
+                    }
+                }
+
+                foreach (var derived in GetImmediatelyDerivedNodes(nd))
+                {
+                    writeTypeHierarchy(derived);
                 }
 
                 WriteComment($"</list>");
@@ -1193,14 +1199,9 @@ namespace CSharpSyntaxGenerator
             CloseBlock();
         }
 
-        private IEnumerable<AbstractNode> GetDescendantAbstractNodes(TreeType node)
+        private IEnumerable<TreeType> GetImmediatelyDerivedNodes(TreeType node)
         {
-            return Tree.Types.OfType<AbstractNode>().Where(n => IsDerivedType(node.Name, n.Name));
-        }
-
-        private IEnumerable<Node> GetDescendantNodes(TreeType node)
-        {
-            return Tree.Types.OfType<Node>().Where(n => IsDerivedType(node.Name, n.Name));
+            return Tree.Types.Where(n => ParentMap[n.Name] == node.Name);
         }
 
         private void WriteRedUpdateMethod(Node node)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -806,6 +806,32 @@ namespace CSharpSyntaxGenerator
             if (node is AbstractNode)
             {
                 var nd = (AbstractNode)node;
+                WriteComment($"<remarks>");
+
+                var descendantAbstractNodes = GetDescendantAbstractNodes(nd).Where(d => d != nd).ToList();
+                if (descendantAbstractNodes.Any())
+                {
+                    WriteComment($"<para>This node is associated with the following abstract syntax nodes:</para>");
+                    WriteComment($"<list type=\"bullet\">");
+
+                    foreach (var descendant in descendantAbstractNodes)
+                    {
+                        WriteComment($"<item><description><see cref=\"{descendant.Name}\"/></description></item>");
+                    }
+
+                    WriteComment($"</list>");
+                }
+
+                WriteComment($"<para>This node is associated with the following syntax nodes:</para>");
+                WriteComment($"<list type=\"bullet\">");
+
+                foreach (var descendant in GetDescendantNodes(nd))
+                {
+                    WriteComment($"<item><description><see cref=\"{descendant.Name}\"/></description></item>");
+                }
+
+                WriteComment($"</list>");
+                WriteComment($"</remarks>");
                 WriteLine($"public abstract partial class {node.Name} : {node.Base}");
                 OpenBlock();
                 WriteLine($"internal {node.Name}(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)");
@@ -1165,6 +1191,16 @@ namespace CSharpSyntaxGenerator
                 WriteLine($"public virtual {(genericResult ? "TResult" : "void")} Visit{StripPost(node.Name, "Syntax")}({node.Name} node) => this.DefaultVisit(node);");
             }
             CloseBlock();
+        }
+
+        private IEnumerable<AbstractNode> GetDescendantAbstractNodes(TreeType node)
+        {
+            return Tree.Types.OfType<AbstractNode>().Where(n => IsDerivedType(node.Name, n.Name));
+        }
+
+        private IEnumerable<Node> GetDescendantNodes(TreeType node)
+        {
+            return Tree.Types.OfType<Node>().Where(n => IsDerivedType(node.Name, n.Name));
         }
 
         private void WriteRedUpdateMethod(Node node)


### PR DESCRIPTION
This is a proposal for additional documentation remarks for abstract syntax nodes.

![image](https://user-images.githubusercontent.com/1408396/80234866-b524b500-860d-11ea-8b8f-b724c9c29fe0.png)

If this design is approved, I will implement the same for Visual Basic abstract syntax nodes and, if applicable, intermediate interfaces in the `IOperation` tree.

Related to #43646