### PR TITLE
Use init-only for records

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/LexicalSortKey.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LexicalSortKey.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static readonly LexicalSortKey NotInitialized = new LexicalSortKey() { _treeOrdinal = -1, _position = -1 };
 
         // Put Record Equals right before synthesized constructors.
-        public static LexicalSortKey SynthesizedRecordEquals => new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 4 };
-        public static LexicalSortKey SynthesizedRecordObjEquals => new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 3 };
+        public static LexicalSortKey SynthesizedRecordEquals => new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 5 };
+        public static LexicalSortKey SynthesizedRecordObjEquals => new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 4 };
 
 
         // Dev12 compiler adds synthetic constructors to the child list after adding all other members.
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // until later when it is known if they can be optimized or not.
         // As a result the last emitted method tokens are synthetic ctor and then synthetic cctor (if not optimized)
         // Since it is not too hard, we will try keeping the same order just to be easy on metadata diffing tools and such.
+        public static readonly LexicalSortKey SynthesizedRecordCopyCtor = new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 3 };
         public static readonly LexicalSortKey SynthesizedRecordCtor = new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 2 };
         public static readonly LexicalSortKey SynthesizedCtor = new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue - 1 };
         public static readonly LexicalSortKey SynthesizedCCtor = new LexicalSortKey() { _treeOrdinal = int.MaxValue, _position = int.MaxValue };

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2939,6 +2939,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             BinderFactory binderFactory = this.DeclaringCompilation.GetBinderFactory(paramList.SyntaxTree);
             var binder = binderFactory.GetBinder(paramList);
 
+            // PROTOTYPE: need to check base members as well
             var memberSignatures = s_duplicateMemberSignatureDictionary.Allocate();
             foreach (var member in members)
             {
@@ -2946,6 +2947,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var ctor = addCtor(paramList);
+            if (!this.IsStructType())
+            {
+                addCopyCtor();
+            }
+            addCloneMethod();
             addProperties(ctor.Parameters);
             var thisEquals = addThisEquals();
             addObjectEquals(thisEquals);
@@ -2970,6 +2976,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ctor;
             }
 
