### PR TITLE
Revert "Remove Razor IVTs"

### DIFF
--- a/src/Tools/ExternalAccess/Razor/RazorDocumentInfoFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentInfoFactory.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal static class RazorDocumentInfoFactory
+    {
+        public static DocumentInfo Create(
+            DocumentId id,
+            string name,
+            IEnumerable<string>? folders,
+            SourceCodeKind sourceCodeKind,
+            TextLoader? loader,
+            string? filePath,
+            bool isGenerated,
+            RazorDocumentServiceProviderWrapper documentServiceProvider)
+        {
+            return DocumentInfo.Create(id, name, folders.ToBoxedImmutableArray(), sourceCodeKind, loader, filePath, isGenerated, documentServiceProvider);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -120,6 +120,7 @@
     <RestrictedInternalsVisibleTo Include="ManagedSourceCodeAnalysis" Key="$(TypeScriptKey)" Partner="LegacyCodeAnalysis" />
     <RestrictedInternalsVisibleTo Include="CodeAnalysis" Key="$(TypeScriptKey)" Partner="LegacyCodeAnalysis" />
     <RestrictedInternalsVisibleTo Include="StanCore" Key="$(TypeScriptKey)" Partner="LegacyCodeAnalysis" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Key="$(RazorKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35079" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Design" />

--- a/src/VisualStudio/Razor/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.csproj
+++ b/src/VisualStudio/Razor/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.csproj
@@ -19,4 +19,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Source: https://github.com/aspnet/AspNetCore-Tooling/tree/master/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor -->
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Key="$(RazorKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35079" />
+  </ItemGroup>
 </Project>

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -89,6 +89,7 @@
     <InternalsVisibleTo Include="MonoDevelop.Refactoring.Tests" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
     <InternalsVisibleTo Include="MonoDevelop.CSharpBinding.Tests" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
     <InternalsVisibleTo Include="MonoDevelop.VBNetBinding.Tests" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.Mac.LanguageServices.Razor" Key="$(RazorKey)" LoadsWithinVisualStudio="false" />
     <!-- this is currently built externally, as part of the MonoDevelop build -->
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Cocoa" LoadsWithinVisualStudio="false" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Cocoa.UnitTests" LoadsWithinVisualStudio="false" />
@@ -124,6 +125,9 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" LoadsWithinVisualStudio="false" />
     <InternalsVisibleTo Include="Microsoft.Test.Apex.VisualStudio" Key="$(VisualStudioKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35081" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Completion.Tests" Key="$(CompletionTestsKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35081" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Workspaces" Key="$(RazorKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35079" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.Editor.Razor" Key="$(RazorKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35079" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Key="$(RazorKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35079" />
   </ItemGroup>
   <ItemGroup>
     <!-- TODO: Remove the below IVTs to CodeStyle Unit test projects once all analyzer/code fix tests are switched to Microsoft.CodeAnalysis.Testing -->

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -93,6 +93,22 @@ namespace Microsoft.CodeAnalysis
                 documentServiceProvider: null);
         }
 
+        // TODO: https://github.com/dotnet/roslyn/issues/35079
+        // Used by Razor: https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioMacDocumentInfoFactory.cs#L38
+        [Obsolete("This is a compatibility shim for Razor; please do not use it.")]
+        internal static DocumentInfo Create(
+            DocumentId id,
+            string name,
+            IEnumerable<string>? folders,
+            SourceCodeKind sourceCodeKind,
+            TextLoader? loader,
+            string? filePath,
+            bool isGenerated,
+            IDocumentServiceProvider? documentServiceProvider)
+        {
+            return new DocumentInfo(new DocumentAttributes(id, name, folders.ToBoxedImmutableArray(), sourceCodeKind, filePath, isGenerated), loader, documentServiceProvider);
+        }
+
         internal static DocumentInfo Create(
             DocumentId id,
             string name,

--- a/src/Workspaces/Remote/Razor/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.csproj
+++ b/src/Workspaces/Remote/Razor/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.csproj
@@ -28,7 +28,7 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Key="$(RazorKey)" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Key="$(RazorKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35079" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ServiceHub\Shared\RoslynJsonConverter.cs">


### PR DESCRIPTION
Reverts dotnet/roslyn#43235, which break ngen and might introduce runtime errors

@tmat @NTaylorMullen 
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/244527
