### PR TITLE
Install ErrorProne.NET analyzers

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,6 +34,7 @@
     <VisualStudioEditorPackagesVersion>16.4.248</VisualStudioEditorPackagesVersion>
     <ILToolsPackageVersion>5.0.0-alpha1.19409.1</ILToolsPackageVersion>
     <MicrosoftVisualStudioLanguageServerPackagesVersion>16.3.27-develop-gdd55e997</MicrosoftVisualStudioLanguageServerPackagesVersion>
+    <ErrorProneNETAnalyzersVersion>0.3.0-beta.0</ErrorProneNETAnalyzersVersion>
   </PropertyGroup>
   <!--
     Dependency versions
@@ -46,6 +47,8 @@
     <DropAppVersion>17.144.28413-buildid7983345</DropAppVersion>
     <EnvDTEVersion>8.0.2</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
+    <ErrorProneNETStructsVersion>$(ErrorProneNETAnalyzersVersion)</ErrorProneNETStructsVersion>
+    <ErrorProneNETCoreAnalyzersVersion>$(ErrorProneNETAnalyzersVersion)</ErrorProneNETCoreAnalyzersVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>5.0.2.5153</ICSharpCodeDecompilerVersion>

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -192,7 +192,7 @@
     <Rule Id="EPS06" Action="None" /> <!-- Hidden struct copy operation -->
     <Rule Id="EPS07" Action="None" /> <!-- A hash table "unfriendly" type is used as the key in a hash table -->
     <Rule Id="EPS08" Action="None" /> <!-- Default 'ValueType.Equals' or 'HashCode' is used for struct equality -->
-    <Rule Id="EPS09" Action="None" /> <!-- Pass an argument for an 'in' parameter explicitly -->
+    <Rule Id="EPS09" Action="Warning" /> <!-- Pass an argument for an 'in' parameter explicitly -->
     <Rule Id="EPS10" Action="None" /> <!-- Do not construct non-defaultable struct with 'default' expression -->
     <Rule Id="EPS11" Action="None" /> <!-- Do not embed non-defaultable structs into another structs -->
   </Rules>

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -183,4 +183,33 @@
     <Rule Id="HAA0603" Action="None" />
     <Rule Id="HeapAnalyzerReadonlyMethodGroupAllocationRule" Action="None" />
   </Rules>
+  <Rules AnalyzerId="ErrorProne.Net.StructAnalyzers" RuleNamespace="ErrorProne.Net.StructAnalyzers">
+    <Rule Id="EPS01" Action="None" /> <!-- A struct can be made readonly -->
+    <Rule Id="EPS02" Action="None" /> <!-- A non-readonly struct used as in-parameter -->
+    <Rule Id="EPS03" Action="None" /> <!-- A non-readonly struct returned by readonly reference -->
+    <Rule Id="EPS04" Action="None" /> <!-- A non-readonly struct is used as a 'ref readonly' local variable -->
+    <Rule Id="EPS05" Action="None" /> <!-- Use in-modifier for a readonly struct -->
+    <Rule Id="EPS06" Action="None" /> <!-- Hidden struct copy operation -->
+    <Rule Id="EPS07" Action="None" /> <!-- A hash table "unfriendly" type is used as the key in a hash table -->
+    <Rule Id="EPS08" Action="None" /> <!-- Default 'ValueType.Equals' or 'HashCode' is used for struct equality -->
+    <Rule Id="EPS09" Action="None" /> <!-- Pass an argument for an 'in' parameter explicitly -->
+    <Rule Id="EPS10" Action="None" /> <!-- Do not construct non-defaultable struct with 'default' expression -->
+    <Rule Id="EPS11" Action="None" /> <!-- Do not embed non-defaultable structs into another structs -->
+  </Rules>
+  <Rules AnalyzerId="ErrorProne.Net.CoreAnalyzers" RuleNamespace="ErrorProne.Net.CoreAnalyzers">
+    <Rule Id="EPC11" Action="None" /> <!-- (no title) -->
+    <Rule Id="EPC11WithoutSuggestion" Action="None" /> <!-- (no title) -->
+    <Rule Id="EPC12" Action="None" /> <!-- (no title) -->
+    <Rule Id="EPC12WithoutSuggestion" Action="None" /> <!-- (no title) -->
+    <Rule Id="EPC13" Action="None" /> <!-- Suspiciously unobserved result -->
+    <Rule Id="EPC14" Action="None" /> <!-- ConfigureAwait(false) call is redundant -->
+    <Rule Id="EPC14WithoutSuggestion" Action="None" /> <!-- (no title) -->
+    <Rule Id="EPC15" Action="None" /> <!-- ConfigureAwait(false) must be used -->
+    <Rule Id="EPC15WithoutSuggestion" Action="None" /> <!-- (no title) -->
+    <Rule Id="EPC16" Action="None" /> <!-- Awaiting the result of a null-conditional expression will cause NullReferenceException -->
+    <Rule Id="EPC17" Action="None" /> <!-- Avoid async-void delegates -->
+    <Rule Id="ERP021" Action="None" /> <!-- Incorrect exception propagation -->
+    <Rule Id="ERP022" Action="None" /> <!-- Unobserved exception in a generic exception handler -->
+    <Rule Id="ERP031" Action="None" /> <!-- The API is not thread-safe -->
+  </Rules>
 </RuleSet>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -128,6 +128,8 @@
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(MicrosoftVisualStudioThreadingAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="$(MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion)" PrivateAssets="all" />
+    <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="$(ErrorProneNETCoreAnalyzersVersion)" PrivateAssets="all" />
+    <PackageReference Include="ErrorProne.NET.Structs" Version="$(ErrorProneNETStructsVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.LocalFunctions.cs
@@ -191,20 +191,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 currentState.InvertedCapturedMask.Invert();
             }
             // Filter the modified state variables to only captured variables
