### PR TITLE
When caching dependent-type-results, don't try to re-infer the originating project.

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -7046,6 +7046,7 @@ class C
             End Using
         End Sub
 
+        <WorkItem(44070, "https://github.com/dotnet/roslyn/issues/44070")>
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeParameterFromCRef(host As TestHost)
             Using result = RenameEngineResult.Create(_outputHelper,

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -7045,5 +7045,26 @@ class C
                 </Workspace>, host:=host, renameTo:="Cat")
             End Using
         End Sub
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameTypeParameterFromCRef(host As TestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document><![CDATA[
+class C
+{
+    /// <summary>
+    /// <see cref="Goo{$${|Complex:{|unresolved:X|}|}}(X)"/>
+    /// </summary>
+    void Goo<T>(T t) { }
+}]]>
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="D")
+
+                result.AssertLabeledSpansAre("Complex", "C.Goo{D}(X)", RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             _ => new ConcurrentDictionary<DefinitionProject, ImmutableArray<DependentProject>>(concurrencyLevel: 2, capacity: 20);
 
         public static async Task<ImmutableArray<Project>> GetDependentProjectsAsync(
-            ISymbol symbol, Solution solution, IImmutableSet<Project> projects, CancellationToken cancellationToken)
+            ISymbol symbol, Solution solution, IImmutableSet<Project>? projects, CancellationToken cancellationToken)
         {
             if (symbol.Kind == SymbolKind.Namespace)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.KeyEqualityComparer.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.KeyEqualityComparer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Roslyn.Utilities;
@@ -14,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Special comparer we need for our cache keys.  Necessary because <see cref="IImmutableSet{T}"/> uses
         /// reference equality and not value-equality semantics.
         /// </summary>
-        private class KeyEqualityComparer : IEqualityComparer<(SymbolKey, ProjectId, IImmutableSet<Project>)>
+        private class KeyEqualityComparer : IEqualityComparer<(SymbolKey, ProjectId?, IImmutableSet<Project>)>
         {
             public static readonly KeyEqualityComparer Instance = new KeyEqualityComparer();
 
@@ -22,8 +24,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
             }
 
-            public bool Equals((SymbolKey, ProjectId, IImmutableSet<Project>) x,
-                               (SymbolKey, ProjectId, IImmutableSet<Project>) y)
+            public bool Equals((SymbolKey, ProjectId?, IImmutableSet<Project>) x,
+                               (SymbolKey, ProjectId?, IImmutableSet<Project>) y)
             {
                 var (xSymbolKey, xProjectId, xProjects) = x;
                 var (ySymbolKey, yProjectId, yProjects) = y;
@@ -31,7 +33,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 if (!xSymbolKey.Equals(ySymbolKey))
                     return false;
 
-                if (!xProjectId.Equals(yProjectId))
+                if (!Equals(xProjectId, yProjectId))
                     return false;
 
                 if (xProjects is null)
@@ -43,7 +45,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return xProjects.SetEquals(yProjects);
             }
 
-            public int GetHashCode((SymbolKey, ProjectId, IImmutableSet<Project>) obj)
+            public int GetHashCode((SymbolKey, ProjectId?, IImmutableSet<Project>) obj)
             {
                 var (symbolKey, projectId, projects) = obj;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Solution solution,
             IImmutableSet<Project> projects,
             RelatedTypeCache cache,
-            Func<CancellationToken, Task<ImmutableArray<(INamedTypeSymbol, Project)>>> findAsync,
+            Func<CancellationToken, Task<ImmutableArray<(INamedTypeSymbol type, Project project)>>> findAsync,
             CancellationToken cancellationToken)
         {
             var dictionary = cache.GetValue(solution, s_createTypeMap);
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         private static async Task<ImmutableArray<(SymbolKey, ProjectId)>> GetSymbolKeysAndProjectIdsAsync(
-            Func<CancellationToken, Task<ImmutableArray<(INamedTypeSymbol, Project)>>> findAsync,
+            Func<CancellationToken, Task<ImmutableArray<(INamedTypeSymbol type, Project project)>>> findAsync,
             CancellationToken cancellationToken)
         {
             // If we're the code that is actually computing the symbols, then just 
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // doesn't need to incur the cost of deserializing the symbol keys that
             // we're create right below this.
             var result = await findAsync(cancellationToken).ConfigureAwait(false);
-            return result.SelectAsArray(t => (t.Item1.GetSymbolKey(), t.Item2.Id));
+            return result.SelectAsArray(t => (t.type.GetSymbolKey(), t.project.Id));
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// inherit from it that would match this search.</param>
         /// <param name="transitive">If this search after finding the direct inherited types that match the provided
         /// predicate, or if the search should continue recursively using those types as the starting point.</param>
-        private static async Task<ImmutableArray<(INamedTypeSymbol, Project)>> DescendInheritanceTreeAsync(
+        private static async Task<ImmutableArray<(INamedTypeSymbol type, Project project)>> DescendInheritanceTreeAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedClasses.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedClasses.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedClasses.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedClasses.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 cancellationToken);
         }
 
-        private static Task<ImmutableArray<INamedTypeSymbol>> FindWithoutCachingDerivedClassesAsync(
+        private static Task<ImmutableArray<(INamedTypeSymbol, Project)>> FindWithoutCachingDerivedClassesAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     cancellationToken: cancellationToken);
             }
 
-            return SpecializedTasks.EmptyImmutableArray<INamedTypeSymbol>();
+            return SpecializedTasks.EmptyImmutableArray<(INamedTypeSymbol, Project)>();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedInterfaces.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedInterfaces.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedInterfaces.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_DerivedInterfaces.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 cancellationToken);
         }
 
-        private static Task<ImmutableArray<INamedTypeSymbol>> FindWithoutCachingDerivedInterfacesAsync(
+        private static Task<ImmutableArray<(INamedTypeSymbol, Project)>> FindWithoutCachingDerivedInterfacesAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     cancellationToken: cancellationToken);
             }
 
-            return SpecializedTasks.EmptyImmutableArray<INamedTypeSymbol>();
+            return SpecializedTasks.EmptyImmutableArray<(INamedTypeSymbol, Project)>();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ImplementingTypes.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ImplementingTypes.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ImplementingTypes.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ImplementingTypes.cs
@@ -90,10 +90,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 // FindDerivedInterfacesAsync.  Delegates/Enums only happen in a few corner cases.  For example, enums
                 // implement IComparable, and delegates implement ICloneable.
                 return allTypes.WhereAsArray(
-                    t => t.Item1.TypeKind == TypeKind.Class ||
-                         t.Item1.TypeKind == TypeKind.Struct ||
-                         t.Item1.TypeKind == TypeKind.Delegate ||
-                         t.Item1.TypeKind == TypeKind.Enum);
+                    t => t.type.TypeKind == TypeKind.Class ||
+                         t.type.TypeKind == TypeKind.Struct ||
+                         t.type.TypeKind == TypeKind.Delegate ||
+                         t.type.TypeKind == TypeKind.Enum);
             }
 
             return ImmutableArray<(INamedTypeSymbol, Project)>.Empty;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ImplementingTypes.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ImplementingTypes.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 cancellationToken);
         }
 
-        private static async Task<ImmutableArray<INamedTypeSymbol>> FindWithoutCachingImplementingTypesAsync(
+        private static async Task<ImmutableArray<(INamedTypeSymbol, Project)>> FindWithoutCachingImplementingTypesAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,
@@ -88,13 +88,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 // FindDerivedInterfacesAsync.  Delegates/Enums only happen in a few corner cases.  For example, enums
                 // implement IComparable, and delegates implement ICloneable.
                 return allTypes.WhereAsArray(
-                    t => t.TypeKind == TypeKind.Class ||
-                         t.TypeKind == TypeKind.Struct ||
-                         t.TypeKind == TypeKind.Delegate ||
-                         t.TypeKind == TypeKind.Enum);
+                    t => t.Item1.TypeKind == TypeKind.Class ||
+                         t.Item1.TypeKind == TypeKind.Struct ||
+                         t.Item1.TypeKind == TypeKind.Delegate ||
+                         t.Item1.TypeKind == TypeKind.Enum);
             }
 
-            return ImmutableArray<INamedTypeSymbol>.Empty;
+            return ImmutableArray<(INamedTypeSymbol, Project)>.Empty;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,7 +56,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var delegates = new MultiDictionary<Document, DeclaredSymbolInfo>();
 
                 var namedTypes = new MultiDictionary<string, (Document, DeclaredSymbolInfo)>(
-                    project.LanguageServices.GetService<ISyntaxFactsService>().StringComparer);
+                    project.LanguageServices.GetRequiredService<ISyntaxFactsService>().StringComparer);
 
                 foreach (var document in project.Documents)
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_Remote.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_Remote.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -35,7 +37,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             WellKnownServiceHubServices.CodeAnalysisService,
                             remoteFunctionName,
                             solution,
-                            new object[]
+                            new object?[]
                             {
                                 SerializableSymbolAndProjectId.Create(type, project, cancellationToken),
                                 projects?.Select(p => p.Id).ToArray(),


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44070

Some symbols (like doc-comment-crefs) don't have an originating assembly/project.  As such, this ends up null ref'ing when we assume it does and we store that information in one of our in-memory caches.

This is trivially solvable as we know exactly which project we found the symbol in.  So instead of trying to reinfer it, we just directly store it.

Likely easier to review a commit at a time.