### PR TITLE
Fix declared dependencies of Microsoft.VisualStudio.LanguageServices

### DIFF
--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -24,6 +24,8 @@
     </PackageDescription>
   </PropertyGroup>
   <ItemGroup Label="NuGet">
+    <NuspecProperty Include="MicrosoftCSharpVersion=$(MicrosoftCSharpVersion)"/>
+    <NuspecProperty Include="MicrosoftVisualStudioCompositionVersion=$(MicrosoftVisualStudioCompositionVersion)"/>
     <NuspecProperty Include="SystemThreadingTasksDataflowVersion=$(SystemThreadingTasksDataflowVersion)"/>
   </ItemGroup>
   <ItemGroup Label="PkgDef">

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.nuspec
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.nuspec
@@ -8,8 +8,8 @@
         <dependency id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="$Version$" />
         <dependency id="Microsoft.CodeAnalysis.Features" version="$Version$" />
         <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$Version$" />
-        <dependency id="Microsoft.CSharp" version="$Version$" />
-        <dependency id="Microsoft.VisualStudio.Composition" version="$Version$" />
+        <dependency id="Microsoft.CSharp" version="$MicrosoftCSharpVersion$" />
+        <dependency id="Microsoft.VisualStudio.Composition" version="$MicrosoftVisualStudioCompositionVersion$" />
         <dependency id="System.Threading.Tasks.Dataflow" version="$SystemThreadingTasksDataflowVersion$" />
       </group>
     </dependencies>


### PR DESCRIPTION
We were incorrectly emitting our dependency of Microsoft.VisualStudio.Composition and Microsoft.CSharp; instead of pointing to the version that we were actually consuming, we were emitting our version in place of version we depending on.