### PR TITLE
Add API to flow a commandline through for F#

### DIFF
--- a/src/Tools/ExternalAccess/FSharp/ProjectExtensions.cs
+++ b/src/Tools/ExternalAccess/FSharp/ProjectExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
+{
+    internal static class ProjectExtensions
+    {
+        public static string FSharpCommandLineOptions(this Project project)
+        {
+            return project.CommandLineOptions;
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/NonCompilableProjectOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/NonCompilableProjectOptionsTests.cs
@@ -37,9 +37,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             Assert.Equal("--test", GetCommandLineOptions());
 
             Assert.Throws<ArgumentException>(() => project.SetOptions(null));
-
-            Assert.Equal("--test", GetCommandLineOptions());
-
         }
 
         [WpfFact]

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/NonCompilableProjectOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/NonCompilableProjectOptionsTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
+{
+    using static CSharpHelpers;
+
+    [UseExportProvider]
+    public class NonCompilableProjectOptionsTests : TestBase
+    {
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void SetOptions_Success()
+        {
+            using var environment = new TestEnvironment();
+            using var project = CreateNonCompilableProject(environment, "project1", @"C:\project1.fsproj");
+
+            string GetCommandLineOptions() => environment.Workspace.CurrentSolution.Projects.Single().CommandLineOptions;
+
+            Assert.Null(GetCommandLineOptions());
+
+            project.SetOptions("--test");
+
+            Assert.Equal("--test", GetCommandLineOptions());
+
+            Assert.Throws<ArgumentException>(() => project.SetOptions(null));
+
+            Assert.Equal("--test", GetCommandLineOptions());
+
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void SetOptionsBatch_Success()
+        {
+            using var environment = new TestEnvironment();
+            using var project = CreateNonCompilableProject(environment, "project1", @"C:\project1.fsproj");
+            string GetCommandLineOptions() => environment.Workspace.CurrentSolution.Projects.Single().CommandLineOptions;
+
+            project.StartBatch();
+
+            Assert.Null(GetCommandLineOptions());
+
+            project.SetOptions("--test");
+
+            Assert.Null(GetCommandLineOptions());
+
+            Assert.Throws<ArgumentException>(() => project.SetOptions(null));
+
+            project.EndBatch();
+
+            Assert.Equal("--test", GetCommandLineOptions());
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -76,6 +76,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         // Effective boolean value to determine if analyzers should be executed based on _runAnalyzersPropertyValue and _runAnalyzersDuringLiveAnalysisPropertyValue.
         private bool _runAnalyzers = true;
 
+        // Stores the F# command-line options that come from the project system, which includes ordered source files that the F# language service needs.
+        private string? _commandLineOptions;
+
         private readonly Dictionary<string, ImmutableArray<MetadataReferenceProperties>> _allMetadataReferences = new Dictionary<string, ImmutableArray<MetadataReferenceProperties>>();
 
         /// <summary>
@@ -218,6 +221,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
 
                 ChangeProjectProperty(ref field, newValue, withNewValue);
+            }
+        }
+
+        internal string? CommandLineOptions
+        {
+            get => _commandLineOptions;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException(nameof(value));
+                }
+
+                ChangeProjectProperty(ref _commandLineOptions, value, s => s.WithProjectCommandLineOptions(Id, value));
             }
         }
 
@@ -529,6 +546,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     }
 
                     ClearAndZeroCapacity(_projectPropertyModificationsInBatch);
+
+                    solutionChanges.UpdateSolutionForProjectAction(Id, newSolution: solutionChanges.Solution.WithProjectCommandLineOptions(Id, _commandLineOptions));
 
                     return solutionChanges;
                 });

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return true;
         }
 
-        public void SetCommandLine(string commandLine)
+        public void SetCommandLine(string? commandLine)
         {
             if (commandLine == null)
                 throw new ArgumentNullException(nameof(commandLine));

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -136,8 +136,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
         public ProjectId Id => _visualStudioProject.Id;
 
-        public void SetOptions(string commandLineForOptions)
-            => _visualStudioProjectOptionsProcessor?.SetCommandLine(commandLineForOptions);
+        public void SetOptions(string? commandLineForOptions)
+        {
+            if (_visualStudioProjectOptionsProcessor != null)
+            {
+                _visualStudioProjectOptionsProcessor.SetCommandLine(commandLineForOptions);
+            }
+            else
+            {
+                // This is only used for F# right now
+                _visualStudioProject.CommandLineOptions = commandLineForOptions;
+            }
+        }
 
         public string? DefaultNamespace
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -172,6 +172,12 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public IReadOnlyList<DocumentId> AdditionalDocumentIds => _projectState.AdditionalDocumentIds;
 
+
+        /// <summary>
+        /// The command line options with this project.
+        /// </summary>
+        internal string? CommandLineOptions => _projectState.CommandLineOptions;
+
         /// <summary>
         /// All the documents associated with this project.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -790,7 +790,7 @@ namespace Microsoft.CodeAnalysis
                 documentIds: documentIds);
         }
 
