### PR TITLE
Covariant returns part 2

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -882,7 +882,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else if (overridingProperty.SetMethod is null ?
                                 !IsValidOverrideReturnType(overridingProperty, overridingMemberType, overriddenMemberType, diagnostics) :
-                                overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
+                                !overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
                                 if (!isOrContainsErrorType(overridingMemberType.Type))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -880,13 +880,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 diagnostics.Add(ErrorCode.ERR_CantChangeRefReturnOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the ref kind is mismatched
                             }
-                            else if (!IsValidOverrideReturnType(overridingProperty, overridingMemberType, overriddenMemberType, diagnostics))
+                            else if (overridingProperty.SetMethod is null ?
+                                !IsValidOverrideReturnType(overridingProperty, overridingMemberType, overriddenMemberType, diagnostics) :
+                                overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
                                 if (!isOrContainsErrorType(overridingMemberType.Type))
                                 {
-                                    diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.Type);
+                                    // If the type would be a valid covariant return, suggest using covariant return feature.
+                                    HashSet<DiagnosticInfo> discardedUseSiteDiagnostics = null;
+                                    if (overridingProperty.SetMethod is null &&
+                                        DeclaringCompilation.Conversions.HasIdentityOrImplicitReferenceConversion(overridingMemberType.Type, overriddenMemberType.Type, ref discardedUseSiteDiagnostics))
+                                    {
+                                        var diagnosticInfo = MessageID.IDS_FeatureCovariantReturnsForOverrides.GetFeatureAvailabilityDiagnosticInfo(this.DeclaringCompilation);
+                                        Debug.Assert(diagnosticInfo is { });
+                                        diagnostics.Add(diagnosticInfo, overridingMemberLocation);
+                                    }
+                                    else
+                                    {
+                                        // error CS1715: 'Derived.M': type must be 'object' to match overridden member 'Base.M'
+                                        diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.Type);
+                                        // PROTOTYPE(covariant-returns): when overriddenMemberType.Type is an inheritable reference type and the covariant return
+                                        // feature is enabled, and the platform supports it, and there is no setter, we can say it has to be 'object' **or a derived type**.
+                                        // That would probably be a new error code.
+                                    }
                                 }
+
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
@@ -413,18 +414,278 @@ public class Derived : Base
                 );
         }
 
+        [Fact]
+        public void NonOverrideTests_01()
+        {
+            var source = @"
+public class Base
+{
+    public virtual object M1 => null;
+    public virtual object M2 => null;
+}
+public class Derived : Base
+{
+    public new string M1 => null;
+    public string M2 => null;
+}
+public class Derived2 : Derived
+{
+    public new string M1 => null;
+    public string M2 => null;
+}
+public class Derived3 : Derived
+{
+    public new object M1 => null;
+    public object M2 => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (10,19): warning CS0114: 'Derived.M2' hides inherited member 'Base.M2'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+                //     public string M2 => null;
+                Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "M2").WithArguments("Derived.M2", "Base.M2").WithLocation(10, 19),
+                // (15,19): warning CS0108: 'Derived2.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
+                //     public string M2 => null;
+                Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived2.M2", "Derived.M2").WithLocation(15, 19),
+                // (20,19): warning CS0108: 'Derived3.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
+                //     public object M2 => null;
+                Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived3.M2", "Derived.M2").WithLocation(20, 19)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (10,19): warning CS0114: 'Derived.M2' hides inherited member 'Base.M2'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+                //     public string M2 => null;
+                Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "M2").WithArguments("Derived.M2", "Base.M2").WithLocation(10, 19),
+                // (15,19): warning CS0108: 'Derived2.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
+                //     public string M2 => null;
+                Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived2.M2", "Derived.M2").WithLocation(15, 19),
+                // (20,19): warning CS0108: 'Derived3.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
+                //     public object M2 => null;
+                Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived3.M2", "Derived.M2").WithLocation(20, 19)
+                );
+        }
 
