### PR TITLE
Expose specific members of System.[U]IntPtr from native integer types

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1215,6 +1215,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                     return methodRef;
                 }
+                else if (methodSymbol is NativeIntegerMethodSymbol { UnderlyingMethod: MethodSymbol underlyingMethod })
+                {
+                    methodSymbol = underlyingMethod;
+                }
             }
 
             if (_embeddedTypesManagerOpt != null)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1178,6 +1178,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if (!methodSymbol.IsDefinition)
             {
                 Debug.Assert(!needDeclaration);
+                Debug.Assert(!(methodSymbol.OriginalDefinition is NativeIntegerMethodSymbol));
+                Debug.Assert(!(methodSymbol.ConstructedFrom is NativeIntegerMethodSymbol));
 
                 return methodSymbol;
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -792,14 +792,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddExplicitInterfaceIfRequired<T>(ImmutableArray<T> implementedMethods) where T : ISymbol
+        private void AddExplicitInterfaceIfRequired<T>(ImmutableArray<T> implementedMembers) where T : ISymbol
         {
-            if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeExplicitInterface) && !implementedMethods.IsEmpty)
+            if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeExplicitInterface) && !implementedMembers.IsEmpty)
             {
-                var implementedMethod = implementedMethods[0];
-                Debug.Assert(implementedMethod.ContainingType != null);
+                var implementedMember = implementedMembers[0];
+                Debug.Assert(implementedMember.ContainingType != null);
 
-                INamedTypeSymbol containingType = implementedMethod.ContainingType;
+                INamedTypeSymbol containingType = implementedMember.ContainingType;
                 if (containingType != null)
                 {
                     containingType.Accept(this.NotFirstVisitor);

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return previous.SubstituteType(this);
         }
 
-        internal ImmutableArray<CustomModifier> SubstituteCustomModifiers(ImmutableArray<CustomModifier> customModifiers)
+        internal virtual ImmutableArray<CustomModifier> SubstituteCustomModifiers(ImmutableArray<CustomModifier> customModifiers)
         {
             if (customModifiers.IsDefaultOrEmpty)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Substitute for a type declaration.  May use alpha renaming if the container is substituted.
         /// </summary>
-        private NamedTypeSymbol SubstituteMemberType(NamedTypeSymbol previous)
+        internal virtual NamedTypeSymbol SubstituteTypeDeclaration(NamedTypeSymbol previous)
         {
             Debug.Assert((object)previous.ConstructedFrom == (object)previous);
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // construct operation here (as VB does), thereby avoiding alpha renaming in most cases.
             // Aleksey has shown that would reduce GC pressure if substitutions of deeply nested generics are common.
             NamedTypeSymbol oldConstructedFrom = previous.ConstructedFrom;
-            NamedTypeSymbol newConstructedFrom = SubstituteMemberType(oldConstructedFrom);
+            NamedTypeSymbol newConstructedFrom = SubstituteTypeDeclaration(oldConstructedFrom);
 
             ImmutableArray<TypeWithAnnotations> oldTypeArguments = previous.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
             bool changed = !ReferenceEquals(oldConstructedFrom, newConstructedFrom);
@@ -264,23 +264,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return result != null ? result.AsImmutableOrNull() : original;
-        }
-
-        internal ImmutableArray<TypeWithAnnotations> SubstituteTypes(ImmutableArray<TypeSymbol> original)
-        {
-            if (original.IsDefault)
-            {
-                return default(ImmutableArray<TypeWithAnnotations>);
-            }
-
-            var result = ArrayBuilder<TypeWithAnnotations>.GetInstance(original.Length);
-
-            foreach (TypeSymbol t in original)
-            {
-                result.Add(SubstituteType(t));
-            }
-
-            return result.ToImmutableAndFree();
         }
 
         internal ImmutableArray<TypeWithAnnotations> SubstituteTypes(ImmutableArray<TypeWithAnnotations> original)

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerRefKindDifferences: true,
             considerCallingConvention: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance is used when trying to determine if one member implicitly implements another,
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance is used as a fallback when it is determined that one member does not implicitly implement
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers); //shouldn't actually matter for source members
+            typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
 
         /// <summary>
         /// This instance is used to determine if two C# member declarations in source conflict with each other.
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers); //shouldn't actually matter for source members
+            typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
 
         /// <summary>
         /// This instance is used to determine if a partial method implementation matches the definition.
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance is used to check whether one member overrides another, according to the C# definition.
@@ -124,33 +124,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance checks whether two signatures match including tuples names, in both return type and parameters.
         /// It is used to detect tuple-name-only differences.
         /// </summary>
-        public static readonly MemberSignatureComparer CSharpWithTupleNamesComparer = new MemberSignatureComparer(
+        private static readonly MemberSignatureComparer CSharpWithTupleNamesComparer = new MemberSignatureComparer(
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames);
 
         /// <summary>
         /// This instance checks whether two signatures match excluding tuples names, in both return type and parameters.
         /// It is used to detect tuple-name-only differences.
         /// </summary>
-        public static readonly MemberSignatureComparer CSharpWithoutTupleNamesComparer = new MemberSignatureComparer(
+        private static readonly MemberSignatureComparer CSharpWithoutTupleNamesComparer = new MemberSignatureComparer(
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance is used to check whether one property or event overrides another, according to the C# definition.
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// Same as <see cref="CSharpOverrideComparer"/> except that it pays attention to custom modifiers and return type.  

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerRefKindDifferences: true,
             considerCallingConvention: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance is used when trying to determine if one member implicitly implements another,
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance is used as a fallback when it is determined that one member does not implicitly implement
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames); //shouldn't actually matter for source members
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers); //shouldn't actually matter for source members
 
         /// <summary>
         /// This instance is used to determine if two C# member declarations in source conflict with each other.
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames); //shouldn't actually matter for source members
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers); //shouldn't actually matter for source members
 
         /// <summary>
         /// This instance is used to determine if a partial method implementation matches the definition.
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance is used to check whether one member overrides another, according to the C# definition.
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance checks whether two signatures match including tuples names, in both return type and parameters.
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamic);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance checks whether two signatures match excluding tuples names, in both return type and parameters.
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance is used to check whether one property or event overrides another, according to the C# definition.
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
+            typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// Same as <see cref="CSharpOverrideComparer"/> except that it pays attention to custom modifiers and return type.  
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
+            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// If this returns false, then the real override comparer (whichever one is appropriate for the scenario)
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: true,
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
+            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// Same as <see cref="RuntimeSignatureComparer"/>, but distinguishes between <c>ref</c> and <c>out</c>. During override resolution,
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: true,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
+            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance is the same as RuntimeSignatureComparer.
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
+            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         // NOTE: Not used anywhere. Do we still need to keep it?
         /// <summary>
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: true,
             considerCallingConvention: true,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
+            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
         /// This instance is used to search for members that have identical signatures in every regard.
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: true,
             considerRefKindDifferences: true,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes); //if it was a true explicit impl, we expect it to remain so after retargeting
+            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers); //if it was a true explicit impl, we expect it to remain so after retargeting
 
         /// <summary>
         /// This instance is used for performing approximate overload resolution of documentation
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool considerTypeConstraints,
             bool considerCallingConvention,
             bool considerRefKindDifferences,