-            stateAtReturn.Assigned.IntersectWith(currentState.CapturedMask);
+            stateAtReturn.Assigned.IntersectWith(in currentState.CapturedMask);
             if (NonMonotonicState.HasValue)
             {
                 var state = NonMonotonicState.Value;
-                state.Assigned.UnionWith(currentState.InvertedCapturedMask);
+                state.Assigned.UnionWith(in currentState.InvertedCapturedMask);
                 NonMonotonicState = state;
             }
 
             // Build a list of variables that are both captured and read before assignment
             var capturedAndRead = currentState.ReadVars;
-            capturedAndRead.IntersectWith(currentState.CapturedMask);
+            capturedAndRead.IntersectWith(in currentState.CapturedMask);
 
             // Union and check to see if there are any changes
-            return savedState.ReadVars.UnionWith(capturedAndRead);
+            return savedState.ReadVars.UnionWith(in capturedAndRead);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2187,7 +2187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Normalize(ref other);
                 }
 
-                return self.Assigned.IntersectWith(other.Assigned);
+                return self.Assigned.IntersectWith(in other.Assigned);
             }
             else if (!self.Reachable)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var descriptor = WellKnownMembers.GetDescriptor(memberValue);
                 var sym = CSharpCompilation.GetRuntimeMember(
                     builderType.OriginalDefinition,
-in descriptor,
+                    in descriptor,
                     F.Compilation.WellKnownMemberSignatureComparer,
                     accessWithinOpt: null);
                 if ((object)sym != null)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var descriptor = WellKnownMembers.GetDescriptor(memberValue);
                 var sym = CSharpCompilation.GetRuntimeMember(
                     builderType.OriginalDefinition,
-                    descriptor,
+in descriptor,
                     F.Compilation.WellKnownMemberSignatureComparer,
                     accessWithinOpt: null);
                 if ((object)sym != null)

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -1248,7 +1248,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -1413,7 +1413,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         }
                         finally
                         {
-                            _pool.Free(dimensionList);
+                            _pool.Free(in dimensionList);
                         }
                     }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -806,7 +806,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             finally
             {
-                _pool.Free(attributes);
+                _pool.Free(in attributes);
             }
         }
 
@@ -924,7 +924,7 @@ tryAgain:
                 }
                 finally
                 {
-                    _pool.Free(argNodes);
+                    _pool.Free(in argNodes);
                 }
             }
 
@@ -1649,7 +1649,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -1731,7 +1731,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(bounds);
+                _pool.Free(in bounds);
             }
         }
 
@@ -3366,7 +3366,7 @@ parse_member_name:;
             }
             finally
             {
-                _pool.Free(parameters);
+                _pool.Free(in parameters);
             }
         }
 
@@ -3391,7 +3391,7 @@ parse_member_name:;
             }
             finally
             {
-                _pool.Free(parameters);
+                _pool.Free(in parameters);
             }
         }
 
@@ -3718,7 +3718,7 @@ tryAgain:
             finally
             {
                 _termState = saveTerm;
-                _pool.Free(variables);
+                _pool.Free(in variables);
             }
         }
 
@@ -3876,7 +3876,7 @@ tryAgain:
             finally
             {
                 _termState = saveTerm;
-                _pool.Free(variables);
+                _pool.Free(in variables);
             }
         }
 
@@ -3923,7 +3923,7 @@ tryAgain:
             finally
             {
                 _termState = saveTerm;
-                _pool.Free(variables);
+                _pool.Free(in variables);
             }
         }
 
@@ -4340,7 +4340,7 @@ tryAgain:
                     }
                     finally
                     {
-                        _pool.Free(args);
+                        _pool.Free(in args);
                     }
 
                     break;