-        // PROTOTYPE: Future tests to be added:
-        // - What is expected for public Derived : Base { public new string M => null;
-        // - What is expected for public Derived : Base { public string M => null;
-        // - What is expected for public Derived2: Derived { public new object/string M => null;
-        // - Please add a test where Base has a property, Derived hides it with a different return type, and Derived2 tries to override with either return type.
-        //   - These are also applicable to virtual methods.
-        // - Please add a test with nested variance involved (returning CIn<object> vs.CIn<string>, or COut<object> vs.COut<string>). Also consider nullability variance (COut<object?>vs.COut<string!>` and some permutations).
-        // - Test with an override that doesn't have an implicit reference conversion from base. For instance, numeric types, types convertible via user-defined operators, etc.
-        // - Test other implicit reference conversion scenarios, such as Interface Base.Method() and TypeThatImplementsInterface Derived.Method(), to lock-in the proper check
-        // - Test some DIM scenarios (no changed behavior)
-        // - Test that UD conversions don't count (not an implicit reference conversion)
-        // - Test three levels of inheritance - overriding one, both, neither, correctly, incorrectly. https://github.com/dotnet/roslyn/pull/43576#discussion_r414074476
+        [Fact]
+        public void ChainedOverrides_01()
+        {
+            var source = @"
+public class Base
+{
+    public virtual object M1 => null;
+    public virtual object M2 => null;
+    public virtual object M3 => null;
+}
+public class Derived : Base
+{
+    public override string M1 => null;
+    public override string M2 => null;
+    public override string M3 => null;
+}
+public class Derived2 : Derived
+{
+    public override string M1 => null;
+    public override object M2 => null;
+    public override Base M3 => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (10,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M1 => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M1").WithArguments("covariant returns").WithLocation(10, 28),
+                // (11,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M2 => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M2").WithArguments("covariant returns").WithLocation(11, 28),
+                // (12,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M3 => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M3").WithArguments("covariant returns").WithLocation(12, 28),
+                // (17,28): error CS1715: 'Derived2.M2': type must be 'string' to match overridden member 'Derived.M2'
+                //     public override object M2 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived2.M2", "Derived.M2", "string").WithLocation(17, 28),
+                // (18,26): error CS1715: 'Derived2.M3': type must be 'string' to match overridden member 'Derived.M3'
+                //     public override Base M3 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M3").WithArguments("Derived2.M3", "Derived.M3", "string").WithLocation(18, 26)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (17,28): error CS1715: 'Derived2.M2': type must be 'string' to match overridden member 'Derived.M2'
+                //     public override object M2 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived2.M2", "Derived.M2", "string").WithLocation(17, 28),
+                // (18,26): error CS1715: 'Derived2.M3': type must be 'string' to match overridden member 'Derived.M3'
+                //     public override Base M3 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M3").WithArguments("Derived2.M3", "Derived.M3", "string").WithLocation(18, 26)
+                );
+        }
+
+        [Fact]
+        public void NestedVariance_01()
+        {
+            var source = @"
+public class Base
+{
+    public virtual IIn<string> M1 => null;
+    public virtual IOut<object> M2 => null;
+}
+public class Derived : Base
+{
+    public override IIn<object> M1 => null;
+    public override IOut<string> M2 => null;
+}
+public interface IOut<out T> { }
+public interface IIn<in T> { }
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (9,33): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override IIn<object> M1 => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M1").WithArguments("covariant returns").WithLocation(9, 33),
+                // (10,34): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override IOut<string> M2 => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M2").WithArguments("covariant returns").WithLocation(10, 34)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void NestedVariance_02()
+        {
+            var source = @"
+public class Base
+{
+    public virtual IIn<object> M1 => null;
+    public virtual IOut<string> M2 => null;
+}
+public class Derived : Base
+{
+    public override IIn<string> M1 => null;
+    public override IOut<object> M2 => null;
+}
+public interface IOut<out T> { }
+public interface IIn<in T> { }
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (9,33): error CS1715: 'Derived.M1': type must be 'IIn<object>' to match overridden member 'Base.M1'
+                //     public override IIn<string> M1 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M1").WithArguments("Derived.M1", "Base.M1", "IIn<object>").WithLocation(9, 33),
+                // (10,34): error CS1715: 'Derived.M2': type must be 'IOut<string>' to match overridden member 'Base.M2'
+                //     public override IOut<object> M2 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "IOut<string>").WithLocation(10, 34)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (9,33): error CS1715: 'Derived.M1': type must be 'IIn<object>' to match overridden member 'Base.M1'
+                //     public override IIn<string> M1 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M1").WithArguments("Derived.M1", "Base.M1", "IIn<object>").WithLocation(9, 33),
+                // (10,34): error CS1715: 'Derived.M2': type must be 'IOut<string>' to match overridden member 'Base.M2'
+                //     public override IOut<object> M2 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "IOut<string>").WithLocation(10, 34)
+                );
+        }
+
+        [Fact]
+        public void BadCovariantReturnType_01()
+        {
+            var source = @"
+public class Base
+{
+    public virtual int M1 => 1;
+    public virtual A M2 => null;
+}
+public class Derived : Base
+{
+    public override short M1 => 1;
+    public override B M2 => null;
+}
+public class A { }
+public class B
+{
+    public static implicit operator A(B b) => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (9,27): error CS1715: 'Derived.M1': type must be 'int' to match overridden member 'Base.M1'
+                //     public override short M1 => 1;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M1").WithArguments("Derived.M1", "Base.M1", "int").WithLocation(9, 27),
+                // (10,23): error CS1715: 'Derived.M2': type must be 'A' to match overridden member 'Base.M2'
+                //     public override B M2 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "A").WithLocation(10, 23)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (9,27): error CS1715: 'Derived.M1': type must be 'int' to match overridden member 'Base.M1'
+                //     public override short M1 => 1;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M1").WithArguments("Derived.M1", "Base.M1", "int").WithLocation(9, 27),
+                // (10,23): error CS1715: 'Derived.M2': type must be 'A' to match overridden member 'Base.M2'
+                //     public override B M2 => null;
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "A").WithLocation(10, 23)
+                );
+        }
+
+        [Fact]
+        public void CovariantReturns_12()
+        {
+            var source = @"
+public class Base
+{
+    public virtual System.IComparable M => null;
+}
+public class Derived : Base
+{
+    public override string M => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void NoCovariantImplementations_01()
+        {
+            var source = @"
+public interface Base
+{
+    public virtual object M1 => null;
+    public virtual object M2() => null;
+}
+public interface Derived : Base
+{
+    string Base.M1 => null;
+    string Base.M2() => null;
+}
+public class C : Base
+{
+    string Base.M1 => null;
+    string Base.M2() => null;
+}
+";
+            // these are poor diagnostics; see https://github.com/dotnet/roslyn/issues/43719
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns, targetFramework: TargetFramework.NetStandardLatest).VerifyDiagnostics(
+                // (9,17): error CS0539: 'Derived.M1' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M1 => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("Derived.M1").WithLocation(9, 17),
+                // (10,17): error CS0539: 'Derived.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M2() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("Derived.M2()").WithLocation(10, 17),
+                // (14,17): error CS0539: 'C.M1' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M1 => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("C.M1").WithLocation(14, 17),
+                // (15,17): error CS0539: 'C.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M2() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("C.M2()").WithLocation(15, 17)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, targetFramework: TargetFramework.NetStandardLatest).VerifyDiagnostics(
+                // (9,17): error CS0539: 'Derived.M1' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M1 => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("Derived.M1").WithLocation(9, 17),
+                // (10,17): error CS0539: 'Derived.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M2() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("Derived.M2()").WithLocation(10, 17),
+                // (14,17): error CS0539: 'C.M1' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M1 => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("C.M1").WithLocation(14, 17),
+                // (15,17): error CS0539: 'C.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     string Base.M2() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("C.M2()").WithLocation(15, 17)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -782,5 +782,150 @@ public class C : Base
             VerifyNoOverride(comp, "C.Base.M1");
             VerifyNoOverride(comp, "C.Base.M2");
         }
+
+        [Fact]
+        public void CovariantReturns_13()
+        {
+            var source = @"
+public class Base
+{
+    public virtual object P { get; set; }
+}
+public class Derived : Base
+{
+    public override string P { get => string.Empty; }
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string P { get; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(8, 28)
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+        }
+
+        [Fact]
+        public void CovariantReturns_14()
+        {
+            var source = @"
+public class Base
+{
+    public virtual object P { get; set; }
+}
+public class Derived : Base
+{
+    public override string P { get => string.Empty; }
+}
+public class Derived2 : Derived
+{
+    public override string P { get => string.Empty; set { } }
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string P { get => string.Empty; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(8, 28),
+                // (12,53): error CS0546: 'Derived2.P.set': cannot override because 'Derived.P' does not have an overridable set accessor
+                //     public override string P { get => string.Empty; set { } }
+                Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 53)
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
+            VerifyOverride(comp, "Derived2.get_P", "System.String Derived.P.get");
+            VerifyNoOverride(comp, "Derived2.set_P");
+            comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (12,53): error CS0546: 'Derived2.P.set': cannot override because 'Derived.P' does not have an overridable set accessor
+                //     public override string P { get => string.Empty; set { } }
+                Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 53)
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
+            VerifyOverride(comp, "Derived2.get_P", "System.String Derived.P.get");
+            VerifyNoOverride(comp, "Derived2.set_P");
+        }
+
+        [Fact]
+        public void CovariantReturns_15()
+        {
+            var source = @"
+public class Base
+{
+    public virtual object P { get; set; }
+}
+public class Derived : Base
+{
+    public override string P { get => string.Empty; }
+}
+public class Derived2 : Derived
+{
+    public override string P { set { } }
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string P { get => string.Empty; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(8, 28),
+                // (12,32): error CS0546: 'Derived2.P.set': cannot override because 'Derived.P' does not have an overridable set accessor
+                //     public override string P { set { } }
+                Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 32)
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
+            VerifyNoOverride(comp, "Derived2.set_P");
+            comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (12,32): error CS0546: 'Derived2.P.set': cannot override because 'Derived.P' does not have an overridable set accessor
+                //     public override string P { set { } }
+                Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 32)
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
+            VerifyNoOverride(comp, "Derived2.set_P");
+        }
+
+        [Fact]
+        public void CovariantReturns_16()
+        {
+            var source = @"
+public class Base
+{
+    public virtual object P { get; set; }
+}
+public class Derived : Base
+{
+    public override System.IComparable P { get => string.Empty; }
+}
+public class Derived2 : Derived
+{
+    public override string P { get => string.Empty; }
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,40): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override System.IComparable P { get => string.Empty; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(8, 40),
+                // (12,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string P { get => string.Empty; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(12, 28)
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            VerifyOverride(comp, "Derived2.P", "System.IComparable Derived.P { get; }");
+            VerifyOverride(comp, "Derived2.get_P", "System.IComparable Derived.P.get");
+            comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                );
+            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
+            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            VerifyOverride(comp, "Derived2.P", "System.IComparable Derived.P { get; }");
+            VerifyOverride(comp, "Derived2.get_P", "System.IComparable Derived.P.get");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -314,20 +314,17 @@ public class Derived : Base
 }
 ";
             var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (9,38): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (9,34): error CS1715: 'Derived.P': type must be 'Func<object>' to match overridden member 'Base.P'
                 //     public override Func<string> P { get; set; }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("covariant returns").WithLocation(9, 38),
-                // (9,43): error CS0115: 'Derived.P.set': no suitable method found to override
-                //     public override Func<string> P { get; set; }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "set").WithArguments("Derived.P.set").WithLocation(9, 43)
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "P").WithArguments("Derived.P", "Base.P", "System.Func<object>").WithLocation(9, 34)
                 );
             VerifyOverride(comp, "Derived.P", "System.Func<System.Object> Base.P { get; set; }");
             VerifyNoOverride(comp, "Derived.set_P");
             VerifyOverride(comp, "Derived.get_P", "System.Func<System.Object> Base.P.get");
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
-                // (9,43): error CS0115: 'Derived.P.set': no suitable method found to override
+                // (9,34): error CS1715: 'Derived.P': type must be 'Func<object>' to match overridden member 'Base.P'
                 //     public override Func<string> P { get; set; }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "set").WithArguments("Derived.P.set").WithLocation(9, 43)
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "P").WithArguments("Derived.P", "Base.P", "System.Func<object>").WithLocation(9, 34)
                 );
             VerifyOverride(comp, "Derived.P", "System.Func<System.Object> Base.P { get; set; }");
             VerifyNoOverride(comp, "Derived.set_P");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
