### PR TITLE
Use project.Name as the display name for Class View

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Extensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Extensions.cs
@@ -5,7 +5,6 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
@@ -47,29 +46,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             return typeSymbol != null
                 ? typeSymbol.ToDisplayString(s_typeDisplayFormat)
                 : string.Empty;
-        }
-
-        public static string GetProjectDisplayName(this Project project)
-        {
-            if (project.Solution.Workspace is VisualStudioWorkspaceImpl workspace)
-            {
-                var hierarchy = workspace.GetHierarchy(project.Id);
-                if (hierarchy != null)
-                {
-                    var solution = (IVsSolution3)ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution));
-                    if (solution != null)
-                    {
-                        if (ErrorHandler.Succeeded(solution.GetUniqueUINameOfProject(hierarchy, out var name)) && name != null)
-                        {
-                            return name;
-                        }
-                    }
-                }
-
-                return project.Name;
-            }
-
-            return project.Name;
         }
 
         public static bool IsVenus(this Project project)

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Extensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Extensions.cs
@@ -5,6 +5,7 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
@@ -46,6 +47,51 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             return typeSymbol != null
                 ? typeSymbol.ToDisplayString(s_typeDisplayFormat)
                 : string.Empty;
+        }
+
+        public static string GetProjectDisplayName(this Project project)
+        {
+            // If the project name is unambiguous within the solution, use that name. Otherwise, use the unique name
+            // provided by IVsSolution3.GetUniqueUINameOfProject. This covers all cases except for a single solution
+            // with two or more multi-targeted projects with the same name and same targets.
+            //
+            // https://github.com/dotnet/roslyn/pull/43800
+            // http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/949113
+
+            if (IsUnambiguousProjectNameInSolution(project))
+            {
+                return project.Name;
+            }
+            else if (project.Solution.Workspace is VisualStudioWorkspaceImpl workspace
+                && workspace.GetHierarchy(project.Id) is { } hierarchy
+                && (IVsSolution3)ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) is { } solution)
+            {
+                if (ErrorHandler.Succeeded(solution.GetUniqueUINameOfProject(hierarchy, out var name)) && name != null)
+                {
+                    return name;
+                }
+            }
+
+            return project.Name;
+
+            // Local functions
+            static bool IsUnambiguousProjectNameInSolution(Project project)
+            {
+                foreach (var other in project.Solution.Projects)
+                {
+                    if (other.Id == project.Id)
+                        continue;
+
+                    if (other.Name == project.Name)
+                    {
+                        // Another project with the same name was found in the solution. This project name is _not_
+                        // unambiguous.
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
 
         public static bool IsVenus(this Project project)

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Extensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Extensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             {
                 return project.Name;
             }
-            else if (project.Solution.Workspace is VisualStudioWorkspaceImpl workspace
+            else if (project.Solution.Workspace is VisualStudioWorkspace workspace
                 && workspace.GetHierarchy(project.Id) is { } hierarchy
                 && (IVsSolution3)ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) is { } solution)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ProjectListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ProjectListItem.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         public ProjectListItem(Project project)
             : base(project.Id, GetProjectGlyph(project))
         {
-            _displayText = project.Name;
+            _displayText = project.GetProjectDisplayName();
         }
 
         private static StandardGlyphGroup GetProjectGlyph(Project project)

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ProjectListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ProjectListItem.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         public ProjectListItem(Project project)
             : base(project.Id, GetProjectGlyph(project))
         {
-            _displayText = project.GetProjectDisplayName();
+            _displayText = project.Name;
         }
 
         private static StandardGlyphGroup GetProjectGlyph(Project project)


### PR DESCRIPTION
Fixes #43712

This implementation uses `project.Name` as the display name for projects in **Class View** and **Object Browser**. This is the approach already used by the project dropdown in navigation bars. This property includes the target framework when the project uses `<TargetFrameworks>` (even if there is only one target), and omits the target framework suffix for non-CPS projects and projects that use `<TargetFramework>`.

~~Blocked on a resolution of dotnet/project-system#6142.~~ (Now resolved with a suggestion that `Project.Name` be used.)