@@ -4447,7 +4447,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(variables);
+                _pool.Free(in variables);
             }
         }
 
@@ -4509,7 +4509,7 @@ tryAgain:
                 var tmpList = _pool.AllocateSeparated<BaseTypeSyntax>();
                 tmpList.Add(_syntaxFactory.SimpleBaseType(type));
                 baseList = _syntaxFactory.BaseList(colon, tmpList);
-                _pool.Free(tmpList);
+                _pool.Free(in tmpList);
             }
 
             var members = default(SeparatedSyntaxList<EnumMemberDeclarationSyntax>);
@@ -4525,7 +4525,7 @@ tryAgain:
                 }
                 finally
                 {
-                    _pool.Free(builder);
+                    _pool.Free(in builder);
                 }
             }
 
@@ -4891,7 +4891,7 @@ tryAgain:
                     this.ParseTypeArgumentList(out open, types, out close);
                     name = _syntaxFactory.GenericName(id.Identifier,
                         _syntaxFactory.TypeArgumentList(open, types, close));
-                    _pool.Free(types);
+                    _pool.Free(in types);
                 }
             }
 
@@ -6177,7 +6177,7 @@ done:;
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -6223,7 +6223,7 @@ done:;
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -7538,8 +7538,8 @@ done:;
             {
                 _termState = saveTerm;
                 this.Release(ref resetPoint);
-                _pool.Free(incrementors);
-                _pool.Free(initializers);
+                _pool.Free(in incrementors);
+                _pool.Free(in initializers);
             }
         }
 
@@ -8297,7 +8297,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(variables);
+                _pool.Free(in variables);
                 _pool.Free(mods);
             }
         }
@@ -8343,7 +8343,7 @@ tryAgain:
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
                 result = _syntaxFactory.ParenthesizedVariableDesignation(openParen, listOfDesignations, closeParen);
-                _pool.Free(listOfDesignations);
+                _pool.Free(in listOfDesignations);
             }
             else
             {
@@ -8395,7 +8395,7 @@ tryAgain:
             ParseLocalDeclaration(variables, false, attributes: default, mods: default, out type, out localFunction);
             Debug.Assert(localFunction == null);
             var result = _syntaxFactory.VariableDeclaration(type, variables);
-            _pool.Free(variables);
+            _pool.Free(in variables);
             return result;
         }
 
@@ -9851,7 +9851,7 @@ tryAgain:
             {
                 if (!list.IsNull)
                 {
-                    _pool.Free(list);
+                    _pool.Free(in list);
                 }
             }
         }
@@ -10288,7 +10288,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -10496,7 +10496,7 @@ tryAgain:
             this.ParseAnonymousTypeMemberInitializers(ref openBrace, ref expressions);
             var closeBrace = this.EatToken(SyntaxKind.CloseBraceToken);
             var result = _syntaxFactory.AnonymousObjectCreationExpression(@new, openBrace, expressions, closeBrace);
-            _pool.Free(expressions);
+            _pool.Free(in expressions);
 
             return result;
         }
@@ -10689,7 +10689,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(initializers);
+                _pool.Free(in initializers);
             }
         }
 
@@ -10827,7 +10827,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(initializers);
+                _pool.Free(in initializers);
             }
         }
 
@@ -10983,7 +10983,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -11205,7 +11205,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(nodes);
+                _pool.Free(in nodes);
             }
         }
 
@@ -11620,7 +11620,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -551,7 +551,7 @@ tryAgain:
             }
             finally
             {
-                _pool.Free(list);
+                _pool.Free(in list);
             }
         }
 
@@ -644,7 +644,7 @@ tryAgain:
             }
 
             SeparatedSyntaxList<SwitchExpressionArmSyntax> result = arms;
