### PR TITLE
dynamic and nint decoding support

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -280,7 +280,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AddSpace();
                 }
 
+                if (ShouldMethodDisplayReadOnly(symbol))
+                {
+                    AddReadOnlyIfRequired();
+                }
+
+                if (symbol.ReturnsByRef)
+                {
+                    AddRefIfRequired();
+                }
+                else if (symbol.ReturnsByRefReadonly)
+                {
+                    AddRefReadonlyIfRequired();
+                }
+
+                AddCustomModifiersIfRequired(symbol.RefCustomModifiers);
+
                 symbol.ReturnType.Accept(this.NotFirstVisitor);
+
+                AddCustomModifiersIfRequired(symbol.ReturnTypeCustomModifiers, leadingSpace: true, trailingSpace: false);
 
                 AddPunctuation(SyntaxKind.GreaterThanToken);
                 return;

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -280,11 +280,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AddSpace();
                 }
 
-                if (ShouldMethodDisplayReadOnly(symbol))
-                {
-                    AddReadOnlyIfRequired();
-                }
-
                 if (symbol.ReturnsByRef)
                 {
                     AddRefIfRequired();

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -978,6 +978,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case TypeKind.Array:
                     case TypeKind.Pointer:
+                    case TypeKind.FunctionPointer:
                     case TypeKind.TypeParameter:
                     case TypeKind.Dynamic:
                         builder.Add(false);

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -920,7 +920,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 static void handleFunctionPointerType(FunctionPointerTypeSymbol funcPtr, ArrayBuilder<bool> transformFlagsBuilder, bool addCustomModifierFlags)
                 {
                     Func<TypeSymbol, (ArrayBuilder<bool>, bool), bool, bool> visitor =
-                        (TypeSymbol type, (ArrayBuilder<bool> builder, bool addCustomModiferFlags) param, bool _) => AddFlags(type, param.builder, isNestedNamedType: false, param.addCustomModiferFlags);
+                        (TypeSymbol type, (ArrayBuilder<bool> builder, bool addCustomModiferFlags) param, bool isNestedNamedType) => AddFlags(type, param.builder, isNestedNamedType, param.addCustomModiferFlags);
 
                     // The function pointer type itself gets a false
                     transformFlagsBuilder.Add(false);

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -221,6 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.NamedType:
                 case SymbolKind.PointerType:
                 case SymbolKind.TypeParameter:
+                case SymbolKind.FunctionPointer:
                     return ((TypeSymbol)m).CustomModifierCount();
                 case SymbolKind.Event:
                     return ((EventSymbol)m).CustomModifierCount();

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return true;
         }
 
-        // Native compiler encodes bools (always false) for custom modifiers and parameter ref-kinds, if ref-kind is ref or out.
+        // Native compiler encodes bools (always false) for custom modifiers and parameter ref-kinds, if ref-kind is not none.
         private bool HandleRefKind(RefKind refKind)
         {
             Debug.Assert(_index >= 0);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -696,9 +696,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static TypeSymbol? visitFunctionPointerType(FunctionPointerTypeSymbol type, Func<TypeWithAnnotations, T, bool, bool>? typeWithAnnotationsPredicate, Func<TypeSymbol, T, bool, bool>? typePredicate, T arg, bool useDefaultType, bool canDigThroughNullable)
             {
-
                 MethodSymbol currentPointer = type.Signature;
-                var result = visitType(currentPointer.ReturnTypeWithAnnotations);
+                var result = VisitType(
+                    typeWithAnnotationsOpt: canDigThroughNullable ? default : currentPointer.ReturnTypeWithAnnotations,
+                    type: canDigThroughNullable ? currentPointer.ReturnTypeWithAnnotations.NullableUnderlyingTypeOrSelf : null,
+                    typeWithAnnotationsPredicate,
+                    typePredicate,
+                    arg,
+                    canDigThroughNullable,
+                    useDefaultType);
                 if (result is object)
                 {
                     return result;
@@ -706,7 +712,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 foreach (var parameter in currentPointer.Parameters)
                 {
-                    result = visitType(parameter.TypeWithAnnotations);
+                    result = VisitType(
+                        typeWithAnnotationsOpt: canDigThroughNullable ? default : parameter.TypeWithAnnotations,
+                        type: canDigThroughNullable ? parameter.TypeWithAnnotations.NullableUnderlyingTypeOrSelf : null,
+                        typeWithAnnotationsPredicate,
+                        typePredicate,
+                        arg,
+                        canDigThroughNullable,
+                        useDefaultType);
                     if (result is object)
                     {
                         return result;
@@ -714,15 +727,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 return null;
-
-                TypeSymbol? visitType(TypeWithAnnotations typeArg) => VisitType(
-                    typeWithAnnotationsOpt: canDigThroughNullable ? default : typeArg,
-                    type: canDigThroughNullable ? typeArg.NullableUnderlyingTypeOrSelf : null,
-                    typeWithAnnotationsPredicate,
-                    typePredicate,
-                    arg,
-                    canDigThroughNullable,
-                    useDefaultType);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -543,6 +543,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public TypeWithAnnotations WithTypeAndModifiers(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers) =>
             _extensions.WithTypeAndModifiers(this, typeSymbol, customModifiers);
 
+        public TypeWithAnnotations WithType(TypeSymbol typeSymbol) =>
+            _extensions.WithTypeAndModifiers(this, typeSymbol, CustomModifiers);
+
         /// <summary>
         /// Used by callers before calling CSharpCompilation.EnsureNullableAttributeExists().
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -108,14 +108,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.FunctionPointer:
                     {
                         var funcPtr = (FunctionPointerTypeSymbol)type;
-                        if (checkTypeWithAnnotations(funcPtr.Signature.ReturnTypeWithAnnotations, flagNonDefaultArraySizesOrLowerBounds))
+                        if (!funcPtr.Signature.RefCustomModifiers.IsEmpty || checkTypeWithAnnotations(funcPtr.Signature.ReturnTypeWithAnnotations, flagNonDefaultArraySizesOrLowerBounds))
                         {
                             return true;
                         }
 
                         foreach (var param in funcPtr.Signature.Parameters)
                         {
-                            if (checkTypeWithAnnotations(param.TypeWithAnnotations, flagNonDefaultArraySizesOrLowerBounds))
+                            if (!param.RefCustomModifiers.IsEmpty || checkTypeWithAnnotations(param.TypeWithAnnotations, flagNonDefaultArraySizesOrLowerBounds))
                             {
                                 return true;
                             }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -1022,6 +1022,52 @@ C<T, U, V>
             }
         }
 
+        [Fact]
+        public void FunctionPointersWithNativeIntegerTypes()
+        {
+            var comp = CompileAndVerify(@"
+unsafe class C
+{
+    public delegate*<nint, nint, nint> F1;
+    public delegate*<System.IntPtr, System.IntPtr, nint> F2;
+    public delegate*<nint, System.IntPtr, System.IntPtr> F3;
+    public delegate*<System.IntPtr, nint, System.IntPtr> F4;
+    public delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, nint> F5;
+    public delegate*<nint, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F6;
+}
+", options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularPreview, symbolValidator: symbolValidator);
+
+            void symbolValidator(ModuleSymbol module)
+            {
+                var expectedAttributes = @"
+C
+    [NativeInteger({ False, True, True, True })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F1
+    [NativeInteger({ False, True, False, False })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F2
+    [NativeInteger({ False, False, True, False })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F3
+    [NativeInteger({ False, False, False, True })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F4
+    [NativeInteger({ False, True, False, False, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr> F5
+    [NativeInteger({ False, False, False, False, False, True })] delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F6
+";
+
+                AssertNativeIntegerAttributes(module, expectedAttributes);
+                var c = module.GlobalNamespace.GetTypeMember("C");
+
+                assert("delegate*<nint, nint, nint>", "F1");
+                assert("delegate*<System.IntPtr, System.IntPtr, nint>", "F2");
+                assert("delegate*<nint, System.IntPtr, System.IntPtr>", "F3");
+                assert("delegate*<System.IntPtr, nint, System.IntPtr>", "F4");
+                assert("delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, nint>", "F5");
+                assert("delegate*<nint, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>>", "F6");
+
+                void assert(string expectedType, string fieldName)
+                {
+                    var field = c.GetField(fieldName);
+                    FunctionPointerUtilities.CommonVerifyFunctionPointer((FunctionPointerTypeSymbol)field.Type);
+                    Assert.Equal(expectedType, c.GetField(fieldName).Type.ToTestDisplayString());
+                }
+            }
+        }
+
         private static TypeDefinition GetTypeDefinitionByName(MetadataReader reader, string name)
         {
             return reader.GetTypeDefinition(reader.TypeDefinitions.Single(h => reader.StringComparer.Equals(reader.GetTypeDefinition(h).Name, name)));

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -1034,10 +1034,12 @@ unsafe class C
     public delegate*<System.IntPtr, nint, System.IntPtr> F4;
     public delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, nint> F5;
     public delegate*<nint, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F6;
+    public delegate*<delegate*<System.IntPtr, System.IntPtr, nint>, System.IntPtr> F7;
+    public delegate*<System.IntPtr, delegate*<System.IntPtr, nint, System.IntPtr>> F8;
 }
 ", options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularPreview, symbolValidator: symbolValidator);
 
-            void symbolValidator(ModuleSymbol module)
+            static void symbolValidator(ModuleSymbol module)
             {
                 var expectedAttributes = @"
 C
@@ -1047,6 +1049,8 @@ C
     [NativeInteger({ False, False, False, True })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F4
     [NativeInteger({ False, True, False, False, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr> F5
     [NativeInteger({ False, False, False, False, False, True })] delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F6
+    [NativeInteger({ False, False, False, True, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr> F7
+    [NativeInteger({ False, False, False, False, True, False })] delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F8
 ";
 
                 AssertNativeIntegerAttributes(module, expectedAttributes);
@@ -1058,6 +1062,8 @@ C
                 assert("delegate*<System.IntPtr, nint, System.IntPtr>", "F4");
                 assert("delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, nint>", "F5");
                 assert("delegate*<nint, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>>", "F6");
+                assert("delegate*<delegate*<System.IntPtr, System.IntPtr, nint>, System.IntPtr>", "F7");
+                assert("delegate*<System.IntPtr, delegate*<System.IntPtr, nint, System.IntPtr>>", "F8");
 
                 void assert(string expectedType, string fieldName)
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -5204,8 +5204,14 @@ unsafe class C
     public delegate*<out dynamic, object> F14;
 
     public D<delegate*<dynamic>[], dynamic> F15;
+
+    public delegate*<A<object>.B<dynamic>> F16;
 }
 class D<T, U> { }
+class A<T>
+{
+    public class B<U> {}
+}
 ", symbolValidator: symbolValidator);
 
             void symbolValidator(ModuleSymbol module)
@@ -5235,6 +5241,8 @@ class D<T, U> { }
 
                 // https://github.com/dotnet/roslyn/issues/44160 tracks fixing this. We're not encoding dynamic correctly for function pointers as type parameters
                 assertField("F15", "System.Runtime.CompilerServices.DynamicAttribute({false, false, false, true})", "D<delegate*<System.Object>[], System.Object>");
+
+                assertField("F16", "System.Runtime.CompilerServices.DynamicAttribute({false, false, false, true})", "delegate*<A<System.Object>.B<dynamic>>");
 
                 void assertField(string field, string? expectedAttribute, string expectedType)
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -397,9 +397,9 @@ unsafe class D
   // Code size       87 (0x57)
   .maxstack  2
   IL_0000:  ldftn      ""ref readonly int D.M()""
-  IL_0006:  stsfld     ""delegate*<int> C.Field1""
-  IL_000b:  ldsfld     ""delegate*<int> C.Field1""
-  IL_0010:  calli      ""delegate*<int>""
+  IL_0006:  stsfld     ""delegate*<ref readonly int> C.Field1""
+  IL_000b:  ldsfld     ""delegate*<ref readonly int> C.Field1""
+  IL_0010:  calli      ""delegate*<ref readonly int>""
   IL_0015:  dup
   IL_0016:  ldind.i4
   IL_0017:  call       ""void System.Console.Write(int)""
@@ -408,11 +408,11 @@ unsafe class D
   IL_0022:  ldind.i4
   IL_0023:  call       ""void System.Console.Write(int)""
   IL_0028:  ldftn      ""ref readonly int D.M()""
-  IL_002e:  stsfld     ""delegate*<int> C.Field2""
+  IL_002e:  stsfld     ""delegate*<ref readonly int> C.Field2""
   IL_0033:  ldc.i4.3
   IL_0034:  stsfld     ""int D.i""
-  IL_0039:  ldsfld     ""delegate*<int> C.Field2""
-  IL_003e:  calli      ""delegate*<int>""
+  IL_0039:  ldsfld     ""delegate*<ref readonly int> C.Field2""
+  IL_003e:  calli      ""delegate*<ref readonly int>""
   IL_0043:  dup
   IL_0044:  ldind.i4
   IL_0045:  call       ""void System.Console.Write(int)""
@@ -538,7 +538,7 @@ unsafe class C
   // Code size       31 (0x1f)
   .maxstack  2
   IL_0000:  ldftn      ""ref readonly int C.GetI()""
-  IL_0006:  calli      ""delegate*<int>""
+  IL_0006:  calli      ""delegate*<ref readonly int>""
   IL_000b:  dup
   IL_000c:  ldind.i4
   IL_000d:  call       ""void System.Console.Write(int)""
@@ -2402,8 +2402,8 @@ unsafe class C
   .maxstack  1
   IL_0000:  ldstr      ""Field""
   IL_0005:  stsfld     ""string Program.field""
-  IL_000a:  call       ""delegate*<string> Program.LoadPtr()""
-  IL_000f:  calli      ""delegate*<string>""
+  IL_000a:  call       ""delegate*<ref string> Program.LoadPtr()""
+  IL_000f:  calli      ""delegate*<ref string>""
   IL_0014:  ldind.ref
   IL_0015:  call       ""void System.Console.WriteLine(string)""
   IL_001a:  ret
@@ -2465,14 +2465,15 @@ unsafe class C
 {
   // Code size       27 (0x1b)
   .maxstack  2
-  IL_0000:  call       ""delegate*<string> Program.LoadPtr()""
-  IL_0005:  calli      ""delegate*<string>""
+  IL_0000:  call       ""delegate*<ref string> Program.LoadPtr()""
+  IL_0005:  calli      ""delegate*<ref string>""
   IL_000a:  ldstr      ""Field""
   IL_000f:  stind.ref
   IL_0010:  ldsfld     ""string Program.field""
   IL_0015:  call       ""void System.Console.WriteLine(string)""
   IL_001a:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -5061,7 +5062,7 @@ unsafe class C
   // Code size       34 (0x22)
   .maxstack  1
   IL_0000:  ldarg.1
-  IL_0001:  calli      ""delegate*<T>""
+  IL_0001:  calli      ""delegate*<ref T>""
   IL_0006:  constrained. ""T""
   IL_000c:  callvirt   ""void C.M1()""
   IL_0011:  ldarg.2

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -5394,6 +5394,157 @@ unsafe class B : A
             }
         }
 
+        [Fact]
+        public void BetterFunctionMember_BreakTiesByCustomModifierCount_TypeMods()
+        {
+            var il = @"
+.class public auto ansi beforefieldinit Program
+    extends [mscorlib]System.Object
+{
+    // Methods
+    .method public hidebysig static 
+        void RetModifiers (method void modopt([mscorlib]System.Object) modopt([mscorlib]System.Object) *()) cil managed 
+    {
+        ldstr ""M""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+
+    .method public hidebysig static 
+        void RetModifiers (method void modopt([mscorlib]System.Object) *()) cil managed 
+    {
+        ldstr ""L""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+
+    .method public hidebysig static 
+        void ParamModifiers (method void *(int32 modopt([mscorlib]System.Object) modopt([mscorlib]System.Object))) cil managed 
+    {
+        ldstr ""M""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+
+    .method public hidebysig static 
+        void ParamModifiers (method void *(int32) modopt([mscorlib]System.Object)) cil managed 
+    {
+        ldstr ""L""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+}";
+
+            var source = @"
+unsafe class C
+{
+    static void Main()
+    {
+        delegate*<void> ptr1 = null;
+        Program.RetModifiers(ptr1);
+        delegate*<int, void> ptr2 = null;
+        Program.ParamModifiers(ptr2);
+    }
+}";
+
+            var verifier = CompileAndVerifyFunctionPointersWithIl(source, il, expectedOutput: "LL");
+            verifier.VerifyIL("C.Main", expectedIL: @"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (delegate*<void> V_0, //ptr1
+                delegate*<int, void> V_1) //ptr2
+  IL_0000:  ldc.i4.0
+  IL_0001:  conv.u
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       ""void Program.RetModifiers(delegate*<void>)""
+  IL_0009:  ldc.i4.0
+  IL_000a:  conv.u
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.1
+  IL_000d:  call       ""void Program.ParamModifiers(delegate*<int, void>)""
+  IL_0012:  ret
+}
+            ");
+        }
+
+        [Fact]
+        public void BetterFunctionMember_BreakTiesByCustomModifierCount_Ref()
+        {
+            var il = @"
+.class public auto ansi beforefieldinit Program
+    extends [mscorlib]System.Object
+{
+    // Methods
+    .method public hidebysig static 
+        void RetModifiers (method int32 & modopt([mscorlib]System.Object) modopt([mscorlib]System.Object) *()) cil managed 
+    {
+        ldstr ""M""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+
+    .method public hidebysig static 
+        void RetModifiers (method int32 & modopt([mscorlib]System.Object) *()) cil managed 
+    {
+        ldstr ""L""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+
+    .method public hidebysig static 
+        void ParamModifiers (method void *(int32 & modopt([mscorlib]System.Object) modopt([mscorlib]System.Object))) cil managed 
+    {
+        ldstr ""M""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+
+    .method public hidebysig static 
+        void ParamModifiers (method void *(int32 & modopt([mscorlib]System.Object))) cil managed 
+    {
+        ldstr ""L""
+        call void [mscorlib]System.Console::Write(string)
+        ret
+    }
+}
+";
+
+            var source = @"
+unsafe class C
+{
+    static void Main()
+    {
+        delegate*<ref int> ptr1 = null;
+        Program.RetModifiers(ptr1);
+        delegate*<ref int, void> ptr2 = null;
+        Program.ParamModifiers(ptr2);
+    }
+}";
+
+            var verifier = CompileAndVerifyFunctionPointersWithIl(source, il, expectedOutput: "LL");
+            verifier.VerifyIL("C.Main", expectedIL: @"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (delegate*<ref int> V_0, //ptr1
+                delegate*<ref int, void> V_1) //ptr2
+  IL_0000:  ldc.i4.0
+  IL_0001:  conv.u
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       ""void Program.RetModifiers(delegate*<ref int>)""
+  IL_0009:  ldc.i4.0
+  IL_000a:  conv.u
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.1
+  IL_000d:  call       ""void Program.ParamModifiers(delegate*<ref int, void>)""
+  IL_0012:  ret
+}
+");
+    }
+
         private static readonly Guid s_guid = new Guid("97F4DBD4-F6D1-4FAD-91B3-1001F92068E5");
         private static readonly BlobContentId s_contentId = new BlobContentId(s_guid, 0x04030201);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -1,4 +1,3 @@
-
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -497,7 +496,7 @@ unsafe class C
   // Code size       10 (0xa)
   .maxstack  1
   .locals init (delegate*<string, ref int, object> V_0, //ptr1
-                delegate*<string, int> V_1, //ptr2
+                delegate*<string, ref int> V_1, //ptr2
                 delegate*<string, void> V_2, //ptr3
                 delegate*<string, out int, object> V_3) //ptr4
   IL_0000:  ldarg.1
@@ -1411,11 +1410,11 @@ unsafe class C
                "delegate*<System.String?>",
                "?",
                "?",
-               "delegate*<System.String>",
+               "delegate*<ref System.String>",
                "delegate*<System.String?>",
                "?",
                "?",
-               "delegate*<System.String>"
+               "delegate*<ref System.String>"
             };
 
             AssertEx.Equal(expectedTypes, invocationTypes);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -1042,5 +1042,30 @@ unsafe class C
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "i").WithLocation(10, 50)
             );
         }
+
+        [Fact]
+        public void FormattingReturnTypeOptions()
+        {
+            var il = @"
+.class public auto ansi beforefieldinit C
+       extends [mscorlib]System.Object
+{
+    .field public method int32& modreq([mscorlib]System.Runtime.InteropServices.InAttribute) *() 'Field1'
+    .field public method int32 modopt([mscorlib]System.Object) & *() 'Field2'
+}
+";
+
+            var comp = CreateCompilation("", references: new[] { CompileIL(il) });
+            comp.VerifyDiagnostics();
+
+            var c = comp.GetTypeByMetadataName("C");
+            var f1 = c.GetField("Field1").Type;
+            var f2 = c.GetField("Field2").Type;
+
+            Assert.Equal("delegate*<ref readonly modreq(System.Runtime.InteropServices.InAttribute) System.Int32>", f1.ToTestDisplayString());
+            Assert.Equal("delegate*<int>", f1.ToDisplayString());
+            Assert.Equal("delegate*<ref System.Int32 modopt(System.Object)>", f2.ToTestDisplayString());
+            Assert.Equal("delegate*<int>", f2.ToDisplayString());
+        }
     }
 }


### PR DESCRIPTION
Supports decoding dynamic and nint nested elements of a function pointer type.

Relates to https://github.com/dotnet/roslyn/issues/43321 (test plan for function pointers)