### PR TITLE
Fix for selected item jumps out of view with long argument list in Change Signature

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -212,6 +212,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 
         private void Members_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
+            Members.SelectedIndex = Members.Items.IndexOf(Members.CurrentItem);
             if (Members.SelectedIndex == -1)
             {
                 Members.SelectedIndex = _viewModel.GetStartingSelectionIndex();


### PR DESCRIPTION
Fixes #40931.
The ```SelectedIndex``` property updates only after the ```Members_GotKeyboardFocus``` is fired, resulting in an outdated selected index. To fix this, we add a line that uses ```Members.CurrentItem``` to update ```SelectedIndex``` at the beginning of ```Members_GotKeyboardFocus```, since ```Members.CurrentItem``` does properly update before the firing of  ```Members_GotKeyboardFocus```.