### PR TITLE
Use lsp hover for 16.7 preview1

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -73,10 +73,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             _clientCapabilities = input["capabilities"].ToObject<VSClientCapabilities>();
             var serverCapabilities = await _protocol.ExecuteRequestAsync<InitializeParams, InitializeResult>(Methods.InitializeName,
                 _workspace.CurrentSolution, input.ToObject<InitializeParams>(), _clientCapabilities, _clientName, cancellationToken).ConfigureAwait(false);
-            // As soon as LSP supports classifications in hover, we can remove this and always advertise hover support.
-            // For now, just support for the razor lsp client.
-            // Tracking - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138/
-            serverCapabilities.Capabilities.HoverProvider = Equals(_clientName, RazorLanguageClient.ClientName);
+            // Always support hover - if any LSP client for a content type advertises support,
+            // then the liveshare provider is disabled.  So we must provide for both C# and razor
+            // until https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1106064/ is fixed
+            // or we have different content types.
+            serverCapabilities.Capabilities.HoverProvider = true;
             return serverCapabilities;
         }
 


### PR DESCRIPTION
Liveshare has a universal hover provider that gets invoked if there is no LSP server for a content type that provides the hover capability.  We use this provider for hover as it has classifications.

However, when we added the razor hover provider there was now an LSP server for C#_LSP providing hover, resulting in the liveshare universal provider being disabled.

For QB 16.7p1, we provide LSP hover for regular C# as well (which has no classifications).  For 16.7p2, the liveshare bug here https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1106064/ will be fixed, or we will switch content types for razor to isolate them.