### PR TITLE
Avoid NRE from TryCreateUnitTestingKeepAliveSessionWrapperAsync

### DIFF
--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingKeepAliveSessionWrapper.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingKeepAliveSessionWrapper.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+#nullable enable
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,27 +13,29 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     internal readonly struct UnitTestingKeepAliveSessionWrapper
     {
-        internal UnitTestingKeepAliveSessionWrapper(KeepAliveSession underlyingObject)
-            => UnderlyingObject = underlyingObject ?? throw new ArgumentNullException(nameof(underlyingObject));
+        internal KeepAliveSession? UnderlyingObject { get; }
 
-        internal KeepAliveSession UnderlyingObject { get; }
+        internal UnitTestingKeepAliveSessionWrapper(KeepAliveSession? underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public bool IsDefault => UnderlyingObject == null;
 
         public Task<T> TryInvokeAsync<T>(string targetName, Solution solution, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
-            => UnderlyingObject.RunRemoteAsync<T>(targetName, solution, arguments, cancellationToken);
+            => UnderlyingObject!.RunRemoteAsync<T>(targetName, solution, arguments, cancellationToken);
 
         public async Task<bool> TryInvokeAsync(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            await UnderlyingObject.RunRemoteAsync(targetName, solution: null, arguments, cancellationToken).ConfigureAwait(false);
+            await UnderlyingObject!.RunRemoteAsync(targetName, solution: null, arguments, cancellationToken).ConfigureAwait(false);
             return true;
         }
 
         public async Task<bool> TryInvokeAsync(string targetName, Solution solution, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            await UnderlyingObject.RunRemoteAsync(targetName, solution, arguments, cancellationToken).ConfigureAwait(false);
+            await UnderlyingObject!.RunRemoteAsync(targetName, solution, arguments, cancellationToken).ConfigureAwait(false);
             return true;
         }
 
         public Task<T> TryInvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
-            => UnderlyingObject.RunRemoteAsync<T>(targetName, solution: null, arguments, cancellationToken);
+            => UnderlyingObject!.RunRemoteAsync<T>(targetName, solution: null, arguments, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingSessionWithSolutionWrapper.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingSessionWithSolutionWrapper.cs
@@ -2,28 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     internal readonly struct UnitTestingSessionWithSolutionWrapper : IDisposable
     {
-        internal SessionWithSolution UnderlyingObject { get; }
+        internal SessionWithSolution? UnderlyingObject { get; }
+
+        public bool IsDefault => UnderlyingObject == null;
 
         public UnitTestingSessionWithSolutionWrapper(SessionWithSolution underlyingObject)
             => UnderlyingObject = underlyingObject;
 
         public Task InvokeAsync(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
-            => UnderlyingObject?.KeepAliveSession.RunRemoteAsync(targetName, solution: null, arguments, cancellationToken) ?? Task.CompletedTask;
+            => UnderlyingObject!.KeepAliveSession.RunRemoteAsync(targetName, solution: null, arguments, cancellationToken);
 
         public Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
-            => UnderlyingObject?.KeepAliveSession.RunRemoteAsync<T>(targetName, solution: null, arguments, cancellationToken);
+            => UnderlyingObject!.KeepAliveSession.RunRemoteAsync<T>(targetName, solution: null, arguments, cancellationToken);
 
         public void Dispose()
             => UnderlyingObject?.Dispose();

--- a/src/Workspaces/Core/Portable/Remote/SessionWithSolution.cs
+++ b/src/Workspaces/Core/Portable/Remote/SessionWithSolution.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.Remote
         internal readonly KeepAliveSession KeepAliveSession;
         private readonly PinnedRemotableDataScope _scope;
 
-
         public static async Task<SessionWithSolution> CreateAsync(KeepAliveSession keepAliveSession, Solution solution, CancellationToken cancellationToken)
         {
             Contract.ThrowIfNull(keepAliveSession);


### PR DESCRIPTION
Throw NRE only when invoking methods on a default instance of the wrapper. UnitTesting is checking for default instances before invoking methods on them so this is not breaking.

Also adds `IsDefault` properties to make it easier to check for default instances.