### PR TITLE
Adjustments for deeply nested scenarios:

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -659,7 +659,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         foreach (var typeArg in ((NamedTypeSymbol)current).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics)
                         {
                             // Let's try to avoid early resolution of nullable types
-                            var result = visitType(typeArg);
+                            var result = VisitType(
+                                typeWithAnnotationsOpt: canDigThroughNullable ? default : typeArg,
+                                type: canDigThroughNullable ? typeArg.NullableUnderlyingTypeOrSelf : null,
+                                typeWithAnnotationsPredicate,
+                                typePredicate,
+                                arg,
+                                canDigThroughNullable,
+                                useDefaultType);
                             if (result is object)
                             {
                                 return result;
@@ -676,25 +683,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case TypeKind.FunctionPointer:
-                        {
-                            MethodSymbol currentPointer = ((FunctionPointerTypeSymbol)current).Signature;
-                            var result = visitType(currentPointer.ReturnTypeWithAnnotations);
-                            if (result is object)
-                            {
-                                return result;
-                            }
-
-                            foreach (var parameter in currentPointer.Parameters)
-                            {
-                                result = visitType(parameter.TypeWithAnnotations);
-                                if (result is object)
-                                {
-                                    return result;
-                                }
-                            }
-                        }
-
-                        return null;
+                        return visitFunctionPointerType((FunctionPointerTypeSymbol)current, typeWithAnnotationsPredicate, typePredicate, arg, useDefaultType, canDigThroughNullable);
 
                     default:
                         throw ExceptionUtilities.UnexpectedValue(current.TypeKind);
@@ -705,7 +694,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 type = canDigThroughNullable ? next.NullableUnderlyingTypeOrSelf : null;
             }
 
-            TypeSymbol? visitType(TypeWithAnnotations typeArg) => VisitType(
+            static TypeSymbol? visitFunctionPointerType(FunctionPointerTypeSymbol type, Func<TypeWithAnnotations, T, bool, bool>? typeWithAnnotationsPredicate, Func<TypeSymbol, T, bool, bool>? typePredicate, T arg, bool useDefaultType, bool canDigThroughNullable)
+            {
+
+                MethodSymbol currentPointer = type.Signature;
+                var result = visitType(currentPointer.ReturnTypeWithAnnotations);
+                if (result is object)
+                {
+                    return result;
+                }
+
+                foreach (var parameter in currentPointer.Parameters)
+                {
+                    result = visitType(parameter.TypeWithAnnotations);
+                    if (result is object)
+                    {
+                        return result;
+                    }
+                }
+
+                return null;
+
+                TypeSymbol? visitType(TypeWithAnnotations typeArg) => VisitType(
                     typeWithAnnotationsOpt: canDigThroughNullable ? default : typeArg,
                     type: canDigThroughNullable ? typeArg.NullableUnderlyingTypeOrSelf : null,
                     typeWithAnnotationsPredicate,
@@ -713,6 +723,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     arg,
                     canDigThroughNullable,
                     useDefaultType);
+            }
         }
 
         private static bool IsAsRestrictive(NamedTypeSymbol s1, Symbol sym2, ref HashSet<DiagnosticInfo>? useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -401,7 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static void VisitRankSpecifiers<TArg>(this TypeSyntax type, Action<ArrayRankSpecifierSyntax, TArg> action, in TArg argument)
         {
             // Use a manual stack here to avoid deeply nested recursion which can blow the real stack
-            var stack = new Stack<ArrayRankSpecifierOrTypeSyntax>();
+            var stack = ArrayBuilder<ArrayRankSpecifierOrTypeSyntax>.GetInstance();
             stack.Push(new ArrayRankSpecifierOrTypeSyntax(type));
 
             while (stack.Count > 0)
@@ -479,6 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            stack.Free();
         }
 
         private struct ArrayRankSpecifierOrTypeSyntax

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 
@@ -390,6 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return p.Designation.Kind() == SyntaxKind.SingleVariableDesignation && p.IsOutDeclaration();
         }
 
+#nullable enable
         /// <summary>
         /// Visits all the ArrayRankSpecifiers of a typeSyntax, invoking an action on each one in turn.
         /// </summary>
@@ -398,84 +400,115 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="argument">The argument that is passed to the action whenever it is invoked</param>
         internal static void VisitRankSpecifiers<TArg>(this TypeSyntax type, Action<ArrayRankSpecifierSyntax, TArg> action, in TArg argument)
         {
-recurse:
-            switch (type.Kind())
+            // Use a manual stack here to avoid deeply nested recursion which can blow the real stack
+            var stack = new Stack<ArrayRankSpecifierOrTypeSyntax>();
+            stack.Push(new ArrayRankSpecifierOrTypeSyntax(type));
+
+            while (stack.Count > 0)
             {
-                case SyntaxKind.ArrayType:
-                    var arrayTypeSyntax = (ArrayTypeSyntax)type;
-                    arrayTypeSyntax.ElementType.VisitRankSpecifiers(action, argument);
-                    foreach (var rankSpecifier in arrayTypeSyntax.RankSpecifiers)
-                    {
-                        action(rankSpecifier, argument);
-                    }
-                    break;
-                case SyntaxKind.NullableType:
-                    var nullableTypeSyntax = (NullableTypeSyntax)type;
-                    type = nullableTypeSyntax.ElementType;
-                    goto recurse;
-                case SyntaxKind.PointerType:
-                    var pointerTypeSyntax = (PointerTypeSyntax)type;
-                    type = pointerTypeSyntax.ElementType;
-                    goto recurse;
-                case SyntaxKind.FunctionPointerType:
-                    visitFunctionPointerType(type, action, argument);
-                    break;
-                case SyntaxKind.TupleType:
-                    var tupleTypeSyntax = (TupleTypeSyntax)type;
-                    var elementsCount = tupleTypeSyntax.Elements.Count;
-                    if (elementsCount == 0)
+                if (stack.Pop().IsRankSpecifier(out var rankSpecifier, out var currentType))
+                {
+                    action(rankSpecifier, argument);
+                    continue;
+                }
+                else
+                {
+                    type = currentType;
+                }
+
+                switch (type.Kind())
+                {
+                    case SyntaxKind.ArrayType:
+                        var arrayTypeSyntax = (ArrayTypeSyntax)type;
+                        for (int i = arrayTypeSyntax.RankSpecifiers.Count - 1; i >= 0; i--)
+                        {
+                            stack.Push(new ArrayRankSpecifierOrTypeSyntax(arrayTypeSyntax.RankSpecifiers[i]));
+                        }
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(arrayTypeSyntax.ElementType));
                         break;
-
-                    for (int index = 0; index < elementsCount - 1; index++)
-                    {
-                        var element = tupleTypeSyntax.Elements[index];
-                        element.Type.VisitRankSpecifiers(action, argument);
-                    }
-
-                    type = tupleTypeSyntax.Elements[elementsCount - 1].Type;
-                    goto recurse;
-                case SyntaxKind.RefType:
-                    var refTypeSyntax = (RefTypeSyntax)type;
-                    type = refTypeSyntax.Type;
-                    goto recurse;
-                case SyntaxKind.GenericName:
-                    var genericNameSyntax = (GenericNameSyntax)type;
-                    var argsCount = genericNameSyntax.TypeArgumentList.Arguments.Count;
-                    if (argsCount == 0)
+                    case SyntaxKind.NullableType:
+                        var nullableTypeSyntax = (NullableTypeSyntax)type;
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(nullableTypeSyntax.ElementType));
                         break;
-
-                    for (int index = 0; index < argsCount - 1; index++)
-                    {
-                        var typeArgument = genericNameSyntax.TypeArgumentList.Arguments[index];
-                        typeArgument.VisitRankSpecifiers(action, argument);
-                    }
-
-                    type = genericNameSyntax.TypeArgumentList.Arguments[argsCount - 1];
-                    goto recurse;
-                case SyntaxKind.QualifiedName:
-                    var qualifiedNameSyntax = (QualifiedNameSyntax)type;
-                    qualifiedNameSyntax.Left.VisitRankSpecifiers(action, argument);
-                    type = qualifiedNameSyntax.Right;
-                    goto recurse;
-                case SyntaxKind.AliasQualifiedName:
-                    var aliasQualifiedNameSyntax = (AliasQualifiedNameSyntax)type;
-                    type = aliasQualifiedNameSyntax.Name;
-                    goto recurse;
-                case SyntaxKind.IdentifierName:
-                case SyntaxKind.OmittedTypeArgument:
-                case SyntaxKind.PredefinedType:
-                    break;
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(type.Kind());
+                    case SyntaxKind.PointerType:
+                        var pointerTypeSyntax = (PointerTypeSyntax)type;
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(pointerTypeSyntax.ElementType));
+                        break;
+                    case SyntaxKind.FunctionPointerType:
+                        var functionPointerTypeSyntax = (FunctionPointerTypeSyntax)type;
+                        for (int i = functionPointerTypeSyntax.Parameters.Count - 1; i >= 0; i--)
+                        {
+                            TypeSyntax? paramType = functionPointerTypeSyntax.Parameters[i].Type;
+                            Debug.Assert(paramType is object);
+                            stack.Push(new ArrayRankSpecifierOrTypeSyntax(paramType));
+                        }
+                        break;
+                    case SyntaxKind.TupleType:
+                        var tupleTypeSyntax = (TupleTypeSyntax)type;
+                        for (int i = tupleTypeSyntax.Elements.Count - 1; i >= 0; i--)
+                        {
+                            stack.Push(new ArrayRankSpecifierOrTypeSyntax(tupleTypeSyntax.Elements[i].Type));
+                        }
+                        break;
+                    case SyntaxKind.RefType:
+                        var refTypeSyntax = (RefTypeSyntax)type;
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(refTypeSyntax.Type));
+                        break;
+                    case SyntaxKind.GenericName:
+                        var genericNameSyntax = (GenericNameSyntax)type;
+                        for (int i = genericNameSyntax.TypeArgumentList.Arguments.Count - 1; i >= 0; i--)
+                        {
+                            stack.Push(new ArrayRankSpecifierOrTypeSyntax(genericNameSyntax.TypeArgumentList.Arguments[i]));
+                        }
+                        break;
+                    case SyntaxKind.QualifiedName:
+                        var qualifiedNameSyntax = (QualifiedNameSyntax)type;
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(qualifiedNameSyntax.Right));
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(qualifiedNameSyntax.Left));
+                        break;
+                    case SyntaxKind.AliasQualifiedName:
+                        var aliasQualifiedNameSyntax = (AliasQualifiedNameSyntax)type;
+                        stack.Push(new ArrayRankSpecifierOrTypeSyntax(aliasQualifiedNameSyntax.Name));
+                        break;
+                    case SyntaxKind.IdentifierName:
+                    case SyntaxKind.OmittedTypeArgument:
+                    case SyntaxKind.PredefinedType:
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(type.Kind());
+                }
             }
 
-            static void visitFunctionPointerType(TypeSyntax type, Action<ArrayRankSpecifierSyntax, TArg> action, TArg argument)
+        }
+
+        private struct ArrayRankSpecifierOrTypeSyntax
+        {
+            private readonly ArrayRankSpecifierSyntax? ArrayRank;
+            private readonly TypeSyntax? Type;
+
+            internal ArrayRankSpecifierOrTypeSyntax(ArrayRankSpecifierSyntax arrayRank)
             {
-                var functionPointerTypeSyntax = (FunctionPointerTypeSyntax)type;
-                foreach (var param in functionPointerTypeSyntax.Parameters)
+                ArrayRank = arrayRank;
+                Type = null;
+            }
+
+            internal ArrayRankSpecifierOrTypeSyntax(TypeSyntax typeSyntax)
+            {
+                ArrayRank = null;
+                Type = typeSyntax;
+            }
+
+            internal bool IsRankSpecifier([NotNullWhen(true)] out ArrayRankSpecifierSyntax? arrayRank, [NotNullWhen(false)] out TypeSyntax? type)
+            {
+                arrayRank = ArrayRank;
+                type = Type;
+                if (arrayRank is object)
                 {
-                    param.Type?.VisitRankSpecifiers(action, argument);
+                    return true;
                 }
+
+                Debug.Assert(type is object);
+                return false;
             }
         }
     }


### PR DESCRIPTION
* Remove shared capturing local function in VisitType. While convenient, the extra stack size from the local function display class was blowing the stack in the constraints test.
* Rewrite VisitArrayRankSpecifiers to be an iterative function. One additional method call in the body of the function was enough to blow the stack here. Rather than doing a half measure of the visitor being kinda-sorta iterative, I rewrote it to use a manual stack and be fully iterative.
