### PR TITLE
🧹 Remove duplicate calls to ThrowIfCancellationRequested

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -309,7 +309,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // follow the originally-intended design.
                 // https://github.com/dotnet/roslyn/issues/40890
                 await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationTokenSource.Token);
-                _cancellationTokenSource.Token.ThrowIfCancellationRequested();
 
                 RaiseSessionSpansUpdated(inlineRenameLocations.Locations.ToImmutableArray());
 
@@ -583,7 +582,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     async t =>
                     {
                         await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _conflictResolutionTaskCancellationSource.Token);
-                        _conflictResolutionTaskCancellationSource.Token.ThrowIfCancellationRequested();
 
                         ApplyReplacements(t.Result.replacementInfo, t.Result.mergeResult, _conflictResolutionTaskCancellationSource.Token);
                     },

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             // This means we have to query for "third party navigation", from
             // XAML, etc. That call has to be done on the UI thread.
             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
 
             var solution = document.Project.Solution;
             var definitions = GoToDefinitionHelpers.GetDefinitions(symbol, solution, thirdPartyNavigationAllowed: true, cancellationToken)

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -637,7 +637,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     // Have to see if this fix is still applicable.  Jump to the foreground thread
                     // to make that check.
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-                    cancellationToken.ThrowIfCancellationRequested();
 
                     var applicable = fix.Action.IsApplicable(document.Project.Solution.Workspace);
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/ModelComputation.cs
@@ -151,7 +151,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                 async tasks =>
                 {
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _stopCancellationToken);
-                    _stopCancellationToken.ThrowIfCancellationRequested();
 
                     if (tasks.All(t => t.Status == TaskStatus.RanToCompletion))
                     {

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -146,7 +146,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                     async t =>
                     {
                         await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-                        cancellationToken.ThrowIfCancellationRequested();
 
                         PushSelectedItemsToPresenter(t.Result);
                     },

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -79,7 +79,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                         async t =>
                         {
                             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken);
-                            _cancellationToken.ThrowIfCancellationRequested();
 
                             stateMachine.UpdateTrackingSessionIfRenamable();
                         },
@@ -107,7 +106,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 task.SafeContinueWithFromAsync(async t =>
                    {
                        await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken);
-                       _cancellationToken.ThrowIfCancellationRequested();
 
                        if (_isRenamableIdentifierTask.Result != TriggerIdentifierKind.NotRenamable)
                        {

--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -85,7 +85,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
                     async () =>
                     {
                         await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                        cancellationToken.ThrowIfCancellationRequested();
 
                         action();
                     },

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager_EventHookupSession.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager_EventHookupSession.cs
@@ -124,7 +124,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                         async t =>
                         {
                             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-                            cancellationToken.ThrowIfCancellationRequested();
 
                             if (t.Result != null)
                             {

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -78,7 +78,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             var hierarchyToProjectMap = _workspace.Services.GetRequiredService<IHierarchyItemToProjectIdMap>();
 
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(context.OperationContext.UserCancellationToken);
-            context.OperationContext.UserCancellationToken.ThrowIfCancellationRequested();
 
             ProjectId projectId = null;
             if (ErrorHandler.Succeeded(hierarchy.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID8.VSHPROPID_ActiveIntellisenseProjectContext, out var contextProjectNameObject))
@@ -224,7 +223,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 var solution = await applyFixAsync(progressTracker, cancellationToken).ConfigureAwait(true);
 
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
 
                 return workspace.TryApplyChanges(solution, progressTracker);
             }

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -188,7 +188,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         {
             // legacy project system can only be talked to on the UI thread.
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
 
             AssertIsForeground();
 
@@ -287,7 +286,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             if (!_cpsProjects.TryGetValue(projectId, out var updateService))
             {
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
                 this.AssertIsForeground();
 
                 updateService = ComputeUpdateService();

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -313,7 +313,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 cmds[0].cmdf = 0;
 
                 await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
 
                 var hr = _oleCommandTarget.QueryStatus(ReSharperCommandGroup, (uint)cmds.Length, cmds, IntPtr.Zero);
                 if (ErrorHandler.Failed(hr))
@@ -335,7 +334,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 }
 
                 await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
 
                 _oleCommandTarget = _serviceProvider.GetService<IOleCommandTarget, SUIHostCommandDispatcher>();
             }

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -398,7 +398,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                         async _ =>
                         {
                             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
-                            cancellationToken.ThrowIfCancellationRequested();
 
                             ProcessBatchedChangesOnForeground(cancellationToken);
                         },
@@ -443,7 +442,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 async () =>
                 {
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                    cancellationToken.ThrowIfCancellationRequested();
 
                     ProcessBatchedChangesOnForeground(cancellationToken);
                 },

--- a/src/VisualStudio/IntegrationTest/TestSetup/IntegrationTestServicePackage.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/IntegrationTestServicePackage.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Setup
         {
             await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
 
             var shell = (IVsShell)await GetServiceAsync(typeof(SVsShell));
             ErrorHandler.ThrowOnFailure(shell.IsPackageInstalled(s_compilerPackage, out var installed));

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
@@ -53,7 +53,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var operation = JoinableTaskFactory.RunAsync(async () =>
             {
                 await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationTokenSource.Token);
-                cancellationTokenSource.Token.ThrowIfCancellationRequested();
 
                 action(cancellationTokenSource.Token);
             });
@@ -67,7 +66,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var operation = JoinableTaskFactory.RunAsync(async () =>
             {
                 await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationTokenSource.Token);
-                cancellationTokenSource.Token.ThrowIfCancellationRequested();
 
                 return action(cancellationTokenSource.Token);
             });

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspaceHost.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspaceHost.cs
@@ -102,7 +102,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
         private async Task LoadRoslynPackageAsync(CancellationToken cancellationToken)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
 
             // Explicitly trigger the load of the Roslyn package. This ensures that UI-bound services are appropriately prefetched,
             // that FatalError is correctly wired up, etc. Ideally once the things happening in the package initialize are cleaned up with


### PR DESCRIPTION
microsoft/vs-threading#576 made these calls redundant in the 16.5 release.