### PR TITLE
Add additional information to our watson dumps to make them easier to bucket.

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis
     {
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void OnFatalException(Exception exception)
+        internal static void OnFatalException(Exception exception, string? unused)
         {
             // EDMAURER Now using the managed API to fail fast so as to default
             // to the managed VS debug engine and hopefully get great

--- a/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             IIOService ioService,
             IPatchService patchService,
             IDatabaseFactoryService databaseFactoryService,
-            Func<Exception, bool> reportAndSwallowException)
+            Func<Exception, string, bool> reportAndSwallowException)
         {
             _delayService = delayService;
             _ioService = ioService;

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             if (errorId == null)
             {
                 // record NFW to see who violates contract.
-                WatsonReporter.ReportNonFatal(new Exception("errorId is null"));
+                WatsonReporter.ReportNonFatal(new Exception("errorId is null"), nameof(CanHandle));
                 return false;
             }
 

--- a/src/VisualStudio/Core/Def/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/Core/Def/Interactive/VsInteractiveWindowPackage.cs
@@ -71,8 +71,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             var handlerSetter = type.GetDeclaredMethod("set_Handler");
             var nonFatalHandlerSetter = type.GetDeclaredMethod("set_NonFatalHandler");
 
-            handlerSetter.Invoke(null, new object[] { new Action<Exception>(FailFast.OnFatalException) });
-            nonFatalHandlerSetter.Invoke(null, new object[] { new Action<Exception>(WatsonReporter.ReportNonFatal) });
+            handlerSetter.Invoke(null, new object[] { new Action<Exception, string>(FailFast.OnFatalException) });
+            nonFatalHandlerSetter.Invoke(null, new object[] { new Action<Exception, string>(WatsonReporter.ReportNonFatal) });
         }
 
         protected TVsInteractiveWindowProvider InteractiveWindowProvider

--- a/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
+++ b/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
@@ -15,8 +15,8 @@ Imports Moq
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
     <[UseExportProvider]>
     Public Class SymbolSearchUpdateEngineTests
-        Private Shared ReadOnly s_allButMoqExceptions As Func(Of Exception, Boolean) =
-            Function(e) TypeOf e IsNot MockException
+        Private Shared ReadOnly s_allButMoqExceptions As Func(Of Exception, String, Boolean) =
+            Function(e, s) TypeOf e IsNot MockException
 
         <Fact, Trait(Traits.Feature, Traits.Features.Packaging)>
         Public Async Function CreateCacheFolderIfMissing() As Task

--- a/src/Workspaces/Core/Portable/Execution/AssetStorages.cs
+++ b/src/Workspaces/Core/Portable/Execution/AssetStorages.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Execution
             if (!_storages.TryAdd(scopeId, storage))
             {
                 // this should make failure more explicit
-                FailFast.OnFatalException(new Exception("who is adding same snapshot?"));
+                FailFast.OnFatalException(new Exception("who is adding same snapshot?"), nameof(RegisterSnapshot));
             }
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Execution
             if (!_storages.TryRemove(scopeId, out _))
             {
                 // this should make failure more explicit
-                FailFast.OnFatalException(new Exception("who is removing same snapshot?"));
+                FailFast.OnFatalException(new Exception("who is removing same snapshot?"), nameof(UnregisterSnapshot));
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private static bool ExpectedCultureIssue(Exception ex)
         {
             // report exception
-            WatsonReporter.ReportNonFatal(ex);
+            WatsonReporter.ReportNonFatal(ex, nameof(ExpectedCultureIssue));
 
             // ignore expected exception
             return ex is ArgumentOutOfRangeException || ex is CultureNotFoundException;


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1114604

This will help the internal NFW system by not having all roslyn NFWs get bucketed into one single bucket.  Instead, we now use CallerMemberName to help pass along information about what the faulting method's name is to help break this up into clearer pieces to initially see what components are having issues.