### PR TITLE
Skip executing analyzers by default on local builds for solutions in the repo

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -103,7 +103,6 @@ stages:
                 -officialSourceBranchName $(SourceBranchName)
                 -officialIbcSourceBranchName $(IbcSourceBranchName)
                 -officialIbcDropId $(IbcDropId)
-                -skipAnalyzers
                 /p:RepositoryName=$(Build.Repository.Name)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
   timeoutInMinutes: 90
 
   steps:
-    - script: eng/cibuild.cmd -configuration $(_configuration) -prepareMachine -testDesktop -$(_testKind) -procdump -skipAnalyzers
+    - script: eng/cibuild.cmd -configuration $(_configuration) -prepareMachine -testDesktop -$(_testKind) -procdump
       displayName: Build and Test
 
     - task: PublishTestResults@2
@@ -65,7 +65,7 @@ jobs:
   timeoutInMinutes: 90
 
   steps:
-    - script: eng/cibuild.cmd -configuration Debug -prepareMachine -testDesktop -skipAnalyzers
+    - script: eng/cibuild.cmd -configuration Debug -prepareMachine -testDesktop
       displayName: Build and Test
 
     - task: PublishTestResults@2
@@ -99,7 +99,7 @@ jobs:
   timeoutInMinutes: 90
 
   steps:
-    - script: eng/cibuild.cmd -configuration $(_configuration) -prepareMachine -msbuildEngine:dotnet -testCoreClr -skipAnalyzers
+    - script: eng/cibuild.cmd -configuration $(_configuration) -prepareMachine -msbuildEngine:dotnet -testCoreClr
       displayName: Build and Test
 
     - task: PublishTestResults@2
@@ -190,7 +190,7 @@ jobs:
 #        _configuration: Debug
   timeoutInMinutes: 90
   steps:
-    - script: ./eng/cibuild.sh --configuration $(_configuration) --prepareMachine --skipAnalyzers $(_args)
+    - script: ./eng/cibuild.sh --configuration $(_configuration) --prepareMachine $(_args)
       displayName: Build and Test
     - task: PublishTestResults@2
       displayName: Publish xUnit Test Results
@@ -216,7 +216,7 @@ jobs:
    queue: BuildPool.Ubuntu.1604.amd64.Open
   timeoutInMinutes: 90
   steps:
-    - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --docker --sourceBuild --skipAnalyzers
+    - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --docker --sourceBuild
       displayName: Build
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
@@ -233,7 +233,7 @@ jobs:
   timeoutInMinutes: 90
 
   steps:
-    - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --testCoreClr --skipAnalyzers
+    - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --testCoreClr
       displayName: Build and Test
 
     - task: PublishTestResults@2

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -247,7 +247,7 @@ function Get-PackageDir([string]$name, [string]$version = "") {
   return $p
 }
 
-function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration, [switch]$skipAnalyzers = $false) {
+function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration, [switch]$runAnalyzers = $false) {
   # Because we override the C#/VB toolset to build against our LKG package, it is important
   # that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
   # we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
@@ -268,8 +268,8 @@ function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]
     $args += " /m"
   }
 