-            TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamic)
+            TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers)
         {
             Debug.Assert(!considerExplicitlyImplementedInterfaces || considerName, "Doesn't make sense to consider interfaces separately from name.");
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -835,7 +835,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 bool filterOutParamArrayAttribute = (!_lazyIsParams.HasValue() || _lazyIsParams.Value());
 
                 ConstantValue defaultValue = this.ExplicitDefaultConstantValue;
-                var filterOutConstantAttributeDescription = default(AttributeDescription);
+                AttributeDescription filterOutConstantAttributeDescription = default(AttributeDescription);
 
                 if ((object)defaultValue != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -835,7 +835,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 bool filterOutParamArrayAttribute = (!_lazyIsParams.HasValue() || _lazyIsParams.Value());
 
                 ConstantValue defaultValue = this.ExplicitDefaultConstantValue;
-                AttributeDescription filterOutConstantAttributeDescription = default(AttributeDescription);
+                var filterOutConstantAttributeDescription = default(AttributeDescription);
 
                 if ((object)defaultValue != null)
                 {
@@ -928,6 +928,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal sealed override CSharpCompilation DeclaringCompilation // perf, not correctness
         {
             get { return null; }
+        }
+
+        public sealed override bool Equals(Symbol other, TypeCompareKind compareKind)
+        {
+            return other is NativeIntegerParameterSymbol nps ?
+                nps.Equals(this, compareKind) :
+                base.Equals(other, compareKind);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1069,6 +1069,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return sms.Equals(this, compareKind);
             }
 
+            if (other is NativeIntegerMethodSymbol nms)
+            {
+                return nms.Equals(this, compareKind);
+            }
+
             return base.Equals(other, compareKind);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -328,31 +328,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Emit should use underlying symbol only.
             throw ExceptionUtilities.Unreachable;
         }
+    }
 
-        private sealed class NativeIntegerParameterSymbol : WrappedParameterSymbol, Cci.IReference
+    internal sealed class NativeIntegerParameterSymbol : WrappedParameterSymbol, Cci.IReference
+    {
+        private readonly NativeIntegerTypeSymbol _containingType;
+        private readonly NativeIntegerMethodSymbol _container;
+
+        internal NativeIntegerParameterSymbol(NativeIntegerTypeSymbol containingType, NativeIntegerMethodSymbol container, ParameterSymbol underlyingParameter) : base(underlyingParameter)
         {
-            private readonly NativeIntegerTypeSymbol _containingType;
-            private readonly NativeIntegerMethodSymbol _container;
+            _containingType = containingType;
+            _container = container;
+            NativeIntegerTypeSymbol.VerifyEquality(this, underlyingParameter);
+        }
 
-            internal NativeIntegerParameterSymbol(NativeIntegerTypeSymbol containingType, NativeIntegerMethodSymbol container, ParameterSymbol underlyingParameter) : base(underlyingParameter)
-            {
-                _containingType = containingType;
-                _container = container;
-            }
+        public override Symbol ContainingSymbol => _container;
 
-            public override Symbol ContainingSymbol => _container;
+        public override TypeWithAnnotations TypeWithAnnotations => _containingType.SubstituteUnderlyingType(_underlyingParameter.TypeWithAnnotations);
 
-            public override TypeWithAnnotations TypeWithAnnotations => _containingType.SubstituteUnderlyingType(_underlyingParameter.TypeWithAnnotations);
+        public override bool Equals(Symbol? other, TypeCompareKind comparison) => NativeIntegerTypeSymbol.EqualsHelper(this, other, comparison, symbol => symbol._underlyingParameter);
 
-            public override bool Equals(Symbol? other, TypeCompareKind comparison) => NativeIntegerTypeSymbol.EqualsHelper(this, other, comparison, symbol => symbol._underlyingParameter);
+        public override int GetHashCode() => _underlyingParameter.GetHashCode();
 
-            public override int GetHashCode() => _underlyingParameter.GetHashCode();
-
-            void Cci.IReference.Dispatch(Cci.MetadataVisitor visitor)
-            {
-                // Emit should use underlying symbol only.
-                throw ExceptionUtilities.Unreachable;
-            }
+        void Cci.IReference.Dispatch(Cci.MetadataVisitor visitor)
+        {
+            // Emit should use underlying symbol only.
+            throw ExceptionUtilities.Unreachable;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -8,6 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -15,14 +18,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class NativeIntegerTypeSymbol : WrappedNamedTypeSymbol, Cci.IReference
     {
         private ImmutableArray<NamedTypeSymbol> _lazyInterfaces;
+        private ImmutableArray<Symbol> _lazyMembers;
+        private NativeIntegerTypeMap? _lazyTypeMap;
 
         internal NativeIntegerTypeSymbol(NamedTypeSymbol underlyingType) : base(underlyingType, tupleData: null)
         {
             Debug.Assert(underlyingType.TupleData is null);
             Debug.Assert(!underlyingType.IsNativeIntegerType);
             Debug.Assert(underlyingType.SpecialType == SpecialType.System_IntPtr || underlyingType.SpecialType == SpecialType.System_UIntPtr);
-            Debug.Assert(this.Equals(underlyingType));
-            Debug.Assert(underlyingType.Equals(this));
+            Debug.Assert(!this.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
+            Debug.Assert(!underlyingType.Equals(this, TypeCompareKind.ConsiderEverything));
+            Debug.Assert(this.Equals(underlyingType, TypeCompareKind.IgnoreNativeIntegers));
+            Debug.Assert(underlyingType.Equals(this, TypeCompareKind.IgnoreNativeIntegers));
         }
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
@@ -39,22 +46,97 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override SpecialType SpecialType => _underlyingType.SpecialType;
 
-        public override IEnumerable<string> MemberNames => Array.Empty<string>();
+        public override IEnumerable<string> MemberNames => GetMembers().Select(m => m.Name);
 
         /// <summary>
-        /// There are no members on <see cref="System.IntPtr"/> that should be exposed directly on nint:
-        /// constructors for nint other than the default parameterless constructor are not supported;
-        /// operators are handled explicitly as built-in operators and conversions;
-        /// 0 should be used instead of Zero;
-        /// sizeof(nint) should be used instead of Size;
-        /// + and - should be used instead of Add() and Subtract();
-        /// ToInt32(), ToInt64(), ToPointer() should be used from System.IntPtr only;
-        /// overridden methods Equals(), GetHashCode(), and ToString() are referenced from System.Object.
-        /// The one remaining member is <see cref="System.IntPtr.ToString(string)"/> which we could expose if needed.
+        /// Certain members from the underlying types are not exposed from the native integer types:
+        ///   constructors other than the default parameterless constructor are not supported;
+        ///   operators are handled explicitly as built-in operators and conversions;
+        ///   0 should be used instead of Zero;
+        ///   sizeof() should be used instead of Size;
+        ///   + and - should be used instead of Add() and Subtract();
+        ///   ToInt32(), ToInt64(), ToPointer() should be used from underlying types only.
+        /// The remaining members are exposed on the native integer types with appropriate
+        /// substitution of underlying types in the signatures.
         /// </summary>
-        public override ImmutableArray<Symbol> GetMembers() => ImmutableArray<Symbol>.Empty;
+        public override ImmutableArray<Symbol> GetMembers()
+        {
+            if (_lazyMembers.IsDefault)
+            {
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyMembers, makeMembers(_underlyingType.GetMembers()));
+            }
+            return _lazyMembers;
 
-        public override ImmutableArray<Symbol> GetMembers(string name) => ImmutableArray<Symbol>.Empty;
+            ImmutableArray<Symbol> makeMembers(ImmutableArray<Symbol> underlyingMembers)
+            {
+                var builder = ArrayBuilder<Symbol>.GetInstance();
+                builder.Add(new SynthesizedInstanceConstructor(this));
+                foreach (var underlyingMember in underlyingMembers)
+                {
+                    Debug.Assert(_underlyingType.Equals(underlyingMember.ContainingSymbol));
+                    switch (underlyingMember)
+                    {
+                        case MethodSymbol underlyingMethod:
+                            if (underlyingMethod.IsGenericMethod)
+                            {
+                                break;
+                            }
+                            switch (underlyingMethod.MethodKind)
+                            {
+                                case MethodKind.Ordinary:
+                                    if (underlyingMethod.IsOverride)
+                                    {
+                                        addMethodIfAny(builder, underlyingMethod);
+                                    }
+                                    else
+                                    {
+                                        switch (underlyingMethod.Name)
+                                        {
+                                            case "Add":
+                                            case "Subtract":
+                                            case "ToInt32":
+                                            case "ToInt64":
+                                            case "ToUInt32":
+                                            case "ToUInt64":
+                                            case "ToPointer":
+                                                break;
+                                            default:
+                                                addMethodIfAny(builder, underlyingMethod);
+                                                break;
+                                        }
+                                    }
+                                    break;
+                                case MethodKind.ExplicitInterfaceImplementation:
+                                    addMethodIfAny(builder, underlyingMethod);
+                                    break;
+                            }
+                            break;
+                        case PropertySymbol underlyingProperty:
+                            if (underlyingProperty.ParameterCount == 0 &&
+                                underlyingProperty.Name != "Size")
+                            {
+                                var property = new NativeIntegerPropertySymbol(this, underlyingProperty);
+                                builder.Add(property);
+                                addMethodIfAny(builder, underlyingProperty.GetMethod, property);
+                                addMethodIfAny(builder, underlyingProperty.SetMethod, property);
+                            }
+                            break;
+                    }
+                }
+                return builder.ToImmutableAndFree();
+            }
+
+            void addMethodIfAny(ArrayBuilder<Symbol> builder, MethodSymbol underlyingMethod, PropertySymbol? associatedProperty = null)
+            {
+                Debug.Assert(associatedProperty is null || (object)associatedProperty.ContainingSymbol == this);
+                if (underlyingMethod is { })
+                {
+                    builder.Add(new NativeIntegerMethodSymbol(this, underlyingMethod, associatedProperty));
+                }
+            }
+        }
+
+        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray((member, name) => member.Name == name, name);
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ImmutableArray<NamedTypeSymbol>.Empty;
 
@@ -93,7 +175,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => _underlyingType;
 
-        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null) => _underlyingType.Equals(t2, comparison, isValueTypeOverrideOpt);
+        internal override bool Equals(TypeSymbol other, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null)
+        {
+            if ((object)other == null)
+            {
+                return false;
+            }
+            if ((object)this == other)
+            {
+                return true;
+            }
+            if (!_underlyingType.Equals(other, comparison, isValueTypeOverrideOpt))
+            {
+                return false;
+            }
+            return (comparison & TypeCompareKind.IgnoreNativeIntegers) != 0 ||
+                other.IsNativeIntegerType;
+        }
 
         public override int GetHashCode() => _underlyingType.GetHashCode();
 
@@ -107,36 +205,134 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (_lazyInterfaces.IsDefault)
             {
-                ImmutableInterlocked.InterlockedCompareExchange(ref _lazyInterfaces, makeInterfaces(_underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved)), default(ImmutableArray<NamedTypeSymbol>));
+                var interfaces = _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved).SelectAsArray((type, map) => map.SubstituteNamedType(type), GetTypeMap());
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyInterfaces, interfaces);
             }
             return _lazyInterfaces;
