### PR TITLE
Add ExternalAccess entrypoint for removing todocomments

### DIFF
--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/IVsTypeScriptTodoCommentService.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/IVsTypeScriptTodoCommentService.cs
@@ -18,5 +18,12 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
         /// cref="Workspace.WorkspaceChanged"/>).  This can be called on any thread.
         /// </summary>
         Task ReportTodoCommentsAsync(Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Legacy entry-point to allow existing in-process TypeScript language service to report when documents
+        /// which have previously reported todo comments are removed from the workspace.
+        /// This can be called on any thread.
+        /// </summary>
+        Task OnDocumentRemovedAsync(DocumentId documentId, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -206,7 +206,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
             workQueue.AddWork(new DocumentAndComments(documentId, infos));
         }
 
-        /// <inheritdoc cref="IVsTypeScriptTodoCommentService.ReportTodoCommentsAsync(Document, ImmutableArray{TodoComment}, CancellationToken)"/>
         async Task IVsTypeScriptTodoCommentService.ReportTodoCommentsAsync(
             Document document, ImmutableArray<TodoComment> todoComments, CancellationToken cancellationToken)
         {
@@ -222,7 +221,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
                 document.Id, converted.ToImmutable(), cancellationToken).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="IVsTypeScriptTodoCommentService.OnDocumentRemovedAsync(DocumentId, CancellationToken)"/>
         Task IVsTypeScriptTodoCommentService.OnDocumentRemovedAsync(DocumentId documentId, CancellationToken cancellationToken) =>
             OnDocumentRemovedAsync(documentId, cancellationToken);
     }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -221,5 +221,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
             await ReportTodoCommentDataAsync(
                 document.Id, converted.ToImmutable(), cancellationToken).ConfigureAwait(false);
         }
+
+        /// <inheritdoc cref="IVsTypeScriptTodoCommentService.OnDocumentRemovedAsync(DocumentId, CancellationToken)"/>
+        Task IVsTypeScriptTodoCommentService.OnDocumentRemovedAsync(DocumentId documentId, CancellationToken cancellationToken) =>
+            OnDocumentRemovedAsync(documentId, cancellationToken);
     }
 }


### PR DESCRIPTION
Currently, if a JS/TS file with todo comments is deleted, the corresponding comments aren't removed from the task list. This is because Roslyn OOP isn't tracking those files, whereas we are.

To handle this, this PR adds an entry point so we can report when documents we track are deleted.