@@ -13,11 +15,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
         public void CovariantReturns_01()
         {
             var source = @"
-class Base
+public class Base
 {
     public virtual object M() => null;
 }
-class Derived : Base
+public class Derived : Base
 {
     public override string M() => null;
 }
@@ -35,11 +37,11 @@ class Derived : Base
         public void CovariantReturns_02()
         {
             var source = @"
-class Base
+public class Base
 {
     public virtual T M<T, U>() where T : class where U : class, T => null;
 }
-class Derived : Base
+public class Derived : Base
 {
     public override U M<T, U>() => null;
 }
@@ -57,11 +59,11 @@ class Derived : Base
         public void CovariantReturns_03()
         {
             var source = @"
-class Base<T> where T : class
+public class Base<T> where T : class
 {
     public virtual T M() => null;
 }
-class Derived<T, U> : Base<T> where T : class where U : class, T
+public class Derived<T, U> : Base<T> where T : class where U : class, T
 {
     public override U M() => null;
 }
@@ -79,12 +81,12 @@ class Derived<T, U> : Base<T> where T : class where U : class, T
         public void CovariantReturns_04()
         {
             var source = @"
-class N { }
-class Base
+public class N { }
+public class Base
 {
     public virtual N M() => null;
 }
-class Derived<T> : Base where T : N
+public class Derived<T> : Base where T : N
 {
     public override T M() => null;
 }
@@ -102,19 +104,19 @@ class Derived<T> : Base where T : N
         public void CovariantReturns_05()
         {
             var source = @"
-class Base
+public class Base
 {
     public virtual object M => null;
 }
-class Derived : Base
+public class Derived : Base
 {
     public override string M => null;
 }
 ";
             CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (8,28): error CS1715: 'Derived.M': type must be 'object' to match overridden member 'Base.M'
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public override string M => null;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M").WithArguments("Derived.M", "Base.M", "object").WithLocation(8, 28)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
                 );
             CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
@@ -124,19 +126,19 @@ class Derived : Base
         public void CovariantReturns_06()
         {
             var source = @"
-class Base<T> where T : class
+public class Base<T> where T : class
 {
     public virtual T M => null;
 }
-class Derived<T, U> : Base<T> where T : class where U : class, T
+public class Derived<T, U> : Base<T> where T : class where U : class, T
 {
     public override U M => null;
 }
 ";
             CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (8,23): error CS1715: 'Derived<T, U>.M': type must be 'T' to match overridden member 'Base<T>.M'
+                // (8,23): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public override U M => null;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M").WithArguments("Derived<T, U>.M", "Base<T>.M", "T").WithLocation(8, 23)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 23)
                 );
             CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
@@ -146,20 +148,20 @@ class Derived<T, U> : Base<T> where T : class where U : class, T
         public void CovariantReturns_07()
         {
             var source = @"
-class N { }
-class Base
+public class N { }
+public class Base
 {
     public virtual N M => null;
 }
-class Derived<T> : Base where T : N
+public class Derived<T> : Base where T : N
 {
     public override T M => null;
 }
 ";
             CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (9,23): error CS1715: 'Derived<T>.M': type must be 'N' to match overridden member 'Base.M'
+                // (9,23): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public override T M => null;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M").WithArguments("Derived<T>.M", "Base.M", "N").WithLocation(9, 23)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(9, 23)
                 );
             CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
@@ -169,19 +171,19 @@ class Derived<T> : Base where T : N
         public void CovariantReturns_08()
         {
             var source = @"
-class Base
+public class Base
 {
     public virtual object this[int i] => null;
 }
-class Derived : Base
+public class Derived : Base
 {
     public override string this[int i] => null;
 }
 ";
             CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (8,28): error CS1715: 'Derived.this[int]': type must be 'object' to match overridden member 'Base.this[int]'
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public override string this[int i] => null;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "this").WithArguments("Derived.this[int]", "Base.this[int]", "object").WithLocation(8, 28)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(8, 28)
                 );
             CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
@@ -191,19 +193,19 @@ class Derived : Base
         public void CovariantReturns_09()
         {
             var source = @"
-class Base<T> where T : class
+public class Base<T> where T : class
 {
     public virtual T this[int i] => null;
 }
-class Derived<T, U> : Base<T> where T : class where U : class, T
+public class Derived<T, U> : Base<T> where T : class where U : class, T
 {
     public override U this[int i] => null;
 }
 ";
             CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (8,23): error CS1715: 'Derived<T, U>.this[int]': type must be 'T' to match overridden member 'Base<T>.this[int]'
+                // (8,23): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public override U this[int i] => null;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "this").WithArguments("Derived<T, U>.this[int]", "Base<T>.this[int]", "T").WithLocation(8, 23)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(8, 23)
                 );
             CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
@@ -213,20 +215,20 @@ class Derived<T, U> : Base<T> where T : class where U : class, T
         public void CovariantReturns_10()
         {
             var source = @"
-class N { }
-class Base
+public class N { }
+public class Base
 {
     public virtual N this[int i] => null;
 }
-class Derived<T> : Base where T : N
+public class Derived<T> : Base where T : N
 {
     public override T this[int i] => null;
 }
 ";
             CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
-                // (9,23): error CS1715: 'Derived<T>.this[int]': type must be 'N' to match overridden member 'Base.this[int]'
+                // (9,23): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public override T this[int i] => null;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "this").WithArguments("Derived<T>.this[int]", "Base.this[int]", "N").WithLocation(9, 23)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(9, 23)
                 );
             CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
@@ -237,12 +239,12 @@ class Derived<T> : Base where T : N
         {
             var source = @"
 using System;
-class Base
+public class Base
 {
     public virtual event Func<object> E;
     private void SuppressUnusedWarning() => E?.Invoke();
 }
-class Derived : Base
+public class Derived : Base
 {
     public override event Func<string> E;
     private void SuppressUnusedWarning() => E?.Invoke();
@@ -260,16 +262,166 @@ class Derived : Base
                 );
         }
 
+        [Fact]
+        public void CovariantReturns_WritableProperties()
+        {
+            var source = @"
+using System;
+public class Base
+{
+    public virtual Func<object> P { get; set; }
+}
+public class Derived : Base
+{
+    public override Func<string> P { get; set; }
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (9,38): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override Func<string> P { get; set; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("covariant returns").WithLocation(9, 38),
+                // (9,43): error CS0115: 'Derived.P.set': no suitable method found to override
+                //     public override Func<string> P { get; set; }
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "set").WithArguments("Derived.P.set").WithLocation(9, 43)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (9,43): error CS0115: 'Derived.P.set': no suitable method found to override
+                //     public override Func<string> P { get; set; }
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "set").WithArguments("Derived.P.set").WithLocation(9, 43)
+                );
+        }
+
+        [Fact]
+        public void CovariantReturns_MetadataVsSource_01()
+        {
+            var s0 = @"
+public class Base
+{
+    public virtual object M() => null;
+}
+";
+            var baseMetadata = CreateCompilation(s0).EmitToImageReference();
+            var source = @"
+public class Derived : Base
+{
+    public override string M() => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
+                // (4,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M() => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(4, 28)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void CovariantReturns_MetadataVsSource_02()
+        {
+            var s0 = @"
+public class Base
+{
+    public virtual object M => null;
+}
+";
+            var baseMetadata = CreateCompilation(s0).EmitToImageReference();
+            var source = @"
+public class Derived : Base
+{
+    public override string M => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
+                // (4,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(4, 28)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void CovariantReturns_MetadataVsSource_03()
+        {
+            var s0 = @"
+public class Base
+{
+    public virtual object this[int i] => null;
+}
+";
+            var baseMetadata = CreateCompilation(s0).EmitToImageReference();
+            var source = @"
+public class Derived : Base
+{
+    public override string this[int i] => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
+                // (4,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string this[int i] => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(4, 28)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void CovariantReturns_11()
+        {
+            var source = @"
+public abstract class Base
+{
+    public abstract object M();
+}
+public class Derived : Base
+{
+    public override string M() => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public override string M() => null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void CovariantReturns_WrongReturnType()
+        {
+            var source = @"
+public class Base
+{
+    public virtual string M() => null;
+}
+public class Derived : Base
+{
+    public override object M() => null;
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS0508: 'Derived.M()': return type must be 'string' to match overridden member 'Base.M()'
+                //     public override object M() => null;
+                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M").WithArguments("Derived.M()", "Base.M()", "string").WithLocation(8, 28)
+                );
+            CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
+                // (8,28): error CS0508: 'Derived.M()': return type must be 'string' to match overridden member 'Base.M()'
+                //     public override object M() => null;
+                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M").WithArguments("Derived.M()", "Base.M()", "string").WithLocation(8, 28)
+                );
+        }
+
+
         // PROTOTYPE: Future tests to be added:
         // - What is expected for public Derived : Base { public new string M => null;
         // - What is expected for public Derived : Base { public string M => null;
         // - What is expected for public Derived2: Derived { public new object/string M => null;
         // - Please add a test where Base has a property, Derived hides it with a different return type, and Derived2 tries to override with either return type.
         //   - These are also applicable to virtual methods.
-        // - I assume that an abstract method can be implemented with a covariant return. Please add a test.
         // - Please add a test with nested variance involved (returning CIn<object> vs.CIn<string>, or COut<object> vs.COut<string>). Also consider nullability variance (COut<object?>vs.COut<string!>` and some permutations).
         // - Test with an override that doesn't have an implicit reference conversion from base. For instance, numeric types, types convertible via user-defined operators, etc.
-        // - Test with wrong variance in override (Base.Method() returns string but override Derived.Method() returns object)
         // - Test other implicit reference conversion scenarios, such as Interface Base.Method() and TypeThatImplementsInterface Derived.Method(), to lock-in the proper check
         // - Test some DIM scenarios (no changed behavior)
         // - Test that UD conversions don't count (not an implicit reference conversion)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -12,14 +12,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class CovariantReturnTests : CSharpTestBase
     {
-        private void VerifyOverride(CSharpCompilation comp, string methodName, string overriddenMethodName)
+        private static void VerifyOverride(CSharpCompilation comp, string methodName, string overridingMethodDisplay, string overriddenMethodDisplay)
         {
             var method = comp.GlobalNamespace.GetMember(methodName);
+            Assert.Equal(overridingMethodDisplay, method.ToTestDisplayString());
             var overridden = method.GetOverriddenMember();
-            Assert.Equal(overriddenMethodName, overridden.ToTestDisplayString());
+            Assert.Equal(overriddenMethodDisplay, overridden.ToTestDisplayString());
         }
 
-        private void VerifyNoOverride(CSharpCompilation comp, string methodName)
+        private static void VerifyNoOverride(CSharpCompilation comp, string methodName)
         {
             var method = comp.GlobalNamespace.GetMember(methodName);
             var overridden = method.GetOverriddenMember();
@@ -44,10 +45,15 @@ public class Derived : Base
                 //     public override string M() => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.String Derived.M()", "System.Object Base.M()");
+            }
         }
 
         [Fact]
@@ -68,10 +74,15 @@ public class Derived : Base
                 //     public override U M<T, U>() => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 23)
                 );
-            VerifyOverride(comp, "Derived.M", "T Base.M<T, U>()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "T Base.M<T, U>()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "U Derived.M<T, U>()", "T Base.M<T, U>()");
+            }
         }
 
         [Fact]
@@ -92,10 +103,15 @@ public class Derived<T, U> : Base<T> where T : class where U : class, T
                 //     public override U M() => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 23)
                 );
-            VerifyOverride(comp, "Derived.M", "T Base<T>.M()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "T Base<T>.M()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "U Derived<T, U>.M()", "T Base<T>.M()");
+            }
         }
 
         [Fact]
@@ -117,10 +133,15 @@ public class Derived<T> : Base where T : N
                 //     public override T M() => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(9, 23)
                 );
-            VerifyOverride(comp, "Derived.M", "N Base.M()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "N Base.M()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "T Derived<T>.M()", "N Base.M()");
+            }
         }
 
         [Fact]
