### PR TITLE
Fix source generators cookbook example

### DIFF
--- a/docs/features/source-generators.cookbook.md
+++ b/docs/features/source-generators.cookbook.md
@@ -90,7 +90,7 @@ public class CustomGenerator : ISourceGenerator
 
     public void Execute(SourceGeneratorContext context)
     {
-        context.AddSource("myGeneratedFile.cs", SourceText.From($@"
+        context.AddSource("myGeneratedFile.cs", SourceText.From(@"
 namespace GeneratedNamespace
 {
     public class GeneratedClass


### PR DESCRIPTION
The snippet's curly braces should be escaped due to the `$`. The `$` isn't actually necessary, so I removed it.