### PR TITLE
Update XliffTasks to 1.0.0-beta.20206.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -211,6 +211,7 @@
     <VSLangProj80Version>8.0.50728</VSLangProj80Version>
     <VsWebsiteInteropVersion>8.0.50727</VsWebsiteInteropVersion>
     <vswhereVersion>2.4.1</vswhereVersion>
+    <XliffTasksVersion>1.0.0-beta.20206.1</XliffTasksVersion>
     <xunitVersion>2.4.1-pre.build.4059</xunitVersion>
     <xunitanalyzersVersion>0.10.0</xunitanalyzersVersion>
     <xunitassertVersion>$(xunitVersion)</xunitassertVersion>


### PR DESCRIPTION
Fixes a failure to account for design time builds in XliffTasks (fixed in January by dotnet/xliff-tasks#297).

Works around a failure of arcade to update this dependency automatically (it should have been updated two weeks ago by dotnet/arcade#5274 but still is not).