### PR TITLE
Add warning message if semantics may change due to inline temporary variable refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4076,7 +4076,7 @@ class C
 {
     public void M()
     {
-        var (x1, x2) = new C();
+        {|Warning:var (x1, x2) = new C()|};
         var x3 = new C();
     }
 }";
@@ -4568,7 +4568,7 @@ class C
 {
     bool M<T>(ref T x) 
     {
-        return M(ref x) || M(ref x);
+        return {|Warning:M(ref x) || M(ref x)|};
     }
 }");
         }
@@ -4593,7 +4593,7 @@ class C
 {
     bool M<T>(out T x) 
     {
-        return M(out x) || M(out x);
+        return {|Warning:M(out x) || M(out x)|};
     }
 }");
         }
@@ -5097,6 +5097,76 @@ class C
     void M2()
     {
         P = 1;
+    }
+}");
+        }
+
+        [WorkItem(42835, "https://github.com/dotnet/roslyn/issues/42835")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task WarnWhenPossibleChangeInSemanticMeaning_NestedObjectInitialization()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        var [||]c = new C[1] { new C() };
+        c[0].P = 1;
+        var c2 = c;
+    }
+}",
+@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        {|Warning:(new C[1] { new C() })[0].P = 1|};
+        var c2 = new C[1] { new C() };
+    }
+}");
+        }
+
+        [WorkItem(42835, "https://github.com/dotnet/roslyn/issues/42835")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task WarnWhenPossibleChangeInSemanticMeaning_NestedMethodCall()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        var [||]c = new C[1] { M2() };
+        c[0].P = 1;
+        var c2 = c;
+    }
+
+    C M2()
+    {
+        P += 1;
+        return new C();
+    }
+}",
+@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        {|Warning:(new C[1] { M2() })[0].P = 1|};
+        var c2 = new C[1] { M2() };
+    }
+
+    C M2()
+    {
+        P += 1;
+        return new C();
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4964,5 +4964,141 @@ static class Goo
     }
 }");
         }