-  if ($skipAnalyzers) {
-    $args += " /p:UseRoslynAnalyzers=false"
+  if ($runAnalyzers) {
+    $args += " /p:UseRoslynAnalyzers=true"
   }
 
   if ($binaryLog) {
@@ -317,7 +317,7 @@ function Make-BootstrapBuild([switch]$force32 = $false) {
   $projectPath = "src\NuGet\$packageName\$packageName.Package.csproj"
   $force32Flag = if ($force32) { " /p:BOOTSTRAP32=true" } else { "" }
 
-  Run-MSBuild $projectPath "/restore /t:Pack /p:RoslynEnforceCodeStyle=false /p:UseRoslynAnalyzers=false /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false /p:PublishWindowsPdb=false $force32Flag" -logFileName "Bootstrap" -configuration $bootstrapConfiguration -skipAnalyzers
+  Run-MSBuild $projectPath "/restore /t:Pack /p:RoslynEnforceCodeStyle=false /p:UseRoslynAnalyzers=false /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false /p:PublishWindowsPdb=false $force32Flag" -logFileName "Bootstrap" -configuration $bootstrapConfiguration -runAnalyzers
   $packageFile = Get-ChildItem -Path $dir -Filter "$packageName.*.nupkg"
   Unzip "$dir\$packageFile" $dir
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -37,7 +37,7 @@ param (
   [switch]$buildServerLog,
   [switch]$ci,
   [switch]$procdump,
-  [switch]$runAnalyzers,
+  [switch][Alias('a')]$runAnalyzers,
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
   [switch]$useGlobalNuGetCache = $true,
@@ -97,7 +97,7 @@ function Print-Usage() {
   Write-Host "  -bootstrapConfiguration   Build configuration for bootstrap compiler: 'Debug' or 'Release'"
   Write-Host "  -msbuildEngine <value>    Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -procdump                 Monitor test runs with procdump"
-  Write-Host "  -runAnalyzers             Run analyzers during build operations"
+  Write-Host "  -runAnalyzers             Run analyzers during build operations (short: -a)"
   Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -warnAsError              Treat all warnings as errors"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -37,7 +37,7 @@ param (
   [switch]$buildServerLog,
   [switch]$ci,
   [switch]$procdump,
-  [switch]$skipAnalyzers,
+  [switch]$runAnalyzers,
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
   [switch]$useGlobalNuGetCache = $true,
@@ -97,7 +97,7 @@ function Print-Usage() {
   Write-Host "  -bootstrapConfiguration   Build configuration for bootstrap compiler: 'Debug' or 'Release'"
   Write-Host "  -msbuildEngine <value>    Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -procdump                 Monitor test runs with procdump"
-  Write-Host "  -skipAnalyzers            Do not run analyzers during build operations"
+  Write-Host "  -runAnalyzers             Run analyzers during build operations"
   Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -warnAsError              Treat all warnings as errors"
@@ -120,7 +120,7 @@ function Print-Usage() {
 # specified.
 #
 # In this function it's okay to use two arguments to extend the effect of another. For
-# example it's okay to look at $testVsi and infer $skipAnalyzers. It's not okay though to infer
+# example it's okay to look at $testVsi and infer $runAnalyzers. It's not okay though to infer
 # $build based on say $testDesktop. It's possible the developer wanted only for testing
 # to execute, not any build.
 function Process-Arguments() {
@@ -178,7 +178,7 @@ function Process-Arguments() {
 
   if ($testVsi) {
     # Avoid spending time in analyzers when requested, and also in the slowest integration test builds
-    $script:skipAnalyzers = $true
+    $script:runAnalyzers = $false
     $script:bootstrap = $false
   }
 
@@ -215,7 +215,6 @@ function BuildSolution() {
   }
 
   $projects = Join-Path $RepoRoot $solution
-  $enableAnalyzers = !$skipAnalyzers
   $toolsetBuildProj = InitializeToolset
 
   $testTargetFrameworks = if ($testCoreClr) { "netcoreapp3.1" } else { "" }
@@ -258,7 +257,7 @@ function BuildSolution() {
       /p:Publish=$publish `
       /p:ContinuousIntegrationBuild=$ci `
       /p:OfficialBuildId=$officialBuildId `
-      /p:UseRoslynAnalyzers=$enableAnalyzers `
+      /p:UseRoslynAnalyzers=$runAnalyzers `
       /p:BootstrapBuildPath=$bootstrapDir `
       /p:TestTargetFrameworks=$testTargetFrameworks `
       /p:TreatWarningsAsErrors=true `

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -31,7 +31,7 @@ usage()
   echo "  --ci                       Building in CI"
   echo "  --docker                   Run in a docker container if applicable"
   echo "  --bootstrap                Build using a bootstrap compilers"
-  echo "  --skipAnalyzers            Do not run analyzers during build operations"
+  echo "  --runAnalyzers             Run analyzers during build operations"
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
   echo "  --warnAsError              Treat all warnings as errors"
   echo "  --sourceBuild              Simulate building for source-build"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -64,7 +64,7 @@ verbosity='minimal'
 binary_log=false
 ci=false
 bootstrap=false
-skip_analyzers=false
+run_analyzers=false
 prepare_machine=false
 warn_as_error=false
 properties=""
@@ -129,8 +129,8 @@ while [[ $# > 0 ]]; do
       # Bootstrap requires restore
       restore=true
       ;;
-    --skipanalyzers)
-      skip_analyzers=true
+    --runAnalyzers)
+      run_analyzers=true
       ;;
     --preparemachine)
       prepare_machine=true
@@ -224,10 +224,9 @@ function BuildSolution {
   local projects="$repo_root/$solution" 
   
   # https://github.com/dotnet/roslyn/issues/23736
-  local enable_analyzers=!$skip_analyzers
   UNAME="$(uname)"
   if [[ "$UNAME" == "Darwin" ]]; then
-    enable_analyzers=false
+    run_analyzers=false
   fi
 
   # NuGet often exceeds the limit of open files on Mac and Linux
@@ -273,7 +272,7 @@ function BuildSolution {
     /p:Test=$test \
     /p:Pack=$pack \
     /p:Publish=$publish \
-    /p:UseRoslynAnalyzers=$enable_analyzers \
+    /p:UseRoslynAnalyzers=$run_analyzers \
     /p:BootstrapBuildPath="$bootstrap_dir" \
     /p:ContinuousIntegrationBuild=$ci \
     /p:TreatWarningsAsErrors=true \

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -34,6 +34,18 @@
     <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true')">true</RoslynCheckCodeStyle>
   </PropertyGroup>
 
+  <!--
+    PERF: Set default value for 'UseRoslynAnalyzers' to determine if analyzers should be executed.
+          Default to 'false' in all non-CI builds to improve local build time (i.e. csc/vbc invocations both inside Visual Studio and from command line prompt), except if:
+            1. We are enforcing code style, i.e. '$(RoslynEnforceCodeStyle)' == 'true' OR
+            2. We are explicitly running code analysis via "Run Code Analysis" command, i.e. '$(RunCodeAnalysis)' == 'true'.
+          Otherwise, default to 'true'.
+  -->
+  <PropertyGroup Condition="'$(UseRoslynAnalyzers)' == ''">
+    <UseRoslynAnalyzers Condition="'$(DesignTimeBuild)' != 'true' AND '$(ContinuousIntegrationBuild)' != 'true' AND !('$(RoslynEnforceCodeStyle)' == 'true' OR '$(RunCodeAnalysis)' == 'true')">false</UseRoslynAnalyzers>
+    <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(DisableNullableWarnings)' == 'true'">
     <NoWarn>$(NoWarn);Nullable</NoWarn>
   </PropertyGroup>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -23,7 +23,6 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
-    <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
 
     <!-- Set to non-existent file to prevent common targets from importing Microsoft.CodeAnalysis.targets -->
     <CodeAnalysisTargets>NON_EXISTENT_FILE</CodeAnalysisTargets>

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -34,7 +34,7 @@ try {
   Push-Location $RepoRoot
 
   Write-Host "Building Roslyn"
-  Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"}
+  Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"}
 
   # Verify the state of our various build artifacts
   Write-Host "Running BuildBoss"

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -249,7 +249,7 @@ try {
   Create-Directory $errorDirLeft
   Create-Directory $errorDirRight
 
-  $skipAnalyzers = $true
+  $runAnalyzers = $false
   $binaryLog = $true
   $officialBuildId = ""
   $ci = $true

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -5,7 +5,6 @@
 #nullable enable
 
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;


### PR DESCRIPTION
## Overview
This change skips executing analyzers by default on explicit builds of solutions in this repo (both inside VS and on command line prompt). We will continue running analyzers for the following:
1. _Inside IDE while typing_: We want to identify analyzer warnings and suggestions during development and apply code fixes or fix all operations. This is the core scenario where we need to execute analyzers for **inner dev loop**.
2. _CI legs_: We build our solutions with analyzers enabled on the `Correctness` leg to catch build breaking analyzer warnings. This is the core scenario where we need to execute analyzers for **build time analyzer enforcement.**

This change should speed up the local build time of Roslyn.sln by **~2X**.

## Running analyzers locally after this change
The only time a developer would want to run analyzers locally, outside the IDE typing scenario, is to compute the exact set of warnings for a specific project/solution before pushing local changes to CI. They can now perform the following steps to achieve this:
1. On command line:
   1. Run `build -runAnalyzers` at the root of the repo.
   2. Build specific project/solution with msbuild argument `/p:UseRoslynAnalyzers=true` or `/p:RunCodeAnalysis=true`.
2. Inside VS:
   1. Start VS with `%RoslynEnforceCodeStyle% = true`, all builds in VS should execute analyzers
   2. Use `Run Code Analysis` command from `Analyze` menu on selected project/solution

## Perf testing - build time measurements

### Steps
1. `restore`
2. `taskkill /F /IM MSBuild.exe`
3. `taskkill /F /IM VBCSCompiler.exe`
4. _[cold]_ `msbuild /m /v:m /t:rebuild Roslyn.sln`
5. _[hot]_ `msbuild /m /v:m /t:rebuild Roslyn.sln`

### Measurements
1. Master branch (commit https://github.com/dotnet/roslyn/commit/27654b066e600a350706a13ebd67d1da542c1a7b)
   1. _[cold - step 4]_: **6 minutes 20 seconds**
   2. _[hot - step 5]_: **5 minutes 45 seconds**

2. This PR branch
   1. _[cold - step 4]_: **3 minutes**
   2. _[hot - step 5]_: **2 minutes 35 seconds**

## Functional testing
1. Local validation:
   1. Command line:
      1. `build.cmd` does not run analyzers.
      2. `build.cmd -runAnalyzers` runs analyzers.
      3. `msbuild Roslyn.sln` does not run analyzers.
      4. `msbuild Roslyn.sln /p:UseRoslynAnalyzers=true` and `msbuild Roslyn.sln /p:RunCodeAnalysis=true` runs analyzers
   2. VS:
      1. `Build` and `Rebuild` menu commands do not run analyzers.
      2. Analyzers run on open files by default.
      3. Switching to "Entire solution" background analysis scope also run analyzers on closed files.
      4. `Run Code Analysis` command on individual projects force completes all applicable analyzers and diagnostics are populated in error list (NOTE: Solution level command seems to be causing a ServiceHub exception right now, I'll file a bug).
      5. FixAll operations find and fix violations in closed files, regardless of the background analysis scope.
2. CI validation:
   1. Dummy commit https://github.com/dotnet/roslyn/pull/44047/commits/71716fd556552c83a8a948324f7c7180020c29ff with a build enforced code style violation leads to:
      1. `build-correctness` test leg to fail with this warning treated as error.
      2. All other test legs pass, no analyzers are executed as `/p:UseRoslynAnalyzers= false` was used.
   2. Revert the above commit to have no code style violations: All test legs pass (this PR must be green)