### PR TITLE
No longer add dumps by default

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -99,10 +99,11 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                         faultUtility.AddFile(path);
                     }
 
-                    // Returning "0" signals that we should send data to Watson; any other value will cancel the Watson report.
-                    // We never want to trigger watson manually, we'll let TargetNotifications determine if a Watson should
-                    // be reported. See https://aka.ms/roslynnfwdocs for more details
-                    return 1;
+                    // Returning "0" signals that, if sampled, we should send data to Watson. 
+                    // Any other value will cancel the Watson report. We never want to trigger a process dump manually, 
+                    // we'll let TargetedNotifications determine if a dump should be collected.
+                    // See https://aka.ms/roslynnfwdocs for more details
+                    return 0;
                 });
 
             // add extra bucket parameters to bucket better in NFW

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -93,9 +93,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 exceptionObject: exception,
                 gatherEventDetails: faultUtility =>
                 {
-                    // add current process dump
-                    faultUtility.AddProcessDump(currentProcess.Id);
-
                     // add ServiceHub log files:
                     foreach (var path in CollectServiceHubLogFilePaths())
                     {
@@ -103,7 +100,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                     }
 
                     // Returning "0" signals that we should send data to Watson; any other value will cancel the Watson report.
-                    return 0;
+                    // We never want to trigger watson manually, we'll let TargetNotifications determine if a Watson should
+                    // be reported. See https://aka.ms/roslynnfwdocs for more details
+                    return 1;
                 });
 
             // add extra bucket parameters to bucket better in NFW

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 exceptionObject: exception,
                 gatherEventDetails: faultUtility =>
                 {
-                    if (faultUtility is FaultEvent faultEvent && faultEvent.IsIncludedInWatsonSample == true)
+                    if (faultUtility is FaultEvent { IsIncludedInWatsonSample: true })
                     {
                         // add ServiceHub log files:
                         foreach (var path in CollectServiceHubLogFilePaths())

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -93,10 +93,13 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 exceptionObject: exception,
                 gatherEventDetails: faultUtility =>
                 {
-                    // add ServiceHub log files:
-                    foreach (var path in CollectServiceHubLogFilePaths())
+                    if (faultUtility is FaultEvent faultEvent && faultEvent.IsIncludedInWatsonSample == true)
                     {
-                        faultUtility.AddFile(path);
+                        // add ServiceHub log files:
+                        foreach (var path in CollectServiceHubLogFilePaths())
+                        {
+                            faultUtility.AddFile(path);
+                        }
                     }
 
                     // Returning "0" signals that, if sampled, we should send data to Watson. 


### PR DESCRIPTION
NFE should no longer collect dumps by default. Instead, we want them to be controlled remotely if possible, or sampled via watson. 