+
+        [WorkItem(42835, "https://github.com/dotnet/roslyn/issues/42835")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task WarnWhenPossibleChangeInSemanticMeaning()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        var [||]c = new C();
+        c.P = 1;
+        var c2 = c;
+    }
+}",
+@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        {|Warning:new C().P = 1|};
+        var c2 = new C();
+    }
+}");
+        }
+
+        [WorkItem(42835, "https://github.com/dotnet/roslyn/issues/42835")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task WarnWhenPossibleChangeInSemanticMeaning_IgnoreParentheses()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        var [||]c = (new C());
+        c.P = 1;
+        var c2 = c;
+    }
+}",
+@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        {|Warning:(new C()).P = 1|};
+        var c2 = (new C());
+    }
+}");
+        }
+
+        [WorkItem(42835, "https://github.com/dotnet/roslyn/issues/42835")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task WarnWhenPossibleChangeInSemanticMeaning_MethodInvocation()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        var [||]c = M2();
+        c.P = 1;
+        var c2 = c;
+    }
+
+    C M2()
+    {
+        return new C();
+    }
+}",
+@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        {|Warning:M2().P = 1|};
+        var c2 = M2();
+    }
+
+    C M2()
+    {
+        return new C();
+    }
+}");
+        }
+
+        [WorkItem(42835, "https://github.com/dotnet/roslyn/issues/42835")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task WarnWhenPossibleChangeInSemanticMeaning_MethodInvocation2()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        var [||]c = new C();
+        c.M2();
+        var c2 = c;
+    }
+
+    void M2()
+    {
+        P = 1;
+    }
+}",
+@"
+class C
+{
+    int P { get; set; }
+
+    void M()
+    {
+        {|Warning:new C().M2()|};
+        var c2 = new C();
+    }
+
+    void M2()
+    {
+        P = 1;
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -588,8 +588,8 @@
   <data name="Warning_Inlining_temporary_into_conditional_method_call" xml:space="preserve">
     <value>Warning: Inlining temporary into conditional method call.</value>
   </data>
-  <data name="Warning_Inlining_temporary_variable_may_change_semantic_meaning" xml:space="preserve">
-    <value>Warning: Inlining temporary variable may change semantic meaning.</value>
+  <data name="Warning_Inlining_temporary_variable_may_change_code_meaning" xml:space="preserve">
+    <value>Warning: Inlining temporary variable may change code meaning.</value>
   </data>
   <data name="local_variable_declaration" xml:space="preserve">
     <value>local variable declaration</value>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -588,6 +588,9 @@
   <data name="Warning_Inlining_temporary_into_conditional_method_call" xml:space="preserve">
     <value>Warning: Inlining temporary into conditional method call.</value>
   </data>
+  <data name="Warning_Inlining_temporary_variable_may_change_semantic_meaning" xml:space="preserve">
+    <value>Warning: Inlining temporary variable may change semantic meaning.</value>
+  </data>
   <data name="local_variable_declaration" xml:space="preserve">
     <value>local variable declaration</value>
   </data>

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -287,11 +287,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             // Checks to see if inlining the temporary variable may change the code's semantics. 
             // This is not meant to be an exhaustive check; it's more like a heuristic for obvious cases we know may cause side effects.
 
-            if (expression.IsKind(SyntaxKind.ParenthesizedExpression, out ParenthesizedExpressionSyntax parenthesizedExpression))
-            {
-                expression = parenthesizedExpression.WalkDownParentheses();
-            }
-
             var descendantNodesAndSelf = expression.DescendantNodesAndSelf();
 
             // Object creation:

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -104,7 +104,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             if (local != null)
             {
                 var findReferencesResult = await SymbolFinder.FindReferencesAsync(local, document.Project.Solution, cancellationToken).ConfigureAwait(false);
-                var locations = findReferencesResult.Single(r => Equals(r.Definition, local)).Locations;
+                var referencedSymbol = findReferencesResult.SingleOrDefault(r => Equals(r.Definition, local));
+                if (referencedSymbol == null)
+                {
+                    return SpecializedCollections.EmptyEnumerable<ReferenceLocation>();
+                }
+
+                var locations = referencedSymbol.Locations;
                 if (!locations.Any(loc => semanticModel.SyntaxTree.OverlapsHiddenPosition(loc.Location.SourceSpan, cancellationToken)))
                 {
                     return locations;

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Upozornění: dočasné vkládání do volání podmíněné metody.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">{0} tady není null.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Upozornění: dočasné vkládání do volání podmíněné metody.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Warnung: temporäres Inlining in bedingtem Methodenaufruf.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Warnung: temporäres Inlining in bedingtem Methodenaufruf.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">"{0}" ist hier nicht NULL.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Advertencia: Inserción de una llamada temporal en otra de método condicional.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">"{0}" no es NULL aquí.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Advertencia: Inserción de una llamada temporal en otra de método condicional.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Avertissement : Inlining temporaire dans un appel de méthode conditionnel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">'{0}' n'a pas une valeur null ici.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Avertissement : Inlining temporaire dans un appel de méthode conditionnel.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Avviso: incorporamento dell'elemento temporaneo nella chiamata a un metodo condizionale.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">'{0}' non è Null in questo punto.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Avviso: incorporamento dell'elemento temporaneo nella chiamata a un metodo condizionale.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -187,9 +187,9 @@
         <target state="translated">警告: 一時メソッド呼び出しを条件付きメソッド呼び出しにインライン展開しています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -187,6 +187,11 @@
         <target state="translated">警告: 一時メソッド呼び出しを条件付きメソッド呼び出しにインライン展開しています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">ここでは、'{0}' は null ではありません。</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -187,6 +187,11 @@
         <target state="translated">경고: 임시 작업을 조건부 메서드 호출로 인라인 처리합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">'{0}'은(는) 여기에서 null이 아닙니다.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -187,9 +187,9 @@
         <target state="translated">경고: 임시 작업을 조건부 메서드 호출로 인라인 처리합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Ostrzeżenie: tymczasowe wbudowywanie do wywołania metody warunkowej.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">Element „{0}” nie ma wartości null w tym miejscu.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Ostrzeżenie: tymczasowe wbudowywanie do wywołania metody warunkowej.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Aviso: embutindo a chamada de método temporária na condicional.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">'{0}' não é nulo aqui.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Aviso: embutindo a chamada de método temporária na condicional.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Предупреждение: встраивание временных элементов в условный вызов метода.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Предупреждение: встраивание временных элементов в условный вызов метода.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">Здесь "{0}" имеет значение, отличное от NULL.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Uyarı: Koşullu yöntem çağrısında geçici öğe satır içinde kullanılıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">'{0}' burada null değil.</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Uyarı: Koşullu yöntem çağrısında geçici öğe satır içinde kullanılıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -187,6 +187,11 @@
         <target state="translated">警告: 即将在条件方法调用中内联临时内容。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">“{0}”在此处不为 null。</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -187,9 +187,9 @@
         <target state="translated">警告: 即将在条件方法调用中内联临时内容。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -187,9 +187,9 @@
         <target state="translated">警告: 內嵌臨時加入條件式方法呼叫。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
-        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
-        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_code_meaning">
+        <source>Warning: Inlining temporary variable may change code meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change code meaning.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_not_null_here">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -187,6 +187,11 @@
         <target state="translated">警告: 內嵌臨時加入條件式方法呼叫。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_Inlining_temporary_variable_may_change_semantic_meaning">
+        <source>Warning: Inlining temporary variable may change semantic meaning.</source>
+        <target state="new">Warning: Inlining temporary variable may change semantic meaning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_not_null_here">
         <source>'{0}' is not null here.</source>
         <target state="translated">'{0}' 在此不是 null。</target>

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
@@ -45,8 +45,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 // that can happen if error is staled build error or user used #line pragma in C#
                 // to point to some random file in error or more.
                 e.Handled = roslynSnapshot.TryNavigateTo(index, e.IsPreview);
-
-                e.Handled = false;
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
@@ -45,6 +45,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 // that can happen if error is staled build error or user used #line pragma in C#
                 // to point to some random file in error or more.
                 e.Handled = roslynSnapshot.TryNavigateTo(index, e.IsPreview);
+
+                e.Handled = false;
             }
         }
     }


### PR DESCRIPTION
Fixes #42835 by adding a warning message in certain refactoring scenarios that may cause semantic changes.

Also fixes #43666. (I was unable to repro the issue on subsequent attempts, but I added some checks where the initial exception occurred in order to hopefully avoid the issue triggering again.)