### PR TITLE
improve vscode tests perf

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -125,6 +125,8 @@
           "${workspaceRoot}/scripts/vscode-run-tests.ps1",
           "-filePath",
           "${file}",
+          "-msbuildEngine",
+          "dotnet",
           "-framework",
           "netcoreapp3.1",
           "-filter",
@@ -142,6 +144,8 @@
           "${workspaceRoot}/scripts/vscode-run-tests.ps1",
           "-filePath",
           "${file}",
+          "-msbuildEngine",
+          "dotnet",
           "-framework",
           "netcoreapp3.1"
         ],

--- a/scripts/vscode-build.ps1
+++ b/scripts/vscode-build.ps1
@@ -1,6 +1,7 @@
 param (
   [Parameter(Mandatory = $true)][string]$filePath,
-  [string]$msbuildEngine = "vs"
+  [string]$msbuildEngine = "vs",
+  [string]$framework = $null
 )
 
 Set-StrictMode -version 3.0
@@ -12,7 +13,8 @@ $fileInfo = Get-ItemProperty $filePath
 $projectFileInfo = Get-ProjectFile $fileInfo
 if ($projectFileInfo) {
   $buildTool = InitializeBuildTool
-  $buildArgs = "$($buildTool.Command) -v:m -m -p:UseRoslynAnalyzers=false -p:GenerateFullPaths=true $($projectFileInfo.FullName)"
+  $frameworkArg = if ($framework) { " -p:TargetFramework=$framework" } else { "" }
+  $buildArgs = "$($buildTool.Command) -v:m -m -p:UseRoslynAnalyzers=false -p:GenerateFullPaths=true$frameworkArg $($projectFileInfo.FullName)"
 
   Write-Host "$($buildTool.Path) $buildArgs"
   Exec-Console $buildTool.Path $buildArgs

--- a/scripts/vscode-build.ps1
+++ b/scripts/vscode-build.ps1
@@ -1,7 +1,7 @@
 param (
   [Parameter(Mandatory = $true)][string]$filePath,
   [string]$msbuildEngine = "vs",
-  [string]$framework = $null
+  [string]$framework = ""
 )
 
 Set-StrictMode -version 3.0
@@ -13,7 +13,7 @@ $fileInfo = Get-ItemProperty $filePath
 $projectFileInfo = Get-ProjectFile $fileInfo
 if ($projectFileInfo) {
   $buildTool = InitializeBuildTool
-  $frameworkArg = if ($framework) { " -p:TargetFramework=$framework" } else { "" }
+  $frameworkArg = if ($framework -ne "") { " -p:TargetFramework=$framework" } else { "" }
   $buildArgs = "$($buildTool.Command) -v:m -m -p:UseRoslynAnalyzers=false -p:GenerateFullPaths=true$frameworkArg $($projectFileInfo.FullName)"
 
   Write-Host "$($buildTool.Path) $buildArgs"

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -1,13 +1,18 @@
 param (
   [Parameter(Mandatory = $true)][string]$filePath,
-  [Parameter(Mandatory = $false)][string]$framework,
-  [Parameter(Mandatory = $false)][string]$filter
+  [string]$msbuildEngine = "vs",
+  [string]$framework = $null,
+  [string]$filter = $null
 )
 
 Set-StrictMode -version 3.0
 $ErrorActionPreference = "Stop"
 
 . (Join-Path $PSScriptRoot "../eng/build-utils.ps1")
+
+# Run a build
+. (Join-Path $PSScriptRoot "./vscode-build.ps1") -filePath $filePath -framework $framework -msbuildEngine $msbuildEngine
+Write-Output ""
 
 $fileInfo = Get-ItemProperty $filePath
 $projectFileInfo = Get-ProjectFile $fileInfo
@@ -25,7 +30,7 @@ if ($projectFileInfo) {
   # Remove old run logs with the same prefix
   Remove-Item (Join-Path $resultsPath "$logFilePrefix*.html")
 
-  $invocation = "$dotnetPath test $projectDir" + $filterArg + $frameworkArg + " --logger `"html;LogFilePrefix=$logfilePrefix`" --results-directory $resultsPath"
+  $invocation = "$dotnetPath test $projectDir" + $filterArg + $frameworkArg + " --logger `"html;LogFilePrefix=$logfilePrefix`" --results-directory $resultsPath --no-build"
   Write-Output "> $invocation"
   Invoke-Expression $invocation
 

--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -2,7 +2,7 @@ param (
   [Parameter(Mandatory = $true)][string]$filePath,
   [string]$msbuildEngine = "vs",
   [string]$framework = $null,
-  [string]$filter = $null
+  [string]$filter = ""
 )
 
 Set-StrictMode -version 3.0
@@ -28,7 +28,7 @@ if ($projectFileInfo) {
   $resultsPath = Resolve-Path (New-Item -ItemType Directory -Force -Path $resultsPath) -Relative
 
   # Remove old run logs with the same prefix
-  Remove-Item (Join-Path $resultsPath "$logFilePrefix*.html")
+  Remove-Item (Join-Path $resultsPath "$logFilePrefix*.html") -ErrorAction SilentlyContinue
 
   $invocation = "$dotnetPath test $projectDir" + $filterArg + $frameworkArg + " --logger `"html;LogFilePrefix=$logfilePrefix`" --results-directory $resultsPath --no-build"
   Write-Output "> $invocation"


### PR DESCRIPTION
This improves the perf of 'run tests in current file (netcoreapp3.1)' and 'run tests in current project (netcoreapp3.1)', mainly by disabling analyzers in the build, but also a bit by passing `--framework netcoreapp3.1` to the build. This only prevents us from building the test project itself in net472, pretty much everything else continues to build the same TFMs they were building before.

incremental build performance and therefore test performance could probably be improved a good bit more by making it so we didn't have to build Microsoft.CodeAnalysis.CSharp.dll in both netstandard2.0 and netcoreapp3.1 flavors whenever we build a test project.