### PR TITLE
Exclude codelens from vs_debugger_start_no_build_cs_scribble coverage

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -402,10 +402,6 @@
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },
             {
-              "filename": "/Microsoft.VisualStudio.LanguageServices.CodeLens.dll",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
               "filename": "/Microsoft.CodeAnalysis.Features.dll",
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1077670

@chsienki 