+        }
 
-            // Return IEquatable<n[u]int> if the underlying type implemented IEquatable<System.[U]IntPtr>.
-            ImmutableArray<NamedTypeSymbol> makeInterfaces(ImmutableArray<NamedTypeSymbol> underlyingInterfaces)
+        private NativeIntegerTypeMap GetTypeMap()
+        {
+            if (_lazyTypeMap is null)
             {
-                Debug.Assert(_underlyingType.SpecialType == SpecialType.System_IntPtr || _underlyingType.SpecialType == SpecialType.System_UIntPtr);
-
-                foreach (var underlyingInterface in underlyingInterfaces)
-                {
-                    // Is the underlying interface IEquatable<System.[U]IntPtr>?
-                    if (underlyingInterface.Name != "IEquatable")
-                    {
-                        continue;
-                    }
-                    var typeArgs = underlyingInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
-                    if (typeArgs.Length == 1 && _underlyingType.SpecialType == typeArgs[0].Type.SpecialType)
-                    {
-                        var def = underlyingInterface.OriginalDefinition;
-                        if (def.ContainingSymbol is NamespaceSymbol { Name: "System", ContainingSymbol: NamespaceSymbol { IsGlobalNamespace: true } })
-                        {
-                            // Return IEquatable<n[u]int>.
-                            return ImmutableArray.Create(def.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(this))));
-                        }
-                    }
-                }
-
-                return ImmutableArray<NamedTypeSymbol>.Empty;
+                Interlocked.CompareExchange(ref _lazyTypeMap, new NativeIntegerTypeMap(this), null);
             }
+            return _lazyTypeMap;
+        }
+
+        /// <summary>
+        /// Replaces references to underlying type with references to native integer type.
+        /// </summary>
+        private TypeWithAnnotations SubstituteUnderlyingType(TypeWithAnnotations type) => type.SubstituteType(GetTypeMap());
+
+        private sealed class NativeIntegerTypeMap : AbstractTypeMap
+        {
+            private readonly NativeIntegerTypeSymbol _type;
+            private readonly SpecialType _specialType;
+
+            internal NativeIntegerTypeMap(NativeIntegerTypeSymbol type)
+            {
+                _type = type;
+                _specialType = _type.UnderlyingNamedType.SpecialType;
+
+                Debug.Assert(_specialType == SpecialType.System_IntPtr || _specialType == SpecialType.System_UIntPtr);
+            }
+
+            internal override NamedTypeSymbol SubstituteTypeDeclaration(NamedTypeSymbol previous)
+            {
+                return previous.SpecialType == _specialType ?
+                    _type :
+                    base.SubstituteTypeDeclaration(previous);
+            }
+        }
+
+        private sealed class NativeIntegerMethodSymbol : WrappedMethodSymbol
+        {
+            private readonly NativeIntegerTypeSymbol _container;
+            private readonly Symbol? _associatedSymbol;
+
+            internal NativeIntegerMethodSymbol(NativeIntegerTypeSymbol container, MethodSymbol underlyingMethod, Symbol? associatedSymbol)
+            {
+                Debug.Assert(!underlyingMethod.IsGenericMethod);
+                _container = container;
+                _associatedSymbol = associatedSymbol;
+                UnderlyingMethod = underlyingMethod;
+            }
+
+            public override Symbol ContainingSymbol => _container;
+
+            public override MethodSymbol UnderlyingMethod { get; }
+
+            public override TypeWithAnnotations ReturnTypeWithAnnotations => _container.SubstituteUnderlyingType(UnderlyingMethod.ReturnTypeWithAnnotations);
+
+            public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations => ImmutableArray<TypeWithAnnotations>.Empty;
+
+            public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
+
+            public override ImmutableArray<ParameterSymbol> Parameters =>
+                UnderlyingMethod.Parameters.SelectAsArray((p, m) => (ParameterSymbol)new NativeIntegerParameterSymbol(m._container, m, p), this);
+
+            public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations =>
+                UnderlyingMethod.ExplicitInterfaceImplementations.SelectAsArray(
+                    (method, map) => method.OriginalDefinition.AsMember(_container.GetTypeMap().SubstituteNamedType(method.ContainingType)),
+                    _container);
+
+            public override ImmutableArray<CustomModifier> RefCustomModifiers => UnderlyingMethod.RefCustomModifiers;
+
+            public override Symbol? AssociatedSymbol => _associatedSymbol;
+
+            internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private sealed class NativeIntegerPropertySymbol : WrappedPropertySymbol
+        {
+            private readonly NativeIntegerTypeSymbol _container;
+
+            internal NativeIntegerPropertySymbol(NativeIntegerTypeSymbol container, PropertySymbol underlyingProperty) : base(underlyingProperty)
+            {
+                Debug.Assert(underlyingProperty.ParameterCount == 0);
+                _container = container;
+            }
+
+            public override Symbol ContainingSymbol => _container;
+
+            public override TypeWithAnnotations TypeWithAnnotations => _container.SubstituteUnderlyingType(_underlyingProperty.TypeWithAnnotations);
+
+            public override ImmutableArray<CustomModifier> RefCustomModifiers => UnderlyingProperty.RefCustomModifiers;
+
+            public override ImmutableArray<ParameterSymbol> Parameters => ImmutableArray<ParameterSymbol>.Empty;
+
+            public override MethodSymbol? GetMethod => MakeAccessor(UnderlyingProperty.GetMethod);
+
+            public override MethodSymbol? SetMethod => MakeAccessor(UnderlyingProperty.SetMethod);
+
+            public override ImmutableArray<PropertySymbol> ExplicitInterfaceImplementations =>
+                UnderlyingProperty.ExplicitInterfaceImplementations.SelectAsArray(
+                    (property, map) => property.OriginalDefinition.AsMember(_container.GetTypeMap().SubstituteNamedType(property.ContainingType)),
+                    _container);
+
+            internal override bool MustCallMethodsDirectly => _underlyingProperty.MustCallMethodsDirectly;
+
+            private NativeIntegerMethodSymbol? MakeAccessor(MethodSymbol? accessor) => accessor is null ? null : new NativeIntegerMethodSymbol(_container, accessor, this);
+        }
+
+        private sealed class NativeIntegerParameterSymbol : WrappedParameterSymbol
+        {
+            private readonly NativeIntegerTypeSymbol _containingType;
+            private readonly Symbol _container;
+
+            internal NativeIntegerParameterSymbol(NativeIntegerTypeSymbol containingType, Symbol container, ParameterSymbol underlyingParameter) : base(underlyingParameter)
+            {
+                _containingType = containingType;
+                _container = container;
+            }
+
+            public override Symbol ContainingSymbol => _container;
+
+            public override TypeWithAnnotations TypeWithAnnotations => _containingType.SubstituteUnderlyingType(UnderlyingParameter.TypeWithAnnotations);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -217,11 +217,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal NamedTypeSymbol SubstituteUnderlyingType(NamedTypeSymbol type) => GetTypeMap().SubstituteNamedType(type);
 
-        /// <summary>
-        /// Replaces references to underlying type with references to native integer type.
-        /// </summary>
-        internal ImmutableArray<CustomModifier> SubstituteCustomModifiers(ImmutableArray<CustomModifier> customModifiers) => GetTypeMap().SubstituteCustomModifiers(customModifiers);
-
         internal static bool EqualsHelper<TSymbol>(TSymbol symbol, Symbol? other, TypeCompareKind comparison, Func<TSymbol, Symbol> getUnderlyingSymbol)
             where TSymbol : Symbol
         {
@@ -270,6 +265,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     _type :
                     base.SubstituteTypeDeclaration(previous);
             }
+
+            internal override ImmutableArray<CustomModifier> SubstituteCustomModifiers(ImmutableArray<CustomModifier> customModifiers)
+            {
+                return customModifiers;
+            }
         }
     }
 
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
 
-        public override ImmutableArray<CustomModifier> RefCustomModifiers => _container.SubstituteCustomModifiers(UnderlyingMethod.RefCustomModifiers);
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => UnderlyingMethod.RefCustomModifiers;
 
         public override Symbol? AssociatedSymbol => _associatedSymbol;
 
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override TypeWithAnnotations TypeWithAnnotations => _containingType.SubstituteUnderlyingType(_underlyingParameter.TypeWithAnnotations);
 
-        public override ImmutableArray<CustomModifier> RefCustomModifiers => _containingType.SubstituteCustomModifiers(_underlyingParameter.RefCustomModifiers);
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => _underlyingParameter.RefCustomModifiers;
 
         public override bool Equals(Symbol? other, TypeCompareKind comparison) => NativeIntegerTypeSymbol.EqualsHelper(this, other, comparison, symbol => symbol._underlyingParameter);
 
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override TypeWithAnnotations TypeWithAnnotations => _container.SubstituteUnderlyingType(_underlyingProperty.TypeWithAnnotations);
 
-        public override ImmutableArray<CustomModifier> RefCustomModifiers => _container.SubstituteCustomModifiers(UnderlyingProperty.RefCustomModifiers);
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => UnderlyingProperty.RefCustomModifiers;
 
         public override ImmutableArray<ParameterSymbol> Parameters => ImmutableArray<ParameterSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -237,13 +237,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         [Conditional("DEBUG")]
-        internal static void VerifyEquality(Symbol nativeIntegerSymbol, Symbol underlyingSymbol)
+        internal static void VerifyEquality(Symbol symbolA, Symbol symbolB)
         {
-            Debug.Assert(!nativeIntegerSymbol.Equals(underlyingSymbol, TypeCompareKind.ConsiderEverything));
-            Debug.Assert(!underlyingSymbol.Equals(nativeIntegerSymbol, TypeCompareKind.ConsiderEverything));
-            Debug.Assert(nativeIntegerSymbol.Equals(underlyingSymbol, TypeCompareKind.IgnoreNativeIntegers));
-            Debug.Assert(underlyingSymbol.Equals(nativeIntegerSymbol, TypeCompareKind.IgnoreNativeIntegers));
-            Debug.Assert(nativeIntegerSymbol.GetHashCode() == underlyingSymbol.GetHashCode());
+            Debug.Assert(!symbolA.Equals(symbolB, TypeCompareKind.ConsiderEverything));
+            Debug.Assert(!symbolB.Equals(symbolA, TypeCompareKind.ConsiderEverything));
+            Debug.Assert(symbolA.Equals(symbolB, TypeCompareKind.IgnoreNativeIntegers));
+            Debug.Assert(symbolB.Equals(symbolA, TypeCompareKind.IgnoreNativeIntegers));
+            Debug.Assert(symbolA.GetHashCode() == symbolB.GetHashCode());
         }
 
         private sealed class NativeIntegerTypeMap : AbstractTypeMap

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (_lazyInterfaces.IsDefault)
             {
-                var interfaces = _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved).SelectAsArray((Func<NamedTypeSymbol, NativeIntegerTypeMap, NamedTypeSymbol>)((type, map) => map.SubstituteNamedType(type)), GetTypeMap());
+                var interfaces = _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved).SelectAsArray((type, map) => map.SubstituteNamedType(type), GetTypeMap());
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyInterfaces, interfaces);
             }
             return _lazyInterfaces;
@@ -304,9 +304,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (_lazyParameters.IsDefault)
                 {
-                    var parameters = UnderlyingMethod.Parameters.SelectAsArray(
-                        (Func<ParameterSymbol, NativeIntegerMethodSymbol, ParameterSymbol>)((p, m) => (ParameterSymbol)new NativeIntegerParameterSymbol(m._container, m, p)),
-                        this);
+                    var parameters = UnderlyingMethod.Parameters.SelectAsArray((p, m) => (ParameterSymbol)new NativeIntegerParameterSymbol(m._container, m, p), this);
                     ImmutableInterlocked.InterlockedInitialize(ref _lazyParameters, parameters);
                 }
                 return _lazyParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -430,6 +429,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (ReferenceEquals(this, other))
             {
                 return true;
+            }
+
+            if (other is NativeIntegerPropertySymbol nps)
+            {
+                return nps.Equals(this, compareKind);
             }
 
             // This checks if the property have the same definition and the type parameters on the containing types have been

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -32,6 +32,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
+            if (obj is NativeIntegerParameterSymbol nps)
+            {
+                return nps.Equals(this, compareKind);
+            }
+
             var symbol = obj as SourceParameterSymbolBase;
             return (object)symbol != null
                 && symbol.Ordinal == this.Ordinal

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -2522,6 +2522,9 @@ namespace System.Reflection
 {
   .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
 }
+.class public interface System.IComparable`1<T>
+{
+}
 .class public sealed System.IntPtr extends System.ValueType
 {
   .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
@@ -2529,6 +2532,8 @@ namespace System.Reflection
   .method public hidebysig static native int& modopt(native int) F2() cil managed { ldnull throw }
   .method public hidebysig static void F3(native int modopt(native int) i) cil managed { ret }
   .method public hidebysig static void F4(native int& modopt(native int) i) cil managed { ret }
+  .method public hidebysig instance class System.IComparable`1<native int modopt(native int)> F5() cil managed { ldnull throw }
+  .method public hidebysig instance void F6(native int modopt(class System.IComparable`1<native int>) i) cil managed { ret }
   .method public hidebysig instance native int modopt(native int) get_P() cil managed { ldnull throw }
   .method public hidebysig instance native int& modopt(native int) get_Q() cil managed { ldnull throw }
   .method public hidebysig instance void set_P(native int modopt(native int) i) cil managed { ret }
@@ -2549,6 +2554,8 @@ namespace System.Reflection
   .method public hidebysig static native uint& modopt(native uint) F2() cil managed { ldnull throw }
   .method public hidebysig static void F3(native uint modopt(native uint) i) cil managed { ret }
   .method public hidebysig static void F4(native uint& modopt(native uint) i) cil managed { ret }
+  .method public hidebysig instance class System.IComparable`1<native uint modopt(native uint)> F5() cil managed { ldnull throw }
+  .method public hidebysig instance void F6(native uint modopt(class System.IComparable`1<native uint>) i) cil managed { ret }
   .method public hidebysig instance native uint modopt(native uint) get_P() cil managed { ldnull throw }
   .method public hidebysig instance native uint& modopt(native uint) get_Q() cil managed { ldnull throw }
   .method public hidebysig instance void set_P(native uint modopt(native uint) i) cil managed { ret }
@@ -2568,23 +2575,27 @@ namespace System.Reflection
 {
     static void F1(nint i)
     {
-        var x1 = nint.F1();
-        var x2 = nint.F2();
+        _ = nint.F1();
+        _ = nint.F2();
         nint.F3(i);
         nint.F4(ref i);
-        var x3 = i.P;
-        var x4 = i.Q;
-        i.P = x3;
+        _ = i.F5();
+        i.F6(i);
+        _ = i.P;
+        _ = i.Q;
+        i.P = i;
     }
     static void F2(nuint u)
     {
-        var y1 = nuint.F1();
-        var y2 = nuint.F2();
+        _ = nuint.F1();
+        _ = nuint.F2();
         nuint.F3(u);
         nuint.F4(ref u);
-        var y3 = u.P;
-        var y4 = u.Q;
-        u.P = y3;
+        _ = u.F5();
+        u.F6(u);
+        _ = u.P;
+        _ = u.Q;
+        u.P = u;
     }
 }";
 
@@ -2606,6 +2617,7 @@ namespace System.Reflection
                 var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
+                    $"System.IComparable<{type} modopt({type})> {type}.F5()",
                     $"{type} modopt({type}) {type}.F1()",
                     $"{type} modopt({type}) {type}.P {{ get; set; }}",
                     $"{type} modopt({type}) {type}.P.get",
@@ -2615,6 +2627,7 @@ namespace System.Reflection
                     $"ref modopt({type}) {type} {type}.Q.get",
                     $"void {type}.F3({type} modopt({type}) i)",
                     $"void {type}.F4(ref modopt({type}) {type} i)",
+                    $"void {type}.F6({type} modopt(System.IComparable<{type}>) i)",
                     $"void {type}.P.set",
                 };
                 AssertEx.Equal(expectedMembers, actualMembers);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -545,15 +545,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
             void verifyTypes(TypeWithAnnotations fromMember, TypeWithAnnotations fromUnderlyingMember)
             {
-                if (fromUnderlyingMember.CustomModifiers.Length > 0)
-                {
-                    // TypeWithAnnotations.Equals does not use TypeCompareKind to compare CustomModifiers.
-                    Assert.True(fromMember.Type.Equals(fromUnderlyingMember.Type, TypeCompareKind.IgnoreNativeIntegers));
-                }
-                else
-                {
-                    Assert.True(fromMember.Equals(fromUnderlyingMember, TypeCompareKind.IgnoreNativeIntegers));
-                }
+                Assert.True(fromMember.Equals(fromUnderlyingMember, TypeCompareKind.IgnoreNativeIntegers));
                 // No use of underlying type in native integer member.
                 Assert.False(containsType(fromMember, useNativeInteger: false));
                 // No use of native integer in underlying member.
@@ -2617,17 +2609,17 @@ namespace System.Reflection
                 var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
-                    $"System.IComparable<{type} modopt({type})> {type}.F5()",
-                    $"{type} modopt({type}) {type}.F1()",
-                    $"{type} modopt({type}) {type}.P {{ get; set; }}",
-                    $"{type} modopt({type}) {type}.P.get",
+                    $"System.IComparable<{type} modopt({underlyingType})> {type}.F5()",
+                    $"{type} modopt({underlyingType}) {type}.F1()",
+                    $"{type} modopt({underlyingType}) {type}.P {{ get; set; }}",
+                    $"{type} modopt({underlyingType}) {type}.P.get",
                     $"{type}..ctor()",
-                    $"ref modopt({type}) {type} {type}.F2()",
-                    $"ref modopt({type}) {type} {type}.Q {{ get; }}",
-                    $"ref modopt({type}) {type} {type}.Q.get",
-                    $"void {type}.F3({type} modopt({type}) i)",
-                    $"void {type}.F4(ref modopt({type}) {type} i)",
-                    $"void {type}.F6({type} modopt(System.IComparable<{type}>) i)",
+                    $"ref modopt({underlyingType}) {type} {type}.F2()",
+                    $"ref modopt({underlyingType}) {type} {type}.Q {{ get; }}",
+                    $"ref modopt({underlyingType}) {type} {type}.Q.get",
+                    $"void {type}.F3({type} modopt({underlyingType}) i)",
+                    $"void {type}.F4(ref modopt({underlyingType}) {type} i)",
+                    $"void {type}.F6({type} modopt(System.IComparable<{underlyingType}>) i)",
                     $"void {type}.P.set",
                 };
                 AssertEx.Equal(expectedMembers, actualMembers);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -597,13 +597,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             }
         }
 
-        private static int SymbolComparison(Symbol x, Symbol y) => NormalizeDisplayString(x.ToTestDisplayString()).CompareTo(NormalizeDisplayString(y.ToTestDisplayString()));
+        private static int SymbolComparison(Symbol x, Symbol y) => SymbolComparison(x.ToTestDisplayString(), y.ToTestDisplayString());
 
-        private static int SymbolComparison(ISymbol x, ISymbol y) => NormalizeDisplayString(x.ToTestDisplayString()).CompareTo(NormalizeDisplayString(y.ToTestDisplayString()));
+        private static int SymbolComparison(ISymbol x, ISymbol y) => SymbolComparison(x.ToTestDisplayString(), y.ToTestDisplayString());
 
-        // Used by SymbolComparison to provide a common ordering for
-        // symbols that include native integer types or underlying types.
-        private static string NormalizeDisplayString(string symbol) => symbol.Replace("System.IntPtr", "nint").Replace("System.UIntPtr", "nuint");
+        private static int SymbolComparison(string x, string y)
+        {
+            return string.CompareOrdinal(normalizeDisplayString(x), normalizeDisplayString(y));
+
+            static string normalizeDisplayString(string s) => s.Replace("System.IntPtr", "nint").Replace("System.UIntPtr", "nuint");
+        }
 
         [Fact]
         public void MissingTypes()
@@ -1681,13 +1684,13 @@ namespace System
                 var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
+                    $"System.Boolean {type}.TryParse(System.String s, out {type} value)",
                     $"{type} {type}.MaxValue {{ get; }}",
                     $"{type} {type}.MaxValue.get",
                     $"{type} {type}.MinValue {{ get; }}",
                     $"{type} {type}.MinValue.get",
                     $"{type} {type}.Parse(System.String s)",
                     $"{type}..ctor()",
-                    $"System.Boolean {type}.TryParse(System.String s, out {type} value)",
                 };
                 AssertEx.Equal(expectedMembers, actualMembers);
 
@@ -1832,13 +1835,13 @@ class Program
                 var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
-                    $"{type}..ctor()",
                     $"System.Boolean {type}.Equals({type} other)",
-                    $"System.Int32 {type}.CompareTo({type} other)",
                     $"System.Int32 {type}.CompareTo(System.Object other)",
+                    $"System.Int32 {type}.CompareTo({type} other)",
                     $"System.String {type}.ToString(System.IFormatProvider provider)",
                     $"System.String {type}.ToString(System.String format)",
                     $"System.String {type}.ToString(System.String format, System.IFormatProvider provider)",
+                    $"{type}..ctor()",
                 };
                 AssertEx.Equal(expectedMembers, actualMembers);
 
@@ -2080,10 +2083,10 @@ class Program
                 var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
-                    $"{type}..ctor()",
                     $"System.Boolean {type}.Equals(System.Object obj)",
                     $"System.Int32 {type}.GetHashCode()",
                     $"System.String {type}.ToString()",
+                    $"{type}..ctor()",
                 };
                 AssertEx.Equal(expectedMembers, actualMembers);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -469,6 +469,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             {
                 Assert.Same(type, member.ContainingSymbol);
                 Assert.Same(type, member.ContainingType);
+
+                var method = member as MethodSymbol;
+                var parameters = method.Parameters;
+                Assert.Equal(parameters, method.Parameters); // same array
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -311,23 +311,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.Null(underlyingType.NativeIntegerUnderlyingType);
             Assert.Same(nativeIntegerType, underlyingType.AsNativeInteger());
             Assert.Same(underlyingType, nativeIntegerType.NativeIntegerUnderlyingType);
-            verifyEqualButDistinct(underlyingType, underlyingType.AsNativeInteger());
-            verifyEqualButDistinct(nativeIntegerType, nativeIntegerType.NativeIntegerUnderlyingType);
-            verifyEqualButDistinct(underlyingType, nativeIntegerType);
+            VerifyEqualButDistinct(underlyingType, underlyingType.AsNativeInteger());
+            VerifyEqualButDistinct(nativeIntegerType, nativeIntegerType.NativeIntegerUnderlyingType);
+            VerifyEqualButDistinct(underlyingType, nativeIntegerType);
 
             VerifyTypes(underlyingType.GetPublicSymbol(), nativeIntegerType.GetPublicSymbol(), signed);
+        }
 
-            static void verifyEqualButDistinct(NamedTypeSymbol underlyingType, NamedTypeSymbol nativeIntegerType)
-            {
-                Assert.NotSame(underlyingType, nativeIntegerType);
-                Assert.NotEqual(underlyingType, nativeIntegerType);
-                Assert.NotEqual(nativeIntegerType, underlyingType);
-                Assert.False(underlyingType.Equals(nativeIntegerType, TypeCompareKind.ConsiderEverything));
-                Assert.False(nativeIntegerType.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
-                Assert.True(underlyingType.Equals(nativeIntegerType, TypeCompareKind.IgnoreNativeIntegers));
-                Assert.True(nativeIntegerType.Equals(underlyingType, TypeCompareKind.IgnoreNativeIntegers));
-                Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
-            }
+        private static void VerifyEqualButDistinct(NamedTypeSymbol underlyingType, NamedTypeSymbol nativeIntegerType)
+        {
+            Assert.NotSame(underlyingType, nativeIntegerType);
+            Assert.NotEqual(underlyingType, nativeIntegerType);
+            Assert.NotEqual(nativeIntegerType, underlyingType);
+            Assert.False(underlyingType.Equals(nativeIntegerType, TypeCompareKind.ConsiderEverything));
+            Assert.False(nativeIntegerType.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
+            Assert.True(underlyingType.Equals(nativeIntegerType, TypeCompareKind.IgnoreNativeIntegers));
+            Assert.True(nativeIntegerType.Equals(underlyingType, TypeCompareKind.IgnoreNativeIntegers));
+            Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
         }
 
         private static void VerifyInterfaces(NamedTypeSymbol underlyingType, ImmutableArray<NamedTypeSymbol> underlyingInterfaces, NamedTypeSymbol nativeIntegerType, ImmutableArray<NamedTypeSymbol> nativeIntegerInterfaces)
@@ -695,6 +695,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
             Assert.Null(underlyingType.NativeIntegerUnderlyingType);
             VerifyErrorType(nativeIntegerType.NativeIntegerUnderlyingType, specialType, isNativeInt: false);
+            VerifyEqualButDistinct(nativeIntegerType.NativeIntegerUnderlyingType, nativeIntegerType);
 
             VerifyErrorTypes(underlyingType.GetPublicSymbol(), nativeIntegerType.GetPublicSymbol(), signed);
         }
@@ -2106,7 +2107,7 @@ class Program
             }
         }
 
-        // ExplicitImplementations properties are empty on native integer types.
+        // Explicit implementations of methods and properties are not included in native integer types.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -2131,6 +2131,7 @@ class Program
             }
         }
 
+        // ExplicitImplementations properties are empty on native integer types.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -2479,6 +2480,7 @@ namespace System.Reflection
             }
         }
 
+        // Custom modifiers are copied to native integer types but not substituted.
         [Fact]
         public void CustomModifiers()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
             VerifyMembers(underlyingType, nativeIntegerType, signed);
 
-            verifyInterfaces(underlyingType, underlyingType.Interfaces, nativeIntegerType, nativeIntegerType.Interfaces);
+            VerifyInterfaces(underlyingType, underlyingType.Interfaces, nativeIntegerType, nativeIntegerType.Interfaces);
 
             Assert.NotSame(underlyingType, nativeIntegerType);
             Assert.Same(underlyingType, nativeIntegerType.NativeIntegerUnderlyingType);
@@ -219,29 +219,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             Assert.False(underlyingType.Equals(nativeIntegerType, SymbolEqualityComparer.ConsiderEverything));
             Assert.True(underlyingType.Equals(nativeIntegerType, TypeCompareKind.IgnoreNativeIntegers));
             Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
+        }
 
-            static void verifyInterfaces(INamedTypeSymbol underlyingType, ImmutableArray<INamedTypeSymbol> underlyingInterfaces, INamedTypeSymbol nativeIntegerType, ImmutableArray<INamedTypeSymbol> nativeIntegerInterfaces)
+        private static void VerifyInterfaces(INamedTypeSymbol underlyingType, ImmutableArray<INamedTypeSymbol> underlyingInterfaces, INamedTypeSymbol nativeIntegerType, ImmutableArray<INamedTypeSymbol> nativeIntegerInterfaces)
+        {
+            Assert.Equal(underlyingInterfaces.Length, nativeIntegerInterfaces.Length);
+
+            for (int i = 0; i < underlyingInterfaces.Length; i++)
             {
-                Assert.Equal(underlyingInterfaces.Length, nativeIntegerInterfaces.Length);
+                verifyInterface(underlyingInterfaces[i], nativeIntegerInterfaces[i]);
+            }
 
-                for (int i = 0; i < underlyingInterfaces.Length; i++)
+            void verifyInterface(INamedTypeSymbol underlyingInterface, INamedTypeSymbol nativeIntegerInterface)
+            {
+                Assert.True(underlyingInterface.Equals(nativeIntegerInterface, TypeCompareKind.IgnoreNativeIntegers));
+
+                for (int i = 0; i < underlyingInterface.TypeArguments.Length; i++)
                 {
-                    verifyInterface(underlyingInterfaces[i], nativeIntegerInterfaces[i]);
-                }
-
-                void verifyInterface(INamedTypeSymbol underlyingInterface, INamedTypeSymbol nativeIntegerInterface)
-                {
-                    Assert.True(underlyingInterface.Equals(nativeIntegerInterface, TypeCompareKind.IgnoreNativeIntegers));
-
-                    for (int i = 0; i < underlyingInterface.TypeArguments.Length; i++)
-                    {
-                        var underlyingTypeArgument = underlyingInterface.TypeArguments[i];
-                        var nativeIntegerTypeArgument = nativeIntegerInterface.TypeArguments[i];
-                        if (underlyingTypeArgument.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
-                        {
-                            Assert.True(nativeIntegerTypeArgument.IsNativeIntegerType);
-                        }
-                    }
+                    var underlyingTypeArgument = underlyingInterface.TypeArguments[i];
+                    var nativeIntegerTypeArgument = nativeIntegerInterface.TypeArguments[i];
+                    Assert.Equal(underlyingTypeArgument.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions), nativeIntegerTypeArgument.Equals(nativeIntegerType, TypeCompareKind.AllIgnoreOptions));
                 }
             }
         }
@@ -308,8 +305,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
             VerifyMembers(underlyingType, nativeIntegerType, signed);
 
-            verifyInterfaces(underlyingType, underlyingType.InterfacesNoUseSiteDiagnostics(), nativeIntegerType, nativeIntegerType.InterfacesNoUseSiteDiagnostics());
-            verifyInterfaces(underlyingType, underlyingType.GetDeclaredInterfaces(null), nativeIntegerType, nativeIntegerType.GetDeclaredInterfaces(null));
+            VerifyInterfaces(underlyingType, underlyingType.InterfacesNoUseSiteDiagnostics(), nativeIntegerType, nativeIntegerType.InterfacesNoUseSiteDiagnostics());
+            VerifyInterfaces(underlyingType, underlyingType.GetDeclaredInterfaces(null), nativeIntegerType, nativeIntegerType.GetDeclaredInterfaces(null));
 
             Assert.Null(underlyingType.NativeIntegerUnderlyingType);
             Assert.Same(nativeIntegerType, underlyingType.AsNativeInteger());
@@ -331,29 +328,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Assert.True(nativeIntegerType.Equals(underlyingType, TypeCompareKind.IgnoreNativeIntegers));
                 Assert.Equal(underlyingType.GetHashCode(), nativeIntegerType.GetHashCode());
             }
+        }
 
-            static void verifyInterfaces(NamedTypeSymbol underlyingType, ImmutableArray<NamedTypeSymbol> underlyingInterfaces, NamedTypeSymbol nativeIntegerType, ImmutableArray<NamedTypeSymbol> nativeIntegerInterfaces)
+        private static void VerifyInterfaces(NamedTypeSymbol underlyingType, ImmutableArray<NamedTypeSymbol> underlyingInterfaces, NamedTypeSymbol nativeIntegerType, ImmutableArray<NamedTypeSymbol> nativeIntegerInterfaces)
+        {
+            Assert.Equal(underlyingInterfaces.Length, nativeIntegerInterfaces.Length);
+
+            for (int i = 0; i < underlyingInterfaces.Length; i++)
             {
-                Assert.Equal(underlyingInterfaces.Length, nativeIntegerInterfaces.Length);
+                verifyInterface(underlyingInterfaces[i], nativeIntegerInterfaces[i]);
+            }
 
-                for (int i = 0; i < underlyingInterfaces.Length; i++)
+            void verifyInterface(NamedTypeSymbol underlyingInterface, NamedTypeSymbol nativeIntegerInterface)
+            {
+                Assert.True(underlyingInterface.Equals(nativeIntegerInterface, TypeCompareKind.IgnoreNativeIntegers));
+
+                for (int i = 0; i < underlyingInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.Length; i++)
                 {
-                    verifyInterface(underlyingInterfaces[i], nativeIntegerInterfaces[i]);
-                }
-
-                void verifyInterface(NamedTypeSymbol underlyingInterface, NamedTypeSymbol nativeIntegerInterface)
-                {
-                    Assert.True(underlyingInterface.Equals(nativeIntegerInterface, TypeCompareKind.IgnoreNativeIntegers));
-
-                    for (int i = 0; i < underlyingInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.Length; i++)
-                    {
-                        var underlyingTypeArgument = underlyingInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i].Type;
-                        var nativeIntegerTypeArgument = nativeIntegerInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i].Type;
-                        if (underlyingTypeArgument.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
-                        {
-                            Assert.True(nativeIntegerTypeArgument.IsNativeIntegerType);
-                        }
-                    }
+                    var underlyingTypeArgument = underlyingInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i].Type;
+                    var nativeIntegerTypeArgument = nativeIntegerInterface.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i].Type;
+                    Assert.Equal(underlyingTypeArgument.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions), nativeIntegerTypeArgument.Equals(nativeIntegerType, TypeCompareKind.AllIgnoreOptions));
                 }
             }
         }
@@ -613,29 +607,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             return string.CompareOrdinal(normalizeDisplayString(x), normalizeDisplayString(y));
 
             static string normalizeDisplayString(string s) => s.Replace("System.IntPtr", "nint").Replace("System.UIntPtr", "nuint");
-        }
-
-        private sealed class SymbolComparer : IEqualityComparer<Symbol>
-        {
-            internal static readonly SymbolComparer ConsiderEverything = new SymbolComparer(TypeCompareKind.ConsiderEverything);
-            internal static readonly SymbolComparer IgnoreNativeIntegers = new SymbolComparer(TypeCompareKind.IgnoreNativeIntegers);
-
-            private readonly TypeCompareKind _compareKind;
-
-            private SymbolComparer(TypeCompareKind compareKind)
-            {
-                _compareKind = compareKind;
-            }
-
-            bool IEqualityComparer<Symbol>.Equals(Symbol x, Symbol y)
-            {
-                return x.Equals(y, _compareKind);
-            }
-
-            int IEqualityComparer<Symbol>.GetHashCode(Symbol obj)
-            {
-                return obj.GetHashCode();
-            }
         }
 
         [Fact]
@@ -1460,11 +1431,15 @@ namespace System
 
             static void verifyInterfaces(CSharpCompilation comp, NamedTypeSymbol type, SpecialType specialType, bool includesIEquatable)
             {
+                var underlyingType = type.NativeIntegerUnderlyingType;
+
                 Assert.True(type.IsNativeIntegerType);
-                Assert.Equal(specialType, type.NativeIntegerUnderlyingType.SpecialType);
+                Assert.Equal(specialType, underlyingType.SpecialType);
 
                 var interfaces = type.InterfacesNoUseSiteDiagnostics(null);
                 Assert.Equal(interfaces, type.GetDeclaredInterfaces(null));
+                VerifyInterfaces(underlyingType, underlyingType.InterfacesNoUseSiteDiagnostics(null), type, interfaces);
+
                 Assert.Equal(1, interfaces.Length);
 
                 if (includesIEquatable)

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -22,12 +22,12 @@ namespace Microsoft.CodeAnalysis
         IgnoreDynamic = 2,
         IgnoreTupleNames = 4,
         IgnoreDynamicAndTupleNames = IgnoreDynamic | IgnoreTupleNames,
-
         IgnoreNullableModifiersForReferenceTypes = 8,
         ObliviousNullableModifierMatchesAny = 16,
+        IgnoreNativeIntegers = 32,
 
         AllNullableIgnoreOptions = IgnoreNullableModifiersForReferenceTypes | ObliviousNullableModifierMatchesAny,
-        AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames | AllNullableIgnoreOptions,
+        AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames | AllNullableIgnoreOptions | IgnoreNativeIntegers,
         AllIgnoreOptionsForVB = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreTupleNames,
 
         CLRSignatureCompareOptions = TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds,

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -5,15 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using System.Reflection.PortableExecutable;
-using System.Text;
-using System.Threading;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -180,9 +174,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             bool appendDefaultHeader,
             bool includePdb,
             out ImmutableArray<byte> assemblyBytes,
-            out ImmutableArray<byte> pdbBytes)
+            out ImmutableArray<byte> pdbBytes,
+            bool autoInherit = true)
         {
-            IlasmUtilities.IlasmTempAssembly(ilSource, appendDefaultHeader, includePdb, out var assemblyPath, out var pdbPath);
+            IlasmUtilities.IlasmTempAssembly(ilSource, appendDefaultHeader, includePdb, autoInherit, out var assemblyPath, out var pdbPath);
 
             Assert.NotNull(assemblyPath);
             Assert.Equal(pdbPath != null, includePdb);
@@ -205,9 +200,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
-        internal static MetadataReference CompileIL(string ilSource, bool prependDefaultHeader = true, bool embedInteropTypes = false)
+        internal static MetadataReference CompileIL(string ilSource, bool prependDefaultHeader = true, bool embedInteropTypes = false, bool autoInherit = true)
         {
-            EmitILToArray(ilSource, prependDefaultHeader, includePdb: false, assemblyBytes: out var assemblyBytes, pdbBytes: out var pdbBytes);
+            EmitILToArray(ilSource, prependDefaultHeader, includePdb: false, assemblyBytes: out var assemblyBytes, pdbBytes: out var pdbBytes, autoInherit: autoInherit);
             return AssemblyMetadata.CreateFromImage(assemblyBytes).GetReference(embedInteropTypes: embedInteropTypes);
         }
 

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Reflection;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -15,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         public static DisposableFile CreateTempAssembly(string declarations, bool prependDefaultHeader = true)
         {
-            IlasmTempAssembly(declarations, prependDefaultHeader, includePdb: false, assemblyPath: out var assemblyPath, pdbPath: out var pdbPath);
+            IlasmTempAssembly(declarations, prependDefaultHeader, includePdb: false, autoInherit: true, assemblyPath: out var assemblyPath, pdbPath: out var pdbPath);
             Assert.NotNull(assemblyPath);
             Assert.Null(pdbPath);
             return new DisposableFile(assemblyPath);
@@ -57,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private static readonly string IlasmPath = GetIlasmPath();
 
-        public static void IlasmTempAssembly(string declarations, bool appendDefaultHeader, bool includePdb, out string assemblyPath, out string pdbPath)
+        public static void IlasmTempAssembly(string declarations, bool appendDefaultHeader, bool includePdb, bool autoInherit, out string assemblyPath, out string pdbPath)
         {
             if (declarations == null) throw new ArgumentNullException(nameof(declarations));
 
@@ -94,7 +93,7 @@ $@".assembly '{sourceFileName}' {{}}
 
                 sourceFile.WriteAllText(completeIL);
 
-                var arguments = $"\"{sourceFile.Path}\" -DLL -out=\"{assemblyPath}\"";
+                var arguments = $"\"{sourceFile.Path}\" -DLL {(autoInherit ? "" : "-noautoinherit")} -out=\"{assemblyPath}\"";
 
                 if (includePdb && !MonoHelpers.IsRunningOnMono())
                 {


### PR DESCRIPTION
Only exclude a few specific members from the underlying types from native integer types. (Previously, only a few specific members were included.) Include all interfaces implemented by the underlying types.

Fixes https://github.com/dotnet/roslyn/issues/42453
Fixes https://github.com/dotnet/roslyn/issues/42957
Fixes https://github.com/dotnet/roslyn/issues/43657