### PR TITLE
Move convert tuple to struct oop

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -9,12 +9,20 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities.RemoteHost;
 using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
 {
+    public enum TestHost
+    {
+        InProcess,
+        OutOfProcess,
+    }
+
     public class ConvertTupleToStructTests : AbstractCSharpCodeActionTest
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
@@ -23,10 +31,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
         protected override ImmutableArray<CodeAction> MassageActions(ImmutableArray<CodeAction> actions)
             => FlattenActions(actions);
 
+        private OptionsCollection GetPreferImplicitTypeOptions(TestHost host)
+        {
+            var options = this.PreferImplicitTypeWithInfo();
+            options.Add(RemoteHostOptions.RemoteHostTest, host != TestHost.InProcess);
+            return options;
+        }
+
         #region update containing member tests
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleType()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleType(TestHost host)
         {
             var text = @"
 class Test
@@ -88,12 +103,12 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
         [WorkItem(39916, "https://github.com/dotnet/roslyn/issues/39916")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleType_Explicit()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleType_Explicit(TestHost host)
         {
             var text = @"
 class Test
@@ -155,11 +170,12 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected);
+            await TestInRegularAndScriptAsync(text, expected,
+                options: Option(RemoteHostOptions.RemoteHostTest, host != TestHost.InProcess));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleTypeNoNames()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleTypeNoNames(TestHost host)
         {
             var text = @"
 class Test
@@ -221,11 +237,11 @@ internal struct NewStruct
         return new NewStruct(value.Item1, value.Item2);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleTypePartialNames()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleTypePartialNames(TestHost host)
         {
             var text = @"
 class Test
@@ -287,11 +303,11 @@ internal struct NewStruct
         return new NewStruct(value.Item1, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertFromType()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertFromType(TestHost host)
         {
             var text = @"
 class Test
@@ -355,11 +371,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertFromType2()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertFromType2(TestHost host)
         {
             var text = @"
 class Test
@@ -423,11 +439,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertFromType3()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertFromType3(TestHost host)
         {
             var text = @"
 class Test
@@ -491,11 +507,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertFromType4()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertFromType4(TestHost host)
         {
             var text = @"
 class Test
@@ -559,11 +575,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleTypeInNamespace()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleTypeInNamespace(TestHost host)
         {
             var text = @"
 namespace N
@@ -632,11 +648,11 @@ namespace N
     }
 }
 ";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestNonLiteralNames()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestNonLiteralNames(TestHost host)
         {
             var text = @"
 class Test
@@ -698,11 +714,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleTypeWithInferredName()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleTypeWithInferredName(TestHost host)
         {
             var text = @"
 class Test
@@ -764,11 +780,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertMultipleInstancesInSameMethod()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertMultipleInstancesInSameMethod(TestHost host)
         {
             var text = @"
 class Test
@@ -832,11 +848,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertMultipleInstancesAcrossMethods()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertMultipleInstancesAcrossMethods(TestHost host)
         {
             var text = @"
 class Test
@@ -912,11 +928,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task OnlyConvertMatchingTypesInSameMethod()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task OnlyConvertMatchingTypesInSameMethod(TestHost host)
         {
             var text = @"
 class Test
@@ -984,11 +1000,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestFixAllMatchesInSingleMethod()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestFixAllMatchesInSingleMethod(TestHost host)
         {
             var text = @"
 class Test
@@ -1056,11 +1072,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestFixNotAcrossMethods()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestFixNotAcrossMethods(TestHost host)
         {
             var text = @"
 class Test
@@ -1136,11 +1152,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestTrivia()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestTrivia(TestHost host)
         {
             var text = @"
 class Test
@@ -1202,11 +1218,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.Item2);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task NotIfReferencesAnonymousTypeInternally()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task NotIfReferencesAnonymousTypeInternally(TestHost host)
         {
             var text = @"
 class Test
@@ -1218,11 +1234,12 @@ class Test
 }
 ";
 
-            await TestMissingInRegularAndScriptAsync(text);
+            await TestMissingInRegularAndScriptAsync(text,
+                parameters: new TestParameters(options: Option(RemoteHostOptions.RemoteHostTest, host != TestHost.InProcess)));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertMultipleNestedInstancesInSameMethod1()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertMultipleNestedInstancesInSameMethod1(TestHost host)
         {
             var text = @"
 class Test
@@ -1286,11 +1303,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertMultipleNestedInstancesInSameMethod2()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertMultipleNestedInstancesInSameMethod2(TestHost host)
         {
             var text = @"
 class Test
@@ -1354,11 +1371,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task RenameAnnotationOnStartingPoint()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task RenameAnnotationOnStartingPoint(TestHost host)
         {
             var text = @"
 class Test
@@ -1422,11 +1439,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task CapturedMethodTypeParameters()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task CapturedMethodTypeParameters(TestHost host)
         {
             var text = @"
 class Test<X> where X : struct
@@ -1495,11 +1512,11 @@ internal struct NewStruct<X, Y>
             {
                 FeaturesResources.updating_usages_in_containing_member
             });
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task NewTypeNameCollision()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task NewTypeNameCollision(TestHost host)
         {
             var text = @"
 class Test
@@ -1569,11 +1586,11 @@ internal struct NewStruct1
         return new NewStruct1(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestDuplicatedName()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestDuplicatedName(TestHost host)
         {
             var text = @"
 class Test
@@ -1635,11 +1652,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.a);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestInLambda1()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestInLambda1(TestHost host)
         {
             var text = @"
 using System;
@@ -1713,11 +1730,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestInLambda2()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestInLambda2(TestHost host)
         {
             var text = @"
 using System;
@@ -1791,11 +1808,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestInLocalFunction1()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestInLocalFunction1(TestHost host)
         {
             var text = @"
 using System;
@@ -1869,11 +1886,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestInLocalFunction2()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestInLocalFunction2(TestHost host)
         {
             var text = @"
 using System;
@@ -1947,11 +1964,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertWithDefaultNames1()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertWithDefaultNames1(TestHost host)
         {
             var text = @"
 class Test
@@ -2026,11 +2043,11 @@ internal struct NewStruct
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type,
             });
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertWithDefaultNames2()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertWithDefaultNames2(TestHost host)
         {
             var text = @"
 class Test
@@ -2104,7 +2121,7 @@ internal struct NewStruct
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type,
             });
-            await TestInRegularAndScriptAsync(text, expected, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, options: GetPreferImplicitTypeOptions(host));
         }
 
         protected override ParseOptions GetScriptOptions()
@@ -2114,8 +2131,8 @@ internal struct NewStruct
 
         #region update containing type tests
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task TestCapturedTypeParameter_UpdateType()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task TestCapturedTypeParameter_UpdateType(TestHost host)
         {
             var text = @"
 using System;
@@ -2210,11 +2227,11 @@ internal struct NewStruct<T>
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type
             });
-            await TestInRegularAndScriptAsync(text, expected, index: 1, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 1, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task UpdateAllInType_SinglePart_SingleFile()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task UpdateAllInType_SinglePart_SingleFile(TestHost host)
         {
             var text = @"
 using System;
@@ -2306,11 +2323,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, index: 1, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 1, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task UpdateAllInType_MultiplePart_SingleFile()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task UpdateAllInType_MultiplePart_SingleFile(TestHost host)
         {
             var text = @"
 using System;
@@ -2408,11 +2425,11 @@ internal struct NewStruct
         return new NewStruct(value.a, value.b);
     }
 }";
-            await TestInRegularAndScriptAsync(text, expected, index: 1, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 1, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task UpdateAllInType_MultiplePart_MultipleFile()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task UpdateAllInType_MultiplePart_MultipleFile(TestHost host)
         {
             var text = @"
 <Workspace>
@@ -2543,15 +2560,15 @@ partial class Other
         </Document>
     </Project>
 </Workspace>";
-            await TestInRegularAndScriptAsync(text, expected, index: 1, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 1, options: GetPreferImplicitTypeOptions(host));
         }
 
         #endregion update containing project tests
 
         #region update containing project tests
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task UpdateAllInProject_MultiplePart_MultipleFile_WithNamespace()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task UpdateAllInProject_MultiplePart_MultipleFile_WithNamespace(TestHost host)
         {
             var text = @"
 <Workspace>
@@ -2689,15 +2706,15 @@ partial class Other
         </Document>
     </Project>
 </Workspace>";
-            await TestInRegularAndScriptAsync(text, expected, index: 2, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 2, options: GetPreferImplicitTypeOptions(host));
         }
 
         #endregion
 
         #region update dependent projects
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task UpdateDependentProjects_DirectDependency()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task UpdateDependentProjects_DirectDependency(TestHost host)
         {
             var text = @"
 <Workspace>
@@ -2817,11 +2834,11 @@ partial class Other
         </Document>
     </Project>
 </Workspace>";
-            await TestInRegularAndScriptAsync(text, expected, index: 3, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 3, options: GetPreferImplicitTypeOptions(host));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task UpdateDependentProjects_NoDependency()
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task UpdateDependentProjects_NoDependency(TestHost host)
         {
             var text = @"
 <Workspace>
@@ -2939,7 +2956,7 @@ partial class Other
         </Document>
     </Project>
 </Workspace>";
-            await TestInRegularAndScriptAsync(text, expected, index: 3, options: this.PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptAsync(text, expected, index: 3, options: GetPreferImplicitTypeOptions(host));
         }
 
         #endregion

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -5,10 +5,17 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Test.Utilities.RemoteHost
 Imports Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStruct
+    Public Enum TestHost
+        InProcess
+        OutOfProcess
+    End Enum
+
     Public Class ConvertTupleToStructTests
         Inherits AbstractVisualBasicCodeActionTest
 
@@ -20,10 +27,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStru
             Return FlattenActions(actions)
         End Function
 
+        Private Function GetTestOptions(host As TestHost) As OptionsCollection
+            Return [Option](RemoteHostOptions.RemoteHostTest, host <> TestHost.InProcess)
+        End Function
+
 #Region "update containing member tests"
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertSingleTupleType() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleType(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -75,11 +86,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertSingleTupleTypeNoNames() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleTypeNoNames(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -131,11 +142,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertSingleTupleTypePartialNames() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleTypePartialNames(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -187,11 +198,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertFromType() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertFromType(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -245,11 +256,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertFromType2() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertFromType2(host As TestHost) As Task
             Dim text = "
 class Test
     function Method() as (a as integer, b as integer)
@@ -303,11 +314,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertFromType3() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertFromType3(host As TestHost) As Task
             Dim text = "
 class Test
     function Method() as (a as integer, b as integer)
@@ -360,11 +371,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertFromType4() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertFromType4(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -417,11 +428,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertSingleTupleTypeInNamespace() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleTypeInNamespace(host As TestHost) As Task
             Dim text = "
 namespace N
     class Test
@@ -477,11 +488,11 @@ namespace N
     End Structure
 end namespace
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestNonLiteralNames() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestNonLiteralNames(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -532,11 +543,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertSingleTupleTypeWithInferredName() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleTypeWithInferredName(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method(b as integer)
@@ -587,11 +598,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertMultipleInstancesInSameMethod() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertMultipleInstancesInSameMethod(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -644,11 +655,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertMultipleInstancesInSameMethod_DifferingCase() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertMultipleInstancesInSameMethod_DifferingCase(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -701,11 +712,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertMultipleInstancesAcrossMethods() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertMultipleInstancesAcrossMethods(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -768,11 +779,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function OnlyConvertMatchingTypesInSameMethod() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function OnlyConvertMatchingTypesInSameMethod(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method(b as integer)
@@ -829,15 +840,15 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
         Sub foo(a As Integer, b As Integer)
 
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestFixAllMatchesInSingleMethod() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestFixAllMatchesInSingleMethod(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method(b as integer)
@@ -894,11 +905,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestFixNotAcrossMethods() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestFixNotAcrossMethods(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -961,11 +972,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function NotIfReferencesAnonymousTypeInternally() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function NotIfReferencesAnonymousTypeInternally(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -976,8 +987,8 @@ end class"
             Await TestMissingInRegularAndScriptAsync(text)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertMultipleNestedInstancesInSameMethod1() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertMultipleNestedInstancesInSameMethod1(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1030,11 +1041,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertMultipleNestedInstancesInSameMethod2() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertMultipleNestedInstancesInSameMethod2(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1087,11 +1098,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function RenameAnnotationOnStartingPoint() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function RenameAnnotationOnStartingPoint(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1144,11 +1155,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function CapturedMethodTypeParameters() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function CapturedMethodTypeParameters(host As TestHost) As Task
             Dim text = "
 imports System.Collections.Generic
 
@@ -1207,11 +1218,11 @@ End Structure
             Await TestExactActionSetOfferedAsync(text, {
                 FeaturesResources.updating_usages_in_containing_member
             })
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function NewTypeNameCollision() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function NewTypeNameCollision(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1268,11 +1279,11 @@ Friend Structure NewStruct1
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function NewTypeNameCollision_CaseInsensitive() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function NewTypeNameCollision_CaseInsensitive(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1329,11 +1340,11 @@ Friend Structure NewStruct1
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestDuplicatedName() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestDuplicatedName(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1384,11 +1395,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestInLambda1() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestInLambda1(host As TestHost) As Task
             Dim text = "
 imports System
 
@@ -1449,11 +1460,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestInLambda2() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestInLambda2(host As TestHost) As Task
             Dim text = "
 imports System
 
@@ -1514,11 +1525,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertWithDefaultNames1() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertWithDefaultNames1(host As TestHost) As Task
             Dim text As String = "
 class Test
     sub Method()
@@ -1583,11 +1594,11 @@ End Structure
                 FeaturesResources.updating_usages_in_containing_type
             })
 
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function ConvertWithDefaultNames2() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertWithDefaultNames2(host As TestHost) As Task
             Dim text As String = "
 class Test
     sub Method()
@@ -1652,7 +1663,7 @@ End Structure
                 FeaturesResources.updating_usages_in_containing_type
             })
 
-            Await TestInRegularAndScriptAsync(text, expected)
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
         Protected Overrides Function GetScriptOptions() As ParseOptions
@@ -1663,8 +1674,8 @@ End Structure
 
 #Region "update containing type tests"
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function TestCapturedTypeParameter_UpdateType() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function TestCapturedTypeParameter_UpdateType(host As TestHost) As Task
             Dim text = "
 imports System
 
@@ -1746,8 +1757,8 @@ End Structure
             Await TestInRegularAndScriptAsync(text, expected, index:=1)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function UpdateAllInType_SinglePart_SingleFile() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function UpdateAllInType_SinglePart_SingleFile(host As TestHost) As Task
             Dim text = "
 imports System
 
@@ -1823,8 +1834,8 @@ End Structure
             Await TestInRegularAndScriptAsync(text, expected, index:=1)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function UpdateAllInType_MultiplePart_SingleFile() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function UpdateAllInType_MultiplePart_SingleFile(host As TestHost) As Task
             Dim text = "
 imports System
 
@@ -1902,8 +1913,8 @@ End Structure
             Await TestInRegularAndScriptAsync(text, expected, index:=1)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function UpdateAllInType_MultiplePart_MultipleFile() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function UpdateAllInType_MultiplePart_MultipleFile(host As TestHost) As Task
             Dim text = "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
@@ -2022,8 +2033,8 @@ end class
 
 #Region "update containing project tests"
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function UpdateAllInProject_MultiplePart_MultipleFile_WithNamespace() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function UpdateAllInProject_MultiplePart_MultipleFile_WithNamespace(host As TestHost) As Task
             Dim text = "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
@@ -2146,8 +2157,8 @@ end class
 
 #Region "update dependent projects"
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function UpdateDependentProjects_DirectDependency() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function UpdateDependentProjects_DirectDependency(host As TestHost) As Task
             Dim text = "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
@@ -2255,8 +2266,8 @@ end class
             Await TestInRegularAndScriptAsync(text, expected, index:=3)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function UpdateDependentProjects_NoDependency() As Task
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function UpdateDependentProjects_NoDependency(host As TestHost) As Task
             Dim text = "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">

--- a/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
@@ -7,10 +7,12 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.ConvertTupleToStruct;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct
 {
     [ExtensionOrder(Before = PredefinedCodeRefactoringProviderNames.IntroduceVariable)]
+    [ExportLanguageService(typeof(IConvertTupleToStructCodeRefactoringProvider), LanguageNames.CSharp)]
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(PredefinedCodeRefactoringProviderNames.ConvertTupleToStruct)), Shared]
     internal class CSharpConvertTupleToStructCodeRefactoringProvider :
         AbstractConvertTupleToStructCodeRefactoringProvider<

--- a/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
@@ -30,12 +30,5 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct
         public CSharpConvertTupleToStructCodeRefactoringProvider()
         {
         }
-
-        protected override ObjectCreationExpressionSyntax CreateObjectCreationExpression(
-            NameSyntax nameNode, SyntaxToken openParen, SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParen)
-        {
-            return SyntaxFactory.ObjectCreationExpression(
-                nameNode, SyntaxFactory.ArgumentList(openParen, arguments, closeParen), initializer: null);
-        }
     }
 }

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -163,6 +163,13 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
         private static async Task<Solution> ConvertToStructAsync(
             Document document, TextSpan span, Scope scope, CancellationToken cancellationToken)
         {
+            return await ConvertToStructInCurrentProcessAsync(
+                document, span, scope, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task<Solution> ConvertToStructInCurrentProcessAsync(
+            Document document, TextSpan span, Scope scope, CancellationToken cancellationToken)
+        {
             var (tupleExprOrTypeNode, tupleType) = await TryGetTupleInfoAsync(
                 document, span, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/ConvertTupleToStruct/IConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/IConvertTupleToStructCodeRefactoringProvider.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
+{
+    internal interface IConvertTupleToStructCodeRefactoringProvider : ILanguageService
+    {
+        Task<Solution> ConvertToStructAsync(
+            Document document, TextSpan span, Scope scope, CancellationToken cancellationToken);
+    }
+}

--- a/src/Features/Core/Portable/ConvertTupleToStruct/IRemoteConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/IRemoteConvertTupleToStructCodeRefactoringProvider.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
+{
+    internal interface IRemoteConvertTupleToStructCodeRefactoringProvider
+    {
+        Task<SerializableConvertTupleToStructResult> ConvertToStructAsync(
+            PinnedSolutionInfo solutionInfo,
+            DocumentId documentId,
+            TextSpan span,
+            Scope scope,
+            CancellationToken cancellationToken);
+    }
+
+    internal class SerializableConvertTupleToStructResult
+    {
+        public (DocumentId, TextChange[])[] DocumentTextChanges;
+        public (DocumentId, TextSpan) RenamedToken;
+    }
+}

--- a/src/Features/Core/Portable/ConvertTupleToStruct/Scope.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/Scope.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
+{
+    internal enum Scope
+    {
+        ContainingMember,
+        ContainingType,
+        ContainingProject,
+        DependentProjects
+    }
+}

--- a/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
@@ -6,10 +6,12 @@ Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.ConvertTupleToStruct
+Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct
     <ExtensionOrder(Before:=PredefinedCodeRefactoringProviderNames.IntroduceVariable)>
+    <ExportLanguageService(GetType(IConvertTupleToStructCodeRefactoringProvider), LanguageNames.VisualBasic)>
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeRefactoringProviderNames.ConvertTupleToStruct), [Shared]>
     Friend Class VisualBasicConvertTupleToStructCodeRefactoringProvider
         Inherits AbstractConvertTupleToStructCodeRefactoringProvider(Of

--- a/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
@@ -28,12 +28,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
         Public Sub New()
         End Sub
-
-        Protected Overrides Function CreateObjectCreationExpression(
-                nameNode As NameSyntax, openParen As SyntaxToken, arguments As SeparatedSyntaxList(Of ArgumentSyntax), closeParen As SyntaxToken) As ObjectCreationExpressionSyntax
-
-            Return SyntaxFactory.ObjectCreationExpression(
-                attributeLists:=Nothing, nameNode, SyntaxFactory.ArgumentList(openParen, arguments, closeParen), initializer:=Nothing)
-        End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3092,6 +3092,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         public override SyntaxNode ObjectCreationExpression(SyntaxNode type, IEnumerable<SyntaxNode> arguments)
             => SyntaxFactory.ObjectCreationExpression((TypeSyntax)type, CreateArgumentList(arguments), null);
 
+        internal override SyntaxNode ObjectCreationExpression(SyntaxNode type, SyntaxToken openParen, SeparatedSyntaxList<SyntaxNode> arguments, SyntaxToken closeParen)
+            => SyntaxFactory.ObjectCreationExpression(
+                (TypeSyntax)type,
+                SyntaxFactory.ArgumentList(openParen, arguments, closeParen),
+                initializer: null);
+
         private static ArgumentListSyntax CreateArgumentList(IEnumerable<SyntaxNode> arguments)
             => SyntaxFactory.ArgumentList(CreateArguments(arguments));
 

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1960,6 +1960,9 @@ namespace Microsoft.CodeAnalysis.Editing
         /// </summary>
         public abstract SyntaxNode ObjectCreationExpression(SyntaxNode namedType, IEnumerable<SyntaxNode> arguments);
 
+        internal abstract SyntaxNode ObjectCreationExpression(
+            SyntaxNode namedType, SyntaxToken openParen, SeparatedSyntaxList<SyntaxNode> arguments, SyntaxToken closeParen);
+
         /// <summary>
         /// Creates an object creation expression.
         /// </summary>

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_ConvertTupleToStruct.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_ConvertTupleToStruct.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.ConvertTupleToStruct;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    // root level service for all Roslyn services
+    internal partial class CodeAnalysisService : IRemoteConvertTupleToStructCodeRefactoringProvider
+    {
+        public Task<SerializableConvertTupleToStructResult> ConvertToStructAsync(
+            PinnedSolutionInfo solutionInfo,
+            DocumentId documentId,
+            TextSpan span,
+            Scope scope,
+            CancellationToken cancellationToken)
+        {
+            return RunServiceAsync<SerializableConvertTupleToStructResult>(async () =>
+            {
+                using (UserOperationBooster.Boost())
+                {
+                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
+                    var document = solution.GetDocument(documentId);
+
+                    var service = document.GetLanguageService<IConvertTupleToStructCodeRefactoringProvider>();
+                    var updatedSolution = await service.ConvertToStructAsync(document, span, scope, cancellationToken).ConfigureAwait(false);
+
+                    var cleanedSolution = await CleanupAsync(solution, updatedSolution, cancellationToken).ConfigureAwait(false);
+
+                    var documentTextChanges = await RemoteUtilities.GetDocumentTextChangesAsync(
+                        solution, cleanedSolution, cancellationToken).ConfigureAwait(false);
+                    var renamedToken = await GetRenamedTokenAsync(
+                        solution, cleanedSolution, cancellationToken).ConfigureAwait(false);
+
+                    return new SerializableConvertTupleToStructResult
+                    {
+                        DocumentTextChanges = documentTextChanges,
+                        RenamedToken = renamedToken,
+                    };
+                }
+            }, cancellationToken);
+        }
+
+        private async Task<(DocumentId, TextSpan)> GetRenamedTokenAsync(
+            Solution oldSolution, Solution newSolution, CancellationToken cancellationToken)
+        {
+            var changes = newSolution.GetChangedDocuments(oldSolution);
+
+            foreach (var docId in changes)
+            {
+                var document = newSolution.GetDocument(docId);
+                var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var renamedToken = root.GetAnnotatedTokens(RenameAnnotation.Kind).FirstOrNull();
+                if (renamedToken == null)
+                    continue;
+
+                return (docId, renamedToken.Value.Span);
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        private async Task<Solution> CleanupAsync(Solution oldSolution, Solution newSolution, CancellationToken cancellationToken)
+        {
+            var changes = newSolution.GetChangedDocuments(oldSolution);
+            var final = newSolution;
+
+            foreach (var docId in changes)
+            {
+                var cleaned = await CodeAction.CleanupDocumentAsync(
+                    newSolution.GetDocument(docId), cancellationToken).ConfigureAwait(false);
+                var cleanedRoot = await cleaned.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                final = final.WithDocumentSyntaxRoot(docId, cleanedRoot);
+            }
+
+            return final;
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -487,5 +487,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         ChangeSignature_Data = 389,
 
         AbstractEncapsulateFieldService_EncapsulateFieldsAsync = 390,
+
+        AbstractConvertTupleToStructCodeRefactoringProvider_ConvertToStructAsync = 400,
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -352,10 +352,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overloads Overrides Function ObjectCreationExpression(typeName As SyntaxNode, arguments As IEnumerable(Of SyntaxNode)) As SyntaxNode
             Return SyntaxFactory.ObjectCreationExpression(
-                Nothing,
+                attributeLists:=Nothing,
                 DirectCast(typeName, TypeSyntax),
                 CreateArgumentList(arguments),
-                Nothing)
+                initializer:=Nothing)
+        End Function
+
+        Friend Overrides Function ObjectCreationExpression(typeName As SyntaxNode, openParen As SyntaxToken, arguments As SeparatedSyntaxList(Of SyntaxNode), closeParen As SyntaxToken) As SyntaxNode
+            Return SyntaxFactory.ObjectCreationExpression(
+                attributeLists:=Nothing,
+                DirectCast(typeName, TypeSyntax),
+                SyntaxFactory.ArgumentList(openParen, arguments, closeParen),
+                initializer:=Nothing)
         End Function
 
         Public Overrides Function QualifiedName(left As SyntaxNode, right As SyntaxNode) As SyntaxNode


### PR DESCRIPTION
This feature uses the SyntaxIndex type.  So we want this to run OOP so that those indices are never produces in-proc.

Reviewing commit by commit may help.