### PR TITLE
Fix Tools Options CodeStyle page to save updates

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
@@ -70,7 +70,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             var key = new OptionKey(option, option.IsPerLanguage ? Language : null);
             if (option.DefaultValue is ICodeStyleOption codeStyleOption)
             {
-                OptionStore.SetOption(key, codeStyleOption.WithValue(value));
+                // The value provided is either an ICodeStyleOption OR the underlying ICodeStyleOption.Value
+                if (value is ICodeStyleOption newCodeStyleOption)
+                {
+                    OptionStore.SetOption(key, codeStyleOption.WithValue(newCodeStyleOption.Value).WithNotification(newCodeStyleOption.Notification));
+                }
+                else
+                {
+                    OptionStore.SetOption(key, codeStyleOption.WithValue(value));
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #43812

My prior Options related code refactoring causes certain CodeStyle option value updates in the CodeStyle Tools Options page to not get saved. As a result, updating these options in this page has no effect and user is forced to workaround by manually updating/creating an editorconfig file.

The core issue is that `SetOptionAndUpdatePreview<T>` method is invoked in two different ways for CodeStyle options:
1. 'T value' argument is the new underlying bool/enum CodeStyle value to set.
1. 'T value' argument is the new CodeStyle option wrapping the new underlying bool/enum + notification preference to set.

We were only handling the first case, and the second one silently throws a cast exception, rendering the option set user action to have no effect. Now we handle both cases. I have manually verified that updating all the CodeStyle Options on the page and closing/re-opening the page has changed values.

We are also doing couple of follow-up items to guard against such regressions in future:
1. Adding the verification of CodeStyle options page scenarios to our internal manual test pass scenario list. These will be manually executed prior to each release.
2. Filed #43813: Investigate writing an integration test for Tools Options CodeStyle page