### PR TITLE
Add a delay in process text changes to analyzer config and additional…

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace.TextTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.TextTracker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
             /// </summary>
             private readonly TimeSpan _delayBetweenProcessingTextChanges;
 
-            private int _lastTextChangeTickCount;
+            private long _lastTextChangeTickCount;
 
             internal TextTracker(
                 Workspace workspace,
@@ -72,10 +72,11 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 var lastTextChangeTickCount = _lastTextChangeTickCount;
-                var currentTickCount = Environment.TickCount;
+                var currentTickCount = DateTime.UtcNow.Ticks;
                 _lastTextChangeTickCount = currentTickCount;
 
-                if (currentTickCount - lastTextChangeTickCount >= _delayBetweenProcessingTextChanges.Ticks)
+                if (lastTextChangeTickCount == 0 ||
+                    currentTickCount - lastTextChangeTickCount >= _delayBetweenProcessingTextChanges.Ticks)
                 {
                     OnTextChangedCore(e.NewText);
                     return;

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 var newSolution = this.SetCurrentSolution(currentSolution);
-                SignupForTextChanges(documentId, textContainer, isCurrentContext, (w, id, text, mode) => w.OnDocumentTextChanged(id, text, mode), delayOnTextChanged: TimeSpan.Zero);
+                SignupForTextChanges(documentId, textContainer, isCurrentContext, (w, id, text, mode) => w.OnDocumentTextChanged(id, text, mode), delayBetweenProcessingTextChanges: TimeSpan.Zero);
 
                 var newDoc = newSolution.GetDocument(documentId);
                 this.OnDocumentTextChanged(newDoc);
@@ -428,9 +428,9 @@ namespace Microsoft.CodeAnalysis
                 : TextAndVersion.Create(newText, version.GetNewerVersion(), filePath);
         }
 
-        private void SignupForTextChanges(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext, Action<Workspace, DocumentId, SourceText, PreservationMode> onChangedHandler, TimeSpan delayOnTextChanged)
+        private void SignupForTextChanges(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext, Action<Workspace, DocumentId, SourceText, PreservationMode> onChangedHandler, TimeSpan delayBetweenProcessingTextChanges)
         {
-            var tracker = new TextTracker(this, documentId, textContainer, onChangedHandler, delayOnTextChanged);
+            var tracker = new TextTracker(this, documentId, textContainer, onChangedHandler, delayBetweenProcessingTextChanges);
             _textTrackers.Add(documentId, tracker);
             this.UpdateCurrentContextMapping_NoLock(textContainer, documentId, isCurrentContext);
             tracker.Connect();
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis
                 var newSolution = this.SetCurrentSolution(currentSolution);
 
                 // PERF: Use a 5-second delay to process text changes to additional files and analyzer config files.
-                SignupForTextChanges(documentId, textContainer, isCurrentContext, onDocumentTextChanged, delayOnTextChanged: TimeSpan.FromSeconds(5));
+                SignupForTextChanges(documentId, textContainer, isCurrentContext, onDocumentTextChanged, delayBetweenProcessingTextChanges: TimeSpan.FromSeconds(5));
 
                 // Fire and forget.
                 this.RaiseWorkspaceChangedEventAsync(workspaceChangeKind, oldSolution, newSolution, documentId: documentId);


### PR DESCRIPTION
… documents

Fixes VSO [#1048866](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1048866): Editing .editorconfig file in large solution makes editor painfully slow, high CPU and RAM usage, sometimes crashes
Addresses #41837

Verified manually that typing in Roslyn.sln's .editorconfig is now fairly responsive. There is obviously a spike in CPU after the typing has finished and text changes are processed after the delay, but that is expected as the analyzer config options for entire solution has changed.