### PR TITLE
Increase completion test timeouts

### DIFF
--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -24,8 +24,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     Friend Class TestState
         Inherits AbstractCommandHandlerTestState
 
-        Private Const timeoutMs = 10000
-        Private Const editorTimeoutMs = 20000
+        Private Const timeoutMs = 60000
+        Private Const editorTimeoutMs = 60000
         Friend Const RoslynItem = "RoslynItem"
         Friend ReadOnly EditorCompletionCommandHandler As ICommandHandler
         Friend ReadOnly CompletionPresenterProvider As ICompletionPresenterProvider


### PR DESCRIPTION
These tests run in parallel on CI machines, which can delay execution of asynchronous operations for long periods of time. Increase test timeouts to reduce the number of cases where tests fail.

This addresses the root cause of both failures impacting #43845.

Fixes #39070
Fixes #42984
Fixes #43565
Fixes #43790