### PR TITLE
 Exclude csc.exe from optprof profiling 

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -603,10 +603,6 @@
               "testCases":[ "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" ]
             },
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/csc.exe",
-              "testCases":[ "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/VBCSCompiler.exe",
               "testCases":[ "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" ]
             },


### PR DESCRIPTION
csc.exe isn't used for build in VS

@chsienki @dotnet/roslyn-infrastructure 