-        internal ProjectState UpdateCommandLineOptions(string commandLineOptions)
+        internal ProjectState UpdateCommandLineOptions(string? commandLineOptions)
         {
             if (_commandLineOptions == commandLineOptions)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1684,6 +1684,17 @@ namespace Microsoft.CodeAnalysis
             return new Solution(newState);
         }
 
+        internal Solution WithProjectCommandLineOptions(ProjectId projectId, string? commandLineOptions)
+        {
+            var newState = _state.WithProjectCommandLineOptions(projectId, commandLineOptions);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
         /// <summary>
         /// Gets a copy of the solution isolated from the original so that they do not share computed state.
         /// 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -788,11 +788,6 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(projectId));
             }
 
-            if (string.IsNullOrWhiteSpace(commandLineOptions))
-            {
-                throw new ArgumentException(nameof(commandLineOptions));
-            }
-
             CheckContainsProject(projectId);
 
             var oldProject = this.GetProjectState(projectId);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -781,6 +781,33 @@ namespace Microsoft.CodeAnalysis
         internal SolutionState WithProjectOptionsChanged(ProjectId projectId)
             => ForkProject(GetRequiredProjectState(projectId));
 
+        internal SolutionState WithProjectCommandLineOptions(ProjectId projectId, string? commandLineOptions)
+        {
+            if (projectId == null)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+
+            if (string.IsNullOrWhiteSpace(commandLineOptions))
+            {
+                throw new ArgumentException(nameof(commandLineOptions));
+            }
+
+            CheckContainsProject(projectId);
+
+            var oldProject = this.GetProjectState(projectId);
+            Contract.ThrowIfNull(oldProject);
+
+            var newProject = oldProject.UpdateCommandLineOptions(commandLineOptions);
+
+            if (oldProject == newProject)
+            {
+                return this;
+            }
+
+            return this.ForkProject(newProject);
+        }
+
         /// <summary>
         /// Create a new solution instance with the project specified updated to have
         /// the specified hasAllInformation.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -740,5 +740,16 @@ namespace Microsoft.CodeAnalysis
                 }
             }
         }
+
+        internal void OnProjectCommandLineOptionsChanged(ProjectId projectId, string commandLineOptions)
+        {
+            using (_serializationLock.DisposableWait())
+            {
+                var oldSolution = CurrentSolution;
+                var newSolution = this.SetCurrentSolution(oldSolution.WithProjectCommandLineOptions(projectId, commandLineOptions));
+
+                RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.ProjectChanged, oldSolution, newSolution, projectId);
+            }
+        }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2985,6 +2985,30 @@ class C
             Assert.Empty(solution.GetDocumentIdsWithFilePath(editorConfigFilePath));
         }
 
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void SetAndRetrieveCommandLineOptions_Success()
+        {
+            var solution = CreateSolution();
+            var pid = ProjectId.CreateNewId();
+
+            solution = solution.AddProject(pid, "test", "test.dll", LanguageNames.CSharp);
+            var project = solution.GetProject(pid);
+
+            // Is null until we set it.
+            Assert.Null(project.CommandLineOptions);
+
+            solution = solution.WithProjectCommandLineOptions(pid, "--test");
+            project = solution.GetProject(pid);
+
+            Assert.Equal("--test", project.CommandLineOptions);
+
+            Assert.Throws<ArgumentException>(() => solution = solution.WithProjectCommandLineOptions(pid, null));
+            project = solution.GetProject(pid);
+
+            Assert.Equal("--test", project.CommandLineOptions);
+        }
+
         private static void GetMultipleProjects(
             out Project csBrokenProject,
             out Project vbNormalProject,

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3002,11 +3002,6 @@ class C
             project = solution.GetProject(pid);
 
             Assert.Equal("--test", project.CommandLineOptions);
-
-            Assert.Throws<ArgumentException>(() => solution = solution.WithProjectCommandLineOptions(pid, null));
-            project = solution.GetProject(pid);
-
-            Assert.Equal("--test", project.CommandLineOptions);
         }
 
         private static void GetMultipleProjects(


### PR DESCRIPTION
This is https://github.com/dotnet/roslyn/pull/32977 as per @TIHan and @KevinRansom and I chatting about getting this up to date.

F# needs to flow its commandline from CPS through Roslyn to:

* Remove our hack where we sniff it via MEF in F# tools
* Participate properly in VS Codespaces

I just took all the changes into a new branch from master, since the rebase was a scary 20k+ commits' worth of rebasing and I am not good at git