### PR TITLE
Revert "Update inline rename code following completion of TypeScript external access work"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -228,3 +228,19 @@ dotnet_diagnostic.RS0005.severity = none
 [src/{Analyzers,CodeStyle,Features,Workspaces}/**/*.{cs,vb}]
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# CONSIDER: Are IDE0051 and IDE0052 too noisy to be warnings for IDE editing scenarios? Should they be made build-only warnings?
+# IDE0051: Remove unused private member
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning

--- a/src/Analyzers/CSharp/Analyzers/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.NameColon, SyntaxKind.NameEquals);
 
-        override protected void LanguageSpecificAnalyzeSyntax(SyntaxNodeAnalysisContext context, SyntaxTree syntaxTree, AnalyzerOptions options, CancellationToken cancellationToken)
+        protected override void LanguageSpecificAnalyzeSyntax(SyntaxNodeAnalysisContext context, SyntaxTree syntaxTree, AnalyzerOptions options, CancellationToken cancellationToken)
         {
             var parseOptions = (CSharpParseOptions)syntaxTree.Options;
             switch (context.Node.Kind())

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -7565,5 +7565,94 @@ public class sign
 
             await VerifyCS.VerifyCodeFixAsync(source, fixedCode);
         }
+
+        [WorkItem(20742, "https://github.com/dotnet/roslyn/issues/20742")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DoNotRemoveNamedArgToParamsParameter1()
+        {
+            var source =
+@"class Program
+{
+    public void M()
+    {
+        object[] takesArgs = null;
+        TakesParams(bar: (object)takesArgs, goo: true);
+    }
+
+    private void TakesParams(bool goo, params object[] bar)
+    {
+    }
+}";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [WorkItem(20742, "https://github.com/dotnet/roslyn/issues/20742")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DoRemoveNamedArgToParamsParameter1()
+        {
+            var source =
+@"class Program
+{
+    public void M()
+    {
+        object[] takesArgs = null;
+        TakesParams(bar: [|(object[])|]takesArgs, goo: true);
+    }
+
+    private void TakesParams(bool goo, params object[] bar)
+    {
+    }
+}";
+            var fixedCode =
+@"class Program
+{
+    public void M()
+    {
+        object[] takesArgs = null;
+        TakesParams(bar: takesArgs, goo: true);
+    }
+
+    private void TakesParams(bool goo, params object[] bar)
+    {
+    }
+}";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedCode);
+        }
+
+        [WorkItem(20742, "https://github.com/dotnet/roslyn/issues/20742")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DoRemoveNamedArgToParamsParameter2()
+        {
+            var source =
+@"class Program
+{
+    public void M()
+    {
+        string[] takesArgs = null;
+        TakesParams(bar: [|(object[])|]takesArgs, goo: true);
+    }
+
+    private void TakesParams(bool goo, params object[] bar)
+    {
+    }
+}";
+            var fixedCode =
+@"class Program
+{
+    public void M()
+    {
+        string[] takesArgs = null;
+        TakesParams(bar: takesArgs, goo: true);
+    }
+
+    private void TakesParams(bool goo, params object[] bar)
+    {
+    }
+}";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedCode);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -41,9 +41,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
         private DiagnosticDescription GetRemoveUnnecessaryParenthesesDiagnostic(string text, int line, int column)
             => TestHelpers.Diagnostic(IDEDiagnosticIds.RemoveUnnecessaryParenthesesDiagnosticId, text, startLocation: new LinePosition(line, column));
 
-        private DiagnosticDescription GetRemoveUnnecessaryParenthesesDiagnostic(string text, int line, int column, DiagnosticSeverity severity)
-            => GetRemoveUnnecessaryParenthesesDiagnostic(text, line, column).WithEffectiveSeverity(severity);
-
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
         public async Task TestVariableInitializer_TestWithAllOptionsSetToIgnore()
         {

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -31,8 +31,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
         // Ensure that we explicitly test missing UnusedParameterDiagnosticId, which has no corresponding code fix (non-fixable diagnostic).
         private Task TestDiagnosticMissingAsync(string initialMarkup, ParseOptions parseOptions = null)
             => TestDiagnosticMissingAsync(initialMarkup, options: null, parseOptions);
-        private Task TestDiagnosticsWithAsync(string initialMarkup, ParseOptions parseOptions, params DiagnosticDescription[] expectedDiagnostics)
-            => TestDiagnosticsAsync(initialMarkup, options: null, parseOptions, expectedDiagnostics);
         private Task TestDiagnosticsAsync(string initialMarkup, params DiagnosticDescription[] expectedDiagnostics)
             => TestDiagnosticsAsync(initialMarkup, options: null, parseOptions: null, expectedDiagnostics);
         private Task TestDiagnosticMissingAsync(string initialMarkup, OptionsCollection options, ParseOptions parseOptions = null)

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -21,13 +21,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicit
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (new CSharpUseExplicitTypeDiagnosticAnalyzer(), new UseExplicitTypeCodeFixProvider());
 
-        private readonly CodeStyleOption2<bool> onWithSilent = new CodeStyleOption2<bool>(true, NotificationOption2.Silent);
         private readonly CodeStyleOption2<bool> offWithSilent = new CodeStyleOption2<bool>(false, NotificationOption2.Silent);
         private readonly CodeStyleOption2<bool> onWithInfo = new CodeStyleOption2<bool>(true, NotificationOption2.Suggestion);
         private readonly CodeStyleOption2<bool> offWithInfo = new CodeStyleOption2<bool>(false, NotificationOption2.Suggestion);
-        private readonly CodeStyleOption2<bool> onWithWarning = new CodeStyleOption2<bool>(true, NotificationOption2.Warning);
         private readonly CodeStyleOption2<bool> offWithWarning = new CodeStyleOption2<bool>(false, NotificationOption2.Warning);
-        private readonly CodeStyleOption2<bool> onWithError = new CodeStyleOption2<bool>(true, NotificationOption2.Error);
         private readonly CodeStyleOption2<bool> offWithError = new CodeStyleOption2<bool>(false, NotificationOption2.Error);
 
         // specify all options explicitly to override defaults.

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -23,13 +23,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicit
             => (new CSharpUseImplicitTypeDiagnosticAnalyzer(), new UseImplicitTypeCodeFixProvider());
 
         private static readonly CodeStyleOption2<bool> onWithSilent = new CodeStyleOption2<bool>(true, NotificationOption2.Silent);
-        private static readonly CodeStyleOption2<bool> offWithSilent = new CodeStyleOption2<bool>(false, NotificationOption2.Silent);
         private static readonly CodeStyleOption2<bool> onWithInfo = new CodeStyleOption2<bool>(true, NotificationOption2.Suggestion);
         private static readonly CodeStyleOption2<bool> offWithInfo = new CodeStyleOption2<bool>(false, NotificationOption2.Suggestion);
         private static readonly CodeStyleOption2<bool> onWithWarning = new CodeStyleOption2<bool>(true, NotificationOption2.Warning);
-        private static readonly CodeStyleOption2<bool> offWithWarning = new CodeStyleOption2<bool>(false, NotificationOption2.Warning);
         private static readonly CodeStyleOption2<bool> onWithError = new CodeStyleOption2<bool>(true, NotificationOption2.Error);
-        private static readonly CodeStyleOption2<bool> offWithError = new CodeStyleOption2<bool>(false, NotificationOption2.Error);
 
         // specify all options explicitly to override defaults.
         internal OptionsCollection ImplicitTypeEverywhere() =>

--- a/src/Analyzers/Core/Analyzers/AbstractCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractCodeStyleDiagnosticAnalyzer.cs
@@ -38,8 +38,6 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected readonly LocalizableString _localizableTitle;
         protected readonly LocalizableString _localizableMessageFormat;
 
-        private readonly bool _configurable;
-
         protected AbstractCodeStyleDiagnosticAnalyzer(
             string descriptorId, LocalizableString title,
             LocalizableString? messageFormat = null,
@@ -48,11 +46,10 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             DescriptorId = descriptorId;
             _localizableTitle = title;
             _localizableMessageFormat = messageFormat ?? title;
-            _configurable = configurable;
 
-            Descriptor = CreateDescriptorWithId(DescriptorId, _localizableTitle, _localizableMessageFormat);
-            UnnecessaryWithSuggestionDescriptor = CreateUnnecessaryDescriptor(DescriptorId);
-            UnnecessaryWithoutSuggestionDescriptor = CreateUnnecessaryDescriptor(descriptorId + "WithoutSuggestion");
+            Descriptor = CreateDescriptorWithId(DescriptorId, _localizableTitle, _localizableMessageFormat, isConfigurable: configurable);
+            UnnecessaryWithSuggestionDescriptor = CreateUnnecessaryDescriptor(DescriptorId, configurable);
+            UnnecessaryWithoutSuggestionDescriptor = CreateUnnecessaryDescriptor(descriptorId + "WithoutSuggestion", configurable);
 
             SupportedDiagnostics = ImmutableArray.Create(
                 Descriptor, UnnecessaryWithoutSuggestionDescriptor, UnnecessaryWithSuggestionDescriptor);
@@ -67,10 +64,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             _localizableMessageFormat = Descriptor.MessageFormat;
         }
 
-        protected DiagnosticDescriptor CreateUnnecessaryDescriptor(string descriptorId)
+        protected DiagnosticDescriptor CreateUnnecessaryDescriptor(string descriptorId, bool isConfigurable = true)
             => CreateDescriptorWithId(
                 descriptorId, _localizableTitle, _localizableMessageFormat,
-                isUnnecessary: true);
+                isUnnecessary: true,
+                isConfigurable);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 return false;
             }
 
-            PooledHashSet<ISymbol> GetCandidateSymbolsReferencedInDocComments(INamedTypeSymbol namedTypeSymbol, Compilation compilation, CancellationToken cancellationToken)
+            private PooledHashSet<ISymbol> GetCandidateSymbolsReferencedInDocComments(INamedTypeSymbol namedTypeSymbol, Compilation compilation, CancellationToken cancellationToken)
             {
                 var builder = PooledHashSet<ISymbol>.GetInstance();
                 foreach (var root in namedTypeSymbol.Locations.Select(l => l.SourceTree.GetRoot(cancellationToken)))
@@ -523,14 +523,14 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 return builder;
             }
 
-            ArrayBuilder<string> GetDebuggerDisplayAttributeArguments(INamedTypeSymbol namedTypeSymbol)
+            private ArrayBuilder<string> GetDebuggerDisplayAttributeArguments(INamedTypeSymbol namedTypeSymbol)
             {
                 var builder = ArrayBuilder<string>.GetInstance();
                 AddDebuggerDisplayAttributeArguments(namedTypeSymbol, builder);
                 return builder;
             }
 
-            void AddDebuggerDisplayAttributeArguments(INamedTypeSymbol namedTypeSymbol, ArrayBuilder<string> builder)
+            private void AddDebuggerDisplayAttributeArguments(INamedTypeSymbol namedTypeSymbol, ArrayBuilder<string> builder)
             {
                 AddDebuggerDisplayAttributeArgumentsCore(namedTypeSymbol, builder);
 
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 }
             }
 
-            void AddDebuggerDisplayAttributeArgumentsCore(ISymbol symbol, ArrayBuilder<string> builder)
+            private void AddDebuggerDisplayAttributeArgumentsCore(ISymbol symbol, ArrayBuilder<string> builder)
             {
                 foreach (var attribute in symbol.GetAttributes())
                 {

--- a/src/Analyzers/Core/Analyzers/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -28,12 +28,6 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
         /// </summary>
         private readonly ImmutableDictionary<TSyntaxKind, TSyntaxKind> _binaryToAssignmentMap;
 
-        /// <summary>
-        /// Maps from an assignment form (like AddAssignmentExpression) to the corresponding
-        /// operator type (like PlusEqualsToken).
-        /// </summary>
-        private readonly ImmutableDictionary<TSyntaxKind, TSyntaxKind> _assignmentToTokenMap;
-
         protected AbstractUseCompoundAssignmentDiagnosticAnalyzer(
             ISyntaxFacts syntaxFacts,
             ImmutableArray<(TSyntaxKind exprKind, TSyntaxKind assignmentKind, TSyntaxKind tokenKind)> kinds)
@@ -43,7 +37,7 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
                        nameof(AnalyzersResources.Use_compound_assignment), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {
             _syntaxFacts = syntaxFacts;
-            UseCompoundAssignmentUtilities.GenerateMaps(kinds, out _binaryToAssignmentMap, out _assignmentToTokenMap);
+            UseCompoundAssignmentUtilities.GenerateMaps(kinds, out _binaryToAssignmentMap, out _);
         }
 
         protected abstract TSyntaxKind GetAnalysisKind();

--- a/src/Analyzers/Core/Analyzers/UseInferredMemberName/AbstractUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseInferredMemberName/AbstractUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.UseInferredMemberName
 {
     internal abstract class AbstractUseInferredMemberNameDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
-        abstract protected void LanguageSpecificAnalyzeSyntax(SyntaxNodeAnalysisContext context, SyntaxTree syntaxTree, AnalyzerOptions options, CancellationToken cancellationToken);
+        protected abstract void LanguageSpecificAnalyzeSyntax(SyntaxNodeAnalysisContext context, SyntaxTree syntaxTree, AnalyzerOptions options, CancellationToken cancellationToken);
 
         public AbstractUseInferredMemberNameDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId,

--- a/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
@@ -84,12 +84,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
             var fixedNames = style.MakeCompliant(symbol.Name);
             foreach (var fixedName in fixedNames)
             {
-                var solution = context.Document.Project.Solution;
                 context.RegisterCodeFix(
                     new FixNameCodeAction(
-                        solution,
+#if !CODE_STYLE
+                        document.Project.Solution,
                         symbol,
                         fixedName,
+#endif
                         string.Format(CodeFixesResources.Fix_Name_Violation_colon_0, fixedName),
                         c => FixAsync(document, symbol, fixedName, c),
                         equivalenceKey: nameof(NamingStyleCodeFixProvider)),
@@ -108,24 +109,31 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
 
         private class FixNameCodeAction : CodeAction
         {
+#if !CODE_STYLE
             private readonly Solution _startingSolution;
             private readonly ISymbol _symbol;
             private readonly string _newName;
+#endif
+
             private readonly string _title;
             private readonly Func<CancellationToken, Task<Solution>> _createChangedSolutionAsync;
             private readonly string _equivalenceKey;
 
             public FixNameCodeAction(
+#if !CODE_STYLE
                 Solution startingSolution,
                 ISymbol symbol,
                 string newName,
+#endif
                 string title,
                 Func<CancellationToken, Task<Solution>> createChangedSolutionAsync,
                 string equivalenceKey)
             {
+#if !CODE_STYLE
                 _startingSolution = startingSolution;
                 _symbol = symbol;
                 _newName = newName;
+#endif
                 _title = title;
                 _createChangedSolutionAsync = createChangedSolutionAsync;
                 _equivalenceKey = equivalenceKey;

--- a/src/Analyzers/Core/CodeFixes/UseInferredMemberName/AbstractUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseInferredMemberName/AbstractUseInferredMemberNameCodeFixProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.UseInferredMemberName
 {
     internal abstract class AbstractUseInferredMemberNameCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
-        abstract protected void LanguageSpecificRemoveSuggestedNode(SyntaxEditor editor, SyntaxNode node);
+        protected abstract void LanguageSpecificRemoveSuggestedNode(SyntaxEditor editor, SyntaxNode node);
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; }
             = ImmutableArray.Create(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -17,14 +17,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal struct ProcessedFieldInitializers
         {
             internal ImmutableArray<BoundInitializer> BoundInitializers { get; set; }
-            internal BoundStatement LoweredInitializers { get; set; }
+            internal BoundStatement? LoweredInitializers { get; set; }
             internal bool HasErrors { get; set; }
             internal ImportChain? FirstImportChain { get; set; }
         }
 
         internal static void BindFieldInitializers(
             CSharpCompilation compilation,
-            SynthesizedInteractiveInitializerMethod scriptInitializerOpt,
+            SynthesizedInteractiveInitializerMethod? scriptInitializerOpt,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> fieldInitializers,
             DiagnosticBag diagnostics,
             ref ProcessedFieldInitializers processedInitializers)
@@ -38,9 +38,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagsForInstanceInitializers.Free();
         }
 
-        private static ImmutableArray<BoundInitializer> BindFieldInitializers(
+        internal static ImmutableArray<BoundInitializer> BindFieldInitializers(
             CSharpCompilation compilation,
-            SynthesizedInteractiveInitializerMethod scriptInitializerOpt,
+            SynthesizedInteractiveInitializerMethod? scriptInitializerOpt,
             ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> initializers,
             DiagnosticBag diagnostics,
             out ImportChain? firstImportChain)
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var boundInitializers = ArrayBuilder<BoundInitializer>.GetInstance();
-            if ((object)scriptInitializerOpt == null)
+            if (scriptInitializerOpt is null)
             {
                 BindRegularCSharpFieldInitializers(compilation, initializers, boundInitializers, diagnostics, out firstImportChain);
             }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1230,28 +1230,31 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        CSharpSyntaxNode syntax = methodSymbol.GetNonNullSyntaxNode();
+                        if (!(methodSymbol is SynthesizedStaticConstructor cctor) || cctor.ShouldEmit(processedInitializers.BoundInitializers))
+                        {
+                            CSharpSyntaxNode syntax = methodSymbol.GetNonNullSyntaxNode();
 
-                        var boundBody = BoundStatementList.Synthesized(syntax, boundStatements);
+                            var boundBody = BoundStatementList.Synthesized(syntax, boundStatements);
 
-                        var emittedBody = GenerateMethodBody(
-                            _moduleBeingBuiltOpt,
-                            methodSymbol,
-                            methodOrdinal,
-                            boundBody,
-                            lambdaDebugInfoBuilder.ToImmutable(),
-                            closureDebugInfoBuilder.ToImmutable(),
-                            stateMachineTypeOpt,
-                            lazyVariableSlotAllocator,
-                            diagsForCurrentMethod,
-                            _debugDocumentProvider,
-                            importChain,
-                            _emittingPdb,
-                            _emitTestCoverageData,
-                            dynamicAnalysisSpans,
-                            entryPointOpt: null);
+                            var emittedBody = GenerateMethodBody(
+                                _moduleBeingBuiltOpt,
+                                methodSymbol,
+                                methodOrdinal,
+                                boundBody,
+                                lambdaDebugInfoBuilder.ToImmutable(),
+                                closureDebugInfoBuilder.ToImmutable(),
+                                stateMachineTypeOpt,
+                                lazyVariableSlotAllocator,
+                                diagsForCurrentMethod,
+                                _debugDocumentProvider,
+                                importChain,
+                                _emittingPdb,
+                                _emitTestCoverageData,
+                                dynamicAnalysisSpans,
+                                entryPointOpt: null);
 
-                        _moduleBeingBuiltOpt.SetMethodBody(methodSymbol.PartialDefinitionPart ?? methodSymbol, emittedBody);
+                            _moduleBeingBuiltOpt.SetMethodBody(methodSymbol.PartialDefinitionPart ?? methodSymbol, emittedBody);
+                        }
                     }
 
                     _diagnostics.AddRange(diagsForCurrentMethod);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -669,6 +669,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var method in this.GetMethodsToEmit())
             {
                 Debug.Assert((object)method != null);
+
                 if ((alwaysIncludeConstructors && method.MethodKind == MethodKind.Constructor) || method.ShouldInclude(context))
                 {
                     yield return method;
@@ -702,22 +703,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (m.Kind == SymbolKind.Method)
                 {
                     var method = (MethodSymbol)m;
-
-                    if (method.IsPartialDefinition())
+                    if (method.ShouldEmit())
                     {
-                        // Don't emit partial methods without an implementation part.
-                        if ((object)method.PartialImplementationPart == null)
-                        {
-                            continue;
-                        }
+                        yield return method;
                     }
-                    // Don't emit the default value type constructor - the runtime handles that
-                    else if (method.IsDefaultValueTypeConstructor())
-                    {
-                        continue;
-                    }
-
-                    yield return method;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -261,8 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                         // NOTE: Dev11 does not add synthesized static constructors to this map,
                                         //       but adds synthesized instance constructors, Roslyn adds both
                                         var method = (MethodSymbol)member;
-                                        if (method.IsDefaultValueTypeConstructor() ||
-                                            method.IsPartialMethod() && (object)method.PartialImplementationPart == null)
+                                        if (!method.ShouldEmit())
                                         {
                                             break;
                                         }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -384,6 +384,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Indicates whether the method should be emitted.
+        /// </summary>
+        internal static bool ShouldEmit(this MethodSymbol method)
+        {
+            // Don't emit the default value type constructor - the runtime handles that
+            if (method.IsDefaultValueTypeConstructor())
+            {
+                return false;
+            }
+
+            if (method is SynthesizedStaticConstructor cctor && !cctor.ShouldEmit())
+            {
+                return false;
+            }
+
+            // Don't emit partial methods without an implementation part.
+            if (method.IsPartialMethod() && method.PartialImplementationPart is null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// If the event has a AddMethod, return that.  Otherwise check the overridden
         /// event, if any.  Repeat for each overridden event.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -11,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class SynthesizedStaticConstructor : MethodSymbol
     {
         private readonly NamedTypeSymbol _containingType;
+        private ThreeState _lazyShouldEmit = ThreeState.Unknown;
 
         internal SynthesizedStaticConstructor(NamedTypeSymbol containingType)
         {
@@ -83,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool TryGetThisParameter(out ParameterSymbol thisParameter)
+        internal override bool TryGetThisParameter(out ParameterSymbol? thisParameter)
         {
             thisParameter = null;
             return true;
@@ -160,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol AssociatedSymbol
+        public override Symbol? AssociatedSymbol
         {
             get
             {
@@ -331,7 +335,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override DllImportData GetDllImportData()
+        public override DllImportData? GetDllImportData()
         {
             return null;
         }
@@ -341,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ContainingType.AreLocalsZeroed; }
         }
 
-        internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation
+        internal override MarshalPseudoCustomAttributeData? ReturnValueMarshallingInformation
         {
             get { return null; }
         }
@@ -356,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
         {
             get { return null; }
         }
@@ -370,6 +374,56 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var containingType = (SourceMemberContainerTypeSymbol)this.ContainingType;
             return containingType.CalculateSyntaxOffsetInSynthesizedConstructor(localPosition, localTree, isStatic: true);
+        }
+
+        internal bool ShouldEmit(ImmutableArray<BoundInitializer> boundInitializersOpt = default)
+        {
+            if (_lazyShouldEmit.HasValue())
+            {
+                return _lazyShouldEmit.Value();
+            }
+
+            var shouldEmit = CalculateShouldEmit(boundInitializersOpt);
+            _lazyShouldEmit = shouldEmit.ToThreeState();
+            return shouldEmit;
+        }
+
+        private bool CalculateShouldEmit(ImmutableArray<BoundInitializer> boundInitializersOpt = default)
+        {
+            if (boundInitializersOpt.IsDefault)
+            {
+                if (!(ContainingType is SourceMemberContainerTypeSymbol sourceType))
+                {
+                    Debug.Assert(ContainingType is SynthesizedClosureEnvironment);
+                    return true;
+                }
+
+                var unusedDiagnostics = DiagnosticBag.GetInstance();
+                boundInitializersOpt = Binder.BindFieldInitializers(
+                    DeclaringCompilation,
+                    sourceType.IsScriptClass ? sourceType.GetScriptInitializer() : null,
+                    sourceType.StaticInitializers,
+                    unusedDiagnostics,
+                    out _);
+                unusedDiagnostics.Free();
+            }
+
+            foreach (var initializer in boundInitializersOpt)
+            {
+                if (!(initializer is BoundFieldEqualsValue { Value: { } value }))
+                {
+                    // this isn't a BoundFieldEqualsValue, so this initializer is doing
+                    // something we don't understand. Better just emit it.
+                    return true;
+                }
+
+                if (!value.IsDefaultValue())
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -592,6 +595,134 @@ public static class Module1
 ");
         }
 
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void DecimalConstInit002()
+        {
+            var source1 = @"
+class C
+{
+    const decimal d1 = 0.1m;
+}
+";
+            var source2 = @"
+class C
+{
+    static readonly decimal d1 = 0.1m;
+}
+";
+            var expectedIL = @"
+{
+  // Code size       16 (0x10)
+  .maxstack  5
+  IL_0000:  ldc.i4.1
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldc.i4.0
+  IL_0003:  ldc.i4.0
+  IL_0004:  ldc.i4.1
+  IL_0005:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
+  IL_000a:  stsfld     ""decimal C.d1""
+  IL_000f:  ret
+}
+";
+            CompileAndVerify(source1).VerifyIL("C..cctor", expectedIL);
+            CompileAndVerify(source2).VerifyIL("C..cctor", expectedIL);
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void DecimalConstInit003()
+        {
+            var source1 = @"
+class C
+{
+    const decimal d1 = 0.0m;
+}
+";
+
+            var source2 = @"
+class C
+{
+    static readonly decimal d1 = 0.0m;
+}
+";
+
+            var expectedIL = @"
+{
+  // Code size       16 (0x10)
+  .maxstack  5
+  IL_0000:  ldc.i4.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldc.i4.0
+  IL_0003:  ldc.i4.0
+  IL_0004:  ldc.i4.1
+  IL_0005:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
+  IL_000a:  stsfld     ""decimal C.d1""
+  IL_000f:  ret
+}
+";
+            CompileAndVerify(source1).VerifyIL("C..cctor", expectedIL);
+            CompileAndVerify(source2).VerifyIL("C..cctor", expectedIL);
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void DecimalConstInit004()
+        {
+            var source1 = @"
+class C
+{
+    const decimal d1 = default;
+    const decimal d2 = 0;
+    const decimal d3 = 0m;
+}
+";
+
+            var source2 = @"
+class C
+{
+    static readonly decimal d1 = default;
+    static readonly decimal d2 = 0;
+    static readonly decimal d3 = 0m;
+}
+";
+            var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(source1, symbolValidator: validator, options: options);
+            CompileAndVerify(source2, symbolValidator: validator, options: options);
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("C");
+                Assert.Null(type.GetMember(".cctor"));
+            }
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void StaticLambdaConstructorAlwaysEmitted()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        System.Action a1 = () => { };
+    }
+}
+";
+            CompileAndVerify(source).
+                VerifyIL("C.<>c..cctor", @"
+{
+  // Code size       11 (0xb)
+  .maxstack  1
+  IL_0000:  newobj     ""C.<>c..ctor()""
+  IL_0005:  stsfld     ""C.<>c C.<>c.<>9""
+  IL_000a:  ret
+}
+");
+        }
+
         [WorkItem(217748, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=217748")]
         [Fact]
         public void BadExpressionConstructor()
@@ -606,6 +737,524 @@ public static class Module1
                 // (4,17): error CS0656: Missing compiler required member 'Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create'
                 //     dynamic d = F() * 2;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F()").WithArguments("Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo", "Create").WithLocation(4, 17));
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_01()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static int i = 0;
+    static bool b = false;
+}";
+            CompileAndVerify(
+                source,
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("C");
+                Assert.Null(type.GetMember(".cctor"));
+            }
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_02()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static string s = null!;
+}";
+            CompileAndVerify(
+                source,
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("C");
+                Assert.Null(type.GetMember(".cctor"));
+            }
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_03()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static (int, object) pair = (0, null!);
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldc.i4.0
+  IL_0001:  ldnull
+  IL_0002:  newobj     ""System.ValueTuple<int, object>..ctor(int, object)""
+  IL_0007:  stsfld     ""System.ValueTuple<int, object> C.pair""
+  IL_000c:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_04()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static (int, object) pair1 = default;
+    static (int, object) pair2 = default((int, object));
+    static (int, object) pair3 = default!;
+    static (int, object) pair4 = default((int, object))!;
+}";
+            // note: we could make the synthesized constructor smarter and realize that
+            // nothing needs to be emitted for these initializers.
+            // but it doesn't serve any realistic scenarios at this time.
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_05()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static C instance = default!;
+}";
+            CompileAndVerify(
+                source,
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("C");
+                Assert.Null(type.GetMember(".cctor"));
+            }
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_06()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+    public int y;
+}
+
+class C
+{
+    static S field1 = default;
+    static S field2 = default(S);
+    static S field3 = new S();
+}";
+            // note: we could make the synthesized constructor smarter and realize that
+            // nothing needs to be emitted for these initializers.
+            // but it doesn't serve any realistic scenarios at this time.
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_08()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static int x = 1;
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldc.i4.1
+  IL_0001:  stsfld     ""int C.x""
+  IL_0006:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_09()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static S? s1 = null;
+    static S? s2 = default(S?);
+}";
+            CompileAndVerify(
+                source,
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("C");
+                Assert.Null(type.GetMember(".cctor"));
+            }
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_10()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static S? s1 = default;
+}";
+            // note: we could make the synthesized constructor smarter and realize that
+            // nothing needs to be emitted for these initializers.
+            // but it doesn't serve any realistic scenarios at this time.
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_11()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static S? s1 = new S?();
+}";
+            // note: we could make the synthesized constructor smarter and realize that
+            // nothing needs to be emitted for these initializers.
+            // but it doesn't serve any realistic scenarios at this time.
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_12()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static S? s1 = default(S);
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.0
+  IL_0009:  newobj     ""S?..ctor(S)""
+  IL_000e:  stsfld     ""S? C.s1""
+  IL_0013:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_13()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static S? s1 = new S();
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.0
+  IL_0009:  newobj     ""S?..ctor(S)""
+  IL_000e:  stsfld     ""S? C.s1""
+  IL_0013:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_14()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static object s1 = default(S);
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.0
+  IL_0009:  box        ""S""
+  IL_000e:  stsfld     ""object C.s1""
+  IL_0013:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_15()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static object s1 = new S();
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.0
+  IL_0009:  box        ""S""
+  IL_000e:  stsfld     ""object C.s1""
+  IL_0013:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_16()
+        {
+            string source = @"
+#nullable enable
+
+struct S
+{
+    public int x;
+}
+
+class C
+{
+    static object s1 = default(S?);
+    static object s2 = (S?)null;
+    static object s3 = new S?();
+}";
+            // note: we could make the synthesized constructor smarter and realize that
+            // nothing needs to be emitted for these initializers.
+            // but it doesn't serve any realistic scenarios at this time.
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void SkipSynthesizedStaticConstructor_17()
+        {
+            string source = @"
+unsafe class C
+{
+    static System.IntPtr s1 = (System.IntPtr)0;
+    static System.UIntPtr s2 = (System.UIntPtr)0;
+    static void* s3 = (void*)0;
+}";
+            // note: we could make the synthesized constructor smarter and realize that
+            // nothing needs to be emitted for the `(void*)0` initializer.
+            // but it doesn't serve any realistic scenarios at this time.
+            CompileAndVerify(source, options: TestOptions.UnsafeDebugDll, verify: Verification.Skipped).VerifyIL("C..cctor()", @"
+{
+  // Code size       31 (0x1f)
+  .maxstack  1
+  IL_0000:  ldc.i4.0
+  IL_0001:  call       ""System.IntPtr System.IntPtr.op_Explicit(int)""
+  IL_0006:  stsfld     ""System.IntPtr C.s1""
+  IL_000b:  ldc.i4.0
+  IL_000c:  conv.i8
+  IL_000d:  call       ""System.UIntPtr System.UIntPtr.op_Explicit(ulong)""
+  IL_0012:  stsfld     ""System.UIntPtr C.s2""
+  IL_0017:  ldc.i4.0
+  IL_0018:  conv.i
+  IL_0019:  stsfld     ""void* C.s3""
+  IL_001e:  ret
+}");
+        }
+
+        [WorkItem(543606, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543606")]
+        [ConditionalFact(typeof(DesktopOnly))]
+        public void StaticNullInitializerHasNoEffectOnTypeIL()
+        {
+            var source1 = @"
+#nullable enable
+class C
+{
+    static string s1;
+}";
+
+            var source2 = @"
+#nullable enable
+class C
+{
+    static string s1 = null!;
+}";
+
+            var expectedIL = @"
+.class private auto ansi beforefieldinit C
+        extends [mscorlib]System.Object
+{
+        // Fields
+        .field private static string s1
+        .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = (
+                01 00 01 00 00
+        )
+        // Methods
+        .method public hidebysig specialname rtspecialname
+                instance void .ctor () cil managed
+        {
+                // Method begins at RVA 0x207f
+                // Code size 7 (0x7)
+                .maxstack 8
+                IL_0000: ldarg.0
+                IL_0001: call instance void [mscorlib]System.Object::.ctor()
+                IL_0006: ret
+        } // end of method C::.ctor
+} // end of class C
+";
+
+            CompileAndVerify(source1).VerifyTypeIL("C", expectedIL);
+            CompileAndVerify(source2).VerifyTypeIL("C", expectedIL);
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void ExplicitStaticConstructor_01()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static string x = null!;
+
+    static C()
+    {
+    }
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
+
+        [WorkItem(42985, "https://github.com/dotnet/roslyn/issues/42985")]
+        [Fact]
+        public void ExplicitStaticConstructor_02()
+        {
+            string source = @"
+#nullable enable
+class C
+{
+    static string x;
+
+    static C()
+    {
+        x = null!;
+    }
+}";
+            CompileAndVerify(source).VerifyIL("C..cctor()", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldnull
+  IL_0001:  stsfld     ""string C.x""
+  IL_0006:  ret
+}");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFieldInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFieldInitTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -560,13 +561,19 @@ class C
 
 ";
             var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
-            CompileAndVerify(compilation).VerifyIL("C<T>..cctor", @"
-{
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}
-");
+            CompileAndVerify(
+                source,
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            void validator(ModuleSymbol module)
+            {
+                // note: we could make the synthesized constructor smarter and realize that
+                // nothing needs to be emitted for these initializers.
+                // but it doesn't serve any realistic scenarios at this time.
+                var type = module.ContainingAssembly.GetTypeByMetadataName("C`1");
+                Assert.NotNull(type.GetMember(".cctor"));
+            }
         }
 
         [WorkItem(530445, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530445")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -906,15 +906,16 @@ public class H
     }
 }
 ";
-            var compilation = CompileAndVerify(source);
+            CompileAndVerify(
+                source,
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
 
-            compilation.VerifyIL("H..cctor",
-@"{
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}
-");
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("H");
+                Assert.Null(type.GetMember(".cctor"));
+            }
         }
 
 
@@ -14700,7 +14701,7 @@ using System;
             var source = @"
 enum MyEnum { first, second, last }
 struct MyStruct { int intStructMember; }
-public class Test
+public unsafe class Test
 {
     static bool boolMember = false;
     static char charMember = '\0';
@@ -14712,13 +14713,37 @@ public class Test
     static uint uintMember = 0;
     static long longMember = 0L;
     static ulong ulongMember = 0;
-    static decimal decimalMember = default(decimal);
+    static nint nintMember = 0;
+    static nuint nuintMember = 0;
+    static decimal decimalMember = 0m;
     static string strMember = null;
     static object objMember = null;
     static float floatMember = 0.0F;
     static double doubleMember = 0.0D;
     static MyEnum enumMember = MyEnum.first;
-    MyStruct structMember = default(MyStruct);
+
+    static bool boolMember2 = default(bool);
+    static char charMember2 = default(char);
+    static sbyte sbyteMember2 = default(sbyte);
+    static byte byteMember2 = default(byte);
+    static short shortMember2 = default(short);
+    static ushort ushortMember2 = default(ushort);
+    static int intMember2 = default(int);
+    static uint uintMember2 = default(uint);
+    static long longMember2 = default(long);
+    static ulong ulongMember2 = default(ulong);
+    static nint nintMember2 = default(nint);
+    static nuint nuintMember2 = default(nuint);
+    static decimal decimalMember2 = default(decimal);
+    static string strMember2 = default(string);
+    static object objMember2 = default(object);
+    static float floatMember2 = default(float);
+    static double doubleMember2 = default(double);
+    static MyEnum enumMember2 = default(MyEnum);
+    static MyStruct structMember2 = default(MyStruct);
+    static System.IntPtr intPtrMember2 = default(System.IntPtr);
+    static System.UIntPtr uintPtrMember2 = default(System.UIntPtr);
+    static void* voidPtrMember2 = default(void*);
 }
 
 class c1
@@ -14730,15 +14755,18 @@ class c1
 
 ";
 
-            CompileAndVerify(source, expectedOutput: @"").
-                VerifyIL("Test..cctor()",
-@"
-{
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}                                                                                           
-"); ;
+            CompileAndVerify(
+                source,
+                expectedOutput: "",
+                symbolValidator: validator,
+                options: TestOptions.UnsafeDebugExe.WithMetadataImportOptions(MetadataImportOptions.All),
+                parseOptions: TestOptions.RegularPreview);
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("Test");
+                Assert.Null(type.GetMember(".cctor"));
+            }
         }
 
         [WorkItem(876784, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/876784")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -9110,8 +9110,16 @@ public class Program
             );
 
             compVerifier = CompileAndVerify(source,
-                options: TestOptions.DebugDll.WithOutputKind(OutputKind.ConsoleApplication),
-                expectedOutput: "");
+                expectedOutput: "",
+                symbolValidator: validator,
+                options: TestOptions.DebugDll.WithOutputKind(OutputKind.ConsoleApplication).WithMetadataImportOptions(MetadataImportOptions.All));
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("Program");
+                Assert.Null(type.GetMember(".cctor"));
+            }
+
             compVerifier.VerifyIL(qualifiedMethodName: "Program.M", sequencePoints: "Program.M", source: source,
 expectedIL: @"{
   // Code size      149 (0x95)
@@ -9311,14 +9319,6 @@ expectedIL: @"{
           <local name=""i"" il_index=""3"" il_start=""0x7c"" il_end=""0x89"" attributes=""0"" />
         </scope>
       </scope>
-    </method>
-    <method containingType=""Program"" name="".cctor"">
-      <customDebugInfo>
-        <forward declaringType=""Program"" methodName=""Main"" />
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""27"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>");

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -60,285 +60,281 @@ class Driver
         return Driver.Result;
     }
 }");
-            var compilation = CreateCompilationWithMscorlib45(text, options: TestOptions.DebugDll).VerifyDiagnostics();
-            var v = CompileAndVerify(compilation);
+            verify(text);
+            verify(text.Replace("public static int Count = 0;", "public static int Count;"));
 
-            v.VerifyIL("TestCase.<Run>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      303 (0x12f)
-  .maxstack  3
-  .locals init (int V_0,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
-                TestCase.<Run>d__1 V_2,
-                bool V_3,
-                System.Exception V_4)
- ~IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int TestCase.<Run>d__1.<>1__state""
-  IL_0006:  stloc.0
-  .try
-  {
-   ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_000c
-    IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_008b
-   -IL_000e:  nop
-   -IL_000f:  ldarg.0
-    IL_0010:  newobj     ""DynamicMembers..ctor()""
-    IL_0015:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-   -IL_001a:  ldarg.0
-    IL_001b:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-    IL_0020:  ldsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
-    IL_0025:  dup
-    IL_0026:  brtrue.s   IL_003f
-    IL_0028:  pop
-    IL_0029:  ldsfld     ""TestCase.<>c TestCase.<>c.<>9""
-    IL_002e:  ldftn      ""System.Threading.Tasks.Task<int> TestCase.<>c.<Run>b__1_0()""
-    IL_0034:  newobj     ""System.Func<System.Threading.Tasks.Task<int>>..ctor(object, System.IntPtr)""
-    IL_0039:  dup
-    IL_003a:  stsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
-    IL_003f:  callvirt   ""void DynamicMembers.Prop.set""
-    IL_0044:  nop
-   -IL_0045:  ldarg.0
-    IL_0046:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-    IL_004b:  callvirt   ""System.Func<System.Threading.Tasks.Task<int>> DynamicMembers.Prop.get""
-    IL_0050:  callvirt   ""System.Threading.Tasks.Task<int> System.Func<System.Threading.Tasks.Task<int>>.Invoke()""
-    IL_0055:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_005a:  stloc.1
-   ~IL_005b:  ldloca.s   V_1
-    IL_005d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0062:  brtrue.s   IL_00a7
-    IL_0064:  ldarg.0
-    IL_0065:  ldc.i4.0
-    IL_0066:  dup
-    IL_0067:  stloc.0
-    IL_0068:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-   <IL_006d:  ldarg.0
-    IL_006e:  ldloc.1
-    IL_006f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
-    IL_0074:  ldarg.0
-    IL_0075:  stloc.2
-    IL_0076:  ldarg.0
-    IL_0077:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-    IL_007c:  ldloca.s   V_1
-    IL_007e:  ldloca.s   V_2
-    IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, TestCase.<Run>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref TestCase.<Run>d__1)""
-    IL_0085:  nop
-    IL_0086:  leave      IL_012e
-   >IL_008b:  ldarg.0
-    IL_008c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
-    IL_0091:  stloc.1
-    IL_0092:  ldarg.0
-    IL_0093:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
-    IL_0098:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_009e:  ldarg.0
-    IL_009f:  ldc.i4.m1
-    IL_00a0:  dup
-    IL_00a1:  stloc.0
-    IL_00a2:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldloca.s   V_1
-    IL_00aa:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00af:  stfld      ""int TestCase.<Run>d__1.<>s__3""
-    IL_00b4:  ldarg.0
-    IL_00b5:  ldarg.0
-    IL_00b6:  ldfld      ""int TestCase.<Run>d__1.<>s__3""
-    IL_00bb:  stfld      ""int TestCase.<Run>d__1.<rez2>5__2""
-   -IL_00c0:  ldarg.0
-    IL_00c1:  ldfld      ""int TestCase.<Run>d__1.<rez2>5__2""
-    IL_00c6:  ldc.i4.3
-    IL_00c7:  ceq
-    IL_00c9:  stloc.3
-   ~IL_00ca:  ldloc.3
-    IL_00cb:  brfalse.s  IL_00d9
-   -IL_00cd:  ldsfld     ""int TestCase.Count""
-    IL_00d2:  ldc.i4.1
-    IL_00d3:  add
-    IL_00d4:  stsfld     ""int TestCase.Count""
-   -IL_00d9:  ldsfld     ""int TestCase.Count""
-    IL_00de:  ldc.i4.1
-    IL_00df:  sub
-    IL_00e0:  stsfld     ""int Driver.Result""
-   -IL_00e5:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
-    IL_00ea:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
-    IL_00ef:  pop
-    IL_00f0:  leave.s    IL_0113
-  }
-  catch System.Exception
-  {
-  ~$IL_00f2:  stloc.s    V_4
-    IL_00f4:  ldarg.0
-    IL_00f5:  ldc.i4.s   -2
-    IL_00f7:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-    IL_00fc:  ldarg.0
-    IL_00fd:  ldnull
-    IL_00fe:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-    IL_0103:  ldarg.0
-    IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-    IL_0109:  ldloc.s    V_4
-    IL_010b:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_0110:  nop
-    IL_0111:  leave.s    IL_012e
-  }
- -IL_0113:  ldarg.0
-  IL_0114:  ldc.i4.s   -2
-  IL_0116:  stfld      ""int TestCase.<Run>d__1.<>1__state""
- ~IL_011b:  ldarg.0
-  IL_011c:  ldnull
-  IL_011d:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-  IL_0122:  ldarg.0
-  IL_0123:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-  IL_0128:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_012d:  nop
-  IL_012e:  ret
-}",
-sequencePoints: "TestCase+<Run>d__1.MoveNext");
+            void verify(string text)
+            {
+                var compilation = CreateCompilationWithMscorlib45(text, options: TestOptions.DebugDll).VerifyDiagnostics();
+                var v = CompileAndVerify(compilation);
 
-            v.VerifyPdb(@"
-<symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
-  <methods>
-    <method containingType=""DynamicMembers"" name=""get_Prop"">
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""39"" document=""1"" />
-      </sequencePoints>
-    </method>
-    <method containingType=""DynamicMembers"" name=""set_Prop"" parameterNames=""value"">
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""40"" endLine=""8"" endColumn=""44"" document=""1"" />
-      </sequencePoints>
-    </method>
-    <method containingType=""TestCase"" name=""Run"">
-      <customDebugInfo>
-        <forwardIterator name=""&lt;Run&gt;d__1"" />
-        <encLocalSlotMap>
-          <slot kind=""0"" offset=""26"" />
-          <slot kind=""0"" offset=""139"" />
-          <slot kind=""28"" offset=""146"" />
-        </encLocalSlotMap>
-        <encLambdaMap>
-          <methodOrdinal>1</methodOrdinal>
-          <lambda offset=""86"" />
-        </encLambdaMap>
-      </customDebugInfo>
-    </method>
-    <method containingType=""TestCase"" name="".cctor"">
-      <customDebugInfo>
-        <using>
-          <namespace usingCount=""3"" />
-        </using>
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""33"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x7"">
-        <namespace name=""System"" />
-        <namespace name=""System.Threading"" />
-        <namespace name=""System.Threading.Tasks"" />
-      </scope>
-    </method>
-    <method containingType=""Driver"" name=""Main"">
-      <customDebugInfo>
-        <forward declaringType=""TestCase"" methodName="".cctor"" />
-        <encLocalSlotMap>
-          <slot kind=""0"" offset=""15"" />
-          <slot kind=""21"" offset=""0"" />
-        </encLocalSlotMap>
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""30"" startColumn=""5"" endLine=""30"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""32"" document=""1"" />
-        <entry offset=""0x7"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""17"" document=""1"" />
-        <entry offset=""0xe"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""35"" document=""1"" />
-        <entry offset=""0x19"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x21"" startLine=""36"" startColumn=""5"" endLine=""36"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x23"">
-        <local name=""t"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
-      </scope>
-    </method>
-    <method containingType=""Driver"" name="".cctor"">
-      <customDebugInfo>
-        <forward declaringType=""TestCase"" methodName="".cctor"" />
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""35"" document=""1"" />
-        <entry offset=""0x6"" startLine=""28"" startColumn=""5"" endLine=""28"" endColumn=""78"" document=""1"" />
-      </sequencePoints>
-    </method>
-    <method containingType=""TestCase+&lt;&gt;c"" name=""&lt;Run&gt;b__1_0"">
-      <customDebugInfo>
-        <forwardIterator name=""&lt;&lt;Run&gt;b__1_0&gt;d"" />
-      </customDebugInfo>
-    </method>
-    <method containingType=""TestCase+&lt;Run&gt;d__1"" name=""MoveNext"">
-      <customDebugInfo>
-        <forward declaringType=""TestCase"" methodName="".cctor"" />
-        <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x12f"" />
-          <slot startOffset=""0x0"" endOffset=""0x12f"" />
-        </hoistedLocalScopes>
-        <encLocalSlotMap>
-          <slot kind=""27"" offset=""0"" />
-          <slot kind=""33"" offset=""146"" />
-          <slot kind=""temp"" />
-          <slot kind=""1"" offset=""173"" />
-          <slot kind=""temp"" />
-        </encLocalSlotMap>
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""51"" document=""1"" />
-        <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" document=""1"" />
-        <entry offset=""0x45"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" document=""1"" />
-        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" document=""1"" />
-        <entry offset=""0xca"" hidden=""true"" document=""1"" />
-        <entry offset=""0xcd"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" document=""1"" />
-        <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" document=""1"" />
-        <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xf2"" hidden=""true"" document=""1"" />
-        <entry offset=""0x113"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x11b"" hidden=""true"" document=""1"" />
-      </sequencePoints>
-      <asyncInfo>
-        <catchHandler offset=""0xf2"" />
-        <kickoffMethod declaringType=""TestCase"" methodName=""Run"" />
-        <await yield=""0x6d"" resume=""0x8b"" declaringType=""TestCase+&lt;Run&gt;d__1"" methodName=""MoveNext"" />
-      </asyncInfo>
-    </method>
-    <method containingType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" name=""MoveNext"">
-      <customDebugInfo>
-        <forward declaringType=""TestCase"" methodName="".cctor"" />
-        <encLocalSlotMap>
-          <slot kind=""27"" offset=""86"" />
-          <slot kind=""20"" offset=""86"" />
-          <slot kind=""33"" offset=""88"" />
-          <slot kind=""temp"" />
-          <slot kind=""temp"" />
-        </encLocalSlotMap>
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xe"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" document=""1"" />
-        <entry offset=""0xf"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" document=""1"" />
-        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
-        <entry offset=""0x70"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" document=""1"" />
-        <entry offset=""0x74"" hidden=""true"" document=""1"" />
-        <entry offset=""0x8e"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" document=""1"" />
-        <entry offset=""0x96"" hidden=""true"" document=""1"" />
-      </sequencePoints>
-      <asyncInfo>
-        <kickoffMethod declaringType=""TestCase+&lt;&gt;c"" methodName=""&lt;Run&gt;b__1_0"" />
-        <await yield=""0x31"" resume=""0x4c"" declaringType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" methodName=""MoveNext"" />
-      </asyncInfo>
-    </method>
-  </methods>
-</symbols>");
+                v.VerifyIL("TestCase.<Run>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
+    {
+    // Code size      303 (0x12f)
+    .maxstack  3
+    .locals init (int V_0,
+                    System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
+                    TestCase.<Run>d__1 V_2,
+                    bool V_3,
+                    System.Exception V_4)
+    ~IL_0000:  ldarg.0
+    IL_0001:  ldfld      ""int TestCase.<Run>d__1.<>1__state""
+    IL_0006:  stloc.0
+    .try
+    {
+    ~IL_0007:  ldloc.0
+        IL_0008:  brfalse.s  IL_000c
+        IL_000a:  br.s       IL_000e
+        IL_000c:  br.s       IL_008b
+    -IL_000e:  nop
+    -IL_000f:  ldarg.0
+        IL_0010:  newobj     ""DynamicMembers..ctor()""
+        IL_0015:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+    -IL_001a:  ldarg.0
+        IL_001b:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+        IL_0020:  ldsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
+        IL_0025:  dup
+        IL_0026:  brtrue.s   IL_003f
+        IL_0028:  pop
+        IL_0029:  ldsfld     ""TestCase.<>c TestCase.<>c.<>9""
+        IL_002e:  ldftn      ""System.Threading.Tasks.Task<int> TestCase.<>c.<Run>b__1_0()""
+        IL_0034:  newobj     ""System.Func<System.Threading.Tasks.Task<int>>..ctor(object, System.IntPtr)""
+        IL_0039:  dup
+        IL_003a:  stsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
+        IL_003f:  callvirt   ""void DynamicMembers.Prop.set""
+        IL_0044:  nop
+    -IL_0045:  ldarg.0
+        IL_0046:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+        IL_004b:  callvirt   ""System.Func<System.Threading.Tasks.Task<int>> DynamicMembers.Prop.get""
+        IL_0050:  callvirt   ""System.Threading.Tasks.Task<int> System.Func<System.Threading.Tasks.Task<int>>.Invoke()""
+        IL_0055:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+        IL_005a:  stloc.1
+    ~IL_005b:  ldloca.s   V_1
+        IL_005d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+        IL_0062:  brtrue.s   IL_00a7
+        IL_0064:  ldarg.0
+        IL_0065:  ldc.i4.0
+        IL_0066:  dup
+        IL_0067:  stloc.0
+        IL_0068:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+    <IL_006d:  ldarg.0
+        IL_006e:  ldloc.1
+        IL_006f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
+        IL_0074:  ldarg.0
+        IL_0075:  stloc.2
+        IL_0076:  ldarg.0
+        IL_0077:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+        IL_007c:  ldloca.s   V_1
+        IL_007e:  ldloca.s   V_2
+        IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, TestCase.<Run>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref TestCase.<Run>d__1)""
+        IL_0085:  nop
+        IL_0086:  leave      IL_012e
+    >IL_008b:  ldarg.0
+        IL_008c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
+        IL_0091:  stloc.1
+        IL_0092:  ldarg.0
+        IL_0093:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
+        IL_0098:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+        IL_009e:  ldarg.0
+        IL_009f:  ldc.i4.m1
+        IL_00a0:  dup
+        IL_00a1:  stloc.0
+        IL_00a2:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+        IL_00a7:  ldarg.0
+        IL_00a8:  ldloca.s   V_1
+        IL_00aa:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+        IL_00af:  stfld      ""int TestCase.<Run>d__1.<>s__3""
+        IL_00b4:  ldarg.0
+        IL_00b5:  ldarg.0
+        IL_00b6:  ldfld      ""int TestCase.<Run>d__1.<>s__3""
+        IL_00bb:  stfld      ""int TestCase.<Run>d__1.<rez2>5__2""
+    -IL_00c0:  ldarg.0
+        IL_00c1:  ldfld      ""int TestCase.<Run>d__1.<rez2>5__2""
+        IL_00c6:  ldc.i4.3
+        IL_00c7:  ceq
+        IL_00c9:  stloc.3
+    ~IL_00ca:  ldloc.3
+        IL_00cb:  brfalse.s  IL_00d9
+    -IL_00cd:  ldsfld     ""int TestCase.Count""
+        IL_00d2:  ldc.i4.1
+        IL_00d3:  add
+        IL_00d4:  stsfld     ""int TestCase.Count""
+    -IL_00d9:  ldsfld     ""int TestCase.Count""
+        IL_00de:  ldc.i4.1
+        IL_00df:  sub
+        IL_00e0:  stsfld     ""int Driver.Result""
+    -IL_00e5:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
+        IL_00ea:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
+        IL_00ef:  pop
+        IL_00f0:  leave.s    IL_0113
+    }
+    catch System.Exception
+    {
+    ~$IL_00f2:  stloc.s    V_4
+        IL_00f4:  ldarg.0
+        IL_00f5:  ldc.i4.s   -2
+        IL_00f7:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+        IL_00fc:  ldarg.0
+        IL_00fd:  ldnull
+        IL_00fe:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+        IL_0103:  ldarg.0
+        IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+        IL_0109:  ldloc.s    V_4
+        IL_010b:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
+        IL_0110:  nop
+        IL_0111:  leave.s    IL_012e
+    }
+    -IL_0113:  ldarg.0
+    IL_0114:  ldc.i4.s   -2
+    IL_0116:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+    ~IL_011b:  ldarg.0
+    IL_011c:  ldnull
+    IL_011d:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+    IL_0122:  ldarg.0
+    IL_0123:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+    IL_0128:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
+    IL_012d:  nop
+    IL_012e:  ret
+    }",
+    sequencePoints: "TestCase+<Run>d__1.MoveNext");
+
+                v.VerifyPdb(@"
+    <symbols>
+    <files>
+        <file id=""1"" name="""" language=""C#"" />
+    </files>
+    <methods>
+        <method containingType=""DynamicMembers"" name=""get_Prop"">
+        <sequencePoints>
+            <entry offset=""0x0"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""39"" document=""1"" />
+        </sequencePoints>
+        </method>
+        <method containingType=""DynamicMembers"" name=""set_Prop"" parameterNames=""value"">
+        <sequencePoints>
+            <entry offset=""0x0"" startLine=""8"" startColumn=""40"" endLine=""8"" endColumn=""44"" document=""1"" />
+        </sequencePoints>
+        </method>
+        <method containingType=""TestCase"" name=""Run"">
+        <customDebugInfo>
+            <forwardIterator name=""&lt;Run&gt;d__1"" />
+            <encLocalSlotMap>
+            <slot kind=""0"" offset=""26"" />
+            <slot kind=""0"" offset=""139"" />
+            <slot kind=""28"" offset=""146"" />
+            </encLocalSlotMap>
+            <encLambdaMap>
+            <methodOrdinal>1</methodOrdinal>
+            <lambda offset=""86"" />
+            </encLambdaMap>
+        </customDebugInfo>
+        </method>
+        <method containingType=""Driver"" name=""Main"">
+        <customDebugInfo>
+            <using>
+            <namespace usingCount=""3"" />
+            </using>
+            <encLocalSlotMap>
+            <slot kind=""0"" offset=""15"" />
+            <slot kind=""21"" offset=""0"" />
+            </encLocalSlotMap>
+        </customDebugInfo>
+        <sequencePoints>
+            <entry offset=""0x0"" startLine=""30"" startColumn=""5"" endLine=""30"" endColumn=""6"" document=""1"" />
+            <entry offset=""0x1"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""32"" document=""1"" />
+            <entry offset=""0x7"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""17"" document=""1"" />
+            <entry offset=""0xe"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""35"" document=""1"" />
+            <entry offset=""0x19"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""30"" document=""1"" />
+            <entry offset=""0x21"" startLine=""36"" startColumn=""5"" endLine=""36"" endColumn=""6"" document=""1"" />
+        </sequencePoints>
+        <scope startOffset=""0x0"" endOffset=""0x23"">
+            <namespace name=""System"" />
+            <namespace name=""System.Threading"" />
+            <namespace name=""System.Threading.Tasks"" />
+            <local name=""t"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
+        </scope>
+        </method>
+        <method containingType=""Driver"" name="".cctor"">
+        <customDebugInfo>
+            <forward declaringType=""Driver"" methodName=""Main"" />
+        </customDebugInfo>
+        <sequencePoints>
+            <entry offset=""0x0"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""35"" document=""1"" />
+            <entry offset=""0x6"" startLine=""28"" startColumn=""5"" endLine=""28"" endColumn=""78"" document=""1"" />
+        </sequencePoints>
+        </method>
+        <method containingType=""TestCase+&lt;&gt;c"" name=""&lt;Run&gt;b__1_0"">
+        <customDebugInfo>
+            <forwardIterator name=""&lt;&lt;Run&gt;b__1_0&gt;d"" />
+        </customDebugInfo>
+        </method>
+        <method containingType=""TestCase+&lt;Run&gt;d__1"" name=""MoveNext"">
+        <customDebugInfo>
+            <forward declaringType=""Driver"" methodName=""Main"" />
+            <hoistedLocalScopes>
+            <slot startOffset=""0x0"" endOffset=""0x12f"" />
+            <slot startOffset=""0x0"" endOffset=""0x12f"" />
+            </hoistedLocalScopes>
+            <encLocalSlotMap>
+            <slot kind=""27"" offset=""0"" />
+            <slot kind=""33"" offset=""146"" />
+            <slot kind=""temp"" />
+            <slot kind=""1"" offset=""173"" />
+            <slot kind=""temp"" />
+            </encLocalSlotMap>
+        </customDebugInfo>
+        <sequencePoints>
+            <entry offset=""0x0"" hidden=""true"" document=""1"" />
+            <entry offset=""0x7"" hidden=""true"" document=""1"" />
+            <entry offset=""0xe"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+            <entry offset=""0xf"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""51"" document=""1"" />
+            <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" document=""1"" />
+            <entry offset=""0x45"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" document=""1"" />
+            <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+            <entry offset=""0xc0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" document=""1"" />
+            <entry offset=""0xca"" hidden=""true"" document=""1"" />
+            <entry offset=""0xcd"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" document=""1"" />
+            <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" document=""1"" />
+            <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" document=""1"" />
+            <entry offset=""0xf2"" hidden=""true"" document=""1"" />
+            <entry offset=""0x113"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+            <entry offset=""0x11b"" hidden=""true"" document=""1"" />
+        </sequencePoints>
+        <asyncInfo>
+            <catchHandler offset=""0xf2"" />
+            <kickoffMethod declaringType=""TestCase"" methodName=""Run"" />
+            <await yield=""0x6d"" resume=""0x8b"" declaringType=""TestCase+&lt;Run&gt;d__1"" methodName=""MoveNext"" />
+        </asyncInfo>
+        </method>
+        <method containingType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" name=""MoveNext"">
+        <customDebugInfo>
+            <forward declaringType=""Driver"" methodName=""Main"" />
+            <encLocalSlotMap>
+            <slot kind=""27"" offset=""86"" />
+            <slot kind=""20"" offset=""86"" />
+            <slot kind=""33"" offset=""88"" />
+            <slot kind=""temp"" />
+            <slot kind=""temp"" />
+            </encLocalSlotMap>
+        </customDebugInfo>
+        <sequencePoints>
+            <entry offset=""0x0"" hidden=""true"" document=""1"" />
+            <entry offset=""0x7"" hidden=""true"" document=""1"" />
+            <entry offset=""0xe"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" document=""1"" />
+            <entry offset=""0xf"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" document=""1"" />
+            <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+            <entry offset=""0x70"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" document=""1"" />
+            <entry offset=""0x74"" hidden=""true"" document=""1"" />
+            <entry offset=""0x8e"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" document=""1"" />
+            <entry offset=""0x96"" hidden=""true"" document=""1"" />
+        </sequencePoints>
+        <asyncInfo>
+            <kickoffMethod declaringType=""TestCase+&lt;&gt;c"" methodName=""&lt;Run&gt;b__1_0"" />
+            <await yield=""0x31"" resume=""0x4c"" declaringType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" methodName=""MoveNext"" />
+        </asyncInfo>
+        </method>
+    </methods>
+    </symbols>");
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBWinMdExpTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBWinMdExpTests.cs
@@ -92,7 +92,6 @@ namespace X
     <token-location token=""0x06xxxxxx"" file=""source.cs"" start-line=""9"" start-column=""38"" end-line=""9"" end-column=""41""/>
     <token-location token=""0x02xxxxxx"" file=""source.cs"" start-line=""11"" start-column=""30"" end-line=""11"" end-column=""38""/>
     <token-location token=""0x06xxxxxx"" file=""source.cs"" start-line=""11"" start-column=""30"" end-line=""11"" end-column=""38""/>
-    <token-location token=""0x06xxxxxx"" file=""source.cs"" start-line=""11"" start-column=""30"" end-line=""11"" end-column=""38""/>
     <token-location token=""0x04xxxxxx"" file=""source.cs"" start-line=""13"" start-column=""22"" end-line=""13"" end-column=""27""/>
     <token-location token=""0x06xxxxxx"" file=""source.cs"" start-line=""14"" start-column=""21"" end-line=""14"" end-column=""24""/>
     <token-location token=""0x06xxxxxx"" file=""source.cs"" start-line=""27"" start-column=""30"" end-line=""27"" end-column=""33""/>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
@@ -675,8 +675,18 @@ class Program
 }
 ";
 
-            var verifier = CompileAndVerify(new string[] { source }, expectedOutput: "1");
+            var verifier = CompileAndVerify(
+                new string[] { source },
+                expectedOutput: "1",
+                symbolValidator: validator,
+                options: TestOptions.ReleaseExe.WithMetadataImportOptions(MetadataImportOptions.All));
             verifier.VerifyIL("Program.Main", expectedIL);
+
+            void validator(ModuleSymbol module)
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("Program");
+                Assert.Null(type.GetMember(".cctor"));
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SynthesizedStaticConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SynthesizedStaticConstructorTests.cs
@@ -265,6 +265,24 @@ class C
             Assert.True(IsBeforeFieldInit(typeSymbol));
         }
 
+        [WorkItem(543606, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543606")]
+        [Fact]
+        public void StaticConstructorNullInitializer()
+        {
+            var source = @"
+#nullable enable
+class C
+{
+    static string s1 = null!;
+}";
+
+            var typeSymbol = CompileAndExtractTypeSymbol(source);
+
+            // Although we do not emit the synthesized static constructor, the source type symbol will still appear to have one
+            Assert.True(HasSynthesizedStaticConstructor(typeSymbol));
+            Assert.True(IsBeforeFieldInit(typeSymbol));
+        }
+
         private static SourceNamedTypeSymbol CompileAndExtractTypeSymbol(string source)
         {
             var compilation = CreateCompilation(source);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1223,9 +1223,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 // When the queue is completed with a pending TryDequeueAsync return, the
                                 // the Optional<T> will not have a value. This signals the queue has reached
                                 // completion and no more items will be added to it.
-
-                                // This failure is being tracked by https://github.com/dotnet/roslyn/issues/5962
-                                // Debug.Assert(CompilationEventQueue.IsCompleted, "TryDequeueAsync should provide a value unless the AsyncQueue<T> is completed.");
+                                Debug.Assert(CompilationEventQueue.IsCompleted, "TryDequeueAsync should provide a value unless the AsyncQueue<T> is completed.");
                                 break;
                             }
 

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -20,8 +20,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         private static Action<Exception>? s_fatalHandler;
         private static Action<Exception>? s_nonFatalHandler;
 
+#pragma warning disable IDE0052 // Remove unread private members - We want to hold onto last exception to make investigation easier
         private static Exception? s_reportedException;
         private static string? s_reportedExceptionMessage;
+#pragma warning restore IDE0052
 
         /// <summary>
         /// Set by the host to a fail fast trigger, 

--- a/src/Compilers/Core/Portable/InternalUtilities/SemaphoreSlimExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SemaphoreSlimExtensions.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Utilities
         }
 
         [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", OftenCompletesSynchronously = true)]
-        public async static ValueTask<SemaphoreDisposer> DisposableWaitAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken = default)
+        public static async ValueTask<SemaphoreDisposer> DisposableWaitAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken = default)
         {
             await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             return new SemaphoreDisposer(semaphore);

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Dictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Dictionary.cs
@@ -22,7 +22,7 @@ namespace Roslyn.Utilities
 #nullable enable
                 where TKey : notnull
             {
-                public static readonly new Dictionary<TKey, TValue> Instance = new Dictionary<TKey, TValue>();
+                public static new readonly Dictionary<TKey, TValue> Instance = new Dictionary<TKey, TValue>();
 
                 private Dictionary()
                 {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
@@ -22,7 +22,7 @@ namespace Roslyn.Utilities
 
             internal class List<T> : Collection<T>, IList<T>, IReadOnlyList<T>
             {
-                public static readonly new List<T> Instance = new List<T>();
+                public static new readonly List<T> Instance = new List<T>();
 
                 protected List()
                 {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Utilities
         {
             internal class Set<T> : Collection<T>, ISet<T>, IReadOnlySet<T>
             {
-                public static readonly new Set<T> Instance = new Set<T>();
+                public static new readonly Set<T> Instance = new Set<T>();
 
                 protected Set()
                 {

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Lock for all data in this type.
         /// </summary>
-        private static object s_gate = new object();
+        private static readonly object s_gate = new object();
 
         /// <summary>
         /// Last created snapshot of our data.  We hand this out instead of exposing our raw

--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GlobalAssemblyCacheLocation.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GlobalAssemblyCacheLocation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DllImport("clr", PreserveSig = true)]
-        private static unsafe extern int GetCachePath(ASM_CACHE id, byte* path, ref int length);
+        private static extern unsafe int GetCachePath(ASM_CACHE id, byte* path, ref int length);
 
         public static ImmutableArray<string> s_rootLocations;
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
@@ -34,13 +33,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public Glyph Glyph => Glyph.None;
 
-            public ImmutableArray<DocumentSpan> DefinitionLocations => default;
-
             public string GetFinalSymbolName(string replacementText) => null;
 
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken) => default;
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken) => default;
 
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken) => null;
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken) => null;
 
             public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => null;
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Rename;
@@ -59,7 +60,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 IEnumerable<IRefactorNotifyService> refactorNotifyServices,
                 Document document,
                 TextSpan triggerSpan,
-                string triggerText,
                 ISymbol renameSymbol,
                 bool forceRenameOverloads,
                 ImmutableArray<DocumentSpan> definitionLocations,
@@ -74,13 +74,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.HasOverloads = RenameLocations.GetOverloadedSymbols(this.RenameSymbol).Any();
                 this.ForceRenameOverloads = forceRenameOverloads;
 
-                _isRenamingAttributePrefix = CanRenameAttributePrefix(document, triggerSpan, triggerText, cancellationToken);
-                this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), triggerText, cancellationToken);
+                _isRenamingAttributePrefix = CanRenameAttributePrefix(document, triggerSpan, cancellationToken);
+                this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), cancellationToken);
 
                 this.DefinitionLocations = definitionLocations;
             }
 
-            private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, string triggerText, CancellationToken cancellationToken)
+            private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
             {
                 // if this isn't an attribute, or it doesn't have the 'Attribute' suffix, then clearly
                 // we can't rename just the attribute prefix.
@@ -94,6 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // we need to rename the entire attribute).
                 var nameWithoutAttribute = GetWithoutAttributeSuffix(this.RenameSymbol.Name);
 
+                var triggerText = GetSpanText(document, triggerSpan, cancellationToken);
                 return triggerText.StartsWith(triggerText); // TODO: Always true? What was it supposed to do?
             }
 
@@ -110,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             ///     - Compiler-generated EventHandler suffix       XEventHandler => X
             ///     - Compiler-generated get_ and set_ prefixes    get_X => X
             /// </summary>
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
             {
                 var searchName = this.RenameSymbol.Name;
                 if (_isRenamingAttributePrefix)
@@ -120,7 +121,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     searchName = GetWithoutAttributeSuffix(this.RenameSymbol.Name);
                 }
 
-                var index = triggerText.LastIndexOf(searchName, StringComparison.Ordinal);
+                var spanText = GetSpanText(location.Document, location.TextSpan, cancellationToken);
+                var index = spanText.LastIndexOf(searchName, StringComparison.Ordinal);
+
                 if (index < 0)
                 {
                     // Couldn't even find the search text at this reference location.  This might happen
@@ -132,15 +135,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return new TextSpan(location.TextSpan.Start + index, searchName.Length);
             }
 
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
             {
-                var position = triggerText.LastIndexOf(replacementText, StringComparison.Ordinal);
+                var spanText = GetSpanText(location.Document, location.TextSpan, cancellationToken);
+                var position = spanText.LastIndexOf(replacementText, StringComparison.Ordinal);
 
                 if (_isRenamingAttributePrefix)
                 {
                     // We're only renaming the attribute prefix part.  We want to adjust the span of 
                     // the reference we've found to only update the prefix portion.
-                    var index = triggerText.LastIndexOf(replacementText + AttributeSuffix, StringComparison.Ordinal);
+                    var index = spanText.LastIndexOf(replacementText + AttributeSuffix, StringComparison.Ordinal);
                     position = index >= 0 ? index : position;
                 }
 
@@ -157,6 +161,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             private bool HasAttributeSuffix(string value)
                 => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _document.GetLanguageService<ISyntaxFactsService>().IsCaseSensitive, result: out var _);
+
+            private static string GetSpanText(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
+            {
+                // TO-DO: Add new 'triggerText' parameter to the callers of this method via IVT so that we can get the text asynchronously instead.
+                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1080161
+                var sourceText = document.GetTextSynchronously(cancellationToken);
+                var triggerText = sourceText.ToString(triggerSpan);
+                return triggerText;
+            }
 
             internal bool IsRenamingAttributeTypeWithAttributeSuffix()
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
@@ -197,11 +197,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var triggerText = sourceText.ToString(triggerToken.Span);
-
             return new SymbolInlineRenameInfo(
-                refactorNotifyServices, document, triggerToken.Span, triggerText,
+                refactorNotifyServices, document, triggerToken.Span,
                 symbol, forceRenameOverloads, documentSpans.ToImmutableAndFree(), cancellationToken);
         }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
@@ -97,12 +97,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             static InlineRenameSessionInfo? IsReadOnlyOrCannotNavigateToSpan(IInlineRenameInfo renameInfo, Document document, CancellationToken cancellationToken)
             {
-                if (renameInfo is IInlineRenameInfo inlineRenameInfo && inlineRenameInfo.DefinitionLocations != default)
+                if (renameInfo is IInlineRenameInfoWithFileRename renameInfoWithFileRename)
                 {
                     var workspace = document.Project.Solution.Workspace;
                     var navigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
-
-                    foreach (var documentSpan in inlineRenameInfo.DefinitionLocations)
+                    foreach (var documentSpan in renameInfoWithFileRename.DefinitionLocations)
                     {
                         var sourceText = documentSpan.Document.GetTextSynchronously(cancellationToken);
                         var textSnapshot = sourceText.FindCorrespondingEditorTextSnapshot();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -184,9 +184,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     _referenceSpanToLinkedRenameSpanMap.Clear();
                     foreach (var span in spans)
                     {
-                        var document = _baseDocuments.First();
                         var renameableSpan = _session._renameInfo.GetReferenceEditSpan(
-                            new InlineRenameLocation(document, span), GetTriggerText(document, span), CancellationToken.None);
+                            new InlineRenameLocation(_baseDocuments.First(), span), CancellationToken.None);
                         var trackingSpan = new RenameTrackingSpan(
                                 _subjectBuffer.CurrentSnapshot.CreateTrackingSpan(renameableSpan.ToSpan(), SpanTrackingMode.EdgeInclusive, TrackingFidelityMode.Forward),
                                 RenameSpanKind.Reference);
@@ -207,12 +206,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
 
                 RaiseSpansChanged();
-            }
-
-            private static string GetTriggerText(Document document, TextSpan span)
-            {
-                var sourceText = document.GetTextSynchronously(CancellationToken.None);
-                return sourceText.ToString(span);
             }
 
             private void OnTextBufferChanged(object sender, TextContentChangedEventArgs args)
@@ -472,10 +465,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                             if (_referenceSpanToLinkedRenameSpanMap.ContainsKey(replacement.OriginalSpan) && kind != RenameSpanKind.Complexified)
                             {
                                 var linkedRenameSpan = _session._renameInfo.GetConflictEditSpan(
-                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetTriggerText(newDocument, replacement.NewSpan),
-                                    GetWithoutAttributeSuffix(_session.ReplacementText,
-                                        document.GetLanguageService<LanguageServices.ISyntaxFactsService>().IsCaseSensitive), cancellationToken);
-
+                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetWithoutAttributeSuffix(_session.ReplacementText, document.GetLanguageService<LanguageServices.ISyntaxFactsService>().IsCaseSensitive), cancellationToken);
                                 if (linkedRenameSpan.HasValue)
                                 {
                                     if (!mergeConflictComments.Any(s => replacement.NewSpan.IntersectsWith(s)))

--- a/src/EditorFeatures/Core.Wpf/Options/LegacyEditorConfigDocumentOptionsProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/LegacyEditorConfigDocumentOptionsProvider.cs
@@ -28,8 +28,11 @@ namespace Microsoft.CodeAnalysis.Editor.Options
         /// </summary>
         private readonly Dictionary<DocumentId, Task<ICodingConventionContext>> _openDocumentContexts = new Dictionary<DocumentId, Task<ICodingConventionContext>>();
 
+#pragma warning disable IDE0052 // Remove unread private members - Used in EditorFeatures project context
         private readonly Workspace _workspace;
         private readonly IAsynchronousOperationListener _listener;
+#pragma warning disable IDE0052
+
         private readonly ICodingConventionsManager _codingConventionsManager;
 
         internal LegacyEditorConfigDocumentOptionsProvider(Workspace workspace, ICodingConventionsManager codingConventionsManager, IAsynchronousOperationListenerProvider listenerProvider)

--- a/src/EditorFeatures/Core.Wpf/Options/LegacyEditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/LegacyEditorConfigDocumentOptionsProviderFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Options
 {
     [Export(typeof(IDocumentOptionsProviderFactory)), Shared]
     [ExportMetadata("Name", PredefinedDocumentOptionsProviderNames.EditorConfig)]
-    class LegacyEditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
+    internal class LegacyEditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
         private readonly ICodingConventionsManager _codingConventionsManager;
         private readonly IFileWatcher _fileWatcher;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             }
         }
 
-        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
+        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
         {
             return _info.GetConflictEditSpan(new VSTypeScriptInlineRenameLocationWrapper(
                 new InlineRenameLocation(location.Document, location.TextSpan)), replacementText, cancellationToken);
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public string GetFinalSymbolName(string replacementText)
             => _info.GetFinalSymbolName(replacementText);
 
-        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
+        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
         {
             return _info.GetReferenceEditSpan(new VSTypeScriptInlineRenameLocationWrapper(
                 new InlineRenameLocation(location.Document, location.TextSpan)), cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
@@ -194,11 +194,6 @@ namespace Microsoft.CodeAnalysis.Editor
         Glyph Glyph { get; }
 
         /// <summary>
-        /// The locations of the potential rename candidates for the symbol.
-        /// </summary>
-        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
-
-        /// <summary>
         /// Gets the final name of the symbol if the user has typed the provided replacement text
         /// in the editor.  Normally, the final name will be same as the replacement text.  However,
         /// that may not always be the same.  For example, when renaming an attribute the replacement
@@ -210,13 +205,13 @@ namespace Microsoft.CodeAnalysis.Editor
         /// Returns the actual span that should be edited in the buffer for a given rename reference
         /// location.
         /// </summary>
-        TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken);
+        TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the actual span that should be edited in the buffer for a given rename conflict
         /// location.
         /// </summary>
-        TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken);
+        TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determine the set of locations to rename given the provided options. May be called 
@@ -245,6 +240,10 @@ namespace Microsoft.CodeAnalysis.Editor
         /// an inline rename
         /// </summary>
         InlineRenameFileRenameInfo GetFileRenameInfo();
+
+        // TO-DO: Move property to IInlineRenameInfo once Typescript moves to the correct IVT layering
+        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1077984
+        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
     }
 
     /// <summary>

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        internal async override Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(
+        internal override async Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(
             TestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, _) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);

--- a/src/EditorFeatures/VisualBasicTest/Utils.vb
+++ b/src/EditorFeatures/VisualBasicTest/Utils.vb
@@ -109,7 +109,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests
             Private ReadOnly _tree As SyntaxTree
             Private ReadOnly _node As T
 
-            Sub New(syntaxTree As SyntaxTree, node As T)
+            Public Sub New(syntaxTree As SyntaxTree, node As T)
 #If Not CODE_STYLE Then
                 Contract.ThrowIfNull(syntaxTree)
                 Contract.ThrowIfNull(node)

--- a/src/Features/CSharp/Portable/CodeRefactorings/LambdaSimplifier/LambdaSimplifierCodeRefactoringProvider.Rewriter.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/LambdaSimplifier/LambdaSimplifierCodeRefactoringProvider.Rewriter.cs
@@ -18,18 +18,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.LambdaSimplifier
     {
         private class Rewriter : CSharpSyntaxRewriter
         {
-            private readonly LambdaSimplifierCodeRefactoringProvider _codeIssueProvider;
             private readonly SemanticDocument _document;
             private readonly Func<SyntaxNode, bool> _predicate;
             private readonly CancellationToken _cancellationToken;
 
             public Rewriter(
-                LambdaSimplifierCodeRefactoringProvider codeIssueProvider,
                 SemanticDocument document,
                 Func<SyntaxNode, bool> predicate,
                 CancellationToken cancellationToken)
             {
-                _codeIssueProvider = codeIssueProvider;
                 _document = document;
                 _predicate = predicate;
                 _cancellationToken = cancellationToken;

--- a/src/Features/CSharp/Portable/CodeRefactorings/LambdaSimplifier/LambdaSimplifierCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/LambdaSimplifier/LambdaSimplifierCodeRefactoringProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.LambdaSimplifier
             CancellationToken cancellationToken)
         {
             var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            var rewriter = new Rewriter(this, semanticDocument, n => n == lambda, cancellationToken);
+            var rewriter = new Rewriter(semanticDocument, n => n == lambda, cancellationToken);
             var result = rewriter.Visit(semanticDocument.Root);
             return document.WithSyntaxRoot(result);
         }
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.LambdaSimplifier
             CancellationToken cancellationToken)
         {
             var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            var rewriter = new Rewriter(this, semanticDocument, n => true, cancellationToken);
+            var rewriter = new Rewriter(semanticDocument, n => true, cancellationToken);
             var result = rewriter.Visit(semanticDocument.Root);
             return document.WithSyntaxRoot(result);
         }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 symbol.Kind == SymbolKind.RangeVariable;
         }
 
-        CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)
+        private CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)
         {
             return CommonCompletionItem.Create(
                 name,

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return ImmutableDictionary<string, string>.Empty.Add(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier());
         }
 
-        public async override Task<TextChange?> GetTextChangeAsync(
+        public override async Task<TextChange?> GetTextChangeAsync(
             Document document, CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
         {
             if (ch == '<')

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 context.SemanticModel, position, context.Workspace, options, cancellationToken);
         }
 
-        protected async override Task<bool> ShouldProvidePreselectedItemsAsync(CompletionContext completionContext, SyntaxContext syntaxContext, Document document, int position, Lazy<ImmutableArray<ITypeSymbol>> inferredTypes, OptionSet options)
+        protected override async Task<bool> ShouldProvidePreselectedItemsAsync(CompletionContext completionContext, SyntaxContext syntaxContext, Document document, int position, Lazy<ImmutableArray<ITypeSymbol>> inferredTypes, OptionSet options)
         {
             var sourceText = await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
             if (ShouldTriggerInArgumentLists(sourceText, options))
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 : CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
         }
 
-        internal async override Task<bool> IsSyntacticTriggerCharacterAsync(Document document, int caretPosition, CompletionTrigger trigger, OptionSet options, CancellationToken cancellationToken)
+        internal override async Task<bool> IsSyntacticTriggerCharacterAsync(Document document, int caretPosition, CompletionTrigger trigger, OptionSet options, CancellationToken cancellationToken)
         {
             if (trigger.Kind == CompletionTriggerKind.Insertion && caretPosition > 0)
             {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/OperatorKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/OperatorKeywordRecommender.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 
@@ -10,13 +9,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
     internal class OperatorKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
     {
-        private static readonly ISet<SyntaxKind> s_validMemberModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.ExternKeyword,
-            };
-
         public OperatorKeywordRecommender()
             : base(SyntaxKind.OperatorKeyword)
         {

--- a/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
         {
         }
 
-        protected async override Task<SyntaxNode> RewriteFieldNameAndAccessibilityAsync(string originalFieldName, bool makePrivate, Document document, SyntaxAnnotation declarationAnnotation, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNode> RewriteFieldNameAndAccessibilityAsync(string originalFieldName, bool makePrivate, Document document, SyntaxAnnotation declarationAnnotation, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaSignatureHelpProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia
         public PythiaSignatureHelpProvider(Lazy<IPythiaSignatureHelpProviderImplementation> implementation)
             => _lazyImplementation = implementation;
 
-        internal async override Task<(ImmutableArray<SignatureHelpItem> items, int? selectedItemIndex)> GetMethodGroupItemsAndSelectionAsync(
+        internal override async Task<(ImmutableArray<SignatureHelpItem> items, int? selectedItemIndex)> GetMethodGroupItemsAndSelectionAsync(
             ImmutableArray<IMethodSymbol> accessibleMethods,
             Document document,
             InvocationExpressionSyntax invocationExpression,

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -7,14 +7,12 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.CSharp.Simplification;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
@@ -24,9 +22,9 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
     internal class CSharpMetadataAsSourceService : AbstractMetadataAsSourceService
     {
         private static readonly AbstractFormattingRule s_memberSeparationRule = new FormattingRule();
+        public static readonly CSharpMetadataAsSourceService Instance = new CSharpMetadataAsSourceService();
 
-        public CSharpMetadataAsSourceService(HostLanguageServices languageServices)
-            : base(languageServices.GetService<ICodeGenerationService>())
+        private CSharpMetadataAsSourceService()
         {
         }
 

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceServiceFactory.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceServiceFactory.cs
@@ -20,6 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
-            => new CSharpMetadataAsSourceService(provider);
+            => CSharpMetadataAsSourceService.Instance;
     }
 }

--- a/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceCodeRefactoringProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MoveDeclarationNearReference
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), Shared]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.InlineTemporary)]
-    class CSharpMoveDeclarationNearReferenceCodeRefactoringProvider : AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<LocalDeclarationStatementSyntax>
+    internal class CSharpMoveDeclarationNearReferenceCodeRefactoringProvider : AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<LocalDeclarationStatementSyntax>
     {
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]

--- a/src/Features/CSharp/Portable/Organizing/Organizers/ModifiersOrganizer.Comparer.cs
+++ b/src/Features/CSharp/Portable/Organizing/Organizers/ModifiersOrganizer.Comparer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Organizing.Organizers
                 return ComparerWithState.CompareTo(x, y, s_comparers);
             }
 
-            private readonly static ImmutableArray<Func<SyntaxToken, IComparable>> s_comparers =
+            private static readonly ImmutableArray<Func<SyntaxToken, IComparable>> s_comparers =
                 ImmutableArray.Create<Func<SyntaxToken, IComparable>>(t => t.Kind() == SyntaxKind.PartialKeyword, t => GetOrdering(t));
 
             private static Ordering GetOrdering(SyntaxToken token)

--- a/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             return CreateItems(position, root, syntaxFacts, targetExpression, semanticModel, inferredTypes, cancellationToken);
         }
 
-        IEnumerable<INamedTypeSymbol> FindNearestTupleConstructionWithInferrableType(SyntaxNode root, SemanticModel semanticModel, int position, SignatureHelpTriggerInfo triggerInfo,
+        private IEnumerable<INamedTypeSymbol> FindNearestTupleConstructionWithInferrableType(SyntaxNode root, SemanticModel semanticModel, int position, SignatureHelpTriggerInfo triggerInfo,
             ITypeInferenceService typeInferrer, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken, out ExpressionSyntax targetExpression)
         {
             // Walk upward through TupleExpressionSyntax/ParenthsizedExpressionSyntax looking for a 
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             return CreateSignatureHelpItems(items, targetExpression.Span, state, selectedItem: null);
         }
 
-        SignatureHelpItem Convert(INamedTypeSymbol tupleType, ImmutableArray<TaggedText> prefixParts, ImmutableArray<TaggedText> suffixParts,
+        private SignatureHelpItem Convert(INamedTypeSymbol tupleType, ImmutableArray<TaggedText> prefixParts, ImmutableArray<TaggedText> suffixParts,
             ImmutableArray<TaggedText> separatorParts, SemanticModel semanticModel, int position)
         {
             return new SymbolKeySignatureHelpItem(

--- a/src/Features/Core/Portable/AddImport/References/Reference.cs
+++ b/src/Features/Core/Portable/AddImport/References/Reference.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                         placeSystemNamespaceFirst: true);
             }
 
-            private readonly static ImmutableArray<Func<Reference, Document, IComparable>> s_comparers
+            private static readonly ImmutableArray<Func<Reference, Document, IComparable>> s_comparers
                 = ImmutableArray.Create<Func<Reference, Document, IComparable>>(
                     // If references have different weights, order by the ones with lower weight (i.e.
                     // they are better matches).

--- a/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
 
         protected abstract bool IncludePrerelease { get; }
 
-        public override abstract FixAllProvider GetFixAllProvider();
+        public abstract override FixAllProvider GetFixAllProvider();
 
         protected async Task<ImmutableArray<CodeAction>> GetAddPackagesCodeActionsAsync(
             CodeFixContext context, ISet<string> assemblyNames)

--- a/src/Features/Core/Portable/AddPackage/InstallPackageParentCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageParentCodeAction.cs
@@ -18,10 +18,6 @@ namespace Microsoft.CodeAnalysis.AddPackage
     /// </summary>
     internal class InstallPackageParentCodeAction : CodeAction.CodeActionWithNestedActions
     {
-        private readonly IPackageInstallerService _installerService;
-        private readonly string _source;
-        private readonly string _packageName;
-
         public override ImmutableArray<string> Tags => WellKnownTagArrays.NuGet;
 
         /// <summary>
@@ -40,9 +36,6 @@ namespace Microsoft.CodeAnalysis.AddPackage
                    CreateNestedActions(installerService, source, packageName, includePrerelease, document),
                    isInlinable: false)
         {
-            _installerService = installerService;
-            _source = source;
-            _packageName = packageName;
         }
 
         private static ImmutableArray<CodeAction> CreateNestedActions(

--- a/src/Features/Core/Portable/CodeFixes/Async/AbstractAsyncCodeFix.cs
+++ b/src/Features/Core/Portable/CodeFixes/Async/AbstractAsyncCodeFix.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Async
 {
     internal abstract partial class AbstractAsyncCodeFix : CodeFixProvider
     {
-        public override abstract FixAllProvider GetFixAllProvider();
+        public abstract override FixAllProvider GetFixAllProvider();
 
         protected abstract Task<CodeAction> GetCodeActionAsync(
             SyntaxNode root, SyntaxNode node, Document document, Diagnostic diagnostic, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 _showPreviewChangesDialog);
         }
 
-        internal async override Task<Solution> GetChangedSolutionAsync(
+        internal override async Task<Solution> GetChangedSolutionAsync(
             IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.FixAllProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.FixAllProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             {
             }
 
-            public async override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+            public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
             {
                 // currently there's no FixAll support for local suppression, just bail out
                 if (NestedSuppressionCodeAction.IsEquivalenceKeyForLocalSuppression(fixAllContext.CodeActionEquivalenceKey))

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.LocalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.LocalSuppressMessageCodeAction.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 _diagnostic = diagnostic;
             }
 
-            protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+            protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {
                 var newTargetNode = _fixer.AddLocalSuppressMessageAttribute(
                     _targetNode, _targetSymbol, _suppressMessageAttribute, _diagnostic);

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaHelpers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         /// </summary>
         private static class PragmaHelpers
         {
-            internal async static Task<Document> GetChangeDocumentWithPragmaAdjustedAsync(
+            internal static async Task<Document> GetChangeDocumentWithPragmaAdjustedAsync(
                 Document document,
                 TextSpan diagnosticSpan,
                 SuppressionTargetInfo suppressionTargetInfo,

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningCodeAction.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             protected override string DiagnosticIdForEquivalenceKey =>
                 _forFixMultipleContext ? string.Empty : _diagnostic.Id;
 
-            protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+            protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
                 => await GetChangedDocumentAsync(includeStartTokenChange: true, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             public async Task<Document> GetChangedDocumentAsync(bool includeStartTokenChange, bool includeEndTokenChange, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                     }
                 }
 
-                protected async override Task AddProjectFixesAsync(
+                protected override async Task AddProjectFixesAsync(
                     Project project, ImmutableArray<Diagnostic> diagnostics,
                     ConcurrentBag<(Diagnostic diagnostic, CodeAction action)> bag,
                     FixAllState fixAllState, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Attribute.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Attribute.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                         attributeNode;
                 }
 
-                protected async override Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+                protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
                 {
                     var attributeNode = await GetAttributeToRemoveAsync(cancellationToken).ConfigureAwait(false);
                     var documentWithAttribute = _project.GetDocument(attributeNode.SyntaxTree);

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Pragma.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Pragma.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 
                 public override SyntaxTree SyntaxTreeToModify => _suppressionTargetInfo.StartToken.SyntaxTree;
 
-                protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+                protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
                     => await GetChangedDocumentAsync(includeStartTokenChange: true, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 public async Task<Document> GetChangedDocumentAsync(bool includeStartTokenChange, bool includeEndTokenChange, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         public IConfigurationFixProvider SuppressionFixProvider => _suppressionFixProvider;
         public override ImmutableArray<string> FixableDiagnosticIds => _originalDiagnosticIds;
 
-        public async override Task RegisterCodeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var diagnostics = context.Diagnostics.Where(_suppressionFixProvider.IsFixableDiagnostic);
 

--- a/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             }
         }
 
-        void AddNonHiddenCorrectTypeNodes<TSyntaxNode>(IEnumerable<SyntaxNode> nodes, ArrayBuilder<TSyntaxNode> resultBuilder, CancellationToken cancellationToken)
+        private void AddNonHiddenCorrectTypeNodes<TSyntaxNode>(IEnumerable<SyntaxNode> nodes, ArrayBuilder<TSyntaxNode> resultBuilder, CancellationToken cancellationToken)
             where TSyntaxNode : SyntaxNode
         {
             var correctTypeNonHiddenNodes = nodes.OfType<TSyntaxNode>().Where(n => !n.OverlapsHiddenPosition(cancellationToken));

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return ImmutableArray<CompletionProvider>.Empty;
         }
 
-        internal protected CompletionProvider GetProvider(CompletionItem item)
+        protected internal CompletionProvider GetProvider(CompletionItem item)
         {
             CompletionProvider provider = null;
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
-    abstract class AbstractCrefCompletionProvider : LSPCompletionProvider
+    internal abstract class AbstractCrefCompletionProvider : LSPCompletionProvider
     {
         protected const string HideAdvancedMembers = nameof(HideAdvancedMembers);
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             private readonly SourceText _text;
             private readonly SyntaxTree _syntaxTree;
             private readonly int _startLineNumber;
-            private readonly TextLine _startLine;
 
             private ItemGetter(
                 AbstractOverrideCompletionProvider overrideCompletionProvider,
@@ -41,7 +40,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 SourceText text,
                 SyntaxTree syntaxTree,
                 int startLineNumber,
-                TextLine startLine,
                 CancellationToken cancellationToken)
             {
                 _provider = overrideCompletionProvider;
@@ -50,7 +48,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 _text = text;
                 _syntaxTree = syntaxTree;
                 _startLineNumber = startLineNumber;
-                _startLine = startLine;
                 _cancellationToken = cancellationToken;
             }
 
@@ -63,8 +60,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var startLineNumber = text.Lines.IndexOf(position);
-                var startLine = text.Lines[startLineNumber];
-                return new ItemGetter(overrideCompletionProvider, document, position, text, syntaxTree, startLineNumber, startLine, cancellationToken);
+                return new ItemGetter(overrideCompletionProvider, document, position, text, syntaxTree, startLineNumber, cancellationToken);
             }
 
             internal async Task<IEnumerable<CompletionItem>> GetItemsAsync()

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
         }
 
-        public async sealed override Task ProvideCompletionsAsync(CompletionContext completionContext)
+        public sealed override async Task ProvideCompletionsAsync(CompletionContext completionContext)
         {
             try
             {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected override void LogCommit()
             => CompletionProvidersLogger.LogCommitOfExtensionMethodImportCompletionItem();
 
-        protected async override Task AddCompletionItemsAsync(
+        protected override async Task AddCompletionItemsAsync(
             CompletionContext completionContext,
             SyntaxContext syntaxContext,
             HashSet<string> namespaceInScope,

--- a/src/Features/Core/Portable/Completion/Providers/SymbolMatchPriority.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolMatchPriority.cs
@@ -9,11 +9,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     internal static class SymbolMatchPriority
     {
-        internal readonly static int Keyword = 100;
-        internal readonly static int PreferType = 200;
-        internal readonly static int PreferNamedArgument = 300;
-        internal readonly static int PreferEventOrMethod = 400;
-        internal readonly static int PreferFieldOrProperty = 500;
-        internal readonly static int PreferLocalOrParameterOrRangeVariable = 600;
+        internal static readonly int Keyword = 100;
+        internal static readonly int PreferType = 200;
+        internal static readonly int PreferNamedArgument = 300;
+        internal static readonly int PreferEventOrMethod = 400;
+        internal static readonly int PreferFieldOrProperty = 500;
+        internal static readonly int PreferLocalOrParameterOrRangeVariable = 600;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -24,8 +24,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal static partial class AnalyzerHelper
     {
-        private const string CSharpCompilerAnalyzerTypeName = "Microsoft.CodeAnalysis.Diagnostics.CSharp.CSharpCompilerDiagnosticAnalyzer";
-        private const string VisualBasicCompilerAnalyzerTypeName = "Microsoft.CodeAnalysis.Diagnostics.VisualBasic.VisualBasicCompilerDiagnosticAnalyzer";
 
         // These are the error codes of the compiler warnings. 
         // Keep the ids the same so that de-duplication against compiler errors

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private static class InMemoryStorage
         {
             // the reason using nested map rather than having tuple as key is so that I dont have a gigantic map
-            private readonly static ConcurrentDictionary<DiagnosticAnalyzer, ConcurrentDictionary<(object key, string stateKey), CacheEntry>> s_map =
+            private static readonly ConcurrentDictionary<DiagnosticAnalyzer, ConcurrentDictionary<(object key, string stateKey), CacheEntry>> s_map =
                 new ConcurrentDictionary<DiagnosticAnalyzer, ConcurrentDictionary<(object key, string stateKey), CacheEntry>>(concurrencyLevel: 2, capacity: 10);
 
             public static bool TryGetValue(DiagnosticAnalyzer analyzer, (object key, string stateKey) key, out CacheEntry entry)

--- a/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    interface IRemoteDiagnosticAnalyzerService
+    internal interface IRemoteDiagnosticAnalyzerService
     {
         Task CalculateDiagnosticsAsync(PinnedSolutionInfo solutionInfo, DiagnosticArguments arguments, string streamName, CancellationToken cancellationToken);
         void ReportAnalyzerPerformance(List<AnalyzerPerformanceInfo> snapshot, int unitCount, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/DocumentationComments/CodeFixes/AbstractAddDocCommentNodesCodeFixProvider.cs
+++ b/src/Features/Core/Portable/DocumentationComments/CodeFixes/AbstractAddDocCommentNodesCodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.DiagnosticComments.CodeFixes
     {
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-        public async sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             var parentMethod = root.FindNode(context.Span).FirstAncestorOrSelf<TMemberDeclarationSyntax>();

--- a/src/Features/Core/Portable/DocumentationComments/CodeFixes/AbstractRemoveDocCommentNodeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/DocumentationComments/CodeFixes/AbstractRemoveDocCommentNodeCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.DiagnosticComments.CodeFixes
         protected abstract bool IsXmlNewLineToken(SyntaxToken token);
         protected abstract bool IsXmlWhitespaceToken(SyntaxToken token);
 
-        public async sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -590,9 +590,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
+#pragma warning disable IDE0052 // Remove unread private members
         // Active statements spans are usually unavailable in crash dumps due to a bug in the debugger (DevDiv #150901), 
         // so we stash them here in plain array (can't use immutable, see the bug) just before we report NFW.
         private static ActiveStatement[]? s_fatalErrorBaseActiveStatements;
+#pragma warning restore IDE0052 // Remove unread private members
 
         [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "'AnalyzeDocumentAsync' is the name of the method where an error occurred.")]
         private static bool ReportFatalErrorAnalyzeDocumentAsync(ImmutableArray<ActiveStatement> baseActiveStatements, Exception e)

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <remarks>
         /// Automatically detects the underlying PDB format and returns the appropriate reader.
         /// </remarks>
-        public unsafe static EditAndContinueMethodDebugInfoReader Create(ISymUnmanagedReader5 symReader, int version = 1)
+        public static unsafe EditAndContinueMethodDebugInfoReader Create(ISymUnmanagedReader5 symReader, int version = 1)
         {
             if (symReader == null)
             {
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <returns>
         /// The resulting reader does not take ownership of the <paramref name="pdbReader"/> or the memory it reads.
         /// </returns>
-        public unsafe static EditAndContinueMethodDebugInfoReader Create(MetadataReader pdbReader)
+        public static unsafe EditAndContinueMethodDebugInfoReader Create(MetadataReader pdbReader)
            => new Portable(pdbReader ?? throw new ArgumentNullException(nameof(pdbReader)));
 
         internal static bool TryGetDocumentChecksum(ISymUnmanagedReader5 symReader, string documentPath, out ImmutableArray<byte> checksum, out Guid algorithmId)

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/EmbeddedCompletionContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/EmbeddedCompletionContext.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
     {
         private readonly struct EmbeddedCompletionContext
         {
-            private static DateTime s_exampleDateTime = DateTime.Parse("2009-06-15T13:45:30.1234567");
-            private static CultureInfo s_enUsCulture = CultureInfo.GetCultureInfo("en-US");
+            private static readonly DateTime s_exampleDateTime = DateTime.Parse("2009-06-15T13:45:30.1234567");
+            private static readonly CultureInfo s_enUsCulture = CultureInfo.GetCultureInfo("en-US");
 
             private readonly ArrayBuilder<DateAndTimeItem> _items;
             private readonly TextSpan _replacementSpan;

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
     {
         private readonly ExtractInterfaceTypeAnalysisResult _typeAnalysisResult;
         private readonly AbstractExtractInterfaceService _extractInterfaceService;
-        private readonly Task<IEnumerable<CodeActionOperation>> _taskReturningNoCodeActionOperations = SpecializedTasks.EmptyEnumerable<CodeActionOperation>();
 
         public ExtractInterfaceCodeAction(AbstractExtractInterfaceService extractInterfaceService, ExtractInterfaceTypeAnalysisResult typeAnalysisResult)
         {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -671,27 +671,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 return style;
             }
 
-            private bool IsParameterUsedOutside(ISymbol localOrParameter)
-            {
-                if (!(localOrParameter is IParameterSymbol parameter))
-                {
-                    return false;
-                }
-
-                return parameter.RefKind != RefKind.None;
-            }
-
-            private bool IsParameterAssigned(ISymbol localOrParameter)
-            {
-                // hack for now.
-                if (!(localOrParameter is IParameterSymbol parameter))
-                {
-                    return false;
-                }
-
-                return parameter.RefKind != RefKind.Out;
-            }
-
             private static bool IsThisParameter(ISymbol localOrParameter)
             {
                 if (!(localOrParameter is IParameterSymbol parameter))

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 {
@@ -34,11 +33,9 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             private readonly SyntaxNode _typeDeclaration;
             private readonly INamedTypeSymbol _containingType;
             private readonly ImmutableArray<ISymbol> _selectedMembers;
-            private readonly TextSpan _textSpan;
 
             public GenerateEqualsAndGetHashCodeAction(
                 Document document,
-                TextSpan textSpan,
                 SyntaxNode typeDeclaration,
                 INamedTypeSymbol containingType,
                 ImmutableArray<ISymbol> selectedMembers,
@@ -51,7 +48,6 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 _typeDeclaration = typeDeclaration;
                 _containingType = containingType;
                 _selectedMembers = selectedMembers;
-                _textSpan = textSpan;
                 _generateEquals = generateEquals;
                 _generateGetHashCode = generateGetHashCode;
                 _implementIEquatable = implementIEquatable;

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.PickMembers;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
@@ -28,7 +27,6 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             private readonly INamedTypeSymbol _containingType;
             private readonly ImmutableArray<ISymbol> _viableMembers;
             private readonly ImmutableArray<PickMembersOption> _pickMembersOptions;
-            private readonly TextSpan _textSpan;
 
             private bool? _implementIEqutableOptionValue;
             private bool? _generateOperatorsOptionValue;
@@ -36,7 +34,6 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             public GenerateEqualsAndGetHashCodeWithDialogCodeAction(
                 GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider service,
                 Document document,
-                TextSpan textSpan,
                 SyntaxNode typeDeclaration,
                 INamedTypeSymbol containingType,
                 ImmutableArray<ISymbol> viableMembers,
@@ -50,7 +47,6 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 _containingType = containingType;
                 _viableMembers = viableMembers;
                 _pickMembersOptions = pickMembersOptions;
-                _textSpan = textSpan;
                 _generateEquals = generateEquals;
                 _generateGetHashCode = generateGetHashCode;
             }
@@ -90,7 +86,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 var generatorOperators = (generateOperatorsOption?.Value).GetValueOrDefault();
 
                 var action = new GenerateEqualsAndGetHashCodeAction(
-                    _document, _textSpan, _typeDeclaration, _containingType, result.Members,
+                    _document, _typeDeclaration, _containingType, result.Members,
                     _generateEquals, _generateGetHashCode, implementIEquatable, generatorOperators);
                 return await action.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 }
             }
 
-            protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+            protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {
                 var newRoot = await GetNewRootAsync(cancellationToken).ConfigureAwait(false);
                 var newDocument = _document.WithSyntaxRoot(newRoot);

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             ImmutableArray.Create("disposed", "value");
 
         // C#: `Dispose(bool disposed)`.  VB: `Dispose(disposed As Boolean)`
-        private static SymbolDisplayFormat s_format = new SymbolDisplayFormat(
+        private static readonly SymbolDisplayFormat s_format = new SymbolDisplayFormat(
             memberOptions: SymbolDisplayMemberOptions.IncludeParameters,
             parameterOptions: SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeType,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 Document = document;
             }
 
-            public async static Task<State> GenerateAsync(
+            public static async Task<State> GenerateAsync(
                 TService service,
                 SemanticDocument document,
                 TextSpan textSpan,

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+            public sealed override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
             {
                 var nextOperationCopy = nextOperation;
                 AddSuppressOperationsSlow(list, node, ref nextOperationCopy);
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed void AddAnchorIndentationOperations(List<AnchorIndentationOperation> list, SyntaxNode node, in NextAnchorIndentationOperationAction nextOperation)
+            public sealed override void AddAnchorIndentationOperations(List<AnchorIndentationOperation> list, SyntaxNode node, in NextAnchorIndentationOperationAction nextOperation)
             {
                 var nextOperationCopy = nextOperation;
                 AddAnchorIndentationOperationsSlow(list, node, ref nextOperationCopy);
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed void AddIndentBlockOperations(List<IndentBlockOperation> list, SyntaxNode node, in NextIndentBlockOperationAction nextOperation)
+            public sealed override void AddIndentBlockOperations(List<IndentBlockOperation> list, SyntaxNode node, in NextIndentBlockOperationAction nextOperation)
             {
                 var nextOperationCopy = nextOperation;
                 AddIndentBlockOperationsSlow(list, node, ref nextOperationCopy);
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed void AddAlignTokensOperations(List<AlignTokensOperation> list, SyntaxNode node, in NextAlignTokensOperationAction nextOperation)
+            public sealed override void AddAlignTokensOperations(List<AlignTokensOperation> list, SyntaxNode node, in NextAlignTokensOperationAction nextOperation)
             {
                 var nextOperationCopy = nextOperation;
                 AddAlignTokensOperationsSlow(list, node, ref nextOperationCopy);
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public sealed override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 var previousTokenCopy = previousToken;
                 var currentTokenCopy = currentToken;
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public override sealed AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public sealed override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
                 var previousTokenCopy = previousToken;
                 var currentTokenCopy = currentToken;

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -23,11 +23,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal abstract partial class AbstractMetadataAsSourceService : IMetadataAsSourceService
     {
-        private readonly ICodeGenerationService _codeGenerationService;
-
-        protected AbstractMetadataAsSourceService(ICodeGenerationService codeGenerationService)
-            => _codeGenerationService = codeGenerationService;
-
         public async Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken)
         {
             if (document == null)

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
@@ -14,15 +13,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
     /// </summary>
     internal class MetadataAsSourceHelpers
     {
-        private static readonly HashSet<SymbolKind> s_validSymbolKinds = new HashSet<SymbolKind>(new[]
-            {
-                SymbolKind.Event,
-                SymbolKind.Field,
-                SymbolKind.Method,
-                SymbolKind.NamedType,
-                SymbolKind.Property,
-                SymbolKind.Parameter,
-            });
 
 #if false
         public static void ValidateSymbolArgument(ISymbol symbol, string parameterName)

--- a/src/Features/Core/Portable/NameTupleElement/AbstractNameTupleElementCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/NameTupleElement/AbstractNameTupleElementCodeRefactoringProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.NameTupleElement
 {
-    abstract class AbstractNameTupleElementCodeRefactoringProvider<TArgumentSyntax, TTupleExpressionSyntax> : CodeRefactoringProvider
+    internal abstract class AbstractNameTupleElementCodeRefactoringProvider<TArgumentSyntax, TTupleExpressionSyntax> : CodeRefactoringProvider
         where TArgumentSyntax : SyntaxNode
         where TTupleExpressionSyntax : SyntaxNode
     {

--- a/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
+++ b/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
     internal abstract partial class AbstractPullMemberUpRefactoringProvider : CodeRefactoringProvider
     {
         private readonly IPullMemberUpOptionsService _service;
-        private const int None = 0;
 
         protected abstract Task<SyntaxNode> GetSelectedNodeAsync(CodeRefactoringContext context);
 

--- a/src/Features/Core/Portable/PullMemberUp/Dialog/PullMemberUpWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/PullMemberUp/Dialog/PullMemberUpWithDialogCodeAction.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
                 return pullMemberUpOptionService.GetPullMemberUpOptions(_document, _selectedMember);
             }
 
-            protected async override Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(object options, CancellationToken cancellationToken)
+            protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(object options, CancellationToken cancellationToken)
             {
                 if (options is PullMembersUpOptions pullMemberUpOptions)
                 {

--- a/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
@@ -18,8 +18,10 @@ namespace Microsoft.CodeAnalysis.Host
         private Workspace _workspace;
         private readonly TaskQueue _taskQueue;
 
+#pragma warning disable IDE0052 // Remove unread private members
         // Used to keep a strong reference to the built compilations so they are not GC'd
         private Compilation[] _mostRecentCompilations;
+#pragma warning restore IDE0052 // Remove unread private members
 
         private readonly object _buildGate = new object();
         private CancellationTokenSource _cancellationSource;

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -122,11 +122,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
                 node.GetAncestor(Of QueryExpressionSyntax)() IsNot Nothing
         End Function
 
-        Private Function IsOutermostQueryExpression(node As SyntaxNode) As Boolean
-            ' TODO(cyrusn): Figure out how to implement this.
-            Return True
-        End Function
-
         Protected Overrides Function CanAddImportForType(
                 diagnosticId As String, node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnosticId

--- a/src/Features/VisualBasic/Portable/AddParameter/VisualBasicAddParameterCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddParameter/VisualBasicAddParameterCodeFixProvider.vb
@@ -23,17 +23,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddParameter
         InvocationExpressionSyntax,
         ObjectCreationExpressionSyntax)
 
-        Const BC30057 As String = NameOf(BC30057) ' error BC30057: Too many arguments to 'Public Sub New()'.
-        Const BC30272 As String = NameOf(BC30272) ' error BC30272: 'p' is not a parameter of 'Public Sub New()'.
-        Const BC30274 As String = NameOf(BC30274) ' error BC30274: Parameter 'prop' of 'Public Sub New(prop As String)' already has a matching argument.
-        Const BC30311 As String = NameOf(BC30311) ' error BC30311: Value of type 'String' cannot be converted to 'Exception'.
-        Const BC30389 As String = NameOf(BC30389) ' error BC30389: 'x' is not accessible in this context
-        Const BC30512 As String = NameOf(BC30512) ' error BC30512: Option Strict On disallows implicit conversions from 'Object' to 'Integer'.
-        Const BC32006 As String = NameOf(BC32006) ' error BC32006: 'Char' values cannot be converted to 'Integer'. 
-        Const BC30387 As String = NameOf(BC30387) ' error BC32006: Class 'Derived' must declare a 'Sub New' because its base class 'Base' does not have an accessible 'Sub New' that can be called with no arguments. 
-        Const BC30516 As String = NameOf(BC30516) ' error BC30516: Overload resolution failed because no accessible 'Blah' accepts this number of arguments.
-        Const BC36582 As String = NameOf(BC36582) ' error BC36582: Too many arguments to extension method 'Public Sub ExtensionM1()' defined in 'Extensions'.
-        Const BC36625 As String = NameOf(BC36625) ' error BC36625: Lambda expression cannot be converted to 'Integer' because 'Integer' is not a delegate type.
+        Private Const BC30057 As String = NameOf(BC30057) ' error BC30057: Too many arguments to 'Public Sub New()'.
+        Private Const BC30272 As String = NameOf(BC30272) ' error BC30272: 'p' is not a parameter of 'Public Sub New()'.
+        Private Const BC30274 As String = NameOf(BC30274) ' error BC30274: Parameter 'prop' of 'Public Sub New(prop As String)' already has a matching argument.
+        Private Const BC30311 As String = NameOf(BC30311) ' error BC30311: Value of type 'String' cannot be converted to 'Exception'.
+        Private Const BC30389 As String = NameOf(BC30389) ' error BC30389: 'x' is not accessible in this context
+        Private Const BC30512 As String = NameOf(BC30512) ' error BC30512: Option Strict On disallows implicit conversions from 'Object' to 'Integer'.
+        Private Const BC32006 As String = NameOf(BC32006) ' error BC32006: 'Char' values cannot be converted to 'Integer'. 
+        Private Const BC30387 As String = NameOf(BC30387) ' error BC32006: Class 'Derived' must declare a 'Sub New' because its base class 'Base' does not have an accessible 'Sub New' that can be called with no arguments. 
+        Private Const BC30516 As String = NameOf(BC30516) ' error BC30516: Overload resolution failed because no accessible 'Blah' accepts this number of arguments.
+        Private Const BC36582 As String = NameOf(BC36582) ' error BC36582: Too many arguments to extension method 'Public Sub ExtensionM1()' defined in 'Extensions'.
+        Private Const BC36625 As String = NameOf(BC36625) ' error BC36625: Lambda expression cannot be converted to 'Integer' because 'Integer' is not a delegate type.
 
         <ImportingConstructor>
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -84,8 +84,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
             SyntaxKind.SubNewStatement,
             SyntaxKind.ConstructorBlock)
 
-        Dim s_createNewParameterSyntaxDelegate As Func(Of AddedParameter, ParameterSyntax) = AddressOf CreateNewParameterSyntax
-        Dim s_createNewCrefParameterSyntaxDelegate As Func(Of AddedParameter, CrefSignaturePartSyntax) = AddressOf CreateNewCrefParameterSyntax
+        Private ReadOnly s_createNewParameterSyntaxDelegate As Func(Of AddedParameter, ParameterSyntax) = AddressOf CreateNewParameterSyntax
+        Private ReadOnly s_createNewCrefParameterSyntaxDelegate As Func(Of AddedParameter, CrefSignaturePartSyntax) = AddressOf CreateNewCrefParameterSyntax
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>

--- a/src/Features/VisualBasic/Portable/CodeFixes/IncorrectExitContinue/IncorrectExitContinueCodeFixProvider.ReplaceTokenKeywordCodeAction.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/IncorrectExitContinue/IncorrectExitContinueCodeFixProvider.ReplaceTokenKeywordCodeAction.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectExitContinue
             Inherits CodeAction
 
             Private ReadOnly _blockKind As SyntaxKind
-            Private _invalidToken As SyntaxToken
+            Private ReadOnly _invalidToken As SyntaxToken
             Private ReadOnly _document As Document
 
             Public Sub New(blockKind As SyntaxKind,

--- a/src/Features/VisualBasic/Portable/CodeFixes/MoveToTopOfFile/MoveToTopOfFileCodeFixProvider.MoveToLineCodeAction.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/MoveToTopOfFile/MoveToTopOfFileCodeFixProvider.MoveToLineCodeAction.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.MoveToTopOfFile
 
             Private ReadOnly _destinationLine As Integer
             Private ReadOnly _document As Document
-            Private _token As SyntaxToken
+            Private ReadOnly _token As SyntaxToken
             Private ReadOnly _title As String
 
             Public Sub New(document As Document, token As SyntaxToken, destinationLine As Integer, title As String)

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/RemoveStatementCodeAction.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/RemoveStatementCodeAction.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeActions
 
         Private ReadOnly _document As Document
         Private ReadOnly _node As SyntaxNode
-        Private ReadOnly _cancellationToken As CancellationToken
         Private ReadOnly _title As String
 
         Public Sub New(document As Document, node As SyntaxNode, title As String)

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/VisualBasicRefactoringHelpersService.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/VisualBasicRefactoringHelpersService.vb
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings
 
         End Function
 
-        Function IsIdentifierOfParameter(node As SyntaxNode) As Boolean
+        Public Function IsIdentifierOfParameter(node As SyntaxNode) As Boolean
             Return (TypeOf node Is ModifiedIdentifierSyntax) AndAlso (TypeOf node.Parent Is ParameterSyntax) AndAlso (CType(node.Parent, ParameterSyntax).Identifier Is node)
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -251,15 +251,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 description:=RecommendedKeyword.CreateDisplayParts("Of", VBFeaturesResources.Identifies_a_type_parameter_on_a_generic_class_structure_interface_delegate_or_procedure))
         End Function
 
-        Private Shared s_WithoutOpenParen As CharacterSetModificationRule = CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, "("c)
-        Private Shared s_WithoutSpace As CharacterSetModificationRule = CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, " "c)
+        Private Shared ReadOnly s_WithoutOpenParen As CharacterSetModificationRule = CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, "("c)
+        Private Shared ReadOnly s_WithoutSpace As CharacterSetModificationRule = CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, " "c)
 
 #If False Then
         Private Shared s_defaultRules As CompletionItemRules =
             CompletionItemRules.Create(commitRules:=ImmutableArray.Create(
                 CommitRule.Create(CommitRuleKind.ExcludeKeysIfMatchEndOfTypedText, " ", "OF", isCaseSensitive:=False)))
 #Else
-        Private Shared s_defaultRules As CompletionItemRules = CompletionItemRules.Default
+        Private Shared ReadOnly s_defaultRules As CompletionItemRules = CompletionItemRules.Default
 #End If
 
         Private Function GetRules(displayText As String) As CompletionItemRules

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Function
 
         ' Typing : or = should not filter the list, but they should commit the list.
-        Private Shared s_itemRules As CompletionItemRules = CompletionItemRules.Default.
+        Private Shared ReadOnly s_itemRules As CompletionItemRules = CompletionItemRules.Default.
             WithFilterCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, ":"c, "="c)).
             WithCommitCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Add, ":"c, "="c))
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return Await VisualBasicSyntaxContext.CreateContextAsync(document.Project.Solution.Workspace, semanticModel, position, cancellationToken).ConfigureAwait(False)
         End Function
 
-        Private Shared s_rules As CompletionItemRules =
+        Private Shared ReadOnly s_rules As CompletionItemRules =
             CompletionItemRules.Create(
                 commitCharacterRules:=ImmutableArray.Create(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, " "c, "("c)),
                 matchPriority:=MatchPriority.Preselect,

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return MyBase.GetFilterText(symbol, displayText, context)
         End Function
 
-        Private Shared cachedRules As Dictionary(Of ValueTuple(Of Boolean, Boolean, Boolean), CompletionItemRules) =
+        Private Shared ReadOnly cachedRules As Dictionary(Of ValueTuple(Of Boolean, Boolean, Boolean), CompletionItemRules) =
             InitCachedRules()
 
         Private Shared Function InitCachedRules() As Dictionary(Of ValueTuple(Of Boolean, Boolean, Boolean), CompletionItemRules)

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -338,7 +338,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return nameSyntax?.LocalName.ValueText
         End Function
 
-        Private Shared s_defaultRules As CompletionItemRules =
+        Private Shared ReadOnly s_defaultRules As CompletionItemRules =
             CompletionItemRules.Create(
                 filterCharacterRules:=FilterRules,
                 enterKeyRule:=EnterKeyRule.Never)

--- a/src/Features/VisualBasic/Portable/Debugging/ProximityExpressionsGetter.RelevantExpressionsCollector.vb
+++ b/src/Features/VisualBasic/Portable/Debugging/ProximityExpressionsGetter.RelevantExpressionsCollector.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Debugging
-    Friend Partial Class VisualBasicProximityExpressionsService
+    Partial Friend Class VisualBasicProximityExpressionsService
         Public Class RelevantExpressionsCollector
             Inherits VisualBasicSyntaxWalker
 

--- a/src/Features/VisualBasic/Portable/Debugging/ProximityExpressionsGetter.Worker.vb
+++ b/src/Features/VisualBasic/Portable/Debugging/ProximityExpressionsGetter.Worker.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Debugging
-    Friend Partial Class VisualBasicProximityExpressionsService
+    Partial Friend Class VisualBasicProximityExpressionsService
         Public Class Worker
 
             Private ReadOnly _syntaxTree As SyntaxTree

--- a/src/Features/VisualBasic/Portable/Debugging/ProximityExpressionsGetter.vb
+++ b/src/Features/VisualBasic/Portable/Debugging/ProximityExpressionsGetter.vb
@@ -13,7 +13,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Debugging
     <ExportLanguageService(GetType(IProximityExpressionsService), LanguageNames.VisualBasic), [Shared]>
-    Friend Partial Class VisualBasicProximityExpressionsService
+    Partial Friend Class VisualBasicProximityExpressionsService
         Implements IProximityExpressionsService
 
         <ImportingConstructor>

--- a/src/Features/VisualBasic/Portable/EditAndContinue/BreakpointSpans.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/BreakpointSpans.vb
@@ -88,20 +88,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return candidate.HasValue
         End Function
 
-        Private Function CreateSpan(startToken As SyntaxToken, endToken As SyntaxToken) As TextSpan
-            Return TextSpan.FromBounds(startToken.SpanStart, endToken.Span.End)
-        End Function
-
         Private Function CreateSpan(node As SyntaxNode) As TextSpan
             Return TextSpan.FromBounds(node.SpanStart, node.Span.End)
-        End Function
-
-        Private Function CreateSpan(node1 As SyntaxNode, node2 As SyntaxNode) As TextSpan
-            Return TextSpan.FromBounds(node1.SpanStart, node2.Span.End)
-        End Function
-
-        Private Function CreateSpan(token As SyntaxToken) As TextSpan
-            Return TextSpan.FromBounds(token.SpanStart, token.Span.End)
         End Function
 
         Private Function TryCreateSpan(Of TNode As SyntaxNode)(list As SeparatedSyntaxList(Of TNode)) As TextSpan?

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2700,18 +2700,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                                              containingType:=DirectCast(newNode.Parent.Parent, TypeBlockSyntax))
             End Sub
 
-            Private Sub ClassifyUpdate(oldNode As AccessorStatementSyntax, newNode As AccessorStatementSyntax)
-                If oldNode.RawKind <> newNode.RawKind Then
-                    ReportError(RudeEditKind.AccessorKindUpdate)
-                    Return
-                End If
-
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
-            End Sub
-
             Private Sub ClassifyUpdate(oldNode As EnumMemberDeclarationSyntax, newNode As EnumMemberDeclarationSyntax)
                 If Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier) Then
                     ReportError(RudeEditKind.Renamed)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
         Partial Private MustInherit Class VisualBasicCodeGenerator
             Inherits CodeGenerator(Of StatementSyntax, ExpressionSyntax, StatementSyntax)
 
-            Private _methodName As SyntaxToken
+            Private ReadOnly _methodName As SyntaxToken
 
             Public Shared Async Function GenerateResultAsync(insertionPoint As InsertionPoint, selectionResult As SelectionResult, analyzerResult As AnalyzerResult, cancellationToken As CancellationToken) As Task(Of GeneratedCode)
                 Dim generator = Create(insertionPoint, selectionResult, analyzerResult)

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceField.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceField.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
-    Friend Partial Class VisualBasicIntroduceVariableService
+    Partial Friend Class VisualBasicIntroduceVariableService
         Protected Overrides Async Function IntroduceFieldAsync(
                 document As SemanticDocument,
                 expression As ExpressionSyntax,

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceLocal.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceLocal.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
-    Friend Partial Class VisualBasicIntroduceVariableService
+    Partial Friend Class VisualBasicIntroduceVariableService
         Protected Overrides Async Function IntroduceLocalAsync(
                 document As SemanticDocument,
                 expression As ExpressionSyntax,

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceQueryLocal.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceQueryLocal.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
-    Friend Partial Class VisualBasicIntroduceVariableService
+    Partial Friend Class VisualBasicIntroduceVariableService
         Protected Overrides Function IntroduceQueryLocalAsync(
                 document As SemanticDocument,
                 expression As ExpressionSyntax,

--- a/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
+++ b/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
@@ -4,11 +4,9 @@
 
 Imports System.Collections.Immutable
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
-Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.MetadataAsSource
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -20,9 +18,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MetadataAsSource
         Inherits AbstractMetadataAsSourceService
 
         Private ReadOnly _memberSeparationRule As AbstractFormattingRule = New FormattingRule()
+        Public Shared ReadOnly Instance As New VisualBasicMetadataAsSourceService()
 
-        Public Sub New(languageServices As HostLanguageServices)
-            MyBase.New(languageServices.GetService(Of ICodeGenerationService)())
+        Private Sub New()
         End Sub
 
         Protected Overrides Async Function AddAssemblyInfoRegionAsync(document As Document, symbolCompilation As Compilation, symbol As ISymbol, cancellationToken As CancellationToken) As Task(Of Document)

--- a/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceServiceFactory.vb
+++ b/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceServiceFactory.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MetadataAsSource
         End Sub
 
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-            Return New VisualBasicMetadataAsSourceService(provider)
+            Return VisualBasicMetadataAsSourceService.Instance
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearRefactoringProvider.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.MoveDeclarationNearReference
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), [Shared]>
     <ExtensionOrder(After:=PredefinedCodeRefactoringProviderNames.InlineTemporary)>
-    Class VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider
+    Friend Class VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider
         Inherits AbstractMoveDeclarationNearReferenceCodeRefactoringProvider(Of LocalDeclarationStatementSyntax)
 
         <ImportingConstructor>

--- a/src/Features/VisualBasic/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.vb
+++ b/src/Features/VisualBasic/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.Comparer.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
-    Friend Partial Class MemberDeclarationsOrganizer
+    Partial Friend Class MemberDeclarationsOrganizer
         Public Class Comparer
             Implements IComparer(Of StatementSyntax)
             ' TODO(cyrusn): Allow users to specify the ordering they want

--- a/src/Features/VisualBasic/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.vb
+++ b/src/Features/VisualBasic/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.vb
@@ -6,7 +6,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
-    Friend Partial Class MemberDeclarationsOrganizer
+    Partial Friend Class MemberDeclarationsOrganizer
         Private Sub New()
         End Sub
 

--- a/src/Features/VisualBasic/Portable/Organizing/VisualBasicOrganizerService.Rewriter.vb
+++ b/src/Features/VisualBasic/Portable/Organizing/VisualBasicOrganizerService.Rewriter.vb
@@ -6,7 +6,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Organizing.Organizers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing
-    Friend Partial Class VisualBasicOrganizingService
+    Partial Friend Class VisualBasicOrganizingService
         Public Class Rewriter
             Inherits VisualBasicSyntaxRewriter
 

--- a/src/Features/VisualBasic/Portable/Organizing/VisualBasicOrganizerService.vb
+++ b/src/Features/VisualBasic/Portable/Organizing/VisualBasicOrganizerService.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.Organizing.Organizers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing
     <ExportLanguageService(GetType(IOrganizingService), LanguageNames.VisualBasic), [Shared]>
-    Friend Partial Class VisualBasicOrganizingService
+    Partial Friend Class VisualBasicOrganizingService
         Inherits AbstractOrganizingService
 
         <ImportingConstructor>

--- a/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorInlineRenameService.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
@@ -129,11 +129,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
         /// The glyph for the symbol being renamed, for use in displaying information to the user.
         /// </summary>
         FSharpGlyph Glyph { get; }
-
-        /// <summary>
-        /// The locations of the potential rename candidates for the symbol.
-        /// </summary>
-        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
 
         /// <summary>
         /// Gets the final name of the symbol if the user has typed the provided replacement text

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
@@ -131,8 +130,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 
         public Glyph Glyph => FSharpGlyphHelpers.ConvertTo(_info.Glyph);
 
-        public ImmutableArray<DocumentSpan> DefinitionLocations => _info.DefinitionLocations;
-
         public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken)
         {
             var set = await _info.FindRenameLocationsAsync(optionSet, cancellationToken).ConfigureAwait(false);
@@ -146,7 +143,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             }
         }
 
-        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
+        public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
         {
             return _info.GetConflictEditSpan(new FSharpInlineRenameLocation(location.Document, location.TextSpan), replacementText, cancellationToken);
         }
@@ -156,7 +153,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             return _info.GetFinalSymbolName(replacementText);
         }
 
-        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
+        public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
         {
             return _info.GetReferenceEditSpan(new FSharpInlineRenameLocation(location.Document, location.TextSpan), cancellationToken);
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioMefHostServices.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioMefHostServices.cs
@@ -79,13 +79,11 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             internal readonly string ExtensionTypeName;
             internal readonly string MetadataTypeName;
-            private readonly int _hash;
 
             public ExportKey(string extensionTypeName, string metadataTypeName)
             {
                 ExtensionTypeName = extensionTypeName;
                 MetadataTypeName = metadataTypeName;
-                _hash = Hash.Combine(metadataTypeName.GetHashCode(), extensionTypeName.GetHashCode());
             }
 
             public bool Equals(ExportKey other)

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -18,13 +18,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 {
     internal static class WatsonReporter
     {
-        /// <summary>
-        /// Controls whether or not we actually report the failure.
-        /// There are situations where we know we're in a bad state and any further reports are unlikely to be
-        /// helpful, so we shouldn't send them.
-        /// </summary>
-        private static bool s_report = true;
-
         private static Dictionary<string, string>? s_capturedFileContent;
 
         private static TelemetrySession? s_telemetrySession;
@@ -79,11 +72,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             if (exception is OutOfMemoryException)
             {
                 FailFast.OnFatalException(exception);
-            }
-
-            if (!s_report)
-            {
-                return;
             }
 
             var emptyCallstack = exception.SetCallstackIfEmpty();

--- a/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -32,10 +31,9 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Rename
             public string DisplayName => null;
             public string FullDisplayName => null;
             public Glyph Glyph => Glyph.None;
-            public ImmutableArray<DocumentSpan> DefinitionLocations => default;
             public string GetFinalSymbolName(string replacementText) => null;
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken) => default;
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken) => null;
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken) => default;
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken) => null;
             public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => null;
             public bool TryOnAfterGlobalSymbolRenamed(CodeAnalysis.Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;
             public bool TryOnBeforeGlobalSymbolRenamed(CodeAnalysis.Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;

--- a/src/VisualStudio/Xaml/Impl/Features/InlineRename/IXamlRenameInfo.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/InlineRename/IXamlRenameInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
@@ -42,11 +41,6 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
         /// The kind of symbol being renamed, for use in displaying information to the user.
         /// </summary>
         SymbolKind Kind { get; }
-
-        /// <summary>
-        /// The locations of the potential rename candidates for the symbol.
-        /// </summary>
-        ImmutableArray<CodeAnalysis.DocumentSpan> DefinitionLocations { get; }
 
         /// <summary>
         /// Find all locations to be renamed.

--- a/src/VisualStudio/Xaml/Impl/Features/InlineRename/XamlEditorInlineRenameService.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/InlineRename/XamlEditorInlineRenameService.cs
@@ -67,8 +67,6 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
 
             public TextSpan TriggerSpan => _renameInfo.TriggerSpan;
 
-            public ImmutableArray<CodeAnalysis.DocumentSpan> DefinitionLocations => _renameInfo.DefinitionLocations;
-
             public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken)
             {
                 var references = new List<InlineRenameLocation>();
@@ -86,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
                     references.ToImmutableArray());
             }
 
-            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken)
+            public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
             {
                 return location.TextSpan;
             }
@@ -96,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
                 return replacementText;
             }
 
-            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken)
+            public TextSpan GetReferenceEditSpan(InlineRenameLocation location, CancellationToken cancellationToken)
             {
                 return location.TextSpan;
             }

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
     internal static class ClassificationHelpers
     {
         private const string FromKeyword = "from";
-        private const string ValueKeyword = "value";
         private const string VarKeyword = "var";
         private const string UnmanagedKeyword = "unmanaged";
         private const string NotNullKeyword = "notnull";

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
@@ -431,18 +431,5 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             return comparisonResult == 0;
         }
-
-        private static bool EqualTypeParameterCount(TypeParameterListSyntax x, TypeParameterListSyntax y, out int comparisonResult)
-        {
-            if (NeitherNull(x, y, out comparisonResult))
-            {
-                var xParameterCount = x.Parameters.Count;
-                var yParameterCount = y.Parameters.Count;
-
-                comparisonResult = xParameterCount - yParameterCount;
-            }
-
-            return comparisonResult == 0;
-        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -285,31 +285,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 return newNode;
             }
 
-            private bool IsExpandWithinMultiLineLambda(SyntaxNode node)
-            {
-                if (node == null)
-                {
-                    return false;
-                }
-
-                if (_conflictLocations.Contains(node.Span))
-                {
-                    return true;
-                }
-
-                if (node.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression, out ParenthesizedLambdaExpressionSyntax parenLambda))
-                {
-                    return ReferenceEquals(parenLambda.ParameterList, node);
-                }
-
-                if (node.IsParentKind(SyntaxKind.SimpleLambdaExpression, out SimpleLambdaExpressionSyntax simpleLambda))
-                {
-                    return ReferenceEquals(simpleLambda.Parameter, node);
-                }
-
-                return true;
-            }
-
             private async Task<SyntaxToken> RenameAndAnnotateAsync(SyntaxToken token, SyntaxToken newToken, bool isRenameLocation, bool isOldText)
             {
                 try

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/AbstractCSharpReducer.AbstractReductionRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/AbstractCSharpReducer.AbstractReductionRewriter.cs
@@ -95,14 +95,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 return topMostCref.Parent;
             }
 
-            private static SyntaxNode GetParentNode(StatementSyntax statement)
-            {
-                return statement
-                    .AncestorsAndSelf()
-                    .OfType<StatementSyntax>()
-                    .LastOrDefault();
-            }
-
             protected SyntaxNode SimplifyNode<TNode>(
                 TNode node,
                 SyntaxNode newNode,

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactory.PathSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactory.PathSyntaxReference.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 public override SyntaxNode GetSyntax(CancellationToken cancellationToken)
                     => this.GetNode(_tree.GetRoot(cancellationToken));
 
-                public async override Task<SyntaxNode> GetSyntaxAsync(CancellationToken cancellationToken = default)
+                public override async Task<SyntaxNode> GetSyntaxAsync(CancellationToken cancellationToken = default)
                 {
                     var root = await _tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
                     return this.GetNode(root);

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.PositionalSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.PositionalSyntaxReference.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return this.GetNode(_tree.GetRoot(cancellationToken));
                 }
 
-                public async override Task<SyntaxNode> GetSyntaxAsync(CancellationToken cancellationToken = default)
+                public override async Task<SyntaxNode> GetSyntaxAsync(CancellationToken cancellationToken = default)
                 {
                     var root = await _tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
                     return this.GetNode(root);

--- a/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
@@ -11,30 +11,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
     public class EditorConfigOptionParserTests
     {
         [Theory,
-        InlineData("expressions", SpacingWithinParenthesesOption.Expressions),
-        InlineData("type_casts", SpacingWithinParenthesesOption.TypeCasts),
-        InlineData("control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements),
-        InlineData("expressions, type_casts", SpacingWithinParenthesesOption.Expressions),
-        InlineData("type_casts, expressions, , ", SpacingWithinParenthesesOption.TypeCasts),
-        InlineData("expressions ,  ,  , control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements),
-        InlineData("expressions ,  ,  , control_flow_statements", SpacingWithinParenthesesOption.Expressions),
-        InlineData(",  ,  , control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements)]
-        static void TestParseParenthesesSpaceOptionsTrue(string value, SpacingWithinParenthesesOption parenthesesSpacingOption)
+        InlineData("expressions", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData("type_casts", (int)SpacingWithinParenthesesOption.TypeCasts),
+        InlineData("control_flow_statements", (int)SpacingWithinParenthesesOption.ControlFlowStatements),
+        InlineData("expressions, type_casts", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData("type_casts, expressions, , ", (int)SpacingWithinParenthesesOption.TypeCasts),
+        InlineData("expressions ,  ,  , control_flow_statements", (int)SpacingWithinParenthesesOption.ControlFlowStatements),
+        InlineData("expressions ,  ,  , control_flow_statements", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData(",  ,  , control_flow_statements", (int)SpacingWithinParenthesesOption.ControlFlowStatements)]
+        public void TestParseParenthesesSpaceOptionsTrue(string value, int parenthesesSpacingOption)
         {
-            Assert.True(DetermineIfSpaceOptionIsSet(value, parenthesesSpacingOption),
+            Assert.True(DetermineIfSpaceOptionIsSet(value, (SpacingWithinParenthesesOption)parenthesesSpacingOption),
                         $"Expected option {value} to be parsed as set.");
         }
 
         [Theory,
-        InlineData("expressions", SpacingWithinParenthesesOption.ControlFlowStatements),
-        InlineData("type_casts", SpacingWithinParenthesesOption.Expressions),
-        InlineData("control_flow_statements", SpacingWithinParenthesesOption.Expressions),
-        InlineData("", SpacingWithinParenthesesOption.Expressions),
-        InlineData(",,,", SpacingWithinParenthesesOption.Expressions),
-        InlineData("*", SpacingWithinParenthesesOption.Expressions)]
-        static void TestParseParenthesesSpaceOptionsFalse(string value, SpacingWithinParenthesesOption parenthesesSpacingOption)
+        InlineData("expressions", (int)SpacingWithinParenthesesOption.ControlFlowStatements),
+        InlineData("type_casts", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData("control_flow_statements", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData("", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData(",,,", (int)SpacingWithinParenthesesOption.Expressions),
+        InlineData("*", (int)SpacingWithinParenthesesOption.Expressions)]
+        public void TestParseParenthesesSpaceOptionsFalse(string value, int parenthesesSpacingOption)
         {
-            Assert.False(DetermineIfSpaceOptionIsSet(value, parenthesesSpacingOption),
+            Assert.False(DetermineIfSpaceOptionIsSet(value, (SpacingWithinParenthesesOption)parenthesesSpacingOption),
                         $"Expected option {value} to be parsed as un-set.");
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("ignore", BinaryOperatorSpacingOptions.Ignore),
         InlineData("none", BinaryOperatorSpacingOptions.Remove),
         InlineData("before_and_after", BinaryOperatorSpacingOptions.Single)]
-        static void TestParseEditorConfigSpacingAroundBinaryOperatorTrue(string value, BinaryOperatorSpacingOptions expectedResult)
+        public void TestParseEditorConfigSpacingAroundBinaryOperatorTrue(string value, BinaryOperatorSpacingOptions expectedResult)
         {
             Assert.True(ParseEditorConfigSpacingAroundBinaryOperator(value) == expectedResult,
                         $"Expected option {value} to be parsed as set.");
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("ignore,"),
         InlineData("non"),
         InlineData("before_and_after,ignore")]
-        static void TestParseEditorConfigSpacingAroundBinaryOperatorFalse(string value)
+        public void TestParseEditorConfigSpacingAroundBinaryOperatorFalse(string value)
         {
             Assert.True(ParseEditorConfigSpacingAroundBinaryOperator(value) == BinaryOperatorSpacingOptions.Single,
                         $"Expected option {value} to be parsed as default option.");
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("flush_left", LabelPositionOptions.LeftMost),
         InlineData("no_change", LabelPositionOptions.NoIndent),
         InlineData("one_less_than_current", LabelPositionOptions.OneLess)]
-        static void TestParseEditorConfigLabelPositioningTrue(string value, LabelPositionOptions expectedValue)
+        public void TestParseEditorConfigLabelPositioningTrue(string value, LabelPositionOptions expectedValue)
         {
             Assert.True(ParseEditorConfigLabelPositioning(value) == expectedValue,
                         $"Expected option {value} to be parsed as set.");
@@ -72,46 +72,46 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("left_most,"),
         InlineData("*"),
         InlineData("one_less_thancurrent")]
-        static void TestParseEditorConfigLabelPositioningFalse(string value)
+        public void TestParseEditorConfigLabelPositioningFalse(string value)
         {
             Assert.True(ParseEditorConfigLabelPositioning(value) == LabelPositionOptions.NoIndent,
                         $"Expected option {value} to be parsed default");
         }
 
         [Theory,
-        InlineData("all", NewLineOption.Types),
-        InlineData("all,none", NewLineOption.Types),
-        InlineData("none,all", NewLineOption.Types),
-        InlineData("types", NewLineOption.Types),
-        InlineData("types,methods", NewLineOption.Types),
-        InlineData(",, types", NewLineOption.Types),
-        InlineData("accessors", NewLineOption.Accessors),
-        InlineData("methods", NewLineOption.Methods),
-        InlineData("properties", NewLineOption.Properties),
-        InlineData("indexers", NewLineOption.Indexers),
-        InlineData("events", NewLineOption.Events),
-        InlineData("anonymous_methods", NewLineOption.AnonymousMethods),
-        InlineData("control_blocks", NewLineOption.ControlBlocks),
-        InlineData("anonymous_types", NewLineOption.AnonymousTypes),
-        InlineData("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
-        InlineData("object_collection_array_initializers", NewLineOption.ObjectCollectionsArrayInitializers),
-        InlineData("lambdas", NewLineOption.Lambdas),
-        InlineData("local_functions", NewLineOption.LocalFunction)]
-        static void TestParseNewLineOptionTrue(string value, NewLineOption option)
+        InlineData("all", (int)NewLineOption.Types),
+        InlineData("all,none", (int)NewLineOption.Types),
+        InlineData("none,all", (int)NewLineOption.Types),
+        InlineData("types", (int)NewLineOption.Types),
+        InlineData("types,methods", (int)NewLineOption.Types),
+        InlineData(",, types", (int)NewLineOption.Types),
+        InlineData("accessors", (int)NewLineOption.Accessors),
+        InlineData("methods", (int)NewLineOption.Methods),
+        InlineData("properties", (int)NewLineOption.Properties),
+        InlineData("indexers", (int)NewLineOption.Indexers),
+        InlineData("events", (int)NewLineOption.Events),
+        InlineData("anonymous_methods", (int)NewLineOption.AnonymousMethods),
+        InlineData("control_blocks", (int)NewLineOption.ControlBlocks),
+        InlineData("anonymous_types", (int)NewLineOption.AnonymousTypes),
+        InlineData("object_collection_array_initalizers", (int)NewLineOption.ObjectCollectionsArrayInitializers),
+        InlineData("object_collection_array_initializers", (int)NewLineOption.ObjectCollectionsArrayInitializers),
+        InlineData("lambdas", (int)NewLineOption.Lambdas),
+        InlineData("local_functions", (int)NewLineOption.LocalFunction)]
+        public void TestParseNewLineOptionTrue(string value, int option)
         {
-            Assert.True(DetermineIfNewLineOptionIsSet(value, option),
+            Assert.True(DetermineIfNewLineOptionIsSet(value, (NewLineOption)option),
                         $"Expected option {value} to be set");
         }
 
         [Theory,
-        InlineData("Accessors", NewLineOption.Accessors),
-        InlineData("none,types", NewLineOption.Types),
-        InlineData("methods", NewLineOption.Types),
-        InlineData("methods, properties", NewLineOption.Types),
-        InlineData(",,,", NewLineOption.Types)]
-        static void TestParseNewLineOptionFalse(string value, NewLineOption option)
+        InlineData("Accessors", (int)NewLineOption.Accessors),
+        InlineData("none,types", (int)NewLineOption.Types),
+        InlineData("methods", (int)NewLineOption.Types),
+        InlineData("methods, properties", (int)NewLineOption.Types),
+        InlineData(",,,", (int)NewLineOption.Types)]
+        public void TestParseNewLineOptionFalse(string value, int option)
         {
-            Assert.False(DetermineIfNewLineOptionIsSet(value, option),
+            Assert.False(DetermineIfNewLineOptionIsSet(value, (NewLineOption)option),
                         $"Expected option {value} to be un-set");
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("ignore "),
         InlineData(" ignore"),
         InlineData(" ignore ")]
-        static void TestDetermineIfIgnoreSpacesAroundVariableDeclarationIsSetTrue(string value)
+        public void TestDetermineIfIgnoreSpacesAroundVariableDeclarationIsSetTrue(string value)
         {
             Assert.True(DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(value),
                         $"Expected option {value} to be set");
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("do_not_ignore"),
         InlineData(", "),
         InlineData(" ignor ")]
-        static void TestDetermineIfIgnoreSpacesAroundVariableDeclarationIsSetFalse(string value)
+        public void TestDetermineIfIgnoreSpacesAroundVariableDeclarationIsSetFalse(string value)
         {
             Assert.False(DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(value),
                         $"Expected option {value} to be un-set");

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
@@ -136,7 +136,9 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 
         internal readonly struct TestAccessor
         {
+#pragma warning disable IDE0052 // Remove unread private members - hold onto the services
             private readonly MefV1HostServices _mefV1HostServices;
+#pragma warning restore IDE0052 // Remove unread private members
 
             public TestAccessor(MefV1HostServices mefV1HostServices)
             {

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// Computes all changes for an entire solution.
         /// Override this method if you want to implement a <see cref="CodeAction"/> subclass that changes more than one document.
         /// </summary>
-        protected async virtual Task<Solution?> GetChangedSolutionAsync(CancellationToken cancellationToken)
+        protected virtual async Task<Solution?> GetChangedSolutionAsync(CancellationToken cancellationToken)
         {
             var changedDocument = await GetChangedDocumentAsync(cancellationToken).ConfigureAwait(false);
             if (changedDocument == null)

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             return fixesBag.ToImmutableArray();
         }
 
-        protected async virtual Task AddDocumentFixesAsync(
+        protected virtual async Task AddDocumentFixesAsync(
             Document document, ImmutableArray<Diagnostic> diagnostics,
             ConcurrentBag<(Diagnostic diagnostic, CodeAction action)> fixes,
             FixAllState fixAllState, CancellationToken cancellationToken)
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             int IIntervalIntrospector<TextChange>.GetLength(TextChange value) => value.Span.Length;
         }
 
-        private static Func<DocumentId, ConcurrentBag<(CodeAction, Document)>> s_getValue =
+        private static readonly Func<DocumentId, ConcurrentBag<(CodeAction, Document)>> s_getValue =
             _ => new ConcurrentBag<(CodeAction, Document)>();
 
         private async Task GetChangedDocumentsAsync(

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationPropertySymbol : CodeGenerationSymbol, IPropertySymbol
     {
-        private RefKind _refKind;
+        private readonly RefKind _refKind;
         public ITypeSymbol Type { get; }
         public NullableAnnotation NullableAnnotation => Type.NullableAnnotation;
         public bool IsIndexer { get; }

--- a/src/Workspaces/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// It is quite common for multiple projects to have the same set of analyzer references, yet we will create
         /// multiple instances of the analyzer list and thus not share the info.
         /// </remarks>
-        private ConditionalWeakTable<IReadOnlyList<AnalyzerReference>, StrongBox<ImmutableDictionary<string, SkippedHostAnalyzersInfo>>> _skippedHostAnalyzers;
+        private readonly ConditionalWeakTable<IReadOnlyList<AnalyzerReference>, StrongBox<ImmutableDictionary<string, SkippedHostAnalyzersInfo>>> _skippedHostAnalyzers;
 
         internal HostDiagnosticAnalyzers(IEnumerable<AnalyzerReference> hostAnalyzerReferences)
         {

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingWorkspaceExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingWorkspaceExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     internal static class UnitTestingWorkspaceExtensions
     {
-        public async static Task<UnitTestingRemoteHostClientWrapper> TryGetUnitTestingRemoteHostClientWrapperAsync(this Workspace workspace, CancellationToken cancellationToken)
+        public static async Task<UnitTestingRemoteHostClientWrapper> TryGetUnitTestingRemoteHostClientWrapperAsync(this Workspace workspace, CancellationToken cancellationToken)
         {
             var client = await RemoteHostClient.TryGetClientAsync(workspace, cancellationToken).ConfigureAwait(false);
             return new UnitTestingRemoteHostClientWrapper(client);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -26,8 +26,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         private struct DefinitionProject
         {
+#pragma warning disable IDE0052 // Remove unread private members - DefinitionProject is used as a key for dictionaries.
             private readonly ProjectId _sourceProjectId;
             private readonly string _assemblyName;
+#pragma warning restore IDE0052 // Remove unread private members
 
             public DefinitionProject(ProjectId sourceProjectId, string assemblyName)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 solution,
                 checksum,
                 loadOnly,
-                createAsync: () => CreateMetadataSymbolTreeInfoAsync(solution, checksum, reference, cancellationToken),
+                createAsync: () => CreateMetadataSymbolTreeInfoAsync(solution, checksum, reference),
                 keySuffix: "_Metadata_" + filePath,
                 tryReadObject: reader => TryReadSymbolTreeInfo(reader, checksum, (names, nodes) => GetSpellCheckerAsync(solution, checksum, filePath, names, nodes)),
                 cancellationToken: cancellationToken);
@@ -204,10 +204,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private static Task<SymbolTreeInfo> CreateMetadataSymbolTreeInfoAsync(
             Solution solution, Checksum checksum,
-            PortableExecutableReference reference,
-            CancellationToken cancellationToken)
+            PortableExecutableReference reference)
         {
-            var creator = new MetadataInfoCreator(solution, checksum, reference, cancellationToken);
+            var creator = new MetadataInfoCreator(solution, checksum, reference);
             return Task.FromResult(creator.Create());
         }
 
@@ -219,7 +218,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private readonly Solution _solution;
             private readonly Checksum _checksum;
             private readonly PortableExecutableReference _reference;
-            private readonly CancellationToken _cancellationToken;
 
             private readonly OrderPreservingMultiDictionary<string, string> _inheritanceMap;
             private readonly OrderPreservingMultiDictionary<MetadataNode, MetadataNode> _parentToChildren;
@@ -242,12 +240,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private bool _containsExtensionsMethod;
 
             public MetadataInfoCreator(
-                Solution solution, Checksum checksum, PortableExecutableReference reference, CancellationToken cancellationToken)
+                Solution solution, Checksum checksum, PortableExecutableReference reference)
             {
                 _solution = solution;
                 _checksum = checksum;
                 _reference = reference;
-                _cancellationToken = cancellationToken;
                 _metadataReader = null;
                 _allTypeDefinitions = new List<MetadataDefinition>();
                 _containsExtensionsMethod = false;

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         private const string GenericTypeNameManglingString = "`";
         private static readonly string[] s_aritySuffixesOneToNine = { "`1", "`2", "`3", "`4", "`5", "`6", "`7", "`8", "`9" };
 
-        private readonly static ObjectPool<List<Dictionary<string, string>>> s_aliasMapListPool
+        private static readonly ObjectPool<List<Dictionary<string, string>>> s_aliasMapListPool
             = SharedPools.Default<List<Dictionary<string, string>>>();
 
         // Note: these names are stored case insensitively.  That way the alias mapping works 
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         // for C#.  However, that's ok.  It will be rare in practice, and all it means is that
         // we'll end up examining slightly more types (likely 0) when doing operations like 
         // Find all references.
-        private readonly static ObjectPool<Dictionary<string, string>> s_aliasMapPool
+        private static readonly ObjectPool<Dictionary<string, string>> s_aliasMapPool
             = SharedPools.StringIgnoreCaseDictionary<string>();
 
         protected static List<Dictionary<string, string>> AllocateAliasMapList()

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingLogger.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingLogger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal class LinkedFileDiffMergingLogger
     {
-        private static LogAggregator LogAggregator = new LogAggregator();
+        private static readonly LogAggregator LogAggregator = new LogAggregator();
 
         internal enum MergeInfo
         {

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis
 
         private readonly Solution _oldSolution;
         private readonly Solution _newSolution;
-        private SolutionChanges _solutionChanges;
+        private readonly SolutionChanges _solutionChanges;
 
         public LinkedFileDiffMergingSession(Solution oldSolution, Solution newSolution, SolutionChanges solutionChanges, bool logSessionInfo)
         {

--- a/src/Workspaces/Core/Portable/Log/RoslynEventSource.LogBlock.cs
+++ b/src/Workspaces/Core/Portable/Log/RoslynEventSource.LogBlock.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             private readonly int _blockId;
             private readonly CancellationToken _cancellationToken;
 
-            private int _tick;
+            private readonly int _tick;
             private bool _startLogged;
             private string? _message;
 

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -32,9 +32,11 @@ namespace Microsoft.CodeAnalysis.Options
 
         private readonly object _gate = new object();
 
+#pragma warning disable IDE0044 // Add readonly modifier - https://github.com/dotnet/roslyn/issues/33009
         private ImmutableDictionary<string, (IOption? option, IEditorConfigStorageLocation2? storageLocation)> _neutralEditorConfigKeysToOptions = s_emptyEditorConfigKeysToOptions;
         private ImmutableDictionary<string, (IOption? option, IEditorConfigStorageLocation2? storageLocation)> _csharpEditorConfigKeysToOptions = s_emptyEditorConfigKeysToOptions;
         private ImmutableDictionary<string, (IOption? option, IEditorConfigStorageLocation2? storageLocation)> _visualBasicEditorConfigKeysToOptions = s_emptyEditorConfigKeysToOptions;
+#pragma warning restore IDE0044 // Add readonly modifier
 
         private ImmutableDictionary<OptionKey, object?> _currentValues;
         private ImmutableHashSet<OptionKey> _changedOptionKeys;

--- a/src/Workspaces/Core/Portable/Options/IDocumentOptions.cs
+++ b/src/Workspaces/Core/Portable/Options/IDocumentOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Options
     /// <summary>
     /// Returned from a <see cref="IDocumentOptionsProvider"/>
     /// </summary>
-    interface IDocumentOptions
+    internal interface IDocumentOptions
     {
         /// <summary>
         /// Attempts to fetch the value for the given option.

--- a/src/Workspaces/Core/Portable/Options/IDocumentOptionsProvider.cs
+++ b/src/Workspaces/Core/Portable/Options/IDocumentOptionsProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Options
     /// This is passed to <see cref="IOptionService.RegisterDocumentOptionsProvider(IDocumentOptionsProvider)"/> to activate it
     /// for a workspace. This instance then lives around for the lifetime of the workspace.
     /// </remarks>
-    interface IDocumentOptionsProvider
+    internal interface IDocumentOptionsProvider
     {
         /// <summary>
         /// Fetches a <see cref="IDocumentOptions"/> for the given document. Any asynchronous work (looking for config files, etc.)

--- a/src/Workspaces/Core/Portable/Options/IDocumentOptionsProviderFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/IDocumentOptionsProviderFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Options
     /// <summary>
     /// A MEF-exported factory which produces <see cref="IDocumentOptionsProvider"/>s for <see cref="Workspace"/>s.
     /// </summary>
-    interface IDocumentOptionsProviderFactory
+    internal interface IDocumentOptionsProviderFactory
     {
         IDocumentOptionsProvider? TryCreate(Workspace workspace);
     }

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatch.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatch.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         public int CompareTo(PatternMatch other, bool ignoreCase)
             => ComparerWithState.CompareTo(this, other, ignoreCase, s_comparers);
 
-        private readonly static ImmutableArray<Func<PatternMatch, bool, IComparable>> s_comparers =
+        private static readonly ImmutableArray<Func<PatternMatch, bool, IComparable>> s_comparers =
             ImmutableArray.Create<Func<PatternMatch, bool, IComparable>>(
                 // Compare types
                 (p, b) => p.Kind,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
     {
         private static readonly ConditionalWeakTable<INamespaceSymbol, List<string>> s_namespaceToNameMap =
             new ConditionalWeakTable<INamespaceSymbol, List<string>>();
-        private static readonly ConditionalWeakTable<INamespaceSymbol, List<string>>.CreateValueCallback s_getNameParts = GetNameParts;
 
         public static readonly Comparison<INamespaceSymbol> CompareNamespaces = CompareTo;
         public static readonly IEqualityComparer<INamespaceSymbol> EqualityComparer = new Comparer();

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -17,7 +17,10 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
     {
         private readonly NonReentrantLock _gate = new NonReentrantLock();
 
+#pragma warning disable IDE0052 // Remove unread private members - Can this field be removed?
         private readonly string _featureName;
+#pragma warning restore IDE0052 // Remove unread private members
+
         private readonly HashSet<TaskCompletionSource<bool>> _pendingTasks = new HashSet<TaskCompletionSource<bool>>();
         private CancellationTokenSource _expeditedDelayCancellationTokenSource;
 

--- a/src/Workspaces/Core/Portable/Storage/StorageDatabaseLogger.cs
+++ b/src/Workspaces/Core/Portable/Storage/StorageDatabaseLogger.cs
@@ -15,8 +15,10 @@ namespace Microsoft.CodeAnalysis.Storage
 
         private static readonly StorageDatabaseLogger Instance = new StorageDatabaseLogger();
 
+#pragma warning disable IDE0052 // Remove unread private members - hold onto last exception to make investigation easier
         private Exception _reportedException;
         private string _reportedExceptionMessage;
+#pragma warning restore IDE0052 // Remove unread private members
 
         private readonly ConcurrentDictionary<Type, Exception> _set = new ConcurrentDictionary<Type, Exception>(concurrencyLevel: 2, capacity: 10);
 

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             return ComparerWithState.CompareTo(this, other, s_comparers);
         }
 
-        private readonly static ImmutableArray<Func<PackageWithAssemblyResult, IComparable>> s_comparers =
+        private static readonly ImmutableArray<Func<PackageWithAssemblyResult, IComparable>> s_comparers =
             ImmutableArray.Create<Func<PackageWithAssemblyResult, IComparable>>(p => p.Rank, p => p.PackageName);
     }
 

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedInfo.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedInfo.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Host
                 _memoryMappedFile.Dispose();
             }
 
-            private unsafe sealed class SharedReadableStream : Stream, ISupportDirectMemoryAccess
+            private sealed unsafe class SharedReadableStream : Stream, ISupportDirectMemoryAccess
             {
                 private readonly ReferenceCountedDisposable<MemoryMappedViewAccessor> _accessor;
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IPersistentStorageLocationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IPersistentStorageLocationService.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    interface IPersistentStorageLocationService : IWorkspaceService
+    internal interface IPersistentStorageLocationService : IWorkspaceService
     {
         bool IsSupported(Workspace workspace);
         string? TryGetStorageLocation(Solution solution);

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Host
     [ExportWorkspaceService(typeof(IWorkspaceStatusService), ServiceLayer.Default), Shared]
     internal sealed class WorkspaceStatusService : IWorkspaceStatusService
     {
-        public readonly static WorkspaceStatusService Default = new WorkspaceStatusService();
+        public static readonly WorkspaceStatusService Default = new WorkspaceStatusService();
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Incorrectly used in production code: https://github.com/dotnet/roslyn/issues/42839")]

--- a/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
@@ -13,7 +13,9 @@ namespace Microsoft.CodeAnalysis
     {
         private static int s_nextId;
 
+#pragma warning disable IDE0052 // Remove unread private members
         private readonly int _id;
+#pragma warning restore IDE0052 // Remove unread private members
 
         private BranchId(int id)
             => _id = id;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProject.cs
@@ -8,7 +8,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis
 {
-    partial class ProjectDependencyGraph
+    public partial class ProjectDependencyGraph
     {
         internal ProjectDependencyGraph WithAdditionalProject(ProjectId projectId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    partial class ProjectDependencyGraph
+    public partial class ProjectDependencyGraph
     {
         internal ProjectDependencyGraph WithAdditionalProjectReferences(ProjectId projectId, IReadOnlyCollection<ProjectReference> projectReferences)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    partial class ProjectDependencyGraph
+    public partial class ProjectDependencyGraph
     {
         internal ProjectDependencyGraph WithProjectRemoved(ProjectId projectId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProjectReference.cs
@@ -10,7 +10,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    partial class ProjectDependencyGraph
+    public partial class ProjectDependencyGraph
     {
         internal ProjectDependencyGraph WithProjectReferenceRemoved(ProjectId projectId, ProjectId referencedProjectId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -167,7 +167,10 @@ namespace Microsoft.CodeAnalysis
 
             internal sealed class AddAdditionalDocumentsAction : CompilationAndGeneratorDriverTranslationAction
             {
+#pragma warning disable IDE0052 // Remove unread private members
+                // PROTOTYPE: right now there is no way to tell a GeneratorDriver that an additional file has been added
                 private readonly ImmutableArray<TextDocumentState> _additionalDocuments;
+#pragma warning restore IDE0052 // Remove unread private members
 
                 public AddAdditionalDocumentsAction(ImmutableArray<TextDocumentState> additionalDocuments)
                 {
@@ -185,7 +188,10 @@ namespace Microsoft.CodeAnalysis
 
             internal sealed class RemoveAdditionalDocumentsAction : CompilationAndGeneratorDriverTranslationAction
             {
+#pragma warning disable IDE0052 // Remove unread private members
+                // PROTOTYPE: right now there is no way to tell a GeneratorDriver that an additional file has been added
                 private readonly ImmutableArray<TextDocumentState> _additionalDocuments;
+#pragma warning restore IDE0052 // Remove unread private members
 
                 public RemoveAdditionalDocumentsAction(ImmutableArray<TextDocumentState> additionalDocuments)
                 {

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticDescriptors.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticDescriptors.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class WorkspaceDiagnosticDescriptors
     {
-        internal readonly static DiagnosticDescriptor ErrorReadingFileContent;
+        internal static readonly DiagnosticDescriptor ErrorReadingFileContent;
 
         internal const string ErrorReadingFileContentId = "IDE1100";
 

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 {
     public class LongestCommonSubsequenceTests
     {
-        LongestCommonSubsequenceString lcs = new LongestCommonSubsequenceString();
+        private readonly LongestCommonSubsequenceString lcs = new LongestCommonSubsequenceString();
 
         private class LongestCommonSubsequenceString : LongestCommonSubsequence<string>
         {

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.TestSolutionsAndProject.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.TestSolutionsAndProject.cs
@@ -59,16 +59,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        private static void VerifyInnerExceptionArgumentNull(AggregateException ex, string argName)
-        {
-            var exception = ex.InnerException as ArgumentNullException;
-            Assert.True(exception != null, string.Format("Expected InnerException to be 'System.ArgumentNullException' was '{0}'", ex.InnerException.ToString()));
-            Assert.True(exception.ParamName.Contains(argName), string.Format("Expected InnerException ParamName to contain '{0}', actual ParamName is: '{1}'", argName, exception.ParamName));
-        }
-
-        private static void VerifyInnerExceptionIsType<T>(Exception ex) where T : Exception
-            => Assert.True(ex.InnerException is T, string.Format("Expected InnerException to be '{0}' was '{1}'", typeof(T).Name, ex.InnerException.ToString()));
-
         private static Solution CreateSolution()
             => new AdhocWorkspace().CurrentSolution;
 

--- a/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static int ThrowTestException() => throw new TestException();
+        private static int ThrowTestException() => throw new TestException();
 
-        class TestException : Exception { }
+        private class TestException : Exception { }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -183,9 +183,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
             GC.Collect(2);
         }
 
-        // We want to keep this test around, but not have it disabled/associated with a bug
-        // [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        private void TestTemporaryStorageScaling()
+        [Fact(Skip = "This test exists so it can be locally executed for scale testing, when required. Do not remove this test or unskip it in CI.")]
+        [Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestTemporaryStorageScaling()
         {
             // This will churn through 4GB of memory.  It validates that we don't
             // use up our address space in a 32 bit process.

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -1170,7 +1170,7 @@ class C1
             });
         }
 
-        private IEnumerable<Assembly> _defaultAssembliesWithoutCSharp = MefHostServices.DefaultAssemblies.Where(a => !a.FullName.Contains("CSharp"));
+        private readonly IEnumerable<Assembly> _defaultAssembliesWithoutCSharp = MefHostServices.DefaultAssemblies.Where(a => !a.FullName.Contains("CSharp"));
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(3931, "https://github.com/dotnet/roslyn/issues/3931")]

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
             }
         }
 
-        private readonly static Func<string, byte[]> s_bytesLoader = LoadBytes;
-        private readonly static Func<string, string> s_textLoader = LoadText;
+        private static readonly Func<string, byte[]> s_bytesLoader = LoadBytes;
+        private static readonly Func<string, string> s_textLoader = LoadText;
         private static Dictionary<string, byte[]> s_bytesCache;
         private static Dictionary<string, string> s_textCache;
 

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildInstalled.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildInstalled.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
 
     internal static class VisualStudioMSBuildLocator
     {
-        private static Lazy<(Version version, string path)> s_versionAndPath = new Lazy<(Version version, string path)>(FindMSBuildToolsPathFromVisualStudioCore);
+        private static readonly Lazy<(Version version, string path)> s_versionAndPath = new Lazy<(Version version, string path)>(FindMSBuildToolsPathFromVisualStudioCore);
 
         public static bool TryFindMSBuildToolsPath(out (Version version, string path) versionAndPath)
         {

--- a/src/Workspaces/Remote/Core/Services/RoslynServices.cs
+++ b/src/Workspaces/Remote/Core/Services/RoslynServices.cs
@@ -81,7 +81,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
         internal readonly struct TestAccessor
         {
+#pragma warning disable IDE0052 // Remove unread private members - hold onto the Roslyn services.
             private readonly RoslynServices _roslynServices;
+#pragma warning restore IDE0052 // Remove unread private members
 
             public TestAccessor(RoslynServices roslynServices)
                 => _roslynServices = roslynServices;

--- a/src/Workspaces/Remote/Core/Services/SolutionService.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionService.cs
@@ -30,8 +30,8 @@ namespace Microsoft.CodeAnalysis.Remote
         private static readonly SemaphoreSlim s_gate = new SemaphoreSlim(initialCount: 1);
 
         // this simple cache hold onto the last and primary solution created
-        private volatile static Tuple<Checksum, Solution>? s_primarySolution;
-        private volatile static Tuple<Checksum, Solution>? s_lastSolution;
+        private static volatile Tuple<Checksum, Solution>? s_primarySolution;
+        private static volatile Tuple<Checksum, Solution>? s_lastSolution;
 
         public AssetProvider AssetProvider { get; }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal partial class RemoteHostService : ServiceBase, IRemoteHostService, IAssetSource
     {
-        private readonly static TimeSpan s_reportInterval = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan s_reportInterval = TimeSpan.FromMinutes(2);
         private readonly CancellationTokenSource _shutdownCancellationSource;
 
         // it is saved here more on debugging purpose.
@@ -46,7 +46,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private string? _host;
         private int _primaryInstance;
+#pragma warning disable IDE0052 // Remove unread private members
         private PerformanceReporter? _performanceReporter;
+#pragma warning restore IDE0052 // Remove unread private members
 
         static RemoteHostService()
         {

--- a/src/Workspaces/Remote/ServiceHub/Shared/RemoteEndPoint.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/RemoteEndPoint.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal sealed class RemoteEndPoint : IDisposable
     {
-        const string UnexpectedExceptionLogMessage = "Unexpected exception from JSON-RPC";
+        private const string UnexpectedExceptionLogMessage = "Unexpected exception from JSON-RPC";
 
         private static readonly JsonRpcTargetOptions s_jsonRpcTargetOptions = new JsonRpcTargetOptions()
         {
@@ -35,11 +35,6 @@ namespace Microsoft.CodeAnalysis.Remote
             // Only allow public methods (may be on internal types) to be invoked remotely.
             AllowNonPublicInvocation = false
         };
-
-        // these are for debugging purpose. once we find out root cause of the issue
-        // we will remove these.
-        private static JsonRpcDisconnectedEventArgs? s_debuggingLastDisconnectReason;
-        private static string? s_debuggingLastDisconnectCallstack;
 
         private readonly TraceSource _logger;
         private readonly JsonRpc _rpc;
@@ -335,9 +330,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private void ReportNonFatalWatson(Exception exception)
         {
-            s_debuggingLastDisconnectReason = _debuggingLastDisconnectReason;
-            s_debuggingLastDisconnectCallstack = _debuggingLastDisconnectCallstack;
-
             FatalError.ReportWithoutCrash(exception);
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -885,9 +885,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             var parent = cast.WalkUpParentheses().Parent;
             if (parent is ArgumentSyntax argument)
             {
-                // If there are any arguments to the right, we can assume that this is not a
-                // *single* argument passed to a params parameter.
-                if (argument.Parent is BaseArgumentListSyntax argumentList)
+                // If there are any arguments to the right (and the argument is not named), we can assume that this is
+                // not a *single* argument passed to a params parameter.
+                if (argument.NameColon == null && argument.Parent is BaseArgumentListSyntax argumentList)
                 {
                     var argumentIndex = argumentList.Arguments.IndexOf(argument);
                     if (argumentIndex < argumentList.Arguments.Count - 1)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.Formatting
         private readonly SyntaxNode _commonRoot;
         private readonly SyntaxToken _token1;
         private readonly SyntaxToken _token2;
-        private readonly string _language;
 
         protected readonly TextSpan SpanToFormat;
 
@@ -78,14 +77,6 @@ namespace Microsoft.CodeAnalysis.Formatting
             // get span and common root
             this.SpanToFormat = GetSpanToFormat();
             _commonRoot = token1.GetCommonRoot(token2) ?? throw ExceptionUtilities.Unreachable;
-            if (token1 == default)
-            {
-                _language = token2.Language;
-            }
-            else
-            {
-                _language = token1.Language;
-            }
         }
 
         protected abstract AbstractTriviaDataFactory CreateTriviaFactory();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+        public sealed override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
         {
             var nextOperationCopy = nextOperation;
             AddSuppressOperationsSlow(list, node, ref nextOperationCopy);
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed void AddAnchorIndentationOperations(List<AnchorIndentationOperation> list, SyntaxNode node, in NextAnchorIndentationOperationAction nextOperation)
+        public sealed override void AddAnchorIndentationOperations(List<AnchorIndentationOperation> list, SyntaxNode node, in NextAnchorIndentationOperationAction nextOperation)
         {
             var nextOperationCopy = nextOperation;
             AddAnchorIndentationOperationsSlow(list, node, ref nextOperationCopy);
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed void AddIndentBlockOperations(List<IndentBlockOperation> list, SyntaxNode node, in NextIndentBlockOperationAction nextOperation)
+        public sealed override void AddIndentBlockOperations(List<IndentBlockOperation> list, SyntaxNode node, in NextIndentBlockOperationAction nextOperation)
         {
             var nextOperationCopy = nextOperation;
             AddIndentBlockOperationsSlow(list, node, ref nextOperationCopy);
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed void AddAlignTokensOperations(List<AlignTokensOperation> list, SyntaxNode node, in NextAlignTokensOperationAction nextOperation)
+        public sealed override void AddAlignTokensOperations(List<AlignTokensOperation> list, SyntaxNode node, in NextAlignTokensOperationAction nextOperation)
         {
             var nextOperationCopy = nextOperation;
             AddAlignTokensOperationsSlow(list, node, ref nextOperationCopy);
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public sealed override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             var previousTokenCopy = previousToken;
             var currentTokenCopy = currentToken;
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override sealed AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public sealed override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             var previousTokenCopy = previousToken;
             var currentTokenCopy = currentToken;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
@@ -208,10 +208,10 @@ namespace Microsoft.CodeAnalysis.NamingStyles
         private static string Substring(string name, TextSpan wordSpan)
             => name.Substring(wordSpan.Start, wordSpan.Length);
 
-        private static Func<string, TextSpan, bool> s_firstCharIsLowerCase = (val, span) => !DoesCharacterHaveCasing(val[span.Start]) || char.IsLower(val[span.Start]);
-        private static Func<string, TextSpan, bool> s_firstCharIsUpperCase = (val, span) => !DoesCharacterHaveCasing(val[span.Start]) || char.IsUpper(val[span.Start]);
+        private static readonly Func<string, TextSpan, bool> s_firstCharIsLowerCase = (val, span) => !DoesCharacterHaveCasing(val[span.Start]) || char.IsLower(val[span.Start]);
+        private static readonly Func<string, TextSpan, bool> s_firstCharIsUpperCase = (val, span) => !DoesCharacterHaveCasing(val[span.Start]) || char.IsUpper(val[span.Start]);
 
-        private static Func<string, TextSpan, bool> s_wordIsAllUpperCase = (val, span) =>
+        private static readonly Func<string, TextSpan, bool> s_wordIsAllUpperCase = (val, span) =>
         {
             for (int i = span.Start, n = span.End; i < n; i++)
             {
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             return true;
         };
 
-        private static Func<string, TextSpan, bool> s_wordIsAllLowerCase = (val, span) =>
+        private static readonly Func<string, TextSpan, bool> s_wordIsAllLowerCase = (val, span) =>
         {
             for (int i = span.Start, n = span.End; i < n; i++)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/IPooled.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/IPooled.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
-    interface IPooled
+    internal interface IPooled
     {
         void Free();
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/Precedence/IPrecedenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/Precedence/IPrecedenceService.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CodeAnalysis.Precedence
 {
-    interface IPrecedenceService
+    internal interface IPrecedenceService
     {
         /// <summary>
         /// Returns the precedence of the given expression, mapped down to one of the 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractSyntaxFacts.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 {
     internal abstract class AbstractSyntaxFacts
     {
-        private readonly static ObjectPool<Stack<(SyntaxNodeOrToken nodeOrToken, bool leading, bool trailing)>> s_stackPool
+        private static readonly ObjectPool<Stack<(SyntaxNodeOrToken nodeOrToken, bool leading, bool trailing)>> s_stackPool
             = SharedPools.Default<Stack<(SyntaxNodeOrToken nodeOrToken, bool leading, bool trailing)>>();
 
         public abstract ISyntaxKinds SyntaxKinds { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AliasSymbolCache.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AliasSymbolCache.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -19,7 +18,6 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         //        in compilation cache in certain host (VS), semantic model comes and goes more frequently which will release cache more often.
         private static readonly ConditionalWeakTable<Compilation, TreeMap> s_treeAliasMap = new ConditionalWeakTable<Compilation, TreeMap>();
         private static readonly ConditionalWeakTable<Compilation, TreeMap>.CreateValueCallback s_createTreeMap = c => new TreeMap();
-        private static readonly Func<ISymbol, string> s_symbolToName = s => s.Name;
 
         public static bool TryGetAliasSymbol(SemanticModel semanticModel, int namespaceId, INamespaceOrTypeSymbol targetSymbol, out IAliasSymbol aliasSymbol)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ComparerWithState.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ComparerWithState.cs
@@ -9,7 +9,7 @@ using System.Collections.Immutable;
 
 namespace Roslyn.Utilities
 {
-    static internal class ComparerWithState
+    internal static class ComparerWithState
     {
         public static int CompareTo<T, S>(T first, T second, S state, ImmutableArray<Func<T, S, IComparable>> comparableMethods)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EditDistance.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EditDistance.cs
@@ -111,7 +111,7 @@ namespace Roslyn.Utilities
         // (i.e. with value <= 127).  This allows us to just use a simple array we can index into instead
         // of needing something more expensive like a dictionary.
         private const int LastSeenIndexLength = 128;
-        private static ThreadLocal<int[]> t_lastSeenIndexPool =
+        private static readonly ThreadLocal<int[]> t_lastSeenIndexPool =
             new ThreadLocal<int[]>(() => new int[LastSeenIndexLength]);
 
         private static int[,] GetMatrix(int width, int height)
@@ -647,7 +647,7 @@ namespace Roslyn.Utilities
         // Keep around a few arrays of size 256 that we can use for operations without
         // causing lots of garbage to be created.  If we do compare items larger than
         // that, then we will just allocate and release those arrays on demand.
-        private static SimplePool<T[]> s_pool = new SimplePool<T[]>(() => new T[MaxPooledArraySize]);
+        private static readonly SimplePool<T[]> s_pool = new SimplePool<T[]>(() => new T[MaxPooledArraySize]);
 
         public static T[] GetArray(int size)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ICacheEntry.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ICacheEntry.cs
@@ -4,7 +4,7 @@
 
 namespace Roslyn.Utilities
 {
-    interface ICacheEntry<out TKey, out TValue>
+    internal interface ICacheEntry<out TKey, out TValue>
     {
         TKey Key { get; }
         TValue Value { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SerializableBytes.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
             return stream;
         }
 
-        internal async static Task<PooledStream> CreateReadableStreamAsync(Stream stream, CancellationToken cancellationToken)
+        internal static async Task<PooledStream> CreateReadableStreamAsync(Stream stream, CancellationToken cancellationToken)
         {
             var length = stream.Length;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharLanguageServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharLanguageServiceFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars
 
         private sealed class CSharpVirtualCharLanguageService : CSharpVirtualCharService, IVirtualCharLanguageService
         {
-            internal static readonly new CSharpVirtualCharLanguageService Instance = new CSharpVirtualCharLanguageService();
+            internal static new readonly CSharpVirtualCharLanguageService Instance = new CSharpVirtualCharLanguageService();
 
             private CSharpVirtualCharLanguageService()
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
@@ -135,9 +135,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 usings.Select(u => u.WithAdditionalAnnotations(annotations)).ToSyntaxList());
         }
 
-        private static bool IsDocCommentOrElastic(SyntaxTrivia t)
-            => t.IsDocComment() || t.IsElastic();
-
         private static List<UsingDirectiveSyntax> AddUsingDirectives(
             CompilationUnitSyntax root, IList<UsingDirectiveSyntax> usingDirectives)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return CreateContextWorker(workspace: null, semanticModel: semanticModel, position: position, cancellationToken: cancellationToken);
         }
 
-        private new static bool IsWithinAsyncMethod()
+        private static new bool IsWithinAsyncMethod()
         {
             // TODO: Implement this if any C# completion code needs to know if it is in an async 
             // method or not.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1808,17 +1808,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return !enclosingSymbol.IsStatic;
         }
 
-        private static bool IsInBlock(BlockSyntax bodyOpt, int position)
-        {
-            if (bodyOpt == null)
-            {
-                return false;
-            }
-
-            return bodyOpt.OpenBraceToken.Span.End <= position &&
-                (bodyOpt.CloseBraceToken.IsMissing || position <= bodyOpt.CloseBraceToken.SpanStart);
-        }
-
         public static bool IsPossibleCastTypeContext(
             this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private sealed class CSharpSyntaxFactsService : CSharpSyntaxFacts, ISyntaxFactsService
         {
-            internal static readonly new CSharpSyntaxFactsService Instance = new CSharpSyntaxFactsService();
+            internal static new readonly CSharpSyntaxFactsService Instance = new CSharpSyntaxFactsService();
 
             public bool IsInInactiveRegion(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxKindsServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxKindsServiceFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
 
         private sealed class CSharpSyntaxKindsService : CSharpSyntaxKinds, ISyntaxKindsService
         {
-            public static readonly new CSharpSyntaxKindsService Instance = new CSharpSyntaxKindsService();
+            public static new readonly CSharpSyntaxKindsService Instance = new CSharpSyntaxKindsService();
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 #endif
 
-        public async static Task<bool> IsGeneratedCodeAsync(this Document document, CancellationToken cancellationToken)
+        public static async Task<bool> IsGeneratedCodeAsync(this Document document, CancellationToken cancellationToken)
         {
             var generatedCodeRecognitionService = document.GetLanguageService<IGeneratedCodeRecognitionService>();
             return generatedCodeRecognitionService != null &&

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
@@ -77,11 +77,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 [imports].Select(Function(u) u.WithAdditionalAnnotations(annotations)).ToSyntaxList())
         End Function
 
-        Private Function IsDocCommentOrElastic(t As SyntaxTrivia) As Boolean
-            Return t.Kind() = SyntaxKind.DocumentationCommentTrivia OrElse t.IsElastic()
-        End Function
-
-
         Private Function AddImportsStatements(root As CompilationUnitSyntax, importsStatements As IList(Of ImportsStatementSyntax)) As List(Of ImportsStatementSyntax)
             ' We need to try and not place the using inside of a directive if possible.
             Dim [imports] = New List(Of ImportsStatementSyntax)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/SemanticModelExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/SemanticModelExtensions.vb
@@ -12,7 +12,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
     Partial Friend Module SemanticModelExtensions
 
         Private Const s_defaultParameterName = "p"
-        Private Const s_defaultBuiltInParameterName = "v"
 
         <Extension()>
         Public Function LookupTypeRegardlessOfArity(semanticModel As SemanticModel,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicAddImportsService.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicAddImportsService.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImports
         Public Sub New()
         End Sub
 
-        Private Shared ImportsStatementComparer As ImportsStatementComparer = New ImportsStatementComparer(New CaseInsensitiveTokenComparer())
+        Private Shared ReadOnly ImportsStatementComparer As ImportsStatementComparer = New ImportsStatementComparer(New CaseInsensitiveTokenComparer())
 
         Protected Overrides Function IsEquivalentImport(a As SyntaxNode, b As SyntaxNode) As Boolean
             Dim importsA = TryCast(a, ImportsStatementSyntax)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicRemoveUnnecessaryImportsService.Rewriter.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicRemoveUnnecessaryImportsService.Rewriter.vb
@@ -105,16 +105,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryImports
                 Return trivia.Any(Function(t) Not t.IsWhitespaceOrEndOfLine())
             End Function
 
-            Private Function FilterLeadingTrivia(importStatement As SyntaxNode) As SyntaxTriviaList
-                ' if the import had leading trivia with something other than EOL or whitespace then we want to preserve it
-                Dim leadingTrivia = importStatement.GetLeadingTrivia()
-                If leadingTrivia.Any(Function(t) t.Kind <> SyntaxKind.EndOfLineTrivia AndAlso t.Kind <> SyntaxKind.WhitespaceTrivia) Then
-                    Return leadingTrivia
-                Else
-                    Return Nothing
-                End If
-            End Function
-
             Public Overrides Function VisitCompilationUnit(node As CompilationUnitSyntax) As SyntaxNode
                 Dim compilationUnit = DirectCast(MyBase.VisitCompilationUnit(node), CompilationUnitSyntax)
 

--- a/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
-    Friend Partial Class VisualBasicCaseCorrectionService
+    Partial Friend Class VisualBasicCaseCorrectionService
         Private Class Rewriter
             Inherits VisualBasicSyntaxRewriter
 

--- a/src/Workspaces/VisualBasic/Portable/Classification/Worker.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/Worker.vb
@@ -167,32 +167,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
             End If
         End Sub
 
-
-        Private Sub ClassifyDisabledMergeCode(trivia As SyntaxTrivia, triviaText As String)
-            Dim equalsLineLength = 0
-            Dim length = triviaText.Length
-
-            While equalsLineLength < length
-                If SyntaxFacts.IsNewLine(triviaText(equalsLineLength)) Then
-                    Exit While
-                End If
-
-                equalsLineLength += 1
-            End While
-
-            AddClassification(New TextSpan(trivia.SpanStart, equalsLineLength), ClassificationTypeNames.Comment)
-
-            ' Now lex out all the tokens in the rest of the trivia text.
-            Dim tokens = SyntaxFactory.ParseTokens(
-                text:=triviaText,
-                offset:=equalsLineLength,
-                initialTokenPosition:=trivia.SpanStart + equalsLineLength)
-
-            For Each token In tokens
-                ClassifyToken(token)
-            Next
-        End Sub
-
         Private Sub ClassifySkippedTokens(skippedTokens As SkippedTokensTriviaSyntax)
             If Not _textSpan.OverlapsWith(skippedTokens.Span) Then
                 Return

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -33,16 +33,11 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
         Private Class AddMissingTokensRewriter
             Inherits AbstractTokensCodeCleanupProvider.Rewriter
 
-            Private ReadOnly _document As Document
-            Private ReadOnly _modifiedSpan As TextSpan
+            Private ReadOnly _model As SemanticModel = Nothing
 
-            Private _model As SemanticModel = Nothing
-
-            Private Sub New(document As Document, semanticModel As SemanticModel, spans As ImmutableArray(Of TextSpan), modifiedSpan As TextSpan, cancellationToken As CancellationToken)
+            Private Sub New(semanticModel As SemanticModel, spans As ImmutableArray(Of TextSpan), cancellationToken As CancellationToken)
                 MyBase.New(spans, cancellationToken)
 
-                Me._document = document
-                Me._modifiedSpan = modifiedSpan
                 Me._model = semanticModel
             End Sub
 
@@ -51,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                 Dim semanticModel = If(document Is Nothing, Nothing,
                     Await document.GetSemanticModelForSpanAsync(modifiedSpan, cancellationToken).ConfigureAwait(False))
 
-                Return New AddMissingTokensRewriter(document, semanticModel, spans, modifiedSpan, cancellationToken)
+                Return New AddMissingTokensRewriter(semanticModel, spans, cancellationToken)
             End Function
 
             Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
@@ -565,38 +560,6 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                 End If
 
                 Return False
-            End Function
-
-            Private Function GetPreviousAndNextToken(token As SyntaxToken) As ValueTuple(Of SyntaxToken, SyntaxToken)
-                ' we need this special method because we can't use regular previous/next token on the omitted token since
-                ' omitted token logically doesn't exist in the tree
-                Debug.Assert(token.Span.IsEmpty)
-                Dim node = token.GetAncestors(Of SyntaxNode).FirstOrDefault(Function(n) n.FullSpan.IntersectsWith(token.Span))
-                If node Is Nothing Then
-                    Return ValueTuple.Create(Of SyntaxToken, SyntaxToken)(Nothing, Nothing)
-                End If
-
-                Dim previousToken = token
-                Dim nextToken = token
-                For Each current In node.DescendantTokens()
-                    If token = current Then
-                        Continue For
-                    End If
-
-                    If token.Span.End <= current.SpanStart Then
-                        nextToken = current
-                        Exit For
-                    End If
-
-                    If current.Span.End <= token.SpanStart Then
-                        previousToken = current
-                    End If
-                Next
-
-                previousToken = If(previousToken.Kind = 0, node.GetFirstToken(includeZeroWidth:=True).GetPreviousToken(includeZeroWidth:=True), previousToken)
-                nextToken = If(nextToken.Kind = 0, node.GetLastToken(includeZeroWidth:=True).GetNextToken(includeZeroWidth:=True), nextToken)
-
-                Return ValueTuple.Create(previousToken, nextToken)
             End Function
 
             Private Function Exist(node As SyntaxNode) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/FixIncorrectTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/FixIncorrectTokensCodeCleanupProvider.vb
@@ -42,20 +42,14 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
         Private Class FixIncorrectTokensRewriter
             Inherits AbstractTokensCodeCleanupProvider.Rewriter
 
-            Private ReadOnly _document As Document
-            Private ReadOnly _modifiedSpan As TextSpan
             Private ReadOnly _semanticModel As SemanticModel
 
-            Private Sub New(document As Document,
-                            semanticModel As SemanticModel,
+            Private Sub New(semanticModel As SemanticModel,
                             spans As ImmutableArray(Of TextSpan),
-                            modifiedSpan As TextSpan,
                             cancellationToken As CancellationToken)
                 MyBase.New(spans, cancellationToken)
 
-                _document = document
                 _semanticModel = semanticModel
-                _modifiedSpan = modifiedSpan
             End Sub
 
             Public Shared Async Function CreateAsync(document As Document, spans As ImmutableArray(Of TextSpan), cancellationToken As CancellationToken) As Task(Of Rewriter)
@@ -64,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                     Nothing,
                     Await document.GetSemanticModelForSpanAsync(modifiedSpan, cancellationToken).ConfigureAwait(False))
 
-                Return New FixIncorrectTokensRewriter(document, semanticModel, spans, modifiedSpan, cancellationToken)
+                Return New FixIncorrectTokensRewriter(semanticModel, spans, cancellationToken)
             End Function
 
             Public Overrides Function VisitTrivia(trivia As SyntaxTrivia) As SyntaxTrivia

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/NormalizeModifiersOrOperatorsCodeCleanupProvider.vb
@@ -474,13 +474,6 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
             End Function
 
             ''' <summary>
-            ''' remove ByVal keyword from parameter list
-            ''' </summary>
-            Private Function RemoveByValKeyword(node As ParameterListSyntax, parameterIndex As Integer) As ParameterListSyntax
-                Return RemoveModifierKeyword(node, Function(n) n.Parameters(parameterIndex).Modifiers, SyntaxKind.ByValKeyword)
-            End Function
-
-            ''' <summary>
             ''' remove a modifier from the given node
             ''' </summary>
             Private Function RemoveModifierKeyword(Of T As SyntaxNode)(node As T, modifiersGetter As Func(Of T, SyntaxTokenList), modifierKind As SyntaxKind) As T

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/ConstructorGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/ConstructorGenerator.vb
@@ -55,11 +55,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 ConditionallyAddDocumentationCommentTo(declaration, constructor, options)))
         End Function
 
-        Private Function GenerateArgumentList(arguments As IList(Of SyntaxNode)) As ArgumentListSyntax
-            Return SyntaxFactory.ArgumentList(
-                arguments:=SyntaxFactory.SeparatedList(arguments.Select(AddressOf ArgumentGenerator.GenerateArgument)))
-        End Function
-
         Private Function GenerateStatements(constructor As IMethodSymbol) As SyntaxList(Of StatementSyntax)
             If CodeGenerationConstructorInfo.GetStatements(constructor).IsDefault AndAlso
                CodeGenerationConstructorInfo.GetBaseConstructorArgumentsOpt(constructor).IsDefault AndAlso

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/ExpressionGenerator.StringPiece.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/ExpressionGenerator.StringPiece.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
-    Friend Partial Module ExpressionGenerator
+    Partial Friend Module ExpressionGenerator
         Private Structure StringPiece
             Public ReadOnly Value As String
             Public ReadOnly Kind As StringPieceKind

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/ExpressionGenerator.StringPieceKind.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/ExpressionGenerator.StringPieceKind.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
-    Friend Partial Module ExpressionGenerator
+    Partial Friend Module ExpressionGenerator
         Private Enum StringPieceKind
             Normal
             NonPrintable

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
@@ -420,16 +420,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
             Return comparisonResult = 0
         End Function
-
-        Private Shared Function EqualTypeParameterCount(x As TypeParameterListSyntax, y As TypeParameterListSyntax, ByRef comparisonResult As Integer) As Boolean
-            If NeitherNull(x, y, comparisonResult) Then
-                Dim xParameterCount = x.Parameters.Count
-                Dim yParameterCount = y.Parameters.Count
-
-                comparisonResult = If(xParameterCount = yParameterCount, 0, If(x.Parameters.Count < y.Parameters.Count, -1, 1))
-            End If
-
-            Return comparisonResult = 0
-        End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
@@ -16,8 +16,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class TriviaDataFactory
         Inherits AbstractTriviaDataFactory
 
-        Private Const s_lineBreakCacheSize = 5
-        Private Const s_indentationLevelCacheSize = 20
         Private Const s_lineContinuationCacheSize = 80
 
         Private ReadOnly _lineContinuations(s_lineContinuationCacheSize) As LineContinuationTrivia

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class VisualBasicTriviaFormatter
         Inherits AbstractTriviaFormatter
 
-        Private _lineContinuationTrivia As SyntaxTrivia = SyntaxFactory.LineContinuationTrivia("_")
+        Private ReadOnly _lineContinuationTrivia As SyntaxTrivia = SyntaxFactory.LineContinuationTrivia("_")
         Private _newLine As SyntaxTrivia
 
         Private _succeeded As Boolean = True

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -6,7 +6,6 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.FindSymbols
-Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Rename
@@ -23,10 +22,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
     Friend Class VisualBasicRenameRewriterLanguageService
         Inherits AbstractRenameRewriterLanguageService
 
-        Private ReadOnly _languageServiceProvider As HostLanguageServices
+        Public Shared ReadOnly Instance As New VisualBasicRenameRewriterLanguageService()
 
-        Public Sub New(provider As HostLanguageServices)
-            _languageServiceProvider = provider
+        Private Sub New()
         End Sub
 
 #Region "Annotate"

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageServiceFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageServiceFactory.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
         End Sub
 
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-            Return New VisualBasicRenameRewriterLanguageService(provider)
+            Return VisualBasicRenameRewriterLanguageService.Instance
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Editting
 
         Private ReadOnly _emptyCompilation As VisualBasicCompilation = VisualBasicCompilation.Create("empty", references:={TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System})
 
-        Private _ienumerableInt As INamedTypeSymbol
+        Private ReadOnly _ienumerableInt As INamedTypeSymbol
 
         Public Sub New()
             Me._ienumerableInt = _emptyCompilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T).Construct(_emptyCompilation.GetSpecialType(SpecialType.System_Int32))
@@ -789,7 +789,7 @@ End Sub")
         End Sub
 
         <Fact, WorkItem(31720, "https://github.com/dotnet/roslyn/issues/31720")>
-        Sub TestGetAttributeOnMethodBodies()
+        Public Sub TestGetAttributeOnMethodBodies()
             Dim compilation = Compile("
 Imports System
 <AttributeUsage(System.AttributeTargets.All)>
@@ -2969,11 +2969,6 @@ End Get")
 
         Private Sub TestRemoveAllMembers(declaration As SyntaxNode)
             Assert.Equal(0, Generator.GetMembers(Generator.RemoveNodes(declaration, Generator.GetMembers(declaration))).Count)
-        End Sub
-
-        Private Sub TestRemoveMember(declaration As SyntaxNode, name As String, remainingNames As String())
-            Dim newDecl = Generator.RemoveNode(declaration, Generator.GetMembers(declaration).First(Function(m) Generator.GetName(m) = name))
-            AssertMemberNamesEqual(remainingNames, newDecl)
         End Sub
 
         <Fact>

--- a/src/Workspaces/VisualBasicTest/EmbeddedLanguages/VirtualChars/VisualBasicVirtualCharServiceTests.vb
+++ b/src/Workspaces/VisualBasicTest/EmbeddedLanguages/VirtualChars/VisualBasicVirtualCharServiceTests.vb
@@ -33,12 +33,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.EmbeddedLanguages.Virtual
             Assert.Equal(expected, actual)
         End Sub
 
-        Private Sub TestFailure(stringText As String)
-            Dim token = GetStringToken(stringText)
-            Dim virtualChars = VisualBasicVirtualCharService.Instance.TryConvertToVirtualChars(token)
-            Assert.True(virtualChars.IsDefault)
-        End Sub
-
         <Fact>
         Public Sub TestEmptyString()
             Test("""""", "")


### PR DESCRIPTION
Reverts dotnet/roslyn#43634

This change breaks XAML language service, will need to do a dual insertion.

@allisonchou @agocke @vatsalyaagrawal 