### PR TITLE
Enforce analyzer consistency in our builds

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -612,7 +612,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             if (response.Type != BuildResponse.ResponseType.Completed)
             {
-                ValidateBootstrapUtil.AddFailedServerConnection();
+                ValidateBootstrapUtil.AddFailedServerConnection(response.Type, OutputAssembly?.ItemSpec);
             }
 
             switch (response.Type)


### PR DESCRIPTION
This changes the bootstrap compiler to enforce that our build doesn't
suffer from analyzer consistency issues. This will prevent us from
introducing build performance issues into the repository in the future.
Essentially adding enforcement to make sure that PRs like #43629 won't
ever be necessary again.

Related to #43629