-            _pool.Free(arms);
+            _pool.Free(in arms);
             return result;
         }
     }

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     if (_currentNode.Token != null)
                     {
-                        this.AddToken(_currentNode);
+                        this.AddToken(in _currentNode);
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!type.IsErrorType())
                 {
-                    result = GetRuntimeMember(type, descriptor, WellKnownMemberSignatureComparer, accessWithinOpt: this.Assembly);
+                    result = GetRuntimeMember(type, in descriptor, WellKnownMemberSignatureComparer, accessWithinOpt: this.Assembly);
                 }
 
                 Interlocked.CompareExchange(ref _lazyWellKnownTypeMembers[(int)member], result, ErrorTypeSymbol.UnknownResultType);
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Symbol? GetRuntimeMember(NamedTypeSymbol declaringType, in MemberDescriptor descriptor, SignatureComparer<MethodSymbol, FieldSymbol, PropertySymbol, TypeSymbol, ParameterSymbol> comparer, AssemblySymbol accessWithinOpt)
         {
             var members = declaringType.GetMembers(descriptor.Name);
-            return GetRuntimeMember(members, descriptor, comparer, accessWithinOpt);
+            return GetRuntimeMember(members, in descriptor, comparer, accessWithinOpt);
         }
 
         internal static Symbol? GetRuntimeMember(ImmutableArray<Symbol> members, in MemberDescriptor descriptor, SignatureComparer<MethodSymbol, FieldSymbol, PropertySymbol, TypeSymbol, ParameterSymbol> comparer, AssemblySymbol? accessWithinOpt)

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -416,13 +416,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private static readonly Func<TypeSymbol, CheckConstraintsArgs, bool, bool> s_checkConstraintsSingleTypeFunc = (type, arg, unused) => CheckConstraintsSingleType(type, arg);
+        private static readonly Func<TypeSymbol, CheckConstraintsArgs, bool, bool> s_checkConstraintsSingleTypeFunc = (type, arg, unused) => CheckConstraintsSingleType(type, in arg);
 
         private static bool CheckConstraintsSingleType(TypeSymbol type, in CheckConstraintsArgs args)
         {
             if (type.Kind == SymbolKind.NamedType)
             {
-                ((NamedTypeSymbol)type).CheckConstraints(args);
+                ((NamedTypeSymbol)type).CheckConstraints(in args);
             }
             else if (type.Kind == SymbolKind.PointerType)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (!type.IsErrorType())
                 {
-                    result = CSharpCompilation.GetRuntimeMember(type, descriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance, accessWithinOpt: null);
+                    result = CSharpCompilation.GetRuntimeMember(type, in descriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance, accessWithinOpt: null);
                 }
 
                 Interlocked.CompareExchange(ref _lazySpecialTypeMembers[(int)member], result, ErrorTypeSymbol.UnknownResultType);

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1231,15 +1231,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.IsReadOnlyAttribute) != 0 &&
-                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.IsReadOnlyAttribute))
+                reportExplicitUseOfReservedAttribute(attribute, in arguments, in AttributeDescription.IsReadOnlyAttribute))
             {
             }
             else if ((reserved & ReservedAttributes.IsUnmanagedAttribute) != 0 &&
-                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.IsUnmanagedAttribute))
+                reportExplicitUseOfReservedAttribute(attribute, in arguments, in AttributeDescription.IsUnmanagedAttribute))
             {
             }
             else if ((reserved & ReservedAttributes.IsByRefLikeAttribute) != 0 &&
-                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.IsByRefLikeAttribute))
+                reportExplicitUseOfReservedAttribute(attribute, in arguments, in AttributeDescription.IsByRefLikeAttribute))
             {
             }
             else if ((reserved & ReservedAttributes.TupleElementNamesAttribute) != 0 &&
@@ -1254,15 +1254,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.NullableContextAttribute) != 0 &&
-                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.NullableContextAttribute))
+                reportExplicitUseOfReservedAttribute(attribute, in arguments, in AttributeDescription.NullableContextAttribute))
             {
             }
             else if ((reserved & ReservedAttributes.NullablePublicOnlyAttribute) != 0 &&
-                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.NullablePublicOnlyAttribute))
+                reportExplicitUseOfReservedAttribute(attribute, in arguments, in AttributeDescription.NullablePublicOnlyAttribute))
             {
             }
             else if ((reserved & ReservedAttributes.NativeIntegerAttribute) != 0 &&
-                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.NativeIntegerAttribute))
+                reportExplicitUseOfReservedAttribute(attribute, in arguments, in AttributeDescription.NativeIntegerAttribute))
             {
             }
             else if ((reserved & ReservedAttributes.CaseSensitiveExtensionAttribute) != 0 &&

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -523,7 +523,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 MemberDescriptor relativeDescriptor = WellKnownMembers.GetDescriptor(relativeMember);
                 var members = type.GetMembers(relativeDescriptor.Name);
 
-                return CSharpCompilation.GetRuntimeMember(members, relativeDescriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance,
+                return CSharpCompilation.GetRuntimeMember(members, in relativeDescriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance,
                                                           accessWithinOpt: null); // force lookup of public members only
             }
         }
@@ -829,7 +829,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(relativeMember >= WellKnownMember.System_ValueTuple_T1__Item1 && relativeMember <= WellKnownMember.System_ValueTuple_TRest__ctor);
 
                 MemberDescriptor relativeDescriptor = WellKnownMembers.GetDescriptor(relativeMember);
-                return CSharpCompilation.GetRuntimeMember(members, relativeDescriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance,
+                return CSharpCompilation.GetRuntimeMember(members, in relativeDescriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance,
                                                           accessWithinOpt: null); // force lookup of public members only
             }
 

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             SyntaxToken nonTriviaToken = this.FindToken(position, findInsideTrivia: false);
 