@@ -141,10 +162,15 @@ public class Derived : Base
                 //     public override string M => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.String Derived.M { get; }", "System.Object Base.M { get; }");
+            }
         }
 
         [Fact]
@@ -165,10 +191,15 @@ public class Derived<T, U> : Base<T> where T : class where U : class, T
                 //     public override U M => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 23)
                 );
-            VerifyOverride(comp, "Derived.M", "T Base<T>.M { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "T Base<T>.M { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "U Derived<T, U>.M { get; }", "T Base<T>.M { get; }");
+            }
         }
 
         [Fact]
@@ -190,10 +221,15 @@ public class Derived<T> : Base where T : N
                 //     public override T M => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(9, 23)
                 );
-            VerifyOverride(comp, "Derived.M", "N Base.M { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "N Base.M { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "T Derived<T>.M { get; }", "N Base.M { get; }");
+            }
         }
 
         [Fact]
@@ -214,10 +250,15 @@ public class Derived : Base
                 //     public override string this[int i] => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.this[]", "System.Object Base.this[System.Int32 i] { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.this[]", "System.Object Base.this[System.Int32 i] { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.this[]", "System.String Derived.this[System.Int32 i] { get; }", "System.Object Base.this[System.Int32 i] { get; }");
+            }
         }
 
         [Fact]
