### PR TITLE
Pass basesBeingResolved to BindTupleType

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -441,7 +441,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.TupleType:
                     {
                         var tupleTypeSyntax = (TupleTypeSyntax)syntax;
-                        return TypeWithAnnotations.Create(AreNullableAnnotationsEnabled(tupleTypeSyntax.CloseParenToken), BindTupleType(tupleTypeSyntax, diagnostics));
+                        return TypeWithAnnotations.Create(AreNullableAnnotationsEnabled(tupleTypeSyntax.CloseParenToken), BindTupleType(tupleTypeSyntax, diagnostics, basesBeingResolved));
                     }
 
                 case SyntaxKind.RefType:
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return type;
         }
 
-        private TypeSymbol BindTupleType(TupleTypeSyntax syntax, DiagnosticBag diagnostics)
+        private TypeSymbol BindTupleType(TupleTypeSyntax syntax, DiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved)
         {
             int numElements = syntax.Elements.Count;
             var types = ArrayBuilder<TypeWithAnnotations>.GetInstance(numElements);
@@ -611,7 +611,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var argumentSyntax = syntax.Elements[i];
 
-                var argumentType = BindType(argumentSyntax.Type, diagnostics);
+                var argumentType = BindType(argumentSyntax.Type, diagnostics, basesBeingResolved);
                 types.Add(argumentType);
 
                 string name = null;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -2304,7 +2304,7 @@ class Derived : Base
 
         [Fact]
         [WorkItem(1107185, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1107185")]
-        public void Tuple_MissingNestedTypeArgument()
+        public void Tuple_MissingNestedTypeArgument_01()
         {
             var source =
 @"interface I<T>
@@ -2318,6 +2318,24 @@ class A : I<(object, A.B)>
                 // (4,24): error CS0146: Circular base class dependency involving 'A' and 'A'
                 // class A : I<(object, A.B)>
                 Diagnostic(ErrorCode.ERR_CircularBase, "B").WithArguments("A", "A").WithLocation(4, 24));
+        }
+
+        [Fact]
+        [WorkItem(1107185, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1107185")]
+        public void Tuple_MissingNestedTypeArgument_02()
+        {
+            var source =
+@"class A<T>
+{
+}
+class B : A<(object, B.C)>
+{
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,24): error CS0146: Circular base class dependency involving 'B' and 'B'
+                // class B : A<(object, B.C)>
+                Diagnostic(ErrorCode.ERR_CircularBase, "C").WithArguments("B", "B").WithLocation(4, 24));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -2337,5 +2337,22 @@ class B : A<(object, B.C)>
                 // class B : A<(object, B.C)>
                 Diagnostic(ErrorCode.ERR_CircularBase, "C").WithArguments("B", "B").WithLocation(4, 24));
         }
+
+        [Fact]
+        public void Tuple_MissingNestedTypeArgument_03()
+        {
+            var source =
+@"interface I<T>
+{
+}
+class A : I<System.ValueTuple<object, A.B>>
+{
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,41): error CS0146: Circular base class dependency involving 'A' and 'A'
+                // class A : I<System.ValueTuple<object, A.B>>
+                Diagnostic(ErrorCode.ERR_CircularBase, "B").WithArguments("A", "A").WithLocation(4, 41));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -2301,5 +2301,23 @@ class Derived : Base
                 //     class E : A<C*>.B { }
                 Diagnostic(ErrorCode.ERR_ManagedAddr, "E").WithArguments("Base.C").WithLocation(12, 11));
         }
+
+        [Fact]
+        [WorkItem(1107185, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1107185")]
+        public void Tuple_MissingNestedTypeArgument()
+        {
+            var source =
+@"interface I<T>
+{
+}
+class A : I<(object, A.B)>
+{
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,24): error CS0146: Circular base class dependency involving 'A' and 'A'
+                // class A : I<(object, A.B)>
+                Diagnostic(ErrorCode.ERR_CircularBase, "B").WithArguments("A", "A").WithLocation(4, 24));
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/BaseClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/BaseClassTests.vb
@@ -2466,6 +2466,22 @@ BC30002: Type 'B.C' is not defined.
 ]]></errors>)
         End Sub
 
+        <Fact>
+        Public Sub Tuple_MissingNestedTypeArgument_03()
+            Dim source =
+"Interface I(Of T)
+End Interface
+Class A
+    Implements I(Of System.ValueTuple(Of Object, A.B))
+End Class"
+            Dim comp = CreateCompilation(source)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC30002: Type 'A.B' is not defined.
+    Implements I(Of System.ValueTuple(Of Object, A.B))
+                                                 ~~~
+]]></errors>)
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/BaseClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/BaseClassTests.vb
@@ -2434,6 +2434,22 @@ BC30296: Interface 'A(Of T)' cannot inherit from itself:
 ]]></errors>)
         End Sub
 
+        <Fact>
+        Public Sub Tuple_MissingNestedTypeArgument()
+            Dim source =
+"Interface I(Of T)
+End Interface
+Class A
+    Implements I(Of (Object, A.B))
+End Class"
+            Dim comp = CreateCompilation(source)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC30002: Type 'A.B' is not defined.
+    Implements I(Of (Object, A.B))
+                             ~~~
+]]></errors>)
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/BaseClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/BaseClassTests.vb
@@ -2435,7 +2435,7 @@ BC30296: Interface 'A(Of T)' cannot inherit from itself:
         End Sub
 
         <Fact>
-        Public Sub Tuple_MissingNestedTypeArgument()
+        Public Sub Tuple_MissingNestedTypeArgument_01()
             Dim source =
 "Interface I(Of T)
 End Interface
@@ -2447,6 +2447,22 @@ End Class"
 BC30002: Type 'A.B' is not defined.
     Implements I(Of (Object, A.B))
                              ~~~
+]]></errors>)
+        End Sub
+
+        <Fact>
+        Public Sub Tuple_MissingNestedTypeArgument_02()
+            Dim source =
+"Class A(Of T)
+End Class
+Class B
+    Inherits A(Of (Object, B.C))
+End Class"
+            Dim comp = CreateCompilation(source)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC30002: Type 'B.C' is not defined.
+    Inherits A(Of (Object, B.C))
+                           ~~~
 ]]></errors>)
         End Sub
 


### PR DESCRIPTION
Pass `basesBeingResolved` to `BindTupleType` to avoid cycles when looking up a missing member on base types.