-            SyntaxTrivia trivia = GetTriviaFromSyntaxToken(position, nonTriviaToken);
+            SyntaxTrivia trivia = GetTriviaFromSyntaxToken(position, in nonTriviaToken);
 
             if (!SyntaxFacts.IsDocumentationCommentTrivia(trivia.Kind()))
             {

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxRewriter.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (node != visitedNode || separator != visitedSeparator)
                     {
                         alternate = new SeparatedSyntaxListBuilder<TNode>(count);
-                        alternate.AddRange(list, i);
+                        alternate.AddRange(in list, i);
                     }
                 }
 
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             throw new InvalidOperationException(CodeAnalysisResources.SeparatorIsExpected);
                         }
-                        alternate.AddSeparator(visitedSeparator);
+                        alternate.AddSeparator(in visitedSeparator);
                     }
                     else
                     {
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (node != visitedNode)
                     {
                         alternate = new SeparatedSyntaxListBuilder<TNode>(count);
-                        alternate.AddRange(list, i);
+                        alternate.AddRange(in list, i);
                     }
                 }
 
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (visited != item && alternate == null)
                     {
                         alternate = new SyntaxTriviaListBuilder(count);
-                        alternate.Add(list, 0, index);
+                        alternate.Add(in list, 0, index);
                     }
 
                     if (alternate != null && visited.Kind() != SyntaxKind.None)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -403,7 +403,7 @@ recurse:
             {
                 case SyntaxKind.ArrayType:
                     var arrayTypeSyntax = (ArrayTypeSyntax)type;
-                    arrayTypeSyntax.ElementType.VisitRankSpecifiers(action, argument);
+                    arrayTypeSyntax.ElementType.VisitRankSpecifiers(action, in argument);
                     foreach (var rankSpecifier in arrayTypeSyntax.RankSpecifiers)
                     {
                         action(rankSpecifier, argument);
@@ -426,7 +426,7 @@ recurse:
                     for (int index = 0; index < elementsCount - 1; index++)
                     {
                         var element = tupleTypeSyntax.Elements[index];
-                        element.Type.VisitRankSpecifiers(action, argument);
+                        element.Type.VisitRankSpecifiers(action, in argument);
                     }
 
                     type = tupleTypeSyntax.Elements[elementsCount - 1].Type;
@@ -444,14 +444,14 @@ recurse:
                     for (int index = 0; index < argsCount - 1; index++)
                     {
                         var typeArgument = genericNameSyntax.TypeArgumentList.Arguments[index];
-                        typeArgument.VisitRankSpecifiers(action, argument);
+                        typeArgument.VisitRankSpecifiers(action, in argument);
                     }
 
                     type = genericNameSyntax.TypeArgumentList.Arguments[argsCount - 1];
                     goto recurse;
                 case SyntaxKind.QualifiedName:
                     var qualifiedNameSyntax = (QualifiedNameSyntax)type;
-                    qualifiedNameSyntax.Left.VisitRankSpecifiers(action, argument);
+                    qualifiedNameSyntax.Left.VisitRankSpecifiers(action, in argument);
                     type = qualifiedNameSyntax.Right;
                     goto recurse;
                 case SyntaxKind.AliasQualifiedName:

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -1388,7 +1388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 do
                 {
-                    builder.AddSeparator(commaToken);
+                    builder.AddSeparator(in commaToken);
                     builder.Add(enumerator.Current);
                 }
                 while (enumerator.MoveNext());
@@ -1423,7 +1423,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         builder.Add(enumerator.Current);
-                        builder.AddSeparator(token);
+                        builder.AddSeparator(in token);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     this.AddEndOfLine(GetEndOfLine(trivia) ?? SyntaxFactory.CarriageReturnLineFeed);
                 }
 
-                _residualTrivia.Add(trivia);
+                _residualTrivia.Add(in trivia);
             }
 
             private void AddEndOfLine(SyntaxTrivia? eolTrivia)
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                     if (alternate != null && visited.Kind() != SyntaxKind.None)
                     {
-                        alternate.Add(visited);
+                        alternate.Add(in visited);
                     }
                 }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -3387,11 +3387,11 @@ class C
 
             Assert.True(first.Concurrent);
             Assert.False(second.Concurrent);
-            Assert.True(first.Append(second).Concurrent);
+            Assert.True(first.Append(in second).Concurrent);
 
             Assert.True(first.Concurrent);
             Assert.False(second.Concurrent);
-            Assert.True(second.Append(first).Concurrent);
+            Assert.True(second.Append(in first).Concurrent);
         }
 
         [Fact, WorkItem(41402, "https://github.com/dotnet/roslyn/issues/41402")]

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/BitArrayTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/BitArrayTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 b1[i] = a1[i] = r.NextBool();
                 b2[i] = a2[i] = r.NextBool();
             }
