### PR TITLE
Diagnose bad 'ref' locals in switch sections

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1084,6 +1084,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (localSymbol.RefKind != RefKind.None)
                 {
+                    if (IsDirectlyInIterator)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_BadIteratorLocalType, localSymbol.Locations[0]);
+                    }
+
                     localSymbol.SetRefEscape(GetRefEscape(initializerOpt, currentScope));
                 }
             }
@@ -1731,14 +1736,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     Debug.Assert(!diagnostics.IsEmptyWithoutResolution);
-                }
-
-                foreach (var local in locals)
-                {
-                    if (local.RefKind != RefKind.None)
-                    {
-                        diagnostics.Add(ErrorCode.ERR_BadIteratorLocalType, local.Locations[0]);
-                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -269,18 +269,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (local.RefKind != RefKind.None)
                         {
                             // The ref-escape of a ref-returning property is decided
-                            // by the value escape of its receiverm, in this case the
+                            // by the value escape of its receiver, in this case the
                             // collection
                             local.SetRefEscape(collectionEscape);
 
-                            if (IsDirectlyInIterator)
+                            if (CheckRefLocalInAsyncOrIteratorMethod(local.IdentifierToken, diagnostics))
                             {
-                                diagnostics.Add(ErrorCode.ERR_BadIteratorLocalType, local.IdentifierToken.GetLocation());
-                                hasErrors = true;
-                            }
-                            else if (IsInAsyncMethod())
-                            {
-                                diagnostics.Add(ErrorCode.ERR_BadAsyncLocalType, local.IdentifierToken.GetLocation());
                                 hasErrors = true;
                             }
                         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1161,7 +1161,7 @@ class C
             comp.VerifyDiagnostics(
                 // (7,26): error CS8177: Async methods cannot have by-reference locals
                 //         ref readonly int x = ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "x = ref (new int[1])[0]").WithLocation(7, 26));
+                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "x").WithLocation(7, 26));
         }
 
         [Fact]
@@ -1185,7 +1185,7 @@ class C
         }
 
         [Fact]
-        public void RefReadonlyInSwitchCaseInIterator()
+        public void RefReadonlyInSwitchCaseInIterator_01()
         {
             var comp = CreateCompilation(@"
 using System.Collections.Generic;
@@ -1213,6 +1213,61 @@ class C
                 // (10,34): error CS8176: Iterators cannot have by-reference locals
                 //                 ref readonly int x = ref (new int[1])[0]; // 1
                 Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 34));
+        }
+
+        [Fact]
+        public void RefReadonlyInSwitchCaseInIterator_02()
+        {
+            var comp = CreateCompilation(@"
+using System.Collections.Generic;
+class C
+{
+    IEnumerable<int> M()
+    {
+        switch (this)
+        {
+            default:
+                ref readonly int x; // 1, 2
+                yield return 1;
+                yield return x; // 3
+                break;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (10,34): error CS8176: Iterators cannot have by-reference locals
+                //                 ref readonly int x; // 1, 2
+                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 34),
+                // (10,34): error CS8174: A declaration of a by-reference variable must have an initializer
+                //                 ref readonly int x; // 1, 2
+                Diagnostic(ErrorCode.ERR_ByReferenceVariableMustBeInitialized, "x").WithLocation(10, 34),
+                // (12,30): error CS0165: Use of unassigned local variable 'x'
+                //                 yield return x; // 3
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(12, 30));
+        }
+
+        [Fact]
+        public void RefReadonlyInSwitchCaseInIterator_03()
+        {
+            var comp = CreateCompilation(@"
+using System.Collections.Generic;
+class C
+{
+    IEnumerable<int> M()
+    {
+        switch (this)
+        {
+            default:
+                foreach (ref readonly int x in (new int[1]))
+                yield return 1;
+                break;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (10,43): error CS8176: Iterators cannot have by-reference locals
+                //                 foreach (ref readonly int x in (new int[1]))
+                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 43));
         }
 
         [Fact]
@@ -2729,10 +2784,10 @@ class TestClass
             CreateCompilationWithMscorlib45(code).VerifyDiagnostics(
                 // (8,17): error CS8177: Async methods cannot have by-reference locals
                 //         ref int y = ref x;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "y = ref x").WithLocation(8, 17),
+                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "y").WithLocation(8, 17),
                 // (11,21): error CS8177: Async methods cannot have by-reference locals
                 //             ref int z = ref x;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "z = ref x").WithLocation(11, 21));
+                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "z").WithLocation(11, 21));
         }
 
         [Fact, WorkItem(13073, "https://github.com/dotnet/roslyn/issues/13073")]
@@ -3047,9 +3102,9 @@ class Program
 ";
 
             CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-                // (8,17): error CS8932: Async methods cannot have by-reference locals
+                // (8,17): error CS8177: Async methods cannot have by-reference locals
                 //         ref int i = ref field;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "i = ref field").WithLocation(8, 17),
+                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "i").WithLocation(8, 17),
                 // (6,23): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     static async void Goo()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Goo").WithLocation(6, 23));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1197,8 +1197,8 @@ class C
         {
             default:
                 ref readonly int x = ref (new int[1])[0]; // 1
-                int i = x;
-                yield return i;
+                yield return 1;
+                yield return x;
 
                 local();
                 void local()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1185,6 +1185,37 @@ class C
         }
 
         [Fact]
+        public void RefReadonlyInSwitchCaseInIterator()
+        {
+            var comp = CreateCompilation(@"
+using System.Collections.Generic;
+class C
+{
+    IEnumerable<int> M()
+    {
+        switch (this)
+        {
+            default:
+                ref readonly int x = ref (new int[1])[0]; // 1
+                int i = x;
+                yield return i;
+
+                local();
+                void local()
+                {
+                    ref readonly int z = ref (new int[1])[0];
+                }
+                break;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (10,34): error CS8176: Iterators cannot have by-reference locals
+                //                 ref readonly int x = ref (new int[1])[0]; // 1
+                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 34));
+        }
+
+        [Fact]
         public void RefReadonlyLocalNotWritable()
         {
             var comp = CreateCompilation(@"


### PR DESCRIPTION
Fixes #44074 by properly diagnosing the underlying issue.

There's maybe multiple ways to handle this. For instance we could find a spot where we gather up the locals in a switch section and check IsDirectlyInIterator there. We could find other spots where there are locals declared but not directly in a block or in a switch case and patch it all up. But it feels simpler and more likely to be right to just check at the time we bind the local whether it is a 'ref' local in an iterator.