+            void addCopyCtor()
+            {
+                var ctor = new SynthesizedRecordCopyCtor(this, diagnostics);
+                if (!memberSignatures.ContainsKey(ctor))
+                {
+                    members.Add(ctor);
+                }
+            }
+
+            void addCloneMethod()
+            {
+                var clone = new SynthesizedRecordClone(this);
+                if (!memberSignatures.ContainsKey(clone))
+                {
+                    members.Add(clone);
+                }
+            }
+
             void addProperties(ImmutableArray<ParameterSymbol> recordParameters)
             {
                 foreach (ParameterSymbol param in ctor.Parameters)
@@ -2979,6 +3003,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         members.Add(property);
                         members.Add(property.GetMethod);
+                        members.Add(property.SetMethod);
                         members.Add(property.BackingField);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SynthesizedRecordClone : SynthesizedInstanceMethodSymbol
+    {
+        public override NamedTypeSymbol ContainingType { get; }
+
+        public SynthesizedRecordClone(NamedTypeSymbol containingType)
+        {
+            ContainingType = containingType;
+        }
+        public override string Name => WellKnownMemberNames.CloneMethodName;
+
+        public override MethodKind MethodKind => MethodKind.Ordinary;
+
+        public override int Arity => 0;
+
+        public override bool IsExtensionMethod => false;
+
+        public override bool HidesBaseMethodsByName => false;
+
+        public override bool IsVararg => false;
+
+        public override bool ReturnsVoid => false;
+
+        public override bool IsAsync => false;
+
+        public override RefKind RefKind => RefKind.None;
+
+        public override ImmutableArray<ParameterSymbol> Parameters => ImmutableArray<ParameterSymbol>.Empty;
+
+        public override TypeWithAnnotations ReturnTypeWithAnnotations => TypeWithAnnotations.Create(
+            isNullableEnabled: true,
+            ContainingType);
+
+        public override FlowAnalysisAnnotations ReturnTypeFlowAnalysisAnnotations => FlowAnalysisAnnotations.None;
+
+        public override ImmutableHashSet<string> ReturnNotNullIfParameterNotNull => ImmutableHashSet<string>.Empty;
+
+        public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
+            => ImmutableArray<TypeWithAnnotations>.Empty;
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
+
+        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
+
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => ImmutableArray<CustomModifier>.Empty;
+
+        public override Symbol? AssociatedSymbol => null;
+
+        public override Symbol ContainingSymbol => ContainingType;
+
+        public override ImmutableArray<Location> Locations => ContainingType.Locations;
+
+        public override Accessibility DeclaredAccessibility => Accessibility.Public;
+
+        public override bool IsStatic => false;
+
+        public override bool IsVirtual => true;
+
+        public override bool IsOverride => false;
+
+        public override bool IsAbstract => false;
+
+        public override bool IsSealed => false;
+
+        public override bool IsExtern => false;
+
+        internal override bool HasSpecialName => true;
+
+        internal override LexicalSortKey GetLexicalSortKey() => LexicalSortKey.SynthesizedRecordEquals;
+
+        internal override MethodImplAttributes ImplementationAttributes => MethodImplAttributes.Managed;
+
+        internal override bool HasDeclarativeSecurity => false;
+
+        internal override MarshalPseudoCustomAttributeData? ReturnValueMarshallingInformation => null;
+
+        internal override bool RequiresSecurityObject => false;
+
+        internal override CallingConvention CallingConvention => CallingConvention.HasThis;
+
+        internal override bool GenerateDebugInfo => false;
+
+        public override DllImportData? GetDllImportData() => null;
+
+        internal override ImmutableArray<string> GetAppliedConditionalSymbols()
+            => ImmutableArray<string>.Empty;
+
+        internal override IEnumerable<SecurityAttribute> GetSecurityInformation()
+            => Array.Empty<SecurityAttribute>();
+
+        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
+
+        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => false;
+
+        internal override bool SynthesizesLoweredBoundBody => true;
+
+        internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
+        {
+            var F = new SyntheticBoundNodeFactory(this, ContainingType.GetNonNullSyntaxNode(), compilationState, diagnostics);
+
+            // If this is a class, call the copy ctor. Otherwise, just return `this
+            if (ContainingType.IsStructType())
+            {
+                F.CloseMethod(F.Block(F.Return(F.This())));
+                return;
+            }
+
+            var members = ContainingType.GetMembers(".ctor");
+            foreach (var member in members)
+            {
+                var ctor = (MethodSymbol)member;
+                if (ctor.ParameterCount == 1 &&
+                    ctor.Parameters[0].Type.Equals(ContainingType, TypeCompareKind.ConsiderEverything))
+                {
+                    F.CloseMethod(F.Block(F.Return(F.New(ctor, F.This()))));
+                    return;
+                }
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SynthesizedRecordCopyCtor : SynthesizedInstanceConstructor
+    {
+        public SynthesizedRecordCopyCtor(
+            SourceMemberContainerTypeSymbol containingType,
+            DiagnosticBag diagnostics)
+            : base(containingType)
+        {
+            Debug.Assert(!containingType.IsStructType(), "only reference types should define copy constructors");
+            Parameters = ImmutableArray.Create(SynthesizedParameterSymbol.Create(
+                this,
+                TypeWithAnnotations.Create(
+                    isNullableEnabled: true,
+                    ContainingType),
+                ordinal: 0,
+                RefKind.None));
+        }
+
+        public override ImmutableArray<ParameterSymbol> Parameters { get; }
+
+        internal override LexicalSortKey GetLexicalSortKey()
+        {
+            // We need a separate sort key because struct records will have two synthesized
+            // constructors: the record constructor, and the parameterless constructor
+            return LexicalSortKey.SynthesizedRecordCopyCtor;
+        }
+
+        internal override void GenerateMethodBodyStatements(SyntheticBoundNodeFactory F, ArrayBuilder<BoundStatement> statements, DiagnosticBag diagnostics)
+        {
+            // Write assignments to backing fields
+            //
+            // {
+            //     this.backingField1 = arg1
+            //     ...
+            //     this.backingFieldN = argN
+            // }
+            var param = F.Parameter(Parameters[0]);
+            foreach (var member in ContainingType.GetMembers())
+            {
+                if (member is FieldSymbol { IsStatic: false } field)
+                {
+                    statements.Add(F.Assignment(F.Field(F.This(), field), F.Field(param, field)));
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -6,10 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -51,8 +48,9 @@ class C(int x, int y);";
                 Add( // C Type parameters
                     "T"),
                 Add( // Members
-                    "System.Int32 C<T>.x { get; }",
-                    "T C<T>.t { get; }",
+                    "C<T> C<T>.Clone()",
+                    "System.Int32 C<T>.x { get; init; }",
+                    "T C<T>.t { get; init; }",
                     "System.Boolean C<T>.Equals(C<T>? )",
                     "System.Boolean C<T>.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
@@ -4,7 +4,6 @@
 
 #nullable enable
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -15,10 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class RecordTests : CompilingTestBase
     {
         private static CSharpCompilation CreateCompilation(CSharpTestSource source)
-            => CSharpTestBase.CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            => CSharpTestBase.CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, parseOptions: TestOptions.RegularPreview);
 
         private CompilationVerifier CompileAndVerify(CSharpTestSource src, string? expectedOutput = null)
-            => base.CompileAndVerify(src, expectedOutput: expectedOutput, parseOptions: TestOptions.RegularPreview);
+            => base.CompileAndVerify(new[] { src, IsExternalInitTypeDefinition },
+                expectedOutput: expectedOutput,
+                parseOptions: TestOptions.RegularPreview,
+                // init-only fails verification
+                verify: Verification.Skipped);
 
         [Fact]
         public void GeneratedConstructor()
@@ -26,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var comp = CreateCompilation(@"data class C(int x, string y);");
             comp.VerifyDiagnostics();
             var c = comp.GlobalNamespace.GetTypeMember("C");
-            var ctor = c.GetMethod(".ctor");
+            var ctor = (MethodSymbol)c.GetMembers(".ctor")[0];
             Assert.Equal(2, ctor.ParameterCount);
 
             var x = ctor.Parameters[0];
@@ -45,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyDiagnostics();
             var c = comp.GlobalNamespace.GetTypeMember("C");
             Assert.Equal(1, c.Arity);
-            var ctor = c.GetMethod(".ctor");
+            var ctor = (MethodSymbol)c.GetMembers(".ctor")[0];
             Assert.Equal(0, ctor.Arity);
             Assert.Equal(2, ctor.ParameterCount);
 
@@ -74,7 +77,7 @@ data class C(int x, string y)
                 Diagnostic(ErrorCode.ERR_DuplicateRecordConstructor, "(int x, string y)").WithLocation(2, 13)
             );
             var c = comp.GlobalNamespace.GetTypeMember("C");
-            var ctor = c.GetMethod(".ctor");
+            var ctor = (MethodSymbol)c.GetMembers(".ctor")[0];
             Assert.Equal(2, ctor.ParameterCount);
 
             var a = ctor.Parameters[0];
@@ -99,26 +102,32 @@ data class C(int x, string y)
             comp.VerifyDiagnostics();
             var c = comp.GlobalNamespace.GetTypeMember("C");
             var ctors = c.GetMembers(".ctor");
-            Assert.Equal(2, ctors.Length);
+            Assert.Equal(3, ctors.Length);
 
             foreach (MethodSymbol ctor in ctors)
             {
-                Assert.Equal(2, ctor.ParameterCount);
-
-                var p1 = ctor.Parameters[0];
-                Assert.Equal(SpecialType.System_Int32, p1.Type.SpecialType);
-                var p2 = ctor.Parameters[1];
-                if (ctor is SynthesizedRecordConstructor)
+                if (ctor.ParameterCount == 2)
                 {
-                    Assert.Equal("x", p1.Name);
-                    Assert.Equal("y", p2.Name);
-                    Assert.Equal(SpecialType.System_String, p2.Type.SpecialType);
+                    var p1 = ctor.Parameters[0];
+                    Assert.Equal(SpecialType.System_Int32, p1.Type.SpecialType);
+                    var p2 = ctor.Parameters[1];
+                    if (ctor is SynthesizedRecordConstructor)
+                    {
+                        Assert.Equal("x", p1.Name);
+                        Assert.Equal("y", p2.Name);
+                        Assert.Equal(SpecialType.System_String, p2.Type.SpecialType);
+                    }
+                    else
+                    {
+                        Assert.Equal("a", p1.Name);
+                        Assert.Equal("b", p2.Name);
+                        Assert.Equal(SpecialType.System_Int32, p2.Type.SpecialType);
+                    }
                 }
                 else
                 {
-                    Assert.Equal("a", p1.Name);
-                    Assert.Equal("b", p2.Name);
-                    Assert.Equal(SpecialType.System_Int32, p2.Type.SpecialType);
+                    Assert.Equal(1, ctor.ParameterCount);
+                    Assert.True(c.Equals(ctor.Parameters[0].Type, TypeCompareKind.ConsiderEverything));
                 }
             }
         }
@@ -134,7 +143,8 @@ data class C(int x, string y)
             Assert.NotNull(x.GetMethod);
             Assert.Equal(MethodKind.PropertyGet, x.GetMethod.MethodKind);
             Assert.Equal(SpecialType.System_Int32, x.Type.SpecialType);
-            Assert.True(x.IsReadOnly);
+            Assert.False(x.IsReadOnly);
+            Assert.False(x.IsWriteOnly);
             Assert.Equal(Accessibility.Public, x.DeclaredAccessibility);
             Assert.False(x.IsVirtual);
             Assert.False(x.IsStatic);
@@ -150,12 +160,21 @@ data class C(int x, string y)
             Assert.Equal(x, getAccessor.AssociatedSymbol);
             Assert.Equal(c, getAccessor.ContainingSymbol);
             Assert.Equal(c, getAccessor.ContainingType);
+            Assert.Equal(Accessibility.Public, getAccessor.DeclaredAccessibility);
+
+            var setAccessor = x.SetMethod;
+            Assert.Equal(x, setAccessor.AssociatedSymbol);
+            Assert.Equal(c, setAccessor.ContainingSymbol);
+            Assert.Equal(c, setAccessor.ContainingType);
+            Assert.Equal(Accessibility.Public, setAccessor.DeclaredAccessibility);
+            Assert.True(setAccessor.IsInitOnly);
 
             var y = (SourceOrRecordPropertySymbol)c.GetProperty("y");
             Assert.NotNull(y.GetMethod);
             Assert.Equal(MethodKind.PropertyGet, y.GetMethod.MethodKind);
             Assert.Equal(SpecialType.System_Int32, y.Type.SpecialType);
-            Assert.True(y.IsReadOnly);
+            Assert.False(y.IsReadOnly);
+            Assert.False(y.IsWriteOnly);
             Assert.Equal(Accessibility.Public, y.DeclaredAccessibility);
             Assert.False(x.IsVirtual);
             Assert.False(x.IsStatic);
@@ -171,423 +190,96 @@ data class C(int x, string y)
             Assert.Equal(y, getAccessor.AssociatedSymbol);
             Assert.Equal(c, getAccessor.ContainingSymbol);
             Assert.Equal(c, getAccessor.ContainingType);
+
+            setAccessor = y.SetMethod;
+            Assert.Equal(y, setAccessor.AssociatedSymbol);
+            Assert.Equal(c, setAccessor.ContainingSymbol);
+            Assert.Equal(c, setAccessor.ContainingType);
+            Assert.Equal(Accessibility.Public, setAccessor.DeclaredAccessibility);
+            Assert.True(setAccessor.IsInitOnly);
         }
 
         [Fact]
-        public void RecordEquals_01()
+        public void RecordClone1()
         {
-            CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
-{
-    public static void Main()
-    {
-        object c = new C(0, 0);
-        Console.WriteLine(c.Equals(c));
-    }
-    public bool Equals(C c) => throw null;
-    public override bool Equals(object o) => false;
-}", expectedOutput: "False");
-        }
+            var comp = CreateCompilation("data class C(int x, int y);");
+            comp.VerifyDiagnostics();
 
-        [Fact]
-        public void RecordEquals_02()
-        {
-            CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
-{
-    public static void Main()
-    {
-        object c = new C(1, 1);
-        var c2 = new C(1, 1);
-        Console.WriteLine(c.Equals(c));
-        Console.WriteLine(c.Equals(c2));
-    }
-}", expectedOutput: @"True
-True");
-        }
+            var c = comp.GlobalNamespace.GetTypeMember("C");
+            var clone = c.GetMethod(WellKnownMemberNames.CloneMethodName);
+            Assert.Equal(0, clone.Arity);
+            Assert.Equal(0, clone.ParameterCount);
+            Assert.Equal(c, clone.ReturnType);
 
-        [Fact]
-        public void RecordEquals_03()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
+            var ctor = (MethodSymbol)c.GetMembers(".ctor")[1];
+            Assert.Equal(1, ctor.ParameterCount);
+            Assert.True(ctor.Parameters[0].Type.Equals(c, TypeCompareKind.ConsiderEverything));
+
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails);
+            verifier.VerifyIL("C." + WellKnownMemberNames.CloneMethodName, @"
 {
-    public static void Main()
-    {
-        object c = new C(0, 0);
-        var c2 = new C(0, 0);
-        var c3 = new C(1, 1);
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals(c3));
-    }
-    public bool Equals(C c) => X == c.X && Y == c.Y;
-}", expectedOutput: @"True
-False");
-            verifier.VerifyIL("C.Equals(object)", @"
-{
-  // Code size       13 (0xd)
-  .maxstack  2
+  // Code size        7 (0x7)
+  .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  isinst     ""C""
-  IL_0007:  call       ""bool C.Equals(C)""
-  IL_000c:  ret
-}");
-            verifier.VerifyIL("C.Equals(C)", @"
+  IL_0001:  newobj     ""C..ctor(C)""
+  IL_0006:  ret
+}
+");
+            verifier.VerifyIL("C..ctor(C)", @"
 {
   // Code size       31 (0x1f)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       ""int C.X.get""
-  IL_0006:  ldarg.1
-  IL_0007:  callvirt   ""int C.X.get""
-  IL_000c:  bne.un.s   IL_001d
-  IL_000e:  ldarg.0
-  IL_000f:  call       ""int C.Y.get""
-  IL_0014:  ldarg.1
-  IL_0015:  callvirt   ""int C.Y.get""
-  IL_001a:  ceq
-  IL_001c:  ret
-  IL_001d:  ldc.i4.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  ldarg.0
+  IL_0007:  ldarg.1
+  IL_0008:  ldfld      ""int C.<x>k__BackingField""
+  IL_000d:  stfld      ""int C.<x>k__BackingField""
+  IL_0012:  ldarg.0
+  IL_0013:  ldarg.1
+  IL_0014:  ldfld      ""int C.<y>k__BackingField""
+  IL_0019:  stfld      ""int C.<y>k__BackingField""
   IL_001e:  ret
 }");
         }
 
         [Fact]
-        public void RecordEquals_04()
+        public void RecordClone2()
         {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
+            var comp = CreateCompilation(@"
+data class C(int x, int y)
 {
-    public static void Main()
-    {
-        object c = new C(0, 0);
-        var c2 = new C(0, 0);
-        var c3 = new C(1, 1);
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals(c3));
-    }
-}", expectedOutput: @"True
-False");
-            verifier.VerifyIL("C.Equals(object)", @"
+    public C(C other) { }
+}");
+            comp.VerifyDiagnostics();
+
+            var c = comp.GlobalNamespace.GetTypeMember("C");
+            var clone = c.GetMethod(WellKnownMemberNames.CloneMethodName);
+            Assert.Equal(0, clone.Arity);
+            Assert.Equal(0, clone.ParameterCount);
+            Assert.Equal(c, clone.ReturnType);
+
+            var ctor = (MethodSymbol)c.GetMembers(".ctor")[0];
+            Assert.Equal(1, ctor.ParameterCount);
+            Assert.True(ctor.Parameters[0].Type.Equals(c, TypeCompareKind.ConsiderEverything));
+
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails);
+            verifier.VerifyIL("C." + WellKnownMemberNames.CloneMethodName, @"
 {
-  // Code size       13 (0xd)
-  .maxstack  2
+  // Code size        7 (0x7)
+  .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  isinst     ""C""
-  IL_0007:  call       ""bool C.Equals(C)""
-  IL_000c:  ret
-}");
-            verifier.VerifyIL("C.Equals(C)", @"
+  IL_0001:  newobj     ""C..ctor(C)""
+  IL_0006:  ret
+}
+");
+            verifier.VerifyIL("C..ctor(C)", @"
 {
-  // Code size       52 (0x34)
-  .maxstack  3
-  IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_0032
-  IL_0003:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0008:  ldarg.0
-  IL_0009:  ldfld      ""int C.<X>k__BackingField""
-  IL_000e:  ldarg.1
-  IL_000f:  ldfld      ""int C.<X>k__BackingField""
-  IL_0014:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0019:  brfalse.s  IL_0032
-  IL_001b:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0020:  ldarg.0
-  IL_0021:  ldfld      ""int C.<Y>k__BackingField""
-  IL_0026:  ldarg.1
-  IL_0027:  ldfld      ""int C.<Y>k__BackingField""
-  IL_002c:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0031:  ret
-  IL_0032:  ldc.i4.0
-  IL_0033:  ret
-}");
-        }
-
-        [Fact]
-        public void RecordEquals_06()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
-{
-    public static void Main()
-    {
-        var c = new C(0, 0);
-        object c2 = null;
-        C c3 = null;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals(c3));
-    }
-}", expectedOutput: @"False
-False");
-        }
-
-        [Fact]
-        public void RecordEquals_07()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int[] X, string Y)
-{
-    public static void Main()
-    {
-        var arr = new[] {1, 2};
-        var c = new C(arr, ""abc"");
-        var c2 = new C(new[] {1, 2}, ""abc"");
-        var c3 = new C(arr, ""abc"");
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals(c3));
-    }
-}", expectedOutput: @"False
-True");
-        }
-
-        [Fact]
-        public void RecordEquals_08()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
-{
-    public int Z;
-
-    public static void Main()
-    {
-        var c = new C(1, 2);
-        c.Z = 3;
-        var c2 = new C(1, 2);
-        c2.Z = 4;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-        c2.Z = 3;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-    }
-}", expectedOutput: @"False
-False
-True
-True");
-            verifier.VerifyIL("C.Equals(C)", @"
-{
-  // Code size       76 (0x4c)
-  .maxstack  3
-  IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_004a
-  IL_0003:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0008:  ldarg.0
-  IL_0009:  ldfld      ""int C.<X>k__BackingField""
-  IL_000e:  ldarg.1
-  IL_000f:  ldfld      ""int C.<X>k__BackingField""
-  IL_0014:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0019:  brfalse.s  IL_004a
-  IL_001b:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0020:  ldarg.0
-  IL_0021:  ldfld      ""int C.<Y>k__BackingField""
-  IL_0026:  ldarg.1
-  IL_0027:  ldfld      ""int C.<Y>k__BackingField""
-  IL_002c:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0031:  brfalse.s  IL_004a
-  IL_0033:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0038:  ldarg.0
-  IL_0039:  ldfld      ""int C.Z""
-  IL_003e:  ldarg.1
-  IL_003f:  ldfld      ""int C.Z""
-  IL_0044:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0049:  ret
-  IL_004a:  ldc.i4.0
-  IL_004b:  ret
-}");
-        }
-
-        [Fact]
-        public void RecordEquals_09()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
-{
-    public int Z { get; set; }
-
-    public static void Main()
-    {
-        var c = new C(1, 2);
-        c.Z = 3;
-        var c2 = new C(1, 2);
-        c2.Z = 4;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-        c2.Z = 3;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-    }
-}", expectedOutput: @"False
-False
-True
-True");
-        }
-
-        [Fact]
-        public void RecordEquals_10()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-data class C(int X, int Y)
-{
-    public static int Z;
-
-    public static void Main()
-    {
-        var c = new C(1, 2);
-        C.Z = 3;
-        var c2 = new C(1, 2);
-        C.Z = 4;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-        C.Z = 3;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-    }
-}", expectedOutput: @"True
-True
-True
-True");
-            verifier.VerifyIL("C.Equals(C)", @"
-{
-  // Code size       52 (0x34)
-  .maxstack  3
-  IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_0032
-  IL_0003:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0008:  ldarg.0
-  IL_0009:  ldfld      ""int C.<X>k__BackingField""
-  IL_000e:  ldarg.1
-  IL_000f:  ldfld      ""int C.<X>k__BackingField""
-  IL_0014:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0019:  brfalse.s  IL_0032
-  IL_001b:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0020:  ldarg.0
-  IL_0021:  ldfld      ""int C.<Y>k__BackingField""
-  IL_0026:  ldarg.1
-  IL_0027:  ldfld      ""int C.<Y>k__BackingField""
-  IL_002c:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0031:  ret
-  IL_0032:  ldc.i4.0
-  IL_0033:  ret
-}");
-        }
-
-        [Fact]
-        public void RecordEquals_11()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-using System.Collections.Generic;
-data class C(int X, int Y)
-{
-    static Dictionary<C, int> s_dict = new Dictionary<C, int>();
-    public int Z { get => s_dict[this]; set => s_dict[this] = value; }
-
-    public static void Main()
-    {
-        var c = new C(1, 2);
-        c.Z = 3;
-        var c2 = new C(1, 2);
-        c2.Z = 4;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-        c2.Z = 3;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-    }
-}", expectedOutput: @"True
-True
-True
-True");
-            verifier.VerifyIL("C.Equals(C)", @"
-{
-  // Code size       52 (0x34)
-  .maxstack  3
-  IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_0032
-  IL_0003:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0008:  ldarg.0
-  IL_0009:  ldfld      ""int C.<X>k__BackingField""
-  IL_000e:  ldarg.1
-  IL_000f:  ldfld      ""int C.<X>k__BackingField""
-  IL_0014:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0019:  brfalse.s  IL_0032
-  IL_001b:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0020:  ldarg.0
-  IL_0021:  ldfld      ""int C.<Y>k__BackingField""
-  IL_0026:  ldarg.1
-  IL_0027:  ldfld      ""int C.<Y>k__BackingField""
-  IL_002c:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0031:  ret
-  IL_0032:  ldc.i4.0
-  IL_0033:  ret
-}");
-        }
-
-        [Fact]
-        public void RecordEquals_12()
-        {
-            var verifier = CompileAndVerify(@"
-using System;
-using System.Collections.Generic;
-data class C(int X, int Y)
-{
-    private event Action E;
-
-    public static void Main()
-    {
-        var c = new C(1, 2);
-        c.E = () => { };
-        var c2 = new C(1, 2);
-        c2.E = () => { };
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-        c2.E = c.E;
-        Console.WriteLine(c.Equals(c2));
-        Console.WriteLine(c.Equals((object)c2));
-    }
-}", expectedOutput: @"False
-False
-True
-True");
-            verifier.VerifyIL("C.Equals(C)", @"
-{
-  // Code size       76 (0x4c)
-  .maxstack  3
-  IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_004a
-  IL_0003:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0008:  ldarg.0
-  IL_0009:  ldfld      ""int C.<X>k__BackingField""
-  IL_000e:  ldarg.1
-  IL_000f:  ldfld      ""int C.<X>k__BackingField""
-  IL_0014:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0019:  brfalse.s  IL_004a
-  IL_001b:  call       ""System.Collections.Generic.EqualityComparer<int> System.Collections.Generic.EqualityComparer<int>.Default.get""
-  IL_0020:  ldarg.0
-  IL_0021:  ldfld      ""int C.<Y>k__BackingField""
-  IL_0026:  ldarg.1
-  IL_0027:  ldfld      ""int C.<Y>k__BackingField""
-  IL_002c:  callvirt   ""bool System.Collections.Generic.EqualityComparer<int>.Equals(int, int)""
-  IL_0031:  brfalse.s  IL_004a
-  IL_0033:  call       ""System.Collections.Generic.EqualityComparer<System.Action> System.Collections.Generic.EqualityComparer<System.Action>.Default.get""
-  IL_0038:  ldarg.0
-  IL_0039:  ldfld      ""System.Action C.E""
-  IL_003e:  ldarg.1
-  IL_003f:  ldfld      ""System.Action C.E""
-  IL_0044:  callvirt   ""bool System.Collections.Generic.EqualityComparer<System.Action>.Equals(System.Action, System.Action)""
-  IL_0049:  ret
-  IL_004a:  ldc.i4.0
-  IL_004b:  ret
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  ret
 }");
         }
     }


### PR DESCRIPTION
Changes records to generate init-only properties instead of get-only,
and modifies the `with` expression to treat arguments as assignments
to the left-hand side, with the safety rules of object initializers
(meaning init-only assignments are allowed).

Also changes records to generate a Clone method and a copy constructor.
The clone calls the copy constructor and the copy constructor does a
memberwise copy of the instance fields of the other type.