-            bool changed = b1.IntersectWith(b2);
+            bool changed = b1.IntersectWith(in b2);
             bool changed2 = false;
             for (int i = 0; i < capacity; i++)
             {
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 b2[i] = a2[i] = r.NextBool();
             }
 
-            bool changed = b1.UnionWith(b2);
+            bool changed = b1.UnionWith(in b2);
             bool changed2 = false;
 
             for (int i = 0; i < maxCapacity; i++)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1392,7 +1392,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 if (!skipDeclarationAnalysis &&
-                    !TryExecuteDeclaringReferenceActions(symbolEvent, analysisScope, analysisStateOpt, isGeneratedCodeSymbol, perSymbolActions, cancellationToken))
+                    !TryExecuteDeclaringReferenceActions(symbolEvent, analysisScope, analysisStateOpt, isGeneratedCodeSymbol, in perSymbolActions, cancellationToken))
                 {
                     processedState = EventProcessedState.NotProcessed;
                 }
@@ -1400,7 +1400,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 ImmutableArray<DiagnosticAnalyzer> subsetProcessedAnalyzers = default;
                 if (processedState.Kind == EventProcessedStateKind.Processed &&
                     hasPerSymbolActions &&
-                    !TryExecuteSymbolEndActions(perSymbolActions, symbolEvent, analysisScope, analysisStateOpt, cancellationToken, out subsetProcessedAnalyzers))
+                    !TryExecuteSymbolEndActions(in perSymbolActions, symbolEvent, analysisScope, analysisStateOpt, cancellationToken, out subsetProcessedAnalyzers))
                 {
                     processedState = subsetProcessedAnalyzers.IsDefaultOrEmpty ? EventProcessedState.NotProcessed : EventProcessedState.CreatePartiallyProcessed(subsetProcessedAnalyzers);
                 }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             builder.EnterRegion(root);
             builder.AppendNewBlock(builder._entry, linkToPrevious: false);
             builder._currentBasicBlock = null;
-            builder.SetCurrentContext(context);
+            builder.SetCurrentContext(in context);
 
             builder.EnterRegion(new RegionBuilder(ControlFlowRegionKind.LocalLifetime));
 
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                                              continueDispatchAfterFinally,
                                                              dispatchedExceptionsFromRegions,
                                                              out bool isolatedFellThrough);
-                    visited.UnionWith(isolated);
+                    visited.UnionWith(in isolated);
 
                     continueDispatch = isolatedFellThrough &&
                                        blocks[@finally.LastBlockOrdinal].FallThrough.Kind == ControlFlowBranchSemantics.StructuredExceptionHandling;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (i >= startIndex)
                 {
-                    if (AreIdentical(stackNode, node))
+                    if (AreIdentical(in stackNode, in node))
                     {
                         var sim = node.FullSpan.Length;
                         if (sim > similarity)
@@ -365,9 +365,9 @@ namespace Microsoft.CodeAnalysis
                             return;
                         }
                     }
-                    else if (AreSimilar(stackNode, node))
+                    else if (AreSimilar(in stackNode, in node))
                     {
-                        var sim = GetSimilarity(stackNode, node);
+                        var sim = GetSimilarity(in stackNode, in node);
 
                         // Are these really the same? This may be expensive so only check this if 
                         // similarity is rated equal to them being identical.
@@ -400,15 +400,15 @@ namespace Microsoft.CodeAnalysis
 
                             j++;
 
-                            if (AreIdentical(child, node))
+                            if (AreIdentical(in child, in node))
                             {
                                 index = i;
                                 similarity = node.FullSpan.Length;
                                 return;
                             }
-                            else if (AreSimilar(child, node))
+                            else if (AreSimilar(in child, in node))
                             {
-                                var sim = GetSimilarity(child, node);
+                                var sim = GetSimilarity(in child, in node);
                                 if (sim > similarity)
                                 {
                                     index = i;
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis
                 var insertedNode = _newNodes.Pop();
                 var newSpan = insertedNode.FullSpan;
 
-                RecordChange(new TextChangeRange(oldSpan, newSpan.Length), removedNode, insertedNode);
+                RecordChange(new TextChangeRange(oldSpan, newSpan.Length), in removedNode, insertedNode);
             }
             else
             {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
@@ -73,22 +73,22 @@ namespace Microsoft.CodeAnalysis
 
         internal SyntaxToken GetPreviousToken(in SyntaxToken current, bool includeZeroWidth, bool includeSkipped, bool includeDirectives, bool includeDocumentationComments)
         {
-            return GetPreviousToken(current, GetPredicateFunction(includeZeroWidth), GetStepIntoFunction(includeSkipped, includeDirectives, includeDocumentationComments));
+            return GetPreviousToken(in current, GetPredicateFunction(includeZeroWidth), GetStepIntoFunction(includeSkipped, includeDirectives, includeDocumentationComments));
         }
 
         internal SyntaxToken GetNextToken(in SyntaxToken current, bool includeZeroWidth, bool includeSkipped, bool includeDirectives, bool includeDocumentationComments)
         {
-            return GetNextToken(current, GetPredicateFunction(includeZeroWidth), GetStepIntoFunction(includeSkipped, includeDirectives, includeDocumentationComments));
+            return GetNextToken(in current, GetPredicateFunction(includeZeroWidth), GetStepIntoFunction(includeSkipped, includeDirectives, includeDocumentationComments));
         }
 
         internal SyntaxToken GetPreviousToken(in SyntaxToken current, Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool>? stepInto)
         {
-            return GetPreviousToken(current, predicate, stepInto != null, stepInto);
+            return GetPreviousToken(in current, predicate, stepInto != null, stepInto);
         }
 
         internal SyntaxToken GetNextToken(in SyntaxToken current, Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool>? stepInto)
         {
-            return GetNextToken(current, predicate, stepInto != null, stepInto);
+            return GetNextToken(in current, predicate, stepInto != null, stepInto);
         }
 
         private static readonly ObjectPool<Stack<ChildSyntaxList.Enumerator>> s_childEnumeratorStackPool

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1392,7 +1392,7 @@ recurse:
             var token = this.FindToken(position, findInsideTrivia: false);
             if (stepInto != null)
             {
-                var trivia = GetTriviaFromSyntaxToken(position, token);
+                var trivia = GetTriviaFromSyntaxToken(position, in token);
 
                 if (trivia.HasStructure && stepInto(trivia))
                 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
@@ -830,7 +830,7 @@ namespace Microsoft.CodeAnalysis
             where TDirective : SyntaxNode
         {
             List<TDirective>? directives = null;
-            GetDirectives(this, filter, ref directives);
+            GetDirectives(in this, filter, ref directives);
             return directives ?? SpecializedCollections.EmptyList<TDirective>();
         }
 
@@ -853,7 +853,7 @@ namespace Microsoft.CodeAnalysis
         {
             foreach (var trivia in node.DescendantTrivia(node => node.ContainsDirectives, descendIntoTrivia: true))
             {
-                _ = GetDirectivesInTrivia(trivia, filter, ref directives);
+                _ = GetDirectivesInTrivia(in trivia, filter, ref directives);
             }
         }
 
@@ -883,7 +883,7 @@ namespace Microsoft.CodeAnalysis
         {
             foreach (var tr in trivia)
             {
-                if (!GetDirectivesInTrivia(tr, filter, ref directives) && tr.GetStructure() is SyntaxNode node)
+                if (!GetDirectivesInTrivia(in tr, filter, ref directives) && tr.GetStructure() is SyntaxNode node)
                 {
                     GetDirectives(node, filter, ref directives);
                 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenListBuilder.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Syntax
         {
             foreach (var n in nodeOrTokens)
             {
-                this.Add(n);
+                this.Add(in n);
             }
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -592,7 +592,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxToken);
             }
 
-            return SyntaxNavigator.Instance.GetNextToken(this, includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
+            return SyntaxNavigator.Instance.GetNextToken(in this, includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
         }
 
         /// <summary>
@@ -609,7 +609,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxToken);
             }
 
-            return SyntaxNavigator.Instance.GetNextToken(this, predicate, stepInto);
+            return SyntaxNavigator.Instance.GetNextToken(in this, predicate, stepInto);
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxToken);
             }
 
-            return SyntaxNavigator.Instance.GetPreviousToken(this, includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
+            return SyntaxNavigator.Instance.GetPreviousToken(in this, includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
         }
 
         /// <summary>
@@ -635,7 +635,7 @@ namespace Microsoft.CodeAnalysis
         /// included in the search.</param>
         internal SyntaxToken GetPreviousToken(Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool>? stepInto = null)
         {
-            return SyntaxNavigator.Instance.GetPreviousToken(this, predicate, stepInto);
+            return SyntaxNavigator.Instance.GetPreviousToken(in this, predicate, stepInto);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Syntax
 
         public void Add(in SyntaxTriviaList list)
         {
-            this.Add(list, 0, list.Count);
+            this.Add(in list, 0, list.Count);
         }
 
         public void Add(in SyntaxTriviaList list, int offset, int length)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxWalker.cs
@@ -63,8 +63,8 @@ namespace Microsoft.CodeAnalysis
         {
             if (this.Depth >= SyntaxWalkerDepth.Trivia)
             {
-                this.VisitLeadingTrivia(token);
-                this.VisitTrailingTrivia(token);
+                this.VisitLeadingTrivia(in token);
+                this.VisitTrailingTrivia(in token);
             }
         }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             var nodeValues = values?.Select(ts => new TagNode(ts, trackingMode));
 
             var introspector = new IntervalIntrospector(textBuffer.CurrentSnapshot);
-            _tree = IntervalTree.Create(introspector, nodeValues);
+            _tree = IntervalTree.Create(in introspector, nodeValues);
         }
 
         public ITextBuffer Buffer => _textBuffer;
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             Debug.Assert(snapshot.TextBuffer == _textBuffer);
 
             var introspector = new IntervalIntrospector(snapshot);
-            var intersectingIntervals = _tree.GetIntervalsThatIntersectWith(snapshotSpan.Start, snapshotSpan.Length, introspector);
+            var intersectingIntervals = _tree.GetIntervalsThatIntersectWith(snapshotSpan.Start, snapshotSpan.Length, in introspector);
 
             List<ITagSpan<TTag>> result = null;
             foreach (var tagNode in intersectingIntervals)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis
         {
             CheckContainsProject(projectId);
 
-            var newState = _state.WithProjectCompilationOutputFilePaths(projectId, paths);
+            var newState = _state.WithProjectCompilationOutputFilePaths(projectId, in paths);
             if (newState == _state)
             {
                 return this;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState WithProjectCompilationOutputFilePaths(ProjectId projectId, in CompilationOutputFilePaths paths)
         {
             var oldProject = GetRequiredProjectState(projectId);
-            var newProject = oldProject.WithCompilationOutputFilePaths(paths);
+            var newProject = oldProject.WithCompilationOutputFilePaths(in paths);
 
             if (oldProject == newProject)
             {

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithFilePath(value), opt => opt.FilePath, "New");
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithOutputFilePath(value), opt => opt.OutputFilePath, "New");
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithOutputRefFilePath(value), opt => opt.OutputRefFilePath, "New");
-            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithCompilationOutputFilePaths(value), opt => opt.CompilationOutputFilePaths, new CompilationOutputFilePaths("NewPath"));
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithCompilationOutputFilePaths(in value), opt => opt.CompilationOutputFilePaths, new CompilationOutputFilePaths("NewPath"));
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithDefaultNamespace(value), opt => opt.DefaultNamespace, "New");
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithHasAllInformation(value), opt => opt.HasAllInformation, true);
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithRunAnalyzers(value), opt => opt.RunAnalyzers, true);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -565,7 +565,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             SolutionTestHelpers.TestProperty(
                 solution,
-                (s, value) => s.WithProjectCompilationOutputFilePaths(projectId, value),
+                (s, value) => s.WithProjectCompilationOutputFilePaths(projectId, in value),
                 s => s.GetProject(projectId)!.CompilationOutputFilePaths,
                 new CompilationOutputFilePaths(path),
                 defaultThrows: false);

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -373,12 +373,12 @@ class C1
                 var document1 = solution1.GetDocument(document.Id);
                 var dversion1 = await document1.GetTextVersionAsync();
                 Assert.NotEqual(dversion, dversion1); // new document version
-                Assert.True(dversion1.GetTestAccessor().IsNewerThan(dversion));
+                Assert.True(dversion1.GetTestAccessor().IsNewerThan(in dversion));
                 Assert.Equal(solution.Version, solution1.Version); // updating document should not have changed solution version
                 Assert.Equal(project.Version, document1.Project.Version); // updating doc should not have changed project version
                 var latestDV1 = await document1.Project.GetLatestDocumentVersionAsync();
                 Assert.NotEqual(latestDV, latestDV1);
-                Assert.True(latestDV1.GetTestAccessor().IsNewerThan(latestDV));
+                Assert.True(latestDV1.GetTestAccessor().IsNewerThan(in latestDV));
                 Assert.Equal(latestDV1, await document1.GetTextVersionAsync()); // projects latest doc version should be this doc's version
 
                 // update project

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SimpleIntervalTree`2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/SimpleIntervalTree`2.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             {
                 foreach (var value in values)
                 {
-                    root = Insert(root, new Node(value), introspector);
+                    root = Insert(root, new Node(value), in introspector);
                 }
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/ContextIntervalTree.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/ContextIntervalTree.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         private readonly Func<T, int, int, bool> _containPredicate;
 
         public ContextIntervalTree(in TIntrospector introspector)
-            : base(introspector, values: null)
+            : base(in introspector, values: null)
         {
             _edgeExclusivePredicate = ContainsEdgeExclusive;
             _edgeInclusivePredicate = ContainsEdgeInclusive;


### PR DESCRIPTION
All diagnostics reported by the analyzers are disabled, with the exception of EPS09 which supports and enforces the code style from #43426.

Supersedes #43426