@@ -238,10 +279,15 @@ public class Derived<T, U> : Base<T> where T : class where U : class, T
                 //     public override U this[int i] => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(8, 23)
                 );
-            VerifyOverride(comp, "Derived.this[]", "T Base<T>.this[System.Int32 i] { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.this[]", "T Base<T>.this[System.Int32 i] { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.this[]", "U Derived<T, U>.this[System.Int32 i] { get; }", "T Base<T>.this[System.Int32 i] { get; }");
+            }
         }
 
         [Fact]
@@ -263,10 +309,15 @@ public class Derived<T> : Base where T : N
                 //     public override T this[int i] => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(9, 23)
                 );
-            VerifyOverride(comp, "Derived.this[]", "N Base.this[System.Int32 i] { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.this[]", "N Base.this[System.Int32 i] { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.this[]", "T Derived<T>.this[System.Int32 i] { get; }", "N Base.this[System.Int32 i] { get; }");
+            }
         }
 
         [Fact]
@@ -290,13 +341,18 @@ public class Derived : Base
                 //     public override event Func<string> E;
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "E").WithArguments("Derived.E", "Base.E", "System.Func<object>").WithLocation(10, 40)
                 );
-            VerifyOverride(comp, "Derived.E", "event System.Func<System.Object> Base.E");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (10,40): error CS1715: 'Derived.E': type must be 'Func<object>' to match overridden member 'Base.E'
                 //     public override event Func<string> E;
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "E").WithArguments("Derived.E", "Base.E", "System.Func<object>").WithLocation(10, 40)
                 );
-            VerifyOverride(comp, "Derived.E", "event System.Func<System.Object> Base.E");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.E", "event System.Func<System.String> Derived.E", "event System.Func<System.Object> Base.E");
+            }
         }
 
         [Fact]
@@ -318,17 +374,20 @@ public class Derived : Base
                 //     public override Func<string> P { get; set; }
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "P").WithArguments("Derived.P", "Base.P", "System.Func<object>").WithLocation(9, 34)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Func<System.Object> Base.P { get; set; }");
-            VerifyNoOverride(comp, "Derived.set_P");
-            VerifyOverride(comp, "Derived.get_P", "System.Func<System.Object> Base.P.get");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (9,34): error CS1715: 'Derived.P': type must be 'Func<object>' to match overridden member 'Base.P'
                 //     public override Func<string> P { get; set; }
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "P").WithArguments("Derived.P", "Base.P", "System.Func<object>").WithLocation(9, 34)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Func<System.Object> Base.P { get; set; }");
-            VerifyNoOverride(comp, "Derived.set_P");
-            VerifyOverride(comp, "Derived.get_P", "System.Func<System.Object> Base.P.get");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.P", "System.Func<System.String> Derived.P { get; set; }", "System.Func<System.Object> Base.P { get; set; }");
+                VerifyNoOverride(comp, "Derived.set_P");
+                VerifyOverride(comp, "Derived.get_P", "System.Func<System.String> Derived.P.get", "System.Func<System.Object> Base.P.get");
+            }
         }
 
         [Fact]
@@ -352,10 +411,15 @@ public class Derived : Base
                 //     public override string M() => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(4, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.String Derived.M()", "System.Object Base.M()");
+            }
         }
 
         [Fact]
@@ -379,10 +443,15 @@ public class Derived : Base
                 //     public override string M => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(4, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.String Derived.M { get; }", "System.Object Base.M { get; }");
+            }
         }
 
         [Fact]
@@ -406,10 +475,15 @@ public class Derived : Base
                 //     public override string this[int i] => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("covariant returns").WithLocation(4, 28)
                 );
-            VerifyOverride(comp, "Derived.this[]", "System.Object Base.this[System.Int32 i] { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, references: new[] { baseMetadata }).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.this[]", "System.Object Base.this[System.Int32 i] { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.this[]", "System.String Derived.this[System.Int32 i] { get; }", "System.Object Base.this[System.Int32 i] { get; }");
+            }
         }
 
         [Fact]
@@ -430,10 +504,15 @@ public class Derived : Base
                 //     public override string M() => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "System.Object Base.M()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.String Derived.M()", "System.Object Base.M()");
+            }
         }
 
         [Fact]
@@ -454,13 +533,18 @@ public class Derived : Base
                 //     public override object M() => null;
                 Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M").WithArguments("Derived.M()", "Base.M()", "string").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.String Base.M()");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (8,28): error CS0508: 'Derived.M()': return type must be 'string' to match overridden member 'Base.M()'
                 //     public override object M() => null;
                 Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M").WithArguments("Derived.M()", "Base.M()", "string").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.String Base.M()");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.Object Derived.M()", "System.String Base.M()");
+            }
         }
 
         [Fact]
@@ -475,12 +559,12 @@ public class Base
 public class Derived : Base
 {
     public new string M1 => null;
-    public string M2 => null;
+    public string M2 => null;    // A
 }
 public class Derived2 : Derived
 {
     public new string M1 => null;
-    public string M2 => null;
+    public string M2 => null;    // B
 }
 public class Derived3 : Derived
 {
@@ -490,38 +574,38 @@ public class Derived3 : Derived
 ";
             var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
                 // (10,19): warning CS0114: 'Derived.M2' hides inherited member 'Base.M2'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
-                //     public string M2 => null;
+                //     public string M2 => null;    // A
                 Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "M2").WithArguments("Derived.M2", "Base.M2").WithLocation(10, 19),
                 // (15,19): warning CS0108: 'Derived2.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
-                //     public string M2 => null;
+                //     public string M2 => null;    // B
                 Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived2.M2", "Derived.M2").WithLocation(15, 19),
                 // (20,19): warning CS0108: 'Derived3.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
                 //     public object M2 => null;
                 Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived3.M2", "Derived.M2").WithLocation(20, 19)
                 );
-            VerifyNoOverride(comp, "Derived.M1");
-            VerifyNoOverride(comp, "Derived.M2");
-            VerifyNoOverride(comp, "Derived2.M1");
-            VerifyNoOverride(comp, "Derived2.M2");
-            VerifyNoOverride(comp, "Derived3.M1");
-            VerifyNoOverride(comp, "Derived3.M2");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (10,19): warning CS0114: 'Derived.M2' hides inherited member 'Base.M2'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
-                //     public string M2 => null;
+                //     public string M2 => null;    // A
                 Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "M2").WithArguments("Derived.M2", "Base.M2").WithLocation(10, 19),
                 // (15,19): warning CS0108: 'Derived2.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
-                //     public string M2 => null;
+                //     public string M2 => null;    // B
                 Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived2.M2", "Derived.M2").WithLocation(15, 19),
                 // (20,19): warning CS0108: 'Derived3.M2' hides inherited member 'Derived.M2'. Use the new keyword if hiding was intended.
                 //     public object M2 => null;
                 Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("Derived3.M2", "Derived.M2").WithLocation(20, 19)
                 );
-            VerifyNoOverride(comp, "Derived.M1");
-            VerifyNoOverride(comp, "Derived.M2");
-            VerifyNoOverride(comp, "Derived2.M1");
-            VerifyNoOverride(comp, "Derived2.M2");
-            VerifyNoOverride(comp, "Derived3.M1");
-            VerifyNoOverride(comp, "Derived3.M2");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyNoOverride(comp, "Derived.M1");
+                VerifyNoOverride(comp, "Derived.M2");
+                VerifyNoOverride(comp, "Derived2.M1");
+                VerifyNoOverride(comp, "Derived2.M2");
+                VerifyNoOverride(comp, "Derived3.M1");
+                VerifyNoOverride(comp, "Derived3.M2");
+            }
         }
 
         [Fact]
@@ -536,54 +620,54 @@ public class Base
 }
 public class Derived : Base
 {
-    public override string M1 => null;
-    public override string M2 => null;
-    public override string M3 => null;
+    public override string M1 => null; // A
+    public override string M2 => null; // B
+    public override string M3 => null; // C
 }
 public class Derived2 : Derived
 {
     public override string M1 => null;
-    public override object M2 => null;
-    public override Base M3 => null;
+    public override object M2 => null; // 1
+    public override Base M3 => null;   // 2
 }
 ";
             var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns).VerifyDiagnostics(
                 // (10,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public override string M1 => null;
+                //     public override string M1 => null; // A
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M1").WithArguments("covariant returns").WithLocation(10, 28),
                 // (11,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public override string M2 => null;
+                //     public override string M2 => null; // B
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M2").WithArguments("covariant returns").WithLocation(11, 28),
                 // (12,28): error CS8652: The feature 'covariant returns' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public override string M3 => null;
+                //     public override string M3 => null; // C
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M3").WithArguments("covariant returns").WithLocation(12, 28),
                 // (17,28): error CS1715: 'Derived2.M2': type must be 'string' to match overridden member 'Derived.M2'
-                //     public override object M2 => null;
+                //     public override object M2 => null; // 1
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived2.M2", "Derived.M2", "string").WithLocation(17, 28),
                 // (18,26): error CS1715: 'Derived2.M3': type must be 'string' to match overridden member 'Derived.M3'
-                //     public override Base M3 => null;
+                //     public override Base M3 => null;   // 2
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M3").WithArguments("Derived2.M3", "Derived.M3", "string").WithLocation(18, 26)
                 );
-            VerifyOverride(comp, "Derived.M1", "System.Object Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "System.Object Base.M2 { get; }");
-            VerifyOverride(comp, "Derived.M3", "System.Object Base.M3 { get; }");
-            VerifyOverride(comp, "Derived2.M1", "System.String Derived.M1 { get; }");
-            VerifyOverride(comp, "Derived2.M2", "System.String Derived.M2 { get; }");
-            VerifyOverride(comp, "Derived2.M3", "System.String Derived.M3 { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (17,28): error CS1715: 'Derived2.M2': type must be 'string' to match overridden member 'Derived.M2'
-                //     public override object M2 => null;
+                //     public override object M2 => null; // 1
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived2.M2", "Derived.M2", "string").WithLocation(17, 28),
                 // (18,26): error CS1715: 'Derived2.M3': type must be 'string' to match overridden member 'Derived.M3'
-                //     public override Base M3 => null;
+                //     public override Base M3 => null;   // 2
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M3").WithArguments("Derived2.M3", "Derived.M3", "string").WithLocation(18, 26)
                 );
-            VerifyOverride(comp, "Derived.M1", "System.Object Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "System.Object Base.M2 { get; }");
-            VerifyOverride(comp, "Derived.M3", "System.Object Base.M3 { get; }");
-            VerifyOverride(comp, "Derived2.M1", "System.String Derived.M1 { get; }");
-            VerifyOverride(comp, "Derived2.M2", "System.String Derived.M2 { get; }");
-            VerifyOverride(comp, "Derived2.M3", "System.String Derived.M3 { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M1", "System.String Derived.M1 { get; }", "System.Object Base.M1 { get; }");
+                VerifyOverride(comp, "Derived.M2", "System.String Derived.M2 { get; }", "System.Object Base.M2 { get; }");
+                VerifyOverride(comp, "Derived.M3", "System.String Derived.M3 { get; }", "System.Object Base.M3 { get; }");
+                VerifyOverride(comp, "Derived2.M1", "System.String Derived2.M1 { get; }", "System.String Derived.M1 { get; }");
+                VerifyOverride(comp, "Derived2.M2", "System.Object Derived2.M2 { get; }", "System.String Derived.M2 { get; }");
+                VerifyOverride(comp, "Derived2.M3", "Base Derived2.M3 { get; }", "System.String Derived.M3 { get; }");
+            }
         }
 
         [Fact]
@@ -611,12 +695,16 @@ public interface IIn<in T> { }
                 //     public override IOut<string> M2 => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M2").WithArguments("covariant returns").WithLocation(10, 34)
                 );
-            VerifyOverride(comp, "Derived.M1", "IIn<System.String> Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "IOut<System.Object> Base.M2 { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M1", "IIn<System.String> Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "IOut<System.Object> Base.M2 { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M1", "IIn<System.Object> Derived.M1 { get; }", "IIn<System.String> Base.M1 { get; }");
+                VerifyOverride(comp, "Derived.M2", "IOut<System.String> Derived.M2 { get; }", "IOut<System.Object> Base.M2 { get; }");
+            }
         }
 
         [Fact]
@@ -644,8 +732,7 @@ public interface IIn<in T> { }
                 //     public override IOut<object> M2 => null;
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "IOut<string>").WithLocation(10, 34)
                 );
-            VerifyOverride(comp, "Derived.M1", "IIn<System.Object> Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "IOut<System.String> Base.M2 { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (9,33): error CS1715: 'Derived.M1': type must be 'IIn<object>' to match overridden member 'Base.M1'
                 //     public override IIn<string> M1 => null;
@@ -654,8 +741,13 @@ public interface IIn<in T> { }
                 //     public override IOut<object> M2 => null;
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "IOut<string>").WithLocation(10, 34)
                 );
-            VerifyOverride(comp, "Derived.M1", "IIn<System.Object> Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "IOut<System.String> Base.M2 { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M1", "IIn<System.String> Derived.M1 { get; }", "IIn<System.Object> Base.M1 { get; }");
+                VerifyOverride(comp, "Derived.M2", "IOut<System.Object> Derived.M2 { get; }", "IOut<System.String> Base.M2 { get; }");
+            }
         }
 
         [Fact]
@@ -686,8 +778,7 @@ public class B
                 //     public override B M2 => null;
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "A").WithLocation(10, 23)
                 );
-            VerifyOverride(comp, "Derived.M1", "System.Int32 Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "A Base.M2 { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (9,27): error CS1715: 'Derived.M1': type must be 'int' to match overridden member 'Base.M1'
                 //     public override short M1 => 1;
@@ -696,8 +787,13 @@ public class B
                 //     public override B M2 => null;
                 Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "M2").WithArguments("Derived.M2", "Base.M2", "A").WithLocation(10, 23)
                 );
-            VerifyOverride(comp, "Derived.M1", "System.Int32 Base.M1 { get; }");
-            VerifyOverride(comp, "Derived.M2", "A Base.M2 { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M1", "System.Int16 Derived.M1 { get; }", "System.Int32 Base.M1 { get; }");
+                VerifyOverride(comp, "Derived.M2", "B Derived.M2 { get; }", "A Base.M2 { get; }");
+            }
         }
 
         [Fact]
@@ -718,10 +814,15 @@ public class Derived : Base
                 //     public override string M => null;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "M").WithArguments("covariant returns").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.M", "System.IComparable Base.M { get; }");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.M", "System.IComparable Base.M { get; }");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.M", "System.String Derived.M { get; }", "System.IComparable Base.M { get; }");
+            }
         }
 
         [Fact]
@@ -735,52 +836,54 @@ public interface Base
 }
 public interface Derived : Base
 {
-    string Base.M1 => null;
-    string Base.M2() => null;
+    string Base.M1 => null;   // 1
+    string Base.M2() => null; // 2
 }
 public class C : Base
 {
-    string Base.M1 => null;
-    string Base.M2() => null;
+    string Base.M1 => null;   // 3
+    string Base.M2() => null; // 4
 }
 ";
             // these are poor diagnostics; see https://github.com/dotnet/roslyn/issues/43719
             var comp = CreateCompilation(source, parseOptions: TestOptions.WithoutCovariantReturns, targetFramework: TargetFramework.NetStandardLatest).VerifyDiagnostics(
                 // (9,17): error CS0539: 'Derived.M1' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M1 => null;
+                //     string Base.M1 => null;   // 1
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("Derived.M1").WithLocation(9, 17),
                 // (10,17): error CS0539: 'Derived.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M2() => null;
+                //     string Base.M2() => null; // 2
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("Derived.M2()").WithLocation(10, 17),
                 // (14,17): error CS0539: 'C.M1' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M1 => null;
+                //     string Base.M1 => null;   // 3
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("C.M1").WithLocation(14, 17),
                 // (15,17): error CS0539: 'C.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M2() => null;
+                //     string Base.M2() => null; // 4
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("C.M2()").WithLocation(15, 17)
                 );
-            VerifyNoOverride(comp, "Derived.Base.M1");
-            VerifyNoOverride(comp, "Derived.Base.M2");
-            VerifyNoOverride(comp, "C.Base.M1");
-            VerifyNoOverride(comp, "C.Base.M2");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns, targetFramework: TargetFramework.NetStandardLatest).VerifyDiagnostics(
                 // (9,17): error CS0539: 'Derived.M1' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M1 => null;
+                //     string Base.M1 => null;   // 1
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("Derived.M1").WithLocation(9, 17),
                 // (10,17): error CS0539: 'Derived.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M2() => null;
+                //     string Base.M2() => null; // 2
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("Derived.M2()").WithLocation(10, 17),
                 // (14,17): error CS0539: 'C.M1' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M1 => null;
+                //     string Base.M1 => null;   // 3
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M1").WithArguments("C.M1").WithLocation(14, 17),
                 // (15,17): error CS0539: 'C.M2()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     string Base.M2() => null;
+                //     string Base.M2() => null; // 4
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("C.M2()").WithLocation(15, 17)
                 );
-            VerifyNoOverride(comp, "Derived.Base.M1");
-            VerifyNoOverride(comp, "Derived.Base.M2");
-            VerifyNoOverride(comp, "C.Base.M1");
-            VerifyNoOverride(comp, "C.Base.M2");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyNoOverride(comp, "Derived.Base.M1");
+                VerifyNoOverride(comp, "Derived.Base.M2");
+                VerifyNoOverride(comp, "C.Base.M1");
+                VerifyNoOverride(comp, "C.Base.M2");
+            }
         }
 
         [Fact]
@@ -801,12 +904,16 @@ public class Derived : Base
                 //     public override string P { get; }
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(8, 28)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.P", "System.String Derived.P { get; }", "System.Object Base.P { get; set; }");
+                VerifyOverride(comp, "Derived.get_P", "System.String Derived.P.get", "System.Object Base.P.get");
+            }
         }
 
         [Fact]
@@ -834,21 +941,22 @@ public class Derived2 : Derived
                 //     public override string P { get => string.Empty; set { } }
                 Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 53)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
-            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
-            VerifyOverride(comp, "Derived2.get_P", "System.String Derived.P.get");
-            VerifyNoOverride(comp, "Derived2.set_P");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (12,53): error CS0546: 'Derived2.P.set': cannot override because 'Derived.P' does not have an overridable set accessor
                 //     public override string P { get => string.Empty; set { } }
                 Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 53)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
-            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
-            VerifyOverride(comp, "Derived2.get_P", "System.String Derived.P.get");
-            VerifyNoOverride(comp, "Derived2.set_P");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.P", "System.String Derived.P { get; }", "System.Object Base.P { get; set; }");
+                VerifyOverride(comp, "Derived.get_P", "System.String Derived.P.get", "System.Object Base.P.get");
+                VerifyOverride(comp, "Derived2.P", "System.String Derived2.P { get; set; }", "System.String Derived.P { get; }");
+                VerifyOverride(comp, "Derived2.get_P", "System.String Derived2.P.get", "System.String Derived.P.get");
+                VerifyNoOverride(comp, "Derived2.set_P");
+            }
         }
 
         [Fact]
@@ -876,19 +984,21 @@ public class Derived2 : Derived
                 //     public override string P { set { } }
                 Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 32)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
-            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
-            VerifyNoOverride(comp, "Derived2.set_P");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 // (12,32): error CS0546: 'Derived2.P.set': cannot override because 'Derived.P' does not have an overridable set accessor
                 //     public override string P { set { } }
                 Diagnostic(ErrorCode.ERR_NoSetToOverride, "set").WithArguments("Derived2.P.set", "Derived.P").WithLocation(12, 32)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
-            VerifyOverride(comp, "Derived2.P", "System.String Derived.P { get; }");
-            VerifyNoOverride(comp, "Derived2.set_P");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.P", "System.String Derived.P { get; }", "System.Object Base.P { get; set; }");
+                VerifyOverride(comp, "Derived.get_P", "System.String Derived.P.get", "System.Object Base.P.get");
+                VerifyOverride(comp, "Derived2.P", "System.String Derived2.P { set; }", "System.String Derived.P { get; }");
+                VerifyNoOverride(comp, "Derived2.set_P");
+            }
         }
 
         [Fact]
@@ -916,16 +1026,18 @@ public class Derived2 : Derived
                 //     public override string P { get => string.Empty; }
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "P").WithArguments("covariant returns").WithLocation(12, 28)
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
-            VerifyOverride(comp, "Derived2.P", "System.IComparable Derived.P { get; }");
-            VerifyOverride(comp, "Derived2.get_P", "System.IComparable Derived.P.get");
+            verify(comp);
             comp = CreateCompilation(source, parseOptions: TestOptions.WithCovariantReturns).VerifyDiagnostics(
                 );
-            VerifyOverride(comp, "Derived.P", "System.Object Base.P { get; set; }");
-            VerifyOverride(comp, "Derived.get_P", "System.Object Base.P.get");
-            VerifyOverride(comp, "Derived2.P", "System.IComparable Derived.P { get; }");
-            VerifyOverride(comp, "Derived2.get_P", "System.IComparable Derived.P.get");
+            verify(comp);
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "Derived.P", "System.IComparable Derived.P { get; }", "System.Object Base.P { get; set; }");
+                VerifyOverride(comp, "Derived.get_P", "System.IComparable Derived.P.get", "System.Object Base.P.get");
+                VerifyOverride(comp, "Derived2.P", "System.String Derived2.P { get; }", "System.IComparable Derived.P { get; }");
+                VerifyOverride(comp, "Derived2.get_P", "System.String Derived2.P.get", "System.IComparable Derived.P.get");
+            }
         }
     }
 }


### PR DESCRIPTION
- Emit language version suggestion for property overrides when applicable.
- Add test for override properties with setters.
- Test relaxed rules for override in source vs a metadata base type.
- Add a number of tests requested in https://github.com/dotnet/roslyn/pull/43576
- Add testing for symbol API (when override is in source)
