### PR TITLE
Dismiss any light bulb session in SetUpEditor

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -69,6 +69,7 @@ namespace Roslyn.VisualStudio.IntegrationTests
             MarkupTestFile.GetPosition(markupCode, out string code, out int caretPosition);
 
             VisualStudio.Editor.DismissCompletionSessions();
+            VisualStudio.Editor.DismissLightBulbSession();
 
             var originalValue = VisualStudio.Workspace.IsPrettyListingOn(LanguageName);
 


### PR DESCRIPTION
Fixes some cases where light bulb was interfering with multiple integration tests.