### PR TITLE
Some IDE support for function pointers

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/IFunctionPointerTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFunctionPointerTypeSymbol.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis
 {
     // PROTOTYPE(func-ptr): Document
     // https://github.com/dotnet/roslyn/issues/39865: Expose calling convention on either this or IMethodSymbol in general
-    public interface IFunctionPointerTypeSymbol : ISymbol
+    public interface IFunctionPointerTypeSymbol : ITypeSymbol
     {
         public IMethodSymbol Signature { get; }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -8804,5 +8804,38 @@ class Class
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestWithFunctionPointerArgument()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class Class
+{
+    unsafe void M()
+    {
+        delegate*<int, float> y;
+        [|M2(y)|];
+    }
+}",
+@"
+using System;
+
+class Class
+{
+    unsafe void M()
+    {
+        delegate*<int, float> y;
+        [|M2(y)|];
+    }
+
+    private unsafe void M2(delegate*<int, float> y)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests_FunctionPointers.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests_FunctionPointers.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
+{
+    [Trait(Traits.Feature, Traits.Features.Formatting)]
+    public class FormattingTests_FunctionPointers : CSharpFormattingTestBase
+    {
+        [Fact]
+        public async Task FormatFunctionPointer()
+        {
+            // TODO(https://github.com/dotnet/roslyn/issues/44312): add a space after the "int"s in the baseline and make this test still pass
+            var content = @"
+unsafe class C
+{
+    delegate * < int,  int> functionPointer;
+}";
+
+            var expected = @"
+unsafe class C
+{
+    delegate*<int, int> functionPointer;
+}";
+
+            await AssertFormatAsync(expected, content);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.AnonymousTypeRemover.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.AnonymousTypeRemover.cs
@@ -33,6 +33,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return _compilation.CreateArrayTypeSymbol(elementType, symbol.Rank);
             }
 
+            public override ITypeSymbol VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+            {
+                // TODO(https://github.com/dotnet/roslyn/issues/43890): function pointers could theoretically
+                // have a parameter of an anonymous type if you have a generic function that returns function
+                // pointers, and that was called with an anonymous type.
+                return symbol;
+            }
+
             public override ITypeSymbol VisitNamedType(INamedTypeSymbol symbol)
             {
                 if (symbol.IsNormalAnonymousType() ||

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.CollectTypeParameterSymbolsVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.CollectTypeParameterSymbolsVisitor.cs
@@ -40,6 +40,21 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 symbol.ElementType.Accept(this);
             }
 
+            public override void VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+            {
+                if (!_visited.Add(symbol))
+                {
+                    return;
+                }
+
+                foreach (var parameter in symbol.Signature.Parameters)
+                {
+                    parameter.Type.Accept(this);
+                }
+
+                symbol.Signature.ReturnType.Accept(this);
+            }
+
             public override void VisitNamedType(INamedTypeSymbol symbol)
             {
                 if (_visited.Add(symbol))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
@@ -45,6 +45,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             public override ITypeSymbol VisitTypeParameter(ITypeParameterSymbol symbol)
                 => VisitType(symbol);
 
+            public override ITypeSymbol VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+            {
+                // TODO(https://github.com/dotnet/roslyn/issues/43890): also visit the underlying types of
+                // the parameters and return value
+                return VisitType(symbol);
+            }
+
             public override ITypeSymbol VisitNamedType(INamedTypeSymbol symbol)
             {
                 var mapped = VisitType(symbol);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.UnavailableTypeParameterRemover.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.UnavailableTypeParameterRemover.cs
@@ -38,6 +38,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return _compilation.CreateArrayTypeSymbol(elementType, symbol.Rank);
             }
 
+            public override ITypeSymbol VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+            {
+                // TODO(https://github.com/dotnet/roslyn/issues/43890): implement this
+                return symbol;
+            }
+
             public override ITypeSymbol VisitNamedType(INamedTypeSymbol symbol)
             {
                 var arguments = symbol.TypeArguments.Select(t => t.Accept(this)).ToArray();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.UnnamedErrorTypeRemover.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.UnnamedErrorTypeRemover.cs
@@ -33,6 +33,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return _compilation.CreateArrayTypeSymbol(elementType, symbol.Rank);
             }
 
+            public override ITypeSymbol VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+            {
+                // TODO(https://github.com/dotnet/roslyn/issues/43890): implement this
+                return symbol;
+            }
+
             public override ITypeSymbol VisitNamedType(INamedTypeSymbol symbol)
             {
                 if (symbol.IsErrorType() && symbol.Name == string.Empty)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public const SyntaxKind NotPattern = (SyntaxKind)9033;
         public const SyntaxKind AndKeyword = (SyntaxKind)8439;
         public const SyntaxKind OrKeyword = (SyntaxKind)8438;
+        public const SyntaxKind FunctionPointerType = (SyntaxKind)9056;
 
 #if !CODE_STYLE
         /// <summary>
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         /// value.
         /// </summary>
         /// <remarks>
-        /// <para>The subtraction will overflow if <see cref="SyntaxKind.DotDotToken"/> is greater, and the conversion
+        /// <para>The subtraction will overflow if <see cref="SyntaxKind.RelationalPattern"/> is greater, and the conversion
         /// to an unsigned value after negation will overflow if <see cref="RelationalPattern"/> is greater.</para>
         /// </remarks>
         private const uint RelationalPatternValueAssertion = -(RelationalPattern - SyntaxKind.RelationalPattern);
@@ -41,6 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         private const uint NotPatternValueAssertion = -(NotPattern - SyntaxKind.NotPattern);
         private const uint AndKeywordValueAssertion = -(AndKeyword - SyntaxKind.AndKeyword);
         private const uint OrKeywordValueAssertion = -(OrKeyword - SyntaxKind.OrKeyword);
+        private const uint FunctionPointerTypeAssertion = -(FunctionPointerType - SyntaxKind.FunctionPointerType);
 #endif
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // generic name
-            if (previousToken.Parent.IsKind(SyntaxKind.TypeArgumentList) || previousToken.Parent.IsKind(SyntaxKind.TypeParameterList))
+            if (previousToken.Parent.IsKind(SyntaxKind.TypeArgumentList, SyntaxKind.TypeParameterList, SyntaxKindEx.FunctionPointerType))
             {
                 // generic name < * 
                 if (previousToken.Kind() == SyntaxKind.LessThanToken)
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             // generic name * < or * >
             if ((currentToken.Kind() == SyntaxKind.LessThanToken || currentToken.Kind() == SyntaxKind.GreaterThanToken) &&
-                (currentToken.Parent.IsKind(SyntaxKind.TypeArgumentList) || currentToken.Parent.IsKind(SyntaxKind.TypeParameterList)))
+                currentToken.Parent.IsKind(SyntaxKind.TypeArgumentList, SyntaxKind.TypeParameterList))
             {
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
@@ -509,9 +509,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
-            // pointer case
+            // pointer case for regular pointers
             if ((currentToken.Kind() == SyntaxKind.AsteriskToken && currentToken.Parent is PointerTypeSyntax) ||
                 (previousToken.Kind() == SyntaxKind.AsteriskToken && previousToken.Parent is PrefixUnaryExpressionSyntax))
+            {
+                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+            }
+
+            // no spaces around the * in a function pointer
+            if ((currentToken.IsKind(SyntaxKind.AsteriskToken) && currentToken.Parent.IsKind(SyntaxKindEx.FunctionPointerType)) ||
+                (previousToken.IsKind(SyntaxKind.AsteriskToken) && previousToken.Parent.IsKind(SyntaxKindEx.FunctionPointerType)))
             {
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
@@ -71,6 +71,20 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return true;
             }
 
+#if !CODE_STYLE
+
+            public override bool VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+            {
+                if (!_visited.Add(symbol))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+#endif
+
             public override bool VisitProperty(IPropertySymbol symbol)
             {
                 if (!_visited.Add(symbol))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             public override bool VisitDynamicType(IDynamicTypeSymbol symbol)
             {
-                // The dynamic type is never unsafe (well....you know what I mean
+                // The dynamic type is never unsafe (well....you know what I mean)
                 return false;
             }
 


### PR DESCRIPTION
1. Fixes some basic formatting behavior.
2. Updates some of our symbol visitors that would otherwise throw that they don't recognize the new type.
3. Adds syntax generation from symbols.

This only ensures the IDE isn't completely fighting you with formatting, and ensures the visitors that would throw don't immediately crash you.