### PR TITLE
Improve VS Code build current project support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,14 +46,43 @@
     },
     {
         "label": "build current project skip analyzers",
-        "command": "./.dotnet/dotnet",
         "type": "shell",
+        "command": "./.dotnet/dotnet",
         "args": [
           "pwsh",
           "${workspaceRoot}/scripts/vscode-build.ps1",
           "-filePath",
-          "${file}"
+          "${file}",
+          "-msbuildEngine",
+          "dotnet"
         ],
+        "windows": {
+          "command": "powershell",
+          "args": [
+            "${workspaceRoot}/scripts/vscode-build.ps1",
+            "-filePath",
+            "${file}",
+            "-msbuildEngine",
+            "dotnet"
+          ],
+        },
+        "problemMatcher": "$msCompile",
+        "group": "build"
+    },
+    {
+        "label": "msbuild current project skip analyzers",
+        "type": "shell",
+        "command": "echo 'Task not supported on this OS'",
+        "windows": {
+          "command": "powershell",
+          "args": [
+            "${workspaceRoot}/scripts/vscode-build.ps1",
+            "-filePath",
+            "${file}",
+            "-msbuildEngine",
+            "vs"
+          ],
+        },
         "problemMatcher": "$msCompile",
         "group": "build"
     },

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -180,7 +180,7 @@ function Get-ProjectFile([object]$fileInfo) {
   Set-Location $fileInfo.Directory
   try {
     while ($true) {
-      # search up from the current file for a folder containing a csproj
+      # search up from the current file for a folder containing a project file
       $files = Get-ChildItem *.csproj,*.vbproj
       if ($files) {
         return $files[0]

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -181,7 +181,7 @@ function Get-ProjectFile([object]$fileInfo) {
   try {
     while ($true) {
       # search up from the current file for a folder containing a csproj
-      $files = Get-ChildItem *.csproj
+      $files = Get-ChildItem *.csproj,*.vbproj
       if ($files) {
         return $files[0]
       }
@@ -247,7 +247,7 @@ function Get-PackageDir([string]$name, [string]$version = "") {
   return $p
 }
 
-function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration) {
+function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration, [switch]$skipAnalyzers = $false) {
   # Because we override the C#/VB toolset to build against our LKG package, it is important
   # that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
   # we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
@@ -317,7 +317,7 @@ function Make-BootstrapBuild([switch]$force32 = $false) {
   $projectPath = "src\NuGet\$packageName\$packageName.Package.csproj"
   $force32Flag = if ($force32) { " /p:BOOTSTRAP32=true" } else { "" }
 
-  Run-MSBuild $projectPath "/restore /t:Pack /p:RoslynEnforceCodeStyle=false /p:UseRoslynAnalyzers=false /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false /p:PublishWindowsPdb=false $force32Flag" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
+  Run-MSBuild $projectPath "/restore /t:Pack /p:RoslynEnforceCodeStyle=false /p:UseRoslynAnalyzers=false /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false /p:PublishWindowsPdb=false $force32Flag" -logFileName "Bootstrap" -configuration $bootstrapConfiguration -skipAnalyzers
   $packageFile = Get-ChildItem -Path $dir -Filter "$packageName.*.nupkg"
   Unzip "$dir\$packageFile" $dir
 


### PR DESCRIPTION
This makes the following changes to our ability to build the current
project from VSCode (essentially implementing the rough equivalent of
build current project in VS).

- Ability to choose `msbuild` in addition to `dotnet msbuild`. The full
framework `msbuild` is still necessary for building parts of the IDE
code base.
- Support for VB projects
- Fixes the execution of the task on Windows. The hard dependency on
`/.dotnet` existing doesn't hold on Windows. Falling back to normal
powershell in that environment