### PR TITLE
Recommenders for `data` and `with`

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/ClassKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ClassKeywordRecommenderTests.cs
@@ -202,6 +202,20 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterData()
+        {
+            await VerifyKeywordAsync(
+@"data $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterPublicData()
+        {
+            await VerifyKeywordAsync(
+@"public data $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAbstract()
         {
             await VerifyKeywordAsync(

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DataKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DataKeywordRecommenderTests.cs
@@ -1,0 +1,348 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
+{
+    public class DataKeywordRecommenderTests : KeywordRecommenderTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAtRoot_Interactive()
+        {
+            await VerifyKeywordAsync(SourceCodeKind.Script,
+@"$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterClass_Interactive()
+        {
+            await VerifyKeywordAsync(SourceCodeKind.Script,
+@"class C { }
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterGlobalStatement_Interactive()
+        {
+            await VerifyKeywordAsync(SourceCodeKind.Script,
+@"System.Console.WriteLine();
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterGlobalVariableDeclaration_Interactive()
+        {
+            await VerifyKeywordAsync(SourceCodeKind.Script,
+@"int i = 0;
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInUsingAlias()
+        {
+            await VerifyAbsenceAsync(
+@"using Goo = $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInEmptyStatement()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"$$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInCompilationUnit()
+        {
+            await VerifyKeywordAsync(
+@"$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterExtern()
+        {
+            await VerifyKeywordAsync(
+@"extern alias Goo;
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterUsing()
+        {
+            await VerifyKeywordAsync(
+@"using Goo;
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNamespace()
+        {
+            await VerifyKeywordAsync(
+@"namespace N {}
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterTypeDeclaration()
+        {
+            await VerifyKeywordAsync(
+@"class C {}
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterDelegateDeclaration()
+        {
+            await VerifyKeywordAsync(
+@"delegate void Goo();
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterMethod()
+        {
+            await VerifyKeywordAsync(
+@"class C {
+  void Goo() {}
+  $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterField()
+        {
+            await VerifyKeywordAsync(
+@"class C {
+  int i;
+  $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterProperty()
+        {
+            await VerifyKeywordAsync(
+@"class C {
+  int i { get; }
+  $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotBeforeUsing()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Regular,
+@"$$
+using Goo;");
+        }
+
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/9880"), Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotBeforeUsing_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"$$
+using Goo;");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterAssemblyAttribute()
+        {
+            await VerifyKeywordAsync(
+@"[assembly: goo]
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterRootAttribute()
+        {
+            await VerifyKeywordAsync(
+@"[goo]
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNestedAttribute()
+        {
+            await VerifyKeywordAsync(
+@"class C {
+  [goo]
+  $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInsideStruct()
+        {
+            await VerifyKeywordAsync(
+@"struct S {
+   $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInsideInterface()
+        {
+            await VerifyKeywordAsync(@"interface I {
+   $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInsideClass()
+        {
+            await VerifyKeywordAsync(
+@"class C {
+   $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterPartial()
+        {
+            await VerifyKeywordAsync(
+@"partial $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterData()
+        {
+            await VerifyAbsenceAsync(
+@"data $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterPublicData()
+        {
+            await VerifyAbsenceAsync(
+@"public data $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterAbstract()
+        {
+            await VerifyKeywordAsync(
+@"abstract $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterInternal()
+        {
+            await VerifyKeywordAsync(
+@"internal $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterStaticPublic()
+        {
+            await VerifyKeywordAsync(
+@"static public $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterPublicStatic()
+        {
+            await VerifyKeywordAsync(
+@"public static $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterInvalidPublic()
+            => await VerifyAbsenceAsync(@"virtual public $$");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterPublic()
+        {
+            await VerifyKeywordAsync(
+@"public $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterPrivate()
+        {
+            await VerifyKeywordAsync(
+@"private $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterProtected()
+        {
+            await VerifyKeywordAsync(
+@"protected $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterSealed()
+        {
+            await VerifyKeywordAsync(
+@"sealed $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterStatic()
+        {
+            await VerifyKeywordAsync(
+@"static $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterStaticInUsingDirective()
+        {
+            await VerifyAbsenceAsync(
+@"using static $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterClass()
+            => await VerifyAbsenceAsync(@"class $$");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotBetweenUsings()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"using Goo;
+$$
+using Bar;"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterClassTypeParameterConstraint()
+        {
+            await VerifyAbsenceAsync(
+@"class C<T> where T : $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterClassTypeParameterConstraint2()
+        {
+            await VerifyAbsenceAsync(
+@"class C<T>
+    where T : $$
+    where U : U");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodTypeParameterConstraint()
+        {
+            await VerifyAbsenceAsync(
+@"class C {
+    void Goo<T>()
+      where T : $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodTypeParameterConstraint2()
+        {
+            await VerifyAbsenceAsync(
+@"class C {
+    void Goo<T>()
+      where T : $$
+      where U : T");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNew()
+        {
+            await VerifyKeywordAsync(
+@"class C {
+    new $$");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DataKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DataKeywordRecommenderTests.cs
@@ -202,6 +202,13 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterRef()
+        {
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterData()
         {
             await VerifyAbsenceAsync(

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StructKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StructKeywordRecommenderTests.cs
@@ -258,6 +258,13 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterData()
+        {
+            await VerifyKeywordAsync(
+@"data $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAbstract()
             => await VerifyAbsenceAsync(@"abstract $$");
 

--- a/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
@@ -12,6 +12,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
     public class WithKeywordRecommenderTests : KeywordRecommenderTests
     {
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWith()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var q = goo with $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAtRoot_Interactive()
         {
             await VerifyAbsenceAsync(SourceCodeKind.Script,

--- a/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
+{
+    public class WithKeywordRecommenderTests : KeywordRecommenderTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAtRoot_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterClass_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"class C { }
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterGlobalStatement_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"System.Console.WriteLine();
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterGlobalVariableDeclaration_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"int i = 0;
+$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInUsingAlias()
+        {
+            await VerifyAbsenceAsync(
+@"using Goo = $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInEmptyStatement()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"$$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterExpr()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var q = goo $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterDottedName()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var q = goo.Current $$"));
+        }
+
+        [WorkItem(543041, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543041")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterVarInForLoop()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"for (var $$"));
+        }
+
+        [WorkItem(1064811, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotBeforeFirstStringHole()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var x = ""\{0}$$\{1}\{2}"""));
+        }
+
+        [WorkItem(1064811, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotBetweenStringHoles()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var x = ""\{0}\{1}$$\{2}"""));
+        }
+
+        [WorkItem(1064811, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterStringHoles()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var x = ""\{0}\{1}\{2}$$"""));
+        }
+
+        [WorkItem(1064811, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterLastStringHole()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var x = ""\{0}\{1}\{2}"" $$"));
+        }
+
+        [WorkItem(1736, "https://github.com/dotnet/roslyn/issues/1736")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotWithinNumericLiteral()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var x = .$$0;"));
+        }
+
+        [WorkItem(28586, "https://github.com/dotnet/roslyn/issues/28586")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterAsync()
+        {
+            await VerifyAbsenceAsync(
+@"
+using System;
+
+class C
+{
+    void Goo()
+    {
+        Bar(async $$
+    }
+
+    void Bar(Func<int, string> f)
+    {
+    }
+}");
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodReference()
+        {
+            await VerifyAbsenceAsync(
+@"
+using System;
+
+class C {
+    void M() {
+        var v = Console.WriteLine $$");
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterAnonymousMethod()
+        {
+            await VerifyAbsenceAsync(
+@"
+using System;
+
+class C {
+    void M() {
+        Action a = delegate { } $$");
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda1()
+        {
+            await VerifyAbsenceAsync(
+@"
+using System;
+
+class C {
+    void M() {
+        Action b = (() => 0) $$");
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda2()
+        {
+            await VerifyAbsenceAsync(
+@"
+using System;
+
+class C {
+    void M() {
+        Action b = () => {} $$");
+        }
+    }
+}

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5061,12 +5061,41 @@ class C
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendTypeChars("w")
+                state.SendTypeChars("z")
                 Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
 
                 state.SendBackspace()
                 state.SendTypeChars("i")
                 Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
+            End Using
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AfterIdentifierInCaseLabel_ClassNameOnly_WithMiscLetters(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                              <Document>
+class identifier { }
+class C
+{
+    void M()
+    {
+        switch (true)
+        {
+            case identifier $$
+        }
+    }
+}
+                              </Document>,
+                  showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
+
+                state.SendBackspace()
+                state.SendTypeChars("w")
+                Await state.AssertSelectedCompletionItem(displayText:="with", isHardSelected:=False)
 
             End Using
         End Function

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new ClassKeywordRecommender(),
                 new ConstKeywordRecommender(),
                 new ContinueKeywordRecommender(),
+                new DataKeywordRecommender(),
                 new DecimalKeywordRecommender(),
                 new DefaultKeywordRecommender(),
                 new DefineKeywordRecommender(),

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -171,6 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new WhenKeywordRecommender(),
                 new WhereKeywordRecommender(),
                 new WhileKeywordRecommender(),
+                new WithKeywordRecommender(),
                 new YieldKeywordRecommender(),
             }.ToImmutableArray();
         }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
@@ -58,7 +58,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             // NOTE: The collector ensures that we're not in "NonUserCode" like comments, strings, inactive code
             // for perf reasons.
-            var syntaxTree = context.SemanticModel.SyntaxTree;
             if (!_isValidInPreprocessorContext &&
                 context.IsPreProcessorDirectiveContext)
             {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ClassKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ClassKeywordRecommender.cs
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 SyntaxKind.AbstractKeyword,
                 SyntaxKind.SealedKeyword,
                 SyntaxKind.StaticKeyword,
-                SyntaxKind.UnsafeKeyword
+                SyntaxKind.UnsafeKeyword,
+                SyntaxKind.DataKeyword
             };
 
         public ClassKeywordRecommender()

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DataKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DataKeywordRecommender.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
@@ -32,12 +31,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 canBePartial: true,
                 cancellationToken: cancellationToken))
             {
-                return CheckPreviousAccessibilityModifiers(context);
+                return CheckPreviousModifiers(context);
             }
 
             return false;
 
-            static bool CheckPreviousAccessibilityModifiers(CSharpSyntaxContext context)
+            static bool CheckPreviousModifiers(CSharpSyntaxContext context)
             {
                 var precedingModifiers = context.PrecedingModifiers;
                 return !precedingModifiers.Contains(SyntaxKind.DataKeyword);

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DataKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DataKeywordRecommender.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
+{
+    internal class DataKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    {
+        public DataKeywordRecommender()
+            : base(SyntaxKind.DataKeyword)
+        {
+        }
+
+        protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            return
+                context.IsGlobalStatementContext ||
+                context.TargetToken.IsUsingKeywordInUsingDirective() ||
+                IsValidContextForType(context, cancellationToken);
+        }
+
+        private static bool IsValidContextForType(CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            if (context.IsTypeDeclarationContext(
+                validModifiers: SyntaxKindSet.AllTypeModifiers,
+                validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructTypeDeclarations,
+                canBePartial: true,
+                cancellationToken: cancellationToken))
+            {
+                return CheckPreviousAccessibilityModifiers(context);
+            }
+
+            return false;
+
+            static bool CheckPreviousAccessibilityModifiers(CSharpSyntaxContext context)
+            {
+                var precedingModifiers = context.PrecedingModifiers;
+                return !precedingModifiers.Contains(SyntaxKind.DataKeyword);
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DataKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DataKeywordRecommender.cs
@@ -19,17 +19,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             return
                 context.IsGlobalStatementContext ||
-                context.TargetToken.IsUsingKeywordInUsingDirective() ||
                 IsValidContextForType(context, cancellationToken);
         }
 
         private static bool IsValidContextForType(CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
             if (context.IsTypeDeclarationContext(
-                validModifiers: SyntaxKindSet.AllTypeModifiers,
-                validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructTypeDeclarations,
-                canBePartial: true,
-                cancellationToken: cancellationToken))
+                    validModifiers: SyntaxKindSet.AllTypeModifiers,
+                    validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructTypeDeclarations,
+                    canBePartial: true,
+                    cancellationToken: cancellationToken))
             {
                 return CheckPreviousModifiers(context);
             }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IsKeywordRecommender.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             // cases:
             //    expr |
-            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
+            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchOrWithExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             return
                 context.IsStatementContext ||
                 context.IsGlobalStatementContext ||
-                context.IsIsOrAsOrSwitchExpressionContext;
+                context.IsIsOrAsOrSwitchOrWithExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WithKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WithKeywordRecommender.cs
@@ -7,10 +7,10 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class AsKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class WithKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
     {
-        public AsKeywordRecommender()
-            : base(SyntaxKind.AsKeyword)
+        public WithKeywordRecommender()
+            : base(SyntaxKind.WithKeyword)
         {
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -56,6 +57,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         if (token.HasMatchingText(SyntaxKind.AsyncKeyword))
                         {
                             result.Add(SyntaxKind.AsyncKeyword);
+                            token = token.GetPreviousToken(includeSkipped: true);
+                            continue;
+                        }
+
+                        if (token.HasMatchingText(SyntaxKindEx.DataKeyword))
+                        {
+                            result.Add(SyntaxKindEx.DataKeyword);
                             token = token.GetPreviousToken(includeSkipped: true);
                             continue;
                         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public const SyntaxKind DataKeyword = (SyntaxKind)8438;
 
 #if !CODE_STYLE
-        private const uint DotDotTokenValueAssertion = -(DataKeyword - SyntaxKind.DataKeyword);
+        private const uint DataKeywordValueAssertion = -(DataKeyword - SyntaxKind.DataKeyword);
 #endif
 
         // When the code style layer needs access to some syntax defined in newer versions of Roslyn,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
@@ -12,12 +12,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     /// </summary>
     internal static class SyntaxKindEx
     {
-        // The code style layer does not currently need access to any syntax defined in newer versions of Roslyn. This
-        // type is included as an example should this change in future updates.
+        public const SyntaxKind DataKeyword = (SyntaxKind)8438;
+
+#if !CODE_STYLE
+        private const uint DotDotTokenValueAssertion = -(DataKeyword - SyntaxKind.DataKeyword);
+#endif
+
+        // When the code style layer needs access to some syntax defined in newer versions of Roslyn,
+        // a check like the following should be included.
 #if false
         public const SyntaxKind DotDotToken = (SyntaxKind)8222;
 
-#if CODE_STYLE
+#if !CODE_STYLE
         /// <summary>
         /// This will only compile if <see cref="DotDotToken"/> and <see cref="SyntaxKind.DotDotToken"/> have the same
         /// value.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public readonly bool IsLabelContext;
         public readonly bool IsTypeArgumentOfConstraintContext;
 
-        public readonly bool IsIsOrAsOrSwitchExpressionContext;
+        public readonly bool IsIsOrAsOrSwitchOrWithExpressionContext;
         public readonly bool IsObjectCreationTypeContext;
         public readonly bool IsDefiniteCastTypeContext;
         public readonly bool IsGenericTypeArgumentContext;
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             bool isLabelContext,
             bool isTypeArgumentOfConstraintContext,
             bool isRightOfDotOrArrowOrColonColon,
-            bool isIsOrAsOrSwitchExpressionContext,
+            bool isIsOrAsOrSwitchOrWithExpressionContext,
             bool isObjectCreationTypeContext,
             bool isDefiniteCastTypeContext,
             bool isGenericTypeArgumentContext,
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             this.IsConstantExpressionContext = isConstantExpressionContext;
             this.IsLabelContext = isLabelContext;
             this.IsTypeArgumentOfConstraintContext = isTypeArgumentOfConstraintContext;
-            this.IsIsOrAsOrSwitchExpressionContext = isIsOrAsOrSwitchExpressionContext;
+            this.IsIsOrAsOrSwitchOrWithExpressionContext = isIsOrAsOrSwitchOrWithExpressionContext;
             this.IsObjectCreationTypeContext = isObjectCreationTypeContext;
             this.IsDefiniteCastTypeContext = isDefiniteCastTypeContext;
             this.IsGenericTypeArgumentContext = isGenericTypeArgumentContext;
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 isLabelContext: syntaxTree.IsLabelContext(position, cancellationToken),
                 isTypeArgumentOfConstraintContext: syntaxTree.IsTypeArgumentOfConstraintClause(position, cancellationToken),
                 isRightOfDotOrArrowOrColonColon: syntaxTree.IsRightOfDotOrArrowOrColonColon(position, targetToken, cancellationToken),
-                isIsOrAsOrSwitchExpressionContext: syntaxTree.IsIsOrAsOrSwitchExpressionContext(semanticModel, position, leftToken, cancellationToken),
+                isIsOrAsOrSwitchOrWithExpressionContext: syntaxTree.IsIsOrAsOrSwitchOrWithExpressionContext(semanticModel, position, leftToken, cancellationToken),
                 isObjectCreationTypeContext: syntaxTree.IsObjectCreationTypeContext(position, leftToken, cancellationToken),
                 isDefiniteCastTypeContext: syntaxTree.IsDefiniteCastTypeContext(position, leftToken),
                 isGenericTypeArgumentContext: syntaxTree.IsGenericTypeArgumentContext(position, leftToken, cancellationToken),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -546,6 +547,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // A type can also show up after certain types of modifiers
             if (canBePartial &&
                 token.IsKindOrHasMatchingText(SyntaxKind.PartialKeyword))
+            {
+                return true;
+            }
+
+            if (token.IsKindOrHasMatchingText(SyntaxKindEx.DataKeyword))
             {
                 return true;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2578,7 +2578,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
-        public static bool IsIsOrAsOrSwitchExpressionContext(
+        public static bool IsIsOrAsOrSwitchOrWithExpressionContext(
             this SyntaxTree syntaxTree,
             SemanticModel semanticModel,
             int position,
@@ -2603,10 +2603,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return false;
             }
 
-            // is/as are valid after expressions.
+            // is/as/with are valid after expressions.
             if (token.IsLastTokenOfNode<ExpressionSyntax>(out var expression))
             {
-                // 'is/as' not allowed after a anonymous-method/lambda/method-group.
+                // 'is/as/with' not allowed after a anonymous-method/lambda/method-group.
                 if (expression.IsAnyLambdaOrAnonymousMethod())
                     return false;
 
@@ -2668,7 +2668,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     // async $$
                     //
                     // 'async' will look like a normal identifier.  But we don't want to follow it
-                    // with 'is' or 'as' if it's actually the start of a lambda.
+                    // with 'is' or 'as' or 'with' if it's actually the start of a lambda.
                     var delegateType = CSharpTypeInferenceService.Instance.InferDelegateType(
                         semanticModel, token.SpanStart, cancellationToken);
                     if (delegateType != null)


### PR DESCRIPTION
The `data` recommender is similar to that for `public`.
The `with` recommender is like the one for `as`.