### PR TITLE
Fix a native integer decoding bug

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
     internal struct NativeIntegerTypeDecoder
     {
+        private class ErrorTypeException : Exception { }
+
         internal static TypeSymbol TransformType(TypeSymbol type, EntityHandle handle, PEModuleSymbol containingModule)
         {
             return containingModule.Module.HasNativeIntegerAttribute(handle, out var transformFlags) ?
@@ -40,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 return new UnsupportedMetadataTypeSymbol();
             }
-            catch (ArgumentException)
+            catch (ErrorTypeException)
             {
                 // If we failed to decode because there was an error type involved, marking the
                 // metadata as unsupported means that we'll cover up the error that would otherwise
@@ -85,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     return TransformNamedType((NamedTypeSymbol)type);
                 default:
                     Debug.Assert(type.TypeKind == TypeKind.Error);
-                    throw new ArgumentException();
+                    throw new ErrorTypeException();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -62,6 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     return TransformPointerType((PointerTypeSymbol)type);
                 case TypeKind.TypeParameter:
                 case TypeKind.Dynamic:
+                    IgnoreIndex();
                     return type;
                 case TypeKind.Class:
                 case TypeKind.Struct:
@@ -83,6 +84,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 return _transformFlags[index] ? TransformTypeDefinition(type) : type;
             }
+
+            Debug.Assert(!_transformFlags[index]);
 
             var allTypeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
             type.GetAllTypeArgumentsNoUseSiteDiagnostics(allTypeArguments);
@@ -106,13 +109,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private ArrayTypeSymbol TransformArrayType(ArrayTypeSymbol type)
         {
-            Increment();
+            IgnoreIndex();
             return type.WithElementType(TransformTypeWithAnnotations(type.ElementTypeWithAnnotations));
         }
 
         private PointerTypeSymbol TransformPointerType(PointerTypeSymbol type)
         {
-            Increment();
+            IgnoreIndex();
             return type.WithPointedAtType(TransformTypeWithAnnotations(type.PointedAtTypeWithAnnotations));
         }
 
@@ -123,6 +126,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return _index++;
             }
             throw new ArgumentException();
+        }
+
+        private void IgnoreIndex()
+        {
+            var index = Increment();
+            Debug.Assert(!_transformFlags[index]);
         }
 
         private static NamedTypeSymbol TransformTypeDefinition(NamedTypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -920,6 +920,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.Type?.ContainsNativeInteger() == true;
         }
 
+        internal static bool ContainsErrorType(this TypeSymbol type)
+        {
+            var result = type.VisitType((type, unused1, unused2) => type.IsErrorType(), (object?)null, canDigThroughNullable: true);
+            return result is object;
+        }
+
         /// <summary>
         /// Return true if the type contains any tuples.
         /// </summary>


### PR DESCRIPTION
We weren't consuming an index when decoding type parameters or dynamic types, meaning that we could get into a scenario where the remaining flags are applying to the wrong types. I also tightened our assertions around ignored indexes.

@cston for review.