### PR TITLE
Move most of Metadata as Source down to the Features layer

### DIFF
--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -20,6 +20,7 @@ using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
+using Microsoft.CodeAnalysis.DecompiledSource;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting;

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceServiceFactory.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceServiceFactory.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using Microsoft.CodeAnalysis.DecompiledSource;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -267,9 +267,6 @@
   <data name="Given_Workspace_doesn_t_support_Undo" xml:space="preserve">
     <value>Given Workspace doesn't support Undo</value>
   </data>
-  <data name="Document_must_be_contained_in_the_workspace_that_created_this_service" xml:space="preserve">
-    <value>Document must be contained in the workspace that created this service</value>
-  </data>
   <data name="Searching" xml:space="preserve">
     <value>Searching...</value>
   </data>
@@ -365,9 +362,6 @@
   </data>
   <data name="Preview_Warning" xml:space="preserve">
     <value>Preview Warning</value>
-  </data>
-  <data name="from_metadata" xml:space="preserve">
-    <value>from metadata</value>
   </data>
   <data name="Automatic_Line_Ender" xml:space="preserve">
     <value>Automatic Line Ender</value>
@@ -587,9 +581,6 @@
   </data>
   <data name="Peek" xml:space="preserve">
     <value>Peek</value>
-  </data>
-  <data name="symbol_cannot_be_a_namespace" xml:space="preserve">
-    <value>'symbol' cannot be a namespace.</value>
   </data>
   <data name="Apply1" xml:space="preserve">
     <value>_Apply</value>

--- a/src/EditorFeatures/Core/Implementation/Peek/DefinitionPeekableItem.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/DefinitionPeekableItem.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Roslyn.Utilities;
 

--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemFactory.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Peek;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -487,11 +487,6 @@
         <target state="translated">Daný pracovní prostor nepodporuje vrácení akce zpátky.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Dokument musí být obsažený v pracovním prostoru, který vytvořil tuto datovou službu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Hledá se...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">z metadat</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Náhled</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'Symbol nemůže být obor názvů.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -487,11 +487,6 @@
         <target state="translated">Angegebener Arbeitsbereich unterstützt die Funktion "Rückgängig" nicht</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Dokument muss in dem Arbeitsbereich enthalten sein, der diesen Dienst erstellt hat</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Suche läuft...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">aus Metadaten</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Vorschau</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'"symbol" kann kein Namespace sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -487,11 +487,6 @@
         <target state="translated">El área de trabajo dada no permite deshacer</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">El documento debe estar contenido en el área de trabajo que creó este servicio</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Buscando...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">de metadatos</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Ver</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'símbolo' no puede ser un espacio de nombres.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -487,11 +487,6 @@
         <target state="translated">L'espace de travail donné ne prend pas en charge la fonction Annuler</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Le document doit être contenu dans l'espace de travail qui a créé ce service</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Recherche...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">à partir des métadonnées</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Aperçu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'symbol' ne peut pas être un espace de noms.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -487,11 +487,6 @@
         <target state="translated">L'area di lavoro specificata non supporta l'annullamento di operazioni</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Il documento deve essere contenuto nell'area di lavoro che ha creato il servizio</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Ricerca...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">da metadati</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Anteprima</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'L'elemento 'symbol' non può essere uno spazio dei nomi.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -487,11 +487,6 @@
         <target state="translated">指定されたワークスペースは元に戻す操作をサポートしていません</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">このサービスを作成したワークスペースにドキュメントが含まれている必要があります</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">検索しています...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">メタデータから</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">ピーク</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'symbol' は名前空間にすることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -487,11 +487,6 @@
         <target state="translated">지정한 작업 영역에서 실행을 취소할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">문서가 이 서비스를 만든 작업 영역에 포함되어 있어야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">검색 중...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">메타데이터에서</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">피킹</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'기호'는 네임스페이스일 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -487,11 +487,6 @@
         <target state="translated">Dany obszar roboczy nie obsługuje operacji cofania</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Dokument musi się znajdować w obszarze roboczym użytym do utworzenia tej usługi</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Trwa wyszukiwanie...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">z metadanych</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Wgląd</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'Element „symbol” nie może być przestrzenią nazw.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -487,11 +487,6 @@
         <target state="translated">Workspace fornecido não suporta Desfazer</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">O Documento deve estar contido no workspace que criou este serviço</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Pesquisando...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">de metadados</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Espiada</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'"símbolo" não pode ser um namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -487,11 +487,6 @@
         <target state="translated">Заданная рабочая область не поддерживает отмену</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Документ должен находиться в рабочей области, в которой была создана эта служба.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Идет поиск...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">из метаданных</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Обзор</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'"символ" не может быть пространством имен.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -487,11 +487,6 @@
         <target state="translated">Verilen Çalışma Alanı, Geri Alma'yı desteklemez</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">Belge, bu hizmeti oluşturan çalışma alanında yer almalıdır</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">Aranıyor...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">meta verilerden</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">Göz At</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'symbol' bir ad alanı olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -487,11 +487,6 @@
         <target state="translated">给定的工作区不支持撤销</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">文件必须包含在创建此服务的工作区中</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">正在搜索...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">从元数据</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">快速查看</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'“symbol” 不能为命名空间。</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -487,11 +487,6 @@
         <target state="translated">指定的工作區不支援復原</target>
         <note />
       </trans-unit>
-      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
-        <source>Document must be contained in the workspace that created this service</source>
-        <target state="translated">文件必須包含在此服務所建立的工作區中</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Searching">
         <source>Searching...</source>
         <target state="translated">正在搜尋...</target>
@@ -655,11 +650,6 @@
       <trans-unit id="external">
         <source>(external)</source>
         <target state="new">(external)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="from_metadata">
-        <source>from metadata</source>
-        <target state="translated">來自中繼資料</target>
         <note />
       </trans-unit>
       <trans-unit id="Automatic_Line_Ender">
@@ -1015,11 +1005,6 @@
       <trans-unit id="Peek">
         <source>Peek</source>
         <target state="translated">查看</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="symbol_cannot_be_a_namespace">
-        <source>'symbol' cannot be a namespace.</source>
-        <target state="translated">'symbol' 不可為命名空間。</target>
         <note />
       </trans-unit>
       <trans-unit id="Apply1">

--- a/src/EditorFeatures/Test2/Peek/PeekTests.vb
+++ b/src/EditorFeatures/Test2/Peek/PeekTests.vb
@@ -57,8 +57,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Peek
                 Dim result = GetPeekResultCollection(workspace)
 
                 Assert.Equal(1, result.Items.Count)
-                Assert.Equal($"String [{EditorFeaturesResources.from_metadata}]", result(0).DisplayInfo.Label)
-                Assert.Equal($"String [{EditorFeaturesResources.from_metadata}]", result(0).DisplayInfo.Title)
+                Assert.Equal($"String [{FeaturesResources.from_metadata}]", result(0).DisplayInfo.Label)
+                Assert.Equal($"String [{FeaturesResources.from_metadata}]", result(0).DisplayInfo.Title)
                 Assert.True(result.GetRemainingIdentifierLineTextOnDisk(index:=0).StartsWith("String", StringComparison.Ordinal))
             End Using
         End Sub
@@ -75,8 +75,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Peek
                 Dim result = GetPeekResultCollection(workspace)
 
                 Assert.Equal(1, result.Items.Count)
-                Assert.Equal($"Enumerable [{EditorFeaturesResources.from_metadata}]", result(0).DisplayInfo.Label)
-                Assert.Equal($"Enumerable [{EditorFeaturesResources.from_metadata}]", result(0).DisplayInfo.Title)
+                Assert.Equal($"Enumerable [{FeaturesResources.from_metadata}]", result(0).DisplayInfo.Label)
+                Assert.Equal($"Enumerable [{FeaturesResources.from_metadata}]", result(0).DisplayInfo.Title)
                 Assert.True(result.GetRemainingIdentifierLineTextOnDisk(index:=0).StartsWith("Distinct", StringComparison.Ordinal))
             End Using
         End Sub
@@ -95,8 +95,8 @@ End Class
                 Dim result = GetPeekResultCollection(workspace)
 
                 Assert.Equal(1, result.Items.Count)
-                Assert.Equal($"SerializableAttribute [{EditorFeaturesResources.from_metadata}]", result(0).DisplayInfo.Label)
-                Assert.Equal($"SerializableAttribute [{EditorFeaturesResources.from_metadata}]", result(0).DisplayInfo.Title)
+                Assert.Equal($"SerializableAttribute [{FeaturesResources.from_metadata}]", result(0).DisplayInfo.Label)
+                Assert.Equal($"SerializableAttribute [{FeaturesResources.from_metadata}]", result(0).DisplayInfo.Title)
                 Assert.True(result.GetRemainingIdentifierLineTextOnDisk(index:=0).StartsWith("New()", StringComparison.Ordinal)) ' Navigates to constructor
             End Using
         End Sub

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Features/Core/Portable/DecompiledSource/IDecompiledSourceService.cs
+++ b/src/Features/Core/Portable/DecompiledSource/IDecompiledSourceService.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 
-namespace Microsoft.CodeAnalysis.Editor
+namespace Microsoft.CodeAnalysis.DecompiledSource
 {
     internal interface IDecompiledSourceService : ILanguageService
     {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2756,4 +2756,13 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Convert_type_to_0" xml:space="preserve">
     <value>Convert type to '{0}'</value>
   </data>
+  <data name="from_metadata" xml:space="preserve">
+    <value>from metadata</value>
+  </data>
+  <data name="symbol_cannot_be_a_namespace" xml:space="preserve">
+    <value>'symbol' cannot be a namespace.</value>
+  </data>
+  <data name="Document_must_be_contained_in_the_workspace_that_created_this_service" xml:space="preserve">
+    <value>Document must be contained in the workspace that created this service</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileService.cs
@@ -4,9 +4,9 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Text;
+using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Editor
+namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal interface IMetadataAsSourceFileService
     {
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <param name="cancellationToken">To cancel project and document operations</param>
         Task<MetadataAsSourceFile> GetGeneratedFileAsync(Project project, ISymbol symbol, bool allowDecompilation, CancellationToken cancellationToken = default);
 
-        bool TryAddDocumentToWorkspace(string filePath, ITextBuffer buffer);
+        bool TryAddDocumentToWorkspace(string filePath, SourceTextContainer buffer);
 
         bool TryRemoveDocumentFromWorkspace(string filePath);
 

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFile.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFile.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-namespace Microsoft.CodeAnalysis.Editor
+namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal sealed class MetadataAsSourceFile
     {

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceGeneratedFileInfo.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceGeneratedFileInfo.cs
@@ -11,7 +11,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
+namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal sealed class MetadataAsSourceGeneratedFileInfo
     {

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceWorkspace.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceWorkspace.cs
@@ -6,7 +6,7 @@
 
 using Microsoft.CodeAnalysis.Host;
 
-namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
+namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal class MetadataAsSourceWorkspace : Workspace
     {

--- a/src/Features/Core/Portable/MetadataAsSource/SymbolMappingServiceFactory.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/SymbolMappingServiceFactory.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.SymbolMapping;
 
-namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
+namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     [ExportWorkspaceServiceFactory(typeof(ISymbolMappingService), WorkspaceKind.MetadataAsSource)]
     [Shared]
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             {
                 if (!(document.Project.Solution.Workspace is MetadataAsSourceWorkspace workspace))
                 {
-                    throw new ArgumentException(EditorFeaturesResources.Document_must_be_contained_in_the_workspace_that_created_this_service, nameof(document));
+                    throw new ArgumentException(FeaturesResources.Document_must_be_contained_in_the_workspace_that_created_this_service, nameof(document));
                 }
 
                 return workspace.FileService.MapSymbolAsync(document, symbolId, cancellationToken);

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Aktuální obsah zdrojového souboru {0} se neshoduje se sestaveným zdrojem. Případné změny provedené v tomto souboru během ladění se nepoužijí, dokud se jeho obsah nebude shodovat se sestaveným zdrojem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Upravit a pokračovat</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">proměnná typu discard</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Der aktuelle Inhalt der Quelldatei "{0}" stimmt nicht mit der erstellten Quelle überein. Alle Änderungen, die während des Debuggens an dieser Datei vorgenommen wurden, werden erst angewendet, wenn der Inhalt der erstellten Quelle entspricht.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Bearbeiten und Fortfahren</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">Ausschussvariable</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">El contenido actual del archivo de origen "{0}" no coincide con el del origen compilado, así que los cambios realizados en este archivo durante la depuración no se aplicarán hasta que coincida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Editar y continuar</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">descartar</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Le contenu actuel du fichier source '{0}' ne correspond pas à la source générée. Les changements apportés à ce fichier durant le débogage ne seront pas appliqués tant que son contenu ne correspondra pas à la source générée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Modifier et continuer</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">discard</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Il contenuto corrente del file di origine '{0}' non corrisponde all'origine compilata. Tutte le modifiche apportate a questo file durante il debug non verranno applicate finché il relativo contenuto non corrisponde all'origine compilata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Modifica e continuazione</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">variabile discard</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">ソース ファイル '{0}' の現在のコンテンツが、ビルドされたソースと一致しません。デバッグ中にこのファイルに加えられた変更は、そのコンテンツがビルドされたソースと一致するまで適用されません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">エディット コンティニュ</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">破棄</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">소스 파일 '{0}'의 현재 콘텐츠가 빌드된 소스와 일치하지 않습니다. 디버그하는 동안 이 파일의 변경된 모든 내용은 해당 콘텐츠가 빌드된 소스와 일치할 때까지 적용되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">편집하며 계속하기</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">무시 항목</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Bieżąca zawartość pliku źródłowego „{0}” nie pasuje do skompilowanego źródła. Wszystkie zmiany wprowadzone w tym pliku podczas debugowania nie zostaną zastosowane do czasu, aż jego zawartość będzie zgodna ze skompilowanym źródłem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Edytuj i kontynuuj</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">odrzuć</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">O conteúdo atual do arquivo de origem '{0}' não corresponde à origem criada. Todas as alterações feitas neste arquivo durante a depuração não serão aplicadas até que o conteúdo corresponda à origem criada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Editar e Continuar</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">discard</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Текущее содержимое исходного файла "{0}" не соответствует скомпилированному исходному коду. Все изменения, внесенные в этот файл во время отладки, не будут применены, пока содержимое файла не будет соответствовать скомпилированному исходному коду.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Операция "Изменить и продолжить"</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">отменить</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">'{0}' kaynak dosyasının geçerli içeriği, oluşturulan kaynakla eşleşmiyor. Hata ayıklama işlemi sırasında bu dosyada yapılan değişiklikler, dosyanın içeriği oluşturulan kaynakla eşleşene kadar uygulanmaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">Düzenle ve Devam Et</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">at</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">源文件 "{0}" 的当前内容与生成的源不匹配。在调试期间对此文件所做的任何更改都不会应用，直到其内容与生成的源匹配为止。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">编辑并继续</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">放弃</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -305,6 +305,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">來源檔案 '{0}' 目前的內容與已建置的來源不一致。等到此檔案的內容與已建置的來源一致後，才會套用於偵錯期間對此檔案所做的所有變更。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Document_must_be_contained_in_the_workspace_that_created_this_service">
+        <source>Document must be contained in the workspace that created this service</source>
+        <target state="new">Document must be contained in the workspace that created this service</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EditAndContinue">
         <source>Edit and Continue</source>
         <target state="translated">編輯並繼續</target>
@@ -2323,6 +2328,11 @@ If the "d" format specifier is used without other custom format specifiers, it's
         <target state="translated">捨棄</target>
         <note />
       </trans-unit>
+      <trans-unit id="from_metadata">
+        <source>from metadata</source>
+        <target state="new">from metadata</target>
+        <note />
+      </trans-unit>
       <trans-unit id="full_long_date_time">
         <source>full long date/time</source>
         <target state="new">full long date/time</target>
@@ -3573,6 +3583,11 @@ When this standard format specifier is used, the formatting or parsing operation
 The purpose of the "s" format specifier is to produce result strings that sort consistently in ascending or descending order based on date and time values. As a result, although the "s" standard format specifier represents a date and time value in a consistent format, the formatting operation does not modify the value of the date and time object that is being formatted to reflect its DateTime.Kind property or its DateTimeOffset.Offset value. For example, the result strings produced by formatting the date and time values 2014-11-15T18:32:17+00:00 and 2014-11-15T18:32:17+08:00 are identical.
 
 When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="symbol_cannot_be_a_namespace">
+        <source>'symbol' cannot be a namespace.</source>
+        <target state="new">'symbol' cannot be a namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="time_separator">

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -6,8 +6,8 @@ using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandlerBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.PooledObjects;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
@@ -6,8 +6,8 @@ using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -9,10 +9,10 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
@@ -249,7 +249,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             _foregroundThreadAffinitization.AssertIsForeground();
 
-            if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer))
+            if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer()))
             {
                 // We already added it, so we will keep it excluded from the misc files workspace
                 return;

--- a/src/VisualStudio/Core/Def/Implementation/VisualStudioMetadataAsSourceFileSupportService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VisualStudioMetadataAsSourceFileSupportService.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -5,17 +5,18 @@
 #nullable enable
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DecompiledSource;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Implementation.Structure;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;

--- a/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
@@ -4,17 +4,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LiveShare.LanguageServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
-using Microsoft.VisualStudio.Shell;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+using Microsoft.VisualStudio.Shell;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare

--- a/src/VisualStudio/LiveShare/Impl/GotoDefinitionWithFindUsagesServiceHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/GotoDefinitionWithFindUsagesServiceHandler.Exports.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
 


### PR DESCRIPTION
Right now Microsoft.VisualStudio.LanguageServer.Provider depends on EditorFeatures, which long term doesn't really make sense if it's running OOP or being used as a part of LSIF indexing. This starts down the path of trying to clean up the dependencies better.