### PR TITLE
⏱ Enable Server GC for FormatterBenchmarks

### DIFF
--- a/src/Tools/IdeBenchmarks/FormatterBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/FormatterBenchmarks.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace IdeBenchmarks
 {
+    [GcServer(true)]
     public class FormatterBenchmarks
     {
         private readonly UseExportProviderAttribute _useExportProviderAttribute = new UseExportProviderAttribute();


### PR DESCRIPTION
This change more accurately measures the formatter in scale scenarios where server GC is already enabled, such as a compilation using FormattingAnalyzer.