### PR TITLE
Place export attributes consistently

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/FileHeaders/CSharpFileHeaderCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/FileHeaders/CSharpFileHeaderCodeFixProvider.cs
@@ -17,8 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FileHeaders
     /// <summary>
     /// Implements a code fix for file header diagnostics.
     /// </summary>
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpFileHeaderCodeFixProvider))]
-    [Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpFileHeaderCodeFixProvider)), Shared]
     internal class CSharpFileHeaderCodeFixProvider : AbstractFileHeaderCodeFixProvider
     {
         [ImportingConstructor]

--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -35,8 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
     /// <summary>
     /// Implements a code fix for all misplaced using statements.
     /// </summary>
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MoveMisplacedUsingDirectives)]
-    [Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MoveMisplacedUsingDirectives), Shared]
     internal sealed partial class MisplacedUsingDirectivesCodeFixProvider : CodeFixProvider
     {
         private static readonly SyntaxAnnotation s_usingPlacementCodeFixAnnotation = new SyntaxAnnotation(nameof(s_usingPlacementCodeFixAnnotation));

--- a/src/Analyzers/VisualBasic/CodeFixes/FileHeaders/VisualBasicFileHeaderCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/FileHeaders/VisualBasicFileHeaderCodeFixProvider.vb
@@ -10,8 +10,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.FileHeaders
-    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicFileHeaderCodeFixProvider))>
-    <[Shared]>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicFileHeaderCodeFixProvider)), [Shared]>
     Friend Class VisualBasicFileHeaderCodeFixProvider
         Inherits AbstractFileHeaderCodeFixProvider
 

--- a/src/CodeStyle/CSharp/CodeFixes/CSharpFormattingCodeFixProvider.cs
+++ b/src/CodeStyle/CSharp/CodeFixes/CSharpFormattingCodeFixProvider.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CodeStyle
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.FixFormatting)]
-    [Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.FixFormatting), Shared]
     internal class CSharpFormattingCodeFixProvider : AbstractFormattingCodeFixProvider
     {
         [ImportingConstructor]

--- a/src/CodeStyle/VisualBasic/CodeFixes/VisualBasicFormattingCodeFixProvider.vb
+++ b/src/CodeStyle/VisualBasic/CodeFixes/VisualBasicFormattingCodeFixProvider.vb
@@ -9,8 +9,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.VisualBasic.Formatting
 
 Namespace Microsoft.CodeAnalysis.CodeStyle
-    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.FixFormatting)>
-    <[Shared]>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.FixFormatting), [Shared]>
     Friend Class VisualBasicFormattingCodeFixProvider
         Inherits AbstractFormattingCodeFixProvider
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
@@ -128,8 +128,7 @@ class C
             await VerifyItemIsAbsentAsync(@"#!$$", MockSnippetInfoService.SnippetShortcut, sourceCodeKind: SourceCodeKind.Script);
         }
 
-        [ExportLanguageService(typeof(ISnippetInfoService), LanguageNames.CSharp, ServiceLayer.Host)]
-        [Shared]
+        [ExportLanguageService(typeof(ISnippetInfoService), LanguageNames.CSharp, ServiceLayer.Host), Shared]
         [PartNotDiscoverable]
         private class MockSnippetInfoService : ISnippetInfoService
         {

--- a/src/EditorFeatures/Core.Wpf/Notification/EditorNotificationServiceFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Notification/EditorNotificationServiceFactory.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Notification;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Notification
 {
-    [ExportWorkspaceServiceFactory(typeof(INotificationService), ServiceLayer.Editor)]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(INotificationService), ServiceLayer.Editor), Shared]
     internal class EditorNotificationServiceFactory : IWorkspaceServiceFactory
     {
         private static readonly object s_gate = new object();

--- a/src/EditorFeatures/Core/DefaultDecompilerEulaService.cs
+++ b/src/EditorFeatures/Core/DefaultDecompilerEulaService.cs
@@ -13,8 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
-    [ExportWorkspaceService(typeof(IDecompilerEulaService), ServiceLayer.Default)]
-    [Shared]
+    [ExportWorkspaceService(typeof(IDecompilerEulaService), ServiceLayer.Default), Shared]
     internal sealed class DefaultDecompilerEulaService : IDecompilerEulaService
     {
         private bool _isAccepted;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptBreakpointResolutionService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptBreakpointResolutionService.cs
@@ -17,8 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    [Shared]
-    [ExportLanguageService(typeof(IBreakpointResolutionService), InternalLanguageNames.TypeScript)]
+    [ExportLanguageService(typeof(IBreakpointResolutionService), InternalLanguageNames.TypeScript), Shared]
     internal sealed class VSTypeScriptBreakpointResolutionService : IBreakpointResolutionService
     {
         private readonly IVSTypeScriptBreakpointResolutionServiceImplementation _implementation;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptEditorInlineRenameService.cs
@@ -13,8 +13,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    [Shared]
-    [ExportLanguageService(typeof(IEditorInlineRenameService), InternalLanguageNames.TypeScript)]
+    [ExportLanguageService(typeof(IEditorInlineRenameService), InternalLanguageNames.TypeScript), Shared]
     internal sealed class VSTypeScriptEditorInlineRenameService : IEditorInlineRenameService
     {
         private readonly Lazy<IVSTypeScriptEditorInlineRenameService> _service;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptLanguageDebugInfoService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptLanguageDebugInfoService.cs
@@ -14,8 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    [Shared]
-    [ExportLanguageService(typeof(ILanguageDebugInfoService), InternalLanguageNames.TypeScript)]
+    [ExportLanguageService(typeof(ILanguageDebugInfoService), InternalLanguageNames.TypeScript), Shared]
     internal sealed class VSTypeScriptLanguageDebugInfoService : ILanguageDebugInfoService
     {
         private readonly IVSTypeScriptLanguageDebugInfoServiceImplementation _implementation;

--- a/src/EditorFeatures/Core/Implementation/DefaultNavigateToLinkService.cs
+++ b/src/EditorFeatures/Core/Implementation/DefaultNavigateToLinkService.cs
@@ -11,8 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation
 {
-    [ExportWorkspaceService(typeof(INavigateToLinkService), layer: ServiceLayer.Default)]
-    [Shared]
+    [ExportWorkspaceService(typeof(INavigateToLinkService), layer: ServiceLayer.Default), Shared]
     internal sealed class DefaultNavigateToLinkService : INavigateToLinkService
     {
         [ImportingConstructor]

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
@@ -13,8 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
 {
-    [Export(typeof(IHighlightingService))]
-    [Shared]
+    [Export(typeof(IHighlightingService)), Shared]
     internal class HighlightingService : IHighlightingService
     {
         private readonly List<Lazy<IHighlighter, LanguageMetadata>> _highlighters;

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/SymbolMappingServiceFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/SymbolMappingServiceFactory.cs
@@ -14,8 +14,7 @@ using Microsoft.CodeAnalysis.SymbolMapping;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
 {
-    [ExportWorkspaceServiceFactory(typeof(ISymbolMappingService), WorkspaceKind.MetadataAsSource)]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(ISymbolMappingService), WorkspaceKind.MetadataAsSource), Shared]
     internal class SymbolMappingServiceFactory : IWorkspaceServiceFactory
     {
         [ImportingConstructor]

--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
@@ -9,8 +9,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
-    [ExportWorkspaceServiceFactory(typeof(IProjectCacheHostService), ServiceLayer.Editor)]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(IProjectCacheHostService), ServiceLayer.Editor), Shared]
     internal partial class ProjectCacheHostServiceFactory : IWorkspaceServiceFactory
     {
         private const int ImplicitCacheTimeoutInMS = 10000;

--- a/src/EditorFeatures/Core/Shared/Utilities/ThreadingContext.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ThreadingContext.cs
@@ -19,8 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
     /// <see cref="VisualStudio.Threading.JoinableTaskContext"/> is available, a new instance is constructed using the
     /// synchronization context of the current thread as the main thread.</para>
     /// </remarks>
-    [Export(typeof(IThreadingContext))]
-    [Shared]
+    [Export(typeof(IThreadingContext)), Shared]
     internal sealed class ThreadingContext : IThreadingContext
     {
         [ImportingConstructor]

--- a/src/EditorFeatures/Test/CodeRefactorings/ErrorCases/CodeRefactoringExceptionInComputeRefactorings.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/ErrorCases/CodeRefactoringExceptionInComputeRefactorings.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService.ErrorCases
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "Test")]
-    [Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "Test"), Shared]
     [PartNotDiscoverable]
     internal class ExceptionInCodeActions : CodeRefactoringProvider
     {

--- a/src/EditorFeatures/Test/CodeRefactorings/ErrorCases/CodeRefactoringExceptionInComputeRefactoringsAsync.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/ErrorCases/CodeRefactoringExceptionInComputeRefactoringsAsync.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService.ErrorCases
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "Test")]
-    [Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "Test"), Shared]
     [PartNotDiscoverable]
     internal class ExceptionInComputeRefactoringsAsync : CodeRefactoringProvider
     {

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3196,8 +3196,7 @@ class C
             End Using
         End Function
 
-        <ExportCompletionProvider(NameOf(SlowProvider), LanguageNames.CSharp)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(SlowProvider), LanguageNames.CSharp), [Shared]>
         <PartNotDiscoverable>
         Private Class SlowProvider
             Inherits CommonCompletionProvider
@@ -4466,8 +4465,7 @@ class C
             End Function
         End Class
 
-        <ExportCompletionProvider(NameOf(CompletedTaskControlledCompletionProvider), LanguageNames.CSharp)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(CompletedTaskControlledCompletionProvider), LanguageNames.CSharp), [Shared]>
         <PartNotDiscoverable>
         Private Class CompletedTaskControlledCompletionProvider
             Inherits TaskControlledCompletionProvider
@@ -4479,8 +4477,7 @@ class C
             End Sub
         End Class
 
-        <ExportCompletionProvider(NameOf(BooleanTaskControlledCompletionProvider), LanguageNames.CSharp)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(BooleanTaskControlledCompletionProvider), LanguageNames.CSharp), [Shared]>
         <PartNotDiscoverable>
         Private Class BooleanTaskControlledCompletionProvider
             Inherits TaskControlledCompletionProvider
@@ -6888,8 +6885,7 @@ namespace NS
             End Using
         End Function
 
-        <ExportCompletionProvider(NameOf(MultipleChangeCompletionProvider), LanguageNames.CSharp)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(MultipleChangeCompletionProvider), LanguageNames.CSharp), [Shared]>
         <PartNotDiscoverable>
         Private Class MultipleChangeCompletionProvider
             Inherits CompletionProvider
@@ -6933,8 +6929,7 @@ class C
             End Function
         End Class
 
-        <ExportCompletionProvider(NameOf(IntelliCodeMockProvider), LanguageNames.CSharp)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(IntelliCodeMockProvider), LanguageNames.CSharp), [Shared]>
         <PartNotDiscoverable>
         Private Class IntelliCodeMockProvider
             Inherits CompletionProvider
@@ -6977,8 +6972,7 @@ class C
         ' Simulates a situation where IntelliCode provides items not included into the Rolsyn original list.
         ' We want to ignore these items in CommitIfUnique.
         ' This situation should not happen. Tests with this provider were added to cover protective scenarios.
-        <ExportCompletionProvider(NameOf(IntelliCodeMockWeirdProvider), LanguageNames.CSharp)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(IntelliCodeMockWeirdProvider), LanguageNames.CSharp), [Shared]>
         <PartNotDiscoverable>
         Private Class IntelliCodeMockWeirdProvider
             Inherits IntelliCodeMockProvider

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests.vb
@@ -52,8 +52,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End Property
         End Class
 
-        <ExportCompletionProvider(NameOf(TestCompletionProvider), "NoCompilation")>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(TestCompletionProvider), "NoCompilation"), [Shared]>
         <PartNotDiscoverable>
         Private Class TestCompletionProvider
             Inherits CompletionProvider

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
@@ -85,8 +85,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End Function
         End Class
 
-        <ExportCompletionProvider(NameOf(CompletionItemNonExclusiveCompletionProvider), "NoCompilation")>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(CompletionItemNonExclusiveCompletionProvider), "NoCompilation"), [Shared]>
         <PartNotDiscoverable>
         Private Class CompletionItemNonExclusiveCompletionProvider
             Inherits TestCompletionProviderWithMockExclusivity
@@ -98,8 +97,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End Sub
         End Class
 
-        <ExportCompletionProvider(NameOf(CompletionItemExclusiveCompletionProvider), "NoCompilation")>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(CompletionItemExclusiveCompletionProvider), "NoCompilation"), [Shared]>
         <PartNotDiscoverable>
         Private Class CompletionItemExclusiveCompletionProvider
             Inherits TestCompletionProviderWithMockExclusivity
@@ -111,8 +109,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End Sub
         End Class
 
-        <ExportCompletionProvider(NameOf(CompletionItemExclusive2CompletionProvider), "NoCompilation")>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(CompletionItemExclusive2CompletionProvider), "NoCompilation"), [Shared]>
         <PartNotDiscoverable>
         Private Class CompletionItemExclusive2CompletionProvider
             Inherits TestCompletionProviderWithMockExclusivity

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -975,8 +975,7 @@ End Class
             End Using
         End Function
 
-        <ExportCompletionProvider(NameOf(TriggeredCompletionProvider), LanguageNames.VisualBasic)>
-        <[Shared]>
+        <ExportCompletionProvider(NameOf(TriggeredCompletionProvider), LanguageNames.VisualBasic), [Shared]>
         <PartNotDiscoverable>
         Friend Class TriggeredCompletionProvider
             Inherits MockCompletionProvider

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -256,8 +256,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
         }
 
         [Export]
-        [ExportWorkspaceServiceFactory(typeof(IDocumentTrackingService), ServiceLayer.Host)]
-        [Shared]
+        [ExportWorkspaceServiceFactory(typeof(IDocumentTrackingService), ServiceLayer.Host), Shared]
         [PartNotDiscoverable]
         public sealed class DocumentTrackingServiceFactory : IWorkspaceServiceFactory
         {

--- a/src/EditorFeatures/TestUtilities/TestExperimentationService.cs
+++ b/src/EditorFeatures/TestUtilities/TestExperimentationService.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    [Shared]
-    [Export(typeof(TestExperimentationService))]
+    [Export(typeof(TestExperimentationService)), Shared]
     [ExportWorkspaceService(typeof(IExperimentationService), WorkspaceKind.Test), PartNotDiscoverable]
     internal sealed class TestExperimentationService : IExperimentationService
     {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/FirstBuiltInCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/FirstBuiltInCompletionProvider.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     /// Provides a completion provider that always appears before any built-in completion provider. This completion
     /// provider does not provide any completions.
     /// </summary>
-    [ExportCompletionProvider(nameof(FirstBuiltInCompletionProvider), LanguageNames.CSharp)]
-    [Shared]
+    [ExportCompletionProvider(nameof(FirstBuiltInCompletionProvider), LanguageNames.CSharp), Shared]
     internal sealed class FirstBuiltInCompletionProvider : CompletionProvider
     {
         [ImportingConstructor]

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -19,8 +19,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    [Shared]
-    [ExportIncrementalAnalyzerProvider(WellKnownSolutionCrawlerAnalyzers.Diagnostic, workspaceKinds: null)]
+    [ExportIncrementalAnalyzerProvider(WellKnownSolutionCrawlerAnalyzers.Diagnostic, workspaceKinds: null), Shared]
     internal partial class DefaultDiagnosticAnalyzerService : IIncrementalAnalyzerProvider, IDiagnosticUpdateSource
     {
         private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -21,8 +21,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    [Export(typeof(IDiagnosticAnalyzerService))]
-    [Shared]
+    [Export(typeof(IDiagnosticAnalyzerService)), Shared]
     internal partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerService
     {
         private const string DiagnosticsUpdatedEventName = "DiagnosticsUpdated";

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -17,8 +17,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    [Export(typeof(EditAndContinueDiagnosticUpdateSource))]
-    [Shared]
+    [Export(typeof(EditAndContinueDiagnosticUpdateSource)), Shared]
     internal sealed class EditAndContinueDiagnosticUpdateSource : IDiagnosticUpdateSource
     {
         [ImportingConstructor]

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingSolutionCrawlerServiceAccessorFactory.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingSolutionCrawlerServiceAccessorFactory.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.SolutionCrawler;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
 {
-    [ExportWorkspaceServiceFactory(typeof(IUnitTestingSolutionCrawlerServiceAccessor))]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(IUnitTestingSolutionCrawlerServiceAccessor)), Shared]
     internal sealed class UnitTestingSolutionCrawlerServiceAccessorFactory : IWorkspaceServiceFactory
     {
         [ImportingConstructor]

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerLanguageService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerLanguageService.cs
@@ -12,8 +12,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    [Shared]
-    [ExportLanguageService(typeof(VSTypeScriptDiagnosticAnalyzerLanguageService), InternalLanguageNames.TypeScript)]
+    [ExportLanguageService(typeof(VSTypeScriptDiagnosticAnalyzerLanguageService), InternalLanguageNames.TypeScript), Shared]
     internal sealed class VSTypeScriptDiagnosticAnalyzerLanguageService : ILanguageService
     {
         internal readonly IVSTypeScriptDiagnosticAnalyzerImplementation? Implementation;

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerService.cs
@@ -13,8 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    [Shared]
-    [Export(typeof(IVSTypeScriptDiagnosticAnalyzerService))]
+    [Export(typeof(IVSTypeScriptDiagnosticAnalyzerService)), Shared]
     internal sealed class VSTypeScriptAnalyzerService : IVSTypeScriptDiagnosticAnalyzerService
     {
         private readonly IDiagnosticAnalyzerService _service;

--- a/src/Features/Core/Portable/Formatting/FormattingCodeFixProvider.cs
+++ b/src/Features/Core/Portable/Formatting/FormattingCodeFixProvider.cs
@@ -15,8 +15,7 @@ using Microsoft.CodeAnalysis.Editing;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeFixProviderNames.FixFormatting)]
-    [Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeFixProviderNames.FixFormatting), Shared]
     internal class FormattingCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         [ImportingConstructor]

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -34,7 +34,8 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
     /// This means that as the project is being indexed, partial results may be returned.  However
     /// once it is fully indexed, then total results will be returned.
     /// </summary>
-    [ExportIncrementalAnalyzerProvider(nameof(SymbolTreeInfoIncrementalAnalyzerProvider), new[, Shared] { WorkspaceKind.Host, WorkspaceKind.RemoteWorkspace })]
+    [Shared]
+    [ExportIncrementalAnalyzerProvider(nameof(SymbolTreeInfoIncrementalAnalyzerProvider), new[] { WorkspaceKind.Host, WorkspaceKind.RemoteWorkspace })]
     [ExportWorkspaceServiceFactory(typeof(ISymbolTreeInfoCacheService))]
     internal class SymbolTreeInfoIncrementalAnalyzerProvider : IIncrementalAnalyzerProvider, IWorkspaceServiceFactory
     {

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -34,8 +34,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
     /// This means that as the project is being indexed, partial results may be returned.  However
     /// once it is fully indexed, then total results will be returned.
     /// </summary>
-    [Shared]
-    [ExportIncrementalAnalyzerProvider(nameof(SymbolTreeInfoIncrementalAnalyzerProvider), new[] { WorkspaceKind.Host, WorkspaceKind.RemoteWorkspace })]
+    [ExportIncrementalAnalyzerProvider(nameof(SymbolTreeInfoIncrementalAnalyzerProvider), new[, Shared] { WorkspaceKind.Host, WorkspaceKind.RemoteWorkspace })]
     [ExportWorkspaceServiceFactory(typeof(ISymbolTreeInfoCacheService))]
     internal class SymbolTreeInfoIncrementalAnalyzerProvider : IIncrementalAnalyzerProvider, IWorkspaceServiceFactory
     {

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -20,8 +20,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// <summary>
     /// Handles the get code actions command.
     /// </summary>
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentCodeActionName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentCodeActionName), Shared]
     internal class CodeActionsHandler : CodeActionsHandlerBase, IRequestHandler<LSP.CodeActionParams, object[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
@@ -14,8 +14,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.WorkspaceExecuteCommandName)]
+    [ExportLspMethod(LSP.Methods.WorkspaceExecuteCommandName), Shared]
     internal class ExecuteWorkspaceCommandHandler : IRequestHandler<LSP.ExecuteCommandParams, object>
     {
         private readonly ImmutableDictionary<string, Lazy<IExecuteWorkspaceCommandHandler, IExecuteWorkspaceCommandHandlerMetadata>> _executeCommandHandlers;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -20,8 +20,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// <summary>
     /// Handle a completion request.
     /// </summary>
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentCompletionName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentCompletionName), Shared]
     internal class CompletionHandler : IRequestHandler<LSP.CompletionParams, object>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -19,8 +19,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// <summary>
     /// Handle a completion resolve request to add description.
     /// </summary>
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentCompletionResolveName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentCompletionResolveName), Shared]
     internal class CompletionResolveHandler : IRequestHandler<LSP.CompletionItem, LSP.CompletionItem>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -12,8 +12,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentDefinitionName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentDefinitionName), Shared]
     internal class GoToDefinitionHandler : GoToDefinitionHandlerBase, IRequestHandler<LSP.TextDocumentPositionParams, object>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
@@ -12,8 +12,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentTypeDefinitionName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentTypeDefinitionName), Shared]
     internal class GoToTypeDefinitionHandler : GoToDefinitionHandlerBase, IRequestHandler<LSP.TextDocumentPositionParams, LSP.Location[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -13,8 +13,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.TextDocumentFoldingRangeName)]
+    [ExportLspMethod(Methods.TextDocumentFoldingRangeName), Shared]
     internal class FoldingRangesHandler : IRequestHandler<FoldingRangeParams, FoldingRange[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -11,8 +11,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentFormattingName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentFormattingName), Shared]
     internal class FormatDocumentHandler : FormatDocumentHandlerBase, IRequestHandler<LSP.DocumentFormattingParams, LSP.TextEdit[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -19,8 +19,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.TextDocumentOnTypeFormattingName)]
+    [ExportLspMethod(Methods.TextDocumentOnTypeFormattingName), Shared]
     internal class FormatDocumentOnTypeHandler : IRequestHandler<DocumentOnTypeFormattingParams, TextEdit[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -11,8 +11,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.TextDocumentRangeFormattingName)]
+    [ExportLspMethod(Methods.TextDocumentRangeFormattingName), Shared]
     internal class FormatDocumentRangeHandler : FormatDocumentHandlerBase, IRequestHandler<DocumentRangeFormattingParams, TextEdit[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
@@ -14,8 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.TextDocumentDocumentHighlightName)]
+    [ExportLspMethod(Methods.TextDocumentDocumentHighlightName), Shared]
     internal class DocumentHighlightsHandler : IRequestHandler<TextDocumentPositionParams, DocumentHighlight[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -13,8 +13,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.TextDocumentHoverName)]
+    [ExportLspMethod(Methods.TextDocumentHoverName), Shared]
     internal class HoverHandler : IRequestHandler<TextDocumentPositionParams, Hover>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
@@ -16,8 +16,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.InitializeName)]
+    [ExportLspMethod(LSP.Methods.InitializeName), Shared]
     internal class InitializeHandler : IRequestHandler<LSP.InitializeParams, LSP.InitializeResult>
     {
         private readonly ImmutableArray<Lazy<CompletionProvider, Completion.Providers.CompletionProviderMetadata>> _completionProviders;

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
@@ -14,8 +14,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentImplementationName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentImplementationName), Shared]
     internal class FindImplementationsHandler : IRequestHandler<LSP.TextDocumentPositionParams, object>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -17,8 +17,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(LSP.Methods.TextDocumentSignatureHelpName)]
+    [ExportLspMethod(LSP.Methods.TextDocumentSignatureHelpName), Shared]
     internal class SignatureHelpHandler : IRequestHandler<LSP.TextDocumentPositionParams, LSP.SignatureHelp>
     {
         private readonly IEnumerable<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> _allProviders;

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -19,8 +19,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.TextDocumentDocumentSymbolName)]
+    [ExportLspMethod(Methods.TextDocumentDocumentSymbolName), Shared]
     internal class DocumentSymbolsHandler : IRequestHandler<DocumentSymbolParams, object[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -14,8 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [Shared]
-    [ExportLspMethod(Methods.WorkspaceSymbolName)]
+    [ExportLspMethod(Methods.WorkspaceSymbolName), Shared]
     internal class WorkspaceSymbolsHandler : IRequestHandler<WorkspaceSymbolParams, SymbolInformation[]>
     {
         [ImportingConstructor]

--- a/src/Features/LanguageServer/Protocol/LanguageServerProtocol.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerProtocol.cs
@@ -20,8 +20,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     /// Implements Language Server Protocol
     /// TODO - Make this public when we're ready.
     /// </summary>
-    [Shared]
-    [Export(typeof(LanguageServerProtocol))]
+    [Export(typeof(LanguageServerProtocol)), Shared]
     internal sealed class LanguageServerProtocol
     {
         private readonly ImmutableDictionary<string, Lazy<IRequestHandler, IRequestHandlerMetadata>> _requestHandlers;

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/FirstBuiltInCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/FirstBuiltInCompletionProvider.vb
@@ -11,8 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     ''' Provides a completion provider that always appears before any built-in completion provider. This completion
     ''' provider does not provide any completions.
     ''' </summary>
-    <ExportCompletionProvider(NameOf(FirstBuiltInCompletionProvider), LanguageNames.VisualBasic)>
-    <[Shared]>
+    <ExportCompletionProvider(NameOf(FirstBuiltInCompletionProvider), LanguageNames.VisualBasic), [Shared]>
     Friend Class FirstBuiltInCompletionProvider
         Inherits CompletionProvider
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/LastBuiltInCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/LastBuiltInCompletionProvider.vb
@@ -11,8 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     ''' Provides a completion provider that always appears after all built-in completion providers. This completion
     ''' provider does not provide any completions.
     ''' </summary>
-    <ExportCompletionProvider(NameOf(LastBuiltInCompletionProvider), LanguageNames.VisualBasic)>
-    <[Shared]>
+    <ExportCompletionProvider(NameOf(LastBuiltInCompletionProvider), LanguageNames.VisualBasic), [Shared]>
     Friend Class LastBuiltInCompletionProvider
         Inherits CompletionProvider
 

--- a/src/Tools/AnalyzerRunner/PersistentStorageLocationService.cs
+++ b/src/Tools/AnalyzerRunner/PersistentStorageLocationService.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace AnalyzerRunner
 {
-    [ExportWorkspaceService(typeof(IPersistentStorageLocationService), ServiceLayer.Host)]
-    [Shared]
+    [ExportWorkspaceService(typeof(IPersistentStorageLocationService), ServiceLayer.Host), Shared]
     internal class PersistentStorageLocationService : IPersistentStorageLocationService
     {
         [ImportingConstructor]

--- a/src/Tools/ExternalAccess/Apex/ApexAsynchronousOperationListenerProviderAccessor.cs
+++ b/src/Tools/ExternalAccess/Apex/ApexAsynchronousOperationListenerProviderAccessor.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Apex
 {
-    [Export(typeof(IApexAsynchronousOperationListenerProviderAccessor))]
-    [Shared]
+    [Export(typeof(IApexAsynchronousOperationListenerProviderAccessor)), Shared]
     internal sealed class ApexAsynchronousOperationListenerProviderAccessor : IApexAsynchronousOperationListenerProviderAccessor
     {
         private readonly AsynchronousOperationListenerProvider _implementation;

--- a/src/Tools/ExternalAccess/Debugger/DebuggerFindReferencesService.cs
+++ b/src/Tools/ExternalAccess/Debugger/DebuggerFindReferencesService.cs
@@ -14,8 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Debugger
 {
-    [Export]
-    [Shared]
+    [Export, Shared]
     internal sealed class DebuggerFindReferencesService
     {
         private readonly IThreadingContext _threadingContext;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
@@ -14,8 +14,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Classification
 {
-    [Shared]
-    [ExportLanguageService(typeof(IClassificationService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IClassificationService), LanguageNames.FSharp), Shared]
     internal class FSharpClassificationService : IClassificationService
     {
         private readonly IFSharpClassificationService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/CommentSelection/FSharpCommentSelectionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/CommentSelection/FSharpCommentSelectionService.cs
@@ -13,8 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.CommentSelection
 {
-    [Shared]
-    [ExportLanguageService(typeof(ICommentSelectionService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(ICommentSelectionService), LanguageNames.FSharp), Shared]
     internal class FSharpCommentSelectionService : ICommentSelectionService
     {
         [ImportingConstructor]

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDiagnosticAnalyzerService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDiagnosticAnalyzerService.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
-    [Shared]
-    [Export(typeof(IFSharpDiagnosticAnalyzerService))]
+    [Export(typeof(IFSharpDiagnosticAnalyzerService)), Shared]
     internal class FSharpDiagnosticAnalyzerService : IFSharpDiagnosticAnalyzerService
     {
         private readonly Microsoft.CodeAnalysis.Diagnostics.IDiagnosticAnalyzerService _delegatee;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDocumentDiagnosticAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDocumentDiagnosticAnalyzer.cs
@@ -15,8 +15,7 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
-    [Shared]
-    [ExportLanguageService(typeof(FSharpDocumentDiagnosticAnalyzerService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(FSharpDocumentDiagnosticAnalyzerService), LanguageNames.FSharp), Shared]
     internal class FSharpDocumentDiagnosticAnalyzerService : ILanguageService
     {
         private readonly IFSharpDocumentDiagnosticAnalyzer _analyzer;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpSimplifyNameDiagnosticAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpSimplifyNameDiagnosticAnalyzer.cs
@@ -15,8 +15,7 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
-    [Shared]
-    [ExportLanguageService(typeof(FSharpSimplifyNameDiagnosticAnalyzerService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(FSharpSimplifyNameDiagnosticAnalyzerService), LanguageNames.FSharp), Shared]
     internal class FSharpSimplifyNameDiagnosticAnalyzerService : ILanguageService
     {
         private readonly IFSharpSimplifyNameDiagnosticAnalyzer _analyzer;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
@@ -15,8 +15,7 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
-    [Shared]
-    [ExportLanguageService(typeof(FSharpUnusedDeclarationsDiagnosticAnalyzerService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(FSharpUnusedDeclarationsDiagnosticAnalyzerService), LanguageNames.FSharp), Shared]
     internal class FSharpUnusedDeclarationsDiagnosticAnalyzerService : ILanguageService
     {
         private readonly IFSharpUnusedDeclarationsDiagnosticAnalyzer _analyzer;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedOpensDiagnosticAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedOpensDiagnosticAnalyzer.cs
@@ -14,8 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
-    [Shared]
-    [ExportLanguageService(typeof(FSharpUnusedOpensDiagnosticAnalyzerService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(FSharpUnusedOpensDiagnosticAnalyzerService), LanguageNames.FSharp), Shared]
     internal class FSharpUnusedOpensDiagnosticAnalyzerService : ILanguageService
     {
         private readonly IFSharpUnusedOpensDiagnosticAnalyzer _analyzer;

--- a/src/Tools/ExternalAccess/FSharp/Internal/DocumentHighlighting/FSharpDocumentHighlightsService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/DocumentHighlighting/FSharpDocumentHighlightsService.cs
@@ -49,8 +49,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.DocumentHighligh
         }
     }
 
-    [Shared]
-    [ExportLanguageService(typeof(IDocumentHighlightsService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IDocumentHighlightsService), LanguageNames.FSharp), Shared]
     internal class FSharpDocumentHighlightsService : IDocumentHighlightsService
     {
         private readonly IFSharpDocumentHighlightsService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorFormattingService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorFormattingService.cs
@@ -16,8 +16,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
-    [Shared]
-    [ExportLanguageService(typeof(IEditorFormattingService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IEditorFormattingService), LanguageNames.FSharp), Shared]
     internal class FSharpEditorFormattingService : IEditorFormattingService
     {
         private readonly IFSharpEditorFormattingService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
@@ -169,8 +169,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         }
     }
 
-    [Shared]
-    [ExportLanguageService(typeof(IEditorInlineRenameService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IEditorInlineRenameService), LanguageNames.FSharp), Shared]
     internal class FSharpEditorInlineRenameService : IEditorInlineRenameService
     {
         private readonly IFSharpEditorInlineRenameService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpGoToDefinitionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpGoToDefinitionService.cs
@@ -16,8 +16,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Navigation;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
-    [Shared]
-    [ExportLanguageService(typeof(IGoToDefinitionService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IGoToDefinitionService), LanguageNames.FSharp), Shared]
     internal class FSharpGoToDefinitionService : IGoToDefinitionService
     {
         private readonly IFSharpGoToDefinitionService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -18,8 +18,7 @@ using Microsoft.CodeAnalysis.Notification;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
-    [Shared]
-    [ExportLanguageService(typeof(INavigationBarItemService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(INavigationBarItemService), LanguageNames.FSharp), Shared]
     internal class FSharpNavigationBarItemService : INavigationBarItemService
     {
         private readonly IFSharpNavigationBarItemService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpSynchronousIndentationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpSynchronousIndentationService.cs
@@ -12,8 +12,7 @@ using Microsoft.CodeAnalysis.Indentation;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
-    [Shared]
-    [ExportLanguageService(typeof(IIndentationService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IIndentationService), LanguageNames.FSharp), Shared]
     internal class FSharpSynchronousIndentationService : IIndentationService
     {
         private readonly IFSharpSynchronousIndentationService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesService.cs
@@ -12,8 +12,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.FindUsages
 {
-    [Shared]
-    [ExportLanguageService(typeof(IFindUsagesService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IFindUsagesService), LanguageNames.FSharp), Shared]
     internal class FSharpFindUsagesService : IFindUsagesService
     {
         private readonly IFSharpFindUsagesService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/Implementation/Debugging/FSharpBreakpointResolutionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/Implementation/Debugging/FSharpBreakpointResolutionService.cs
@@ -17,8 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.Implementation.Debugging
 {
-    [Shared]
-    [ExportLanguageService(typeof(IBreakpointResolutionService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(IBreakpointResolutionService), LanguageNames.FSharp), Shared]
     internal class FSharpBreakpointResolutionService : IBreakpointResolutionService
     {
         private readonly IFSharpBreakpointResolutionService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/Implementation/Debugging/FSharpLanguageDebugInfoService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/Implementation/Debugging/FSharpLanguageDebugInfoService.cs
@@ -12,8 +12,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.Implementation.Debugging
 {
-    [Shared]
-    [ExportLanguageService(typeof(ILanguageDebugInfoService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(ILanguageDebugInfoService), LanguageNames.FSharp), Shared]
     internal class FSharpLanguageDebugInfoService : ILanguageDebugInfoService
     {
         private readonly IFSharpLanguageDebugInfoService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/NavigateTo/FSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/NavigateTo/FSharpNavigateToSearchService.cs
@@ -13,8 +13,7 @@ using Microsoft.CodeAnalysis.NavigateTo;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.NavigateTo
 {
-    [Shared]
-    [ExportLanguageService(typeof(INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate), LanguageNames.FSharp), Shared]
     internal class FSharpNavigateToSearchService : INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate
     {
         private readonly IFSharpNavigateToSearchService _service;

--- a/src/Tools/ExternalAccess/FSharp/Internal/SignatureHelp/FSharpSignatureHelpProvider.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/SignatureHelp/FSharpSignatureHelpProvider.cs
@@ -13,8 +13,7 @@ using Microsoft.CodeAnalysis.SignatureHelp;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.SignatureHelp
 {
-    [Shared]
-    [ExportSignatureHelpProvider(nameof(FSharpSignatureHelpProvider), LanguageNames.FSharp)]
+    [ExportSignatureHelpProvider(nameof(FSharpSignatureHelpProvider), LanguageNames.FSharp), Shared]
     internal class FSharpSignatureHelpProvider : ISignatureHelpProvider
     {
         private readonly IFSharpSignatureHelpProvider _provider;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Structure/FSharpBlockStructureService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Structure/FSharpBlockStructureService.cs
@@ -12,8 +12,7 @@ using System;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Structure
 {
-    [Shared]
-    [ExportLanguageService(typeof(BlockStructureService), LanguageNames.FSharp)]
+    [ExportLanguageService(typeof(BlockStructureService), LanguageNames.FSharp), Shared]
     internal class FSharpBlockStructureService : BlockStructureService
     {
         private readonly IFSharpBlockStructureService _service;

--- a/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    [Shared]
-    [ExportMetadata("Extensions", new string[] { "cshtml", "razor", })]
+    [ExportMetadata("Extensions", new string[, Shared] { "cshtml", "razor", })]
     [Export(typeof(IDynamicFileInfoProvider))]
     internal sealed class RazorDynamicFileInfoProviderWrapper : IDynamicFileInfoProvider
     {

--- a/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
@@ -11,7 +11,8 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    [ExportMetadata("Extensions", new string[, Shared] { "cshtml", "razor", })]
+    [Shared]
+    [ExportMetadata("Extensions", new string[] { "cshtml", "razor", })]
     [Export(typeof(IDynamicFileInfoProvider))]
     internal sealed class RazorDynamicFileInfoProviderWrapper : IDynamicFileInfoProvider
     {

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
@@ -12,8 +12,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
 {
-    [Export(typeof(ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor))]
-    [Shared]
+    [Export(typeof(ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor)), Shared]
     internal sealed class LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor
         : ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor
     {

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticListSuppressionStateServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticListSuppressionStateServiceAccessor.cs
@@ -10,8 +10,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
 {
-    [Export(typeof(ILegacyCodeAnalysisVisualStudioDiagnosticListSuppressionStateServiceAccessor))]
-    [Shared]
+    [Export(typeof(ILegacyCodeAnalysisVisualStudioDiagnosticListSuppressionStateServiceAccessor)), Shared]
     internal sealed class LegacyCodeAnalysisVisualStudioDiagnosticListSuppressionStateServiceAccessor
         : ILegacyCodeAnalysisVisualStudioDiagnosticListSuppressionStateServiceAccessor
     {

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
@@ -11,8 +11,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
 {
-    [Export(typeof(ILegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor))]
-    [Shared]
+    [Export(typeof(ILegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor)), Shared]
     internal sealed class LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor
         : ILegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor
     {

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioDebuggeeModuleMetadataProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioDebuggeeModuleMetadataProvider.cs
@@ -18,8 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 {
-    [Shared]
-    [Export(typeof(IDebuggeeModuleMetadataProvider))]
+    [Export(typeof(IDebuggeeModuleMetadataProvider)), Shared]
     [Export(typeof(VisualStudioDebuggeeModuleMetadataProvider))]
     internal sealed class VisualStudioDebuggeeModuleMetadataProvider : IDebuggeeModuleMetadataProvider
     {

--- a/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioNavigateToLinkService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioNavigateToLinkService.cs
@@ -12,8 +12,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
 {
-    [ExportWorkspaceService(typeof(INavigateToLinkService), layer: ServiceLayer.Host)]
-    [Shared]
+    [ExportWorkspaceService(typeof(INavigateToLinkService), layer: ServiceLayer.Host), Shared]
     internal sealed class VisualStudioNavigateToLinkService : INavigateToLinkService
     {
         [ImportingConstructor]

--- a/src/VisualStudio/Core/Def/Implementation/VisualStudioDecompilerEulaService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VisualStudioDecompilerEulaService.cs
@@ -19,8 +19,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    [ExportWorkspaceService(typeof(IDecompilerEulaService), ServiceLayer.Host)]
-    [Shared]
+    [ExportWorkspaceService(typeof(IDecompilerEulaService), ServiceLayer.Host), Shared]
     internal sealed class VisualStudioDecompilerEulaService : IDecompilerEulaService
     {
         private readonly IAsyncServiceProvider _serviceProvider;

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioProjectCacheHostServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioProjectCacheHostServiceFactory.cs
@@ -10,8 +10,7 @@ using Microsoft.VisualStudio.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
-    [ExportWorkspaceServiceFactory(typeof(IProjectCacheHostService), ServiceLayer.Host)]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(IProjectCacheHostService), ServiceLayer.Host), Shared]
     internal partial class VisualStudioProjectCacheHostServiceFactory : IWorkspaceServiceFactory
     {
         private const int ImplicitCacheTimeoutInMS = 10000;

--- a/src/VisualStudio/Core/Test/Completion/CSharpMockCompletionProvider.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpMockCompletionProvider.vb
@@ -8,8 +8,7 @@ Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
-    <ExportCompletionProvider(NameOf(CSharpMockCompletionProvider), LanguageNames.CSharp)>
-    <[Shared]>
+    <ExportCompletionProvider(NameOf(CSharpMockCompletionProvider), LanguageNames.CSharp), [Shared]>
     <PartNotDiscoverable>
     Friend Class CSharpMockCompletionProvider
         Inherits MockCompletionProvider

--- a/src/VisualStudio/Core/Test/Completion/VisualBasicMockCompletionProvider.vb
+++ b/src/VisualStudio/Core/Test/Completion/VisualBasicMockCompletionProvider.vb
@@ -8,8 +8,7 @@ Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
-    <ExportCompletionProvider(NameOf(VisualBasicMockCompletionProvider), LanguageNames.VisualBasic)>
-    <[Shared]>
+    <ExportCompletionProvider(NameOf(VisualBasicMockCompletionProvider), LanguageNames.VisualBasic), [Shared]>
     <PartNotDiscoverable>
     Friend Class VisualBasicMockCompletionProvider
         Inherits MockCompletionProvider

--- a/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
@@ -124,8 +124,7 @@ End Class</File>.Value
         End Function
     End Class
 
-    <ExportLanguageService(GetType(ISnippetInfoService), LanguageNames.VisualBasic)>
-    <[Shared]>
+    <ExportLanguageService(GetType(ISnippetInfoService), LanguageNames.VisualBasic), [Shared]>
     <PartNotDiscoverable>
     Friend Class MockSnippetInfoService
         Implements ISnippetInfoService

--- a/src/VisualStudio/IntegrationTest/TestSetup/AsyncCompletionTracker.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/AsyncCompletionTracker.cs
@@ -12,8 +12,7 @@ using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Setup
 {
-    [Export]
-    [Shared]
+    [Export, Shared]
     internal class AsyncCompletionTracker
     {
         private readonly IAsynchronousOperationListenerProvider _asynchronousOperationListenerProvider;

--- a/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynCodeActionProvider.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynCodeActionProvider.Exports.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.CodeActions
 {
-    [Shared]
-    [ExportCodeRefactoringProvider(StringConstants.CSharpLspLanguageName)]
+    [ExportCodeRefactoringProvider(StringConstants.CSharpLspLanguageName), Shared]
     internal class CSharpLspCodeActionProvider : RoslynCodeActionProvider
     {
         [ImportingConstructor]
@@ -22,8 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.CodeActions
         }
     }
 
-    [Shared]
-    [ExportCodeRefactoringProvider(StringConstants.VBLspLanguageName)]
+    [ExportCodeRefactoringProvider(StringConstants.VBLspLanguageName), Shared]
     internal class VBLspCodeActionProvider : RoslynCodeActionProvider
     {
         [ImportingConstructor]

--- a/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
+++ b/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
@@ -15,8 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
 {
     using Workspace = CodeAnalysis.Workspace;
 
-    [Shared]
-    [ExportWorkspaceServiceFactory(typeof(IDocumentNavigationService), WorkspaceKind.Test)]
+    [ExportWorkspaceServiceFactory(typeof(IDocumentNavigationService), WorkspaceKind.Test), Shared]
     [PartNotDiscoverable]
     internal class MockDocumentNavigationServiceFactory : IWorkspaceServiceFactory
     {

--- a/src/Workspaces/Core/MSBuild/MSBuild/CSharp/CSharpProjectFileLoaderFactory.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/CSharp/CSharpProjectFileLoaderFactory.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    [Shared]
-    [ExportLanguageServiceFactory(typeof(IProjectFileLoader), LanguageNames.CSharp)]
+    [ExportLanguageServiceFactory(typeof(IProjectFileLoader), LanguageNames.CSharp), Shared]
     [ProjectFileExtension("csproj")]
     internal class CSharpProjectFileLoaderFactory : ILanguageServiceFactory
     {

--- a/src/Workspaces/Core/MSBuild/MSBuild/VisualBasic/VisualBasicProjectFileLoaderFactory.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/VisualBasic/VisualBasicProjectFileLoaderFactory.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Microsoft.CodeAnalysis.VisualBasic
 {
-    [Shared]
-    [ExportLanguageServiceFactory(typeof(IProjectFileLoader), LanguageNames.VisualBasic)]
+    [ExportLanguageServiceFactory(typeof(IProjectFileLoader), LanguageNames.VisualBasic), Shared]
     [ProjectFileExtension("vbproj")]
     internal class VisualBasicProjectFileLoaderFactory : ILanguageServiceFactory
     {

--- a/src/Workspaces/Core/Portable/Execution/Desktop/DefaultAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/Portable/Execution/Desktop/DefaultAnalyzerAssemblyLoaderService.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    [Shared]
-    [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider))]
+    [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider)), Shared]
     internal sealed class DefaultAnalyzerAssemblyLoaderService : IAnalyzerAssemblyLoaderProvider
     {
         private readonly DefaultAnalyzerAssemblyLoader _loader = new DefaultAnalyzerAssemblyLoader();

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/UnitTestingExperimentationServiceAccessorFactory.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/UnitTestingExperimentationServiceAccessorFactory.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
 {
-    [ExportWorkspaceServiceFactory(typeof(IUnitTestingExperimentationServiceAccessor))]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(IUnitTestingExperimentationServiceAccessor)), Shared]
     internal class UnitTestingExperimentationServiceAccessorFactory : IWorkspaceServiceFactory
     {
         [ImportingConstructor]

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
@@ -34,8 +34,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
     /// <see cref="IAsynchronousOperationListener" /> and use
     /// <see cref="AsynchronousOperationListenerProvider" /> in test to get waiter.
     /// </summary>
-    [Shared]
-    [Export(typeof(IAsynchronousOperationListenerProvider))]
+    [Export(typeof(IAsynchronousOperationListenerProvider)), Shared]
     [Export(typeof(AsynchronousOperationListenerProvider))]
     internal sealed class AsynchronousOperationListenerProvider : IAsynchronousOperationListenerProvider
     {

--- a/src/Workspaces/Core/Portable/Workspace/Host/Caching/ProjectCacheServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Caching/ProjectCacheServiceFactory.cs
@@ -8,8 +8,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    [ExportWorkspaceServiceFactory(typeof(IProjectCacheService), ServiceLayer.Default)]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(IProjectCacheService), ServiceLayer.Default), Shared]
     internal class ProjectCacheServiceFactory : IWorkspaceServiceFactory
     {
         [ImportingConstructor]

--- a/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/TaskSchedulerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/TaskSchedulerProvider.cs
@@ -12,8 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    [ExportWorkspaceService(typeof(ITaskSchedulerProvider), ServiceLayer.Default)]
-    [Shared]
+    [ExportWorkspaceService(typeof(ITaskSchedulerProvider), ServiceLayer.Default), Shared]
     internal sealed class TaskSchedulerProvider : ITaskSchedulerProvider
     {
         [ImportingConstructor]

--- a/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/WorkspaceAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/WorkspaceAsynchronousOperationListenerProvider.cs
@@ -11,8 +11,7 @@ using System.Composition;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    [ExportWorkspaceService(typeof(IWorkspaceAsynchronousOperationListenerProvider), ServiceLayer.Default)]
-    [Shared]
+    [ExportWorkspaceService(typeof(IWorkspaceAsynchronousOperationListenerProvider), ServiceLayer.Default), Shared]
     internal sealed class WorkspaceAsynchronousOperationListenerProvider : IWorkspaceAsynchronousOperationListenerProvider
     {
         private readonly IAsynchronousOperationListener _listener;

--- a/src/Workspaces/CoreTest/WorkspaceTests/DynamicFileInfoProviderMefTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/DynamicFileInfoProviderMefTests.cs
@@ -54,8 +54,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             return factory.CreateExportProvider().GetExport<IDynamicFileInfoProvider, FileExtensionsMetadata>();
         }
 
-        [ExportDynamicFileInfoProvider("cshtml", "vbhtml")]
-        [Shared]
+        [ExportDynamicFileInfoProvider("cshtml", "vbhtml"), Shared]
         [PartNotDiscoverable]
         internal class TestDynamicFileInfoProvider : IDynamicFileInfoProvider
         {

--- a/src/Workspaces/CoreTestUtilities/Fakes/StubStreamingFindUsagesPresenter.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/StubStreamingFindUsagesPresenter.cs
@@ -14,8 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Fakes
 {
-    [Export(typeof(IStreamingFindUsagesPresenter))]
-    [Shared]
+    [Export(typeof(IStreamingFindUsagesPresenter)), Shared]
     [PartNotDiscoverable]
     internal class StubStreamingFindUsagesPresenter : IStreamingFindUsagesPresenter
     {

--- a/src/Workspaces/Remote/Core/Services/ProjectCacheHostServiceFactory.cs
+++ b/src/Workspaces/Remote/Core/Services/ProjectCacheHostServiceFactory.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
-    [ExportWorkspaceServiceFactory(typeof(IProjectCacheHostService), ServiceLayer.Host)]
-    [Shared]
+    [ExportWorkspaceServiceFactory(typeof(IProjectCacheHostService), ServiceLayer.Host), Shared]
     internal partial class ProjectCacheHostServiceFactory : IWorkspaceServiceFactory
     {
         private const int ImplicitCacheTimeoutInMS = 10000;


### PR DESCRIPTION
We have roughly 1500 in one style, and 100 in another.  This brings those outliers in line with how the rest of hte codebase is organized.