### PR TITLE
Remove workaround in build scripts for #42166

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -50,12 +50,6 @@
     <NoWarn>$(NoWarn);Nullable</NoWarn>
   </PropertyGroup>
   
-  <!-- Workaround for https://github.com/dotnet/roslyn/issues/42166 -->
-  <!-- PERF: This property group prevents the analyzers from CodeStyle NuGet package from being executed by default in all explicit builds (i.e. csc/vbc invocations both inside Visual Studio and from command line prompt) -->
-  <PropertyGroup Condition="'$(DesignTimeBuild)' != 'true'">
-    <NoWarn>$(NoWarn);IDE0004;IDE0004WithoutSuggestion;IDE0005;IDE0007;IDE0007WithoutSuggestion;IDE0008;IDE0008WithoutSuggestion;IDE0009;IDE0009WithoutSuggestion;IDE0010;IDE0010WithoutSuggestion;IDE0011;IDE0011WithoutSuggestion;IDE0016;IDE0016WithoutSuggestion;IDE0017;IDE0017WithoutSuggestion;IDE0018;IDE0018WithoutSuggestion;IDE0019;IDE0019WithoutSuggestion;IDE0020;IDE0020WithoutSuggestion;IDE0021;IDE0022;IDE0023;IDE0024;IDE0025;IDE0026;IDE0027;IDE0028;IDE0028WithoutSuggestion;IDE0029;IDE0029WithoutSuggestion;IDE0030;IDE0030WithoutSuggestion;IDE0031;IDE0031WithoutSuggestion;IDE0032;IDE0032WithoutSuggestion;IDE0033;IDE0033WithoutSuggestion;IDE0034;IDE0034WithoutSuggestion;IDE0035;IDE0035WithoutSuggestion;IDE0036;IDE0036WithoutSuggestion;IDE0037;IDE0037WithoutSuggestion;IDE0040;IDE0040WithoutSuggestion;IDE0041;IDE0041WithoutSuggestion;IDE0042;IDE0042WithoutSuggestion;IDE0043;IDE0044;IDE0044WithoutSuggestion;IDE0045;IDE0045WithoutSuggestion;IDE0046;IDE0046WithoutSuggestion;IDE0047;IDE0048;IDE0048WithoutSuggestion;IDE0050;IDE0050WithoutSuggestion;IDE0051;IDE0052;IDE0054;IDE0054WithoutSuggestion;IDE0055;IDE0056;IDE0056WithoutSuggestion;IDE0057;IDE0057WithoutSuggestion;IDE0058;IDE0059;IDE0060;IDE0061;IDE0062;IDE0062WithoutSuggestion;IDE0063;IDE0063WithoutSuggestion;IDE0064;IDE0065;IDE0066;IDE0066WithoutSuggestion;IDE0070;IDE0070WithoutSuggestion;IDE0071;IDE0071WithoutSuggestion;IDE0072;IDE0072WithoutSuggestion;IDE0073;IDE0073WithoutSuggestion;IDE0074;IDE0074WithoutSuggestion;IDE0075;IDE0075WithoutSuggestion;IDE1005;IDE1005WithoutSuggestion;IDE1006;IDE1006WithoutSuggestion</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(Language)' == 'CSharp' and '$(TargetFramework)' == 'net20'">
     <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
   </ItemGroup>

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryPatternParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryPatternParenthesesTests.cs
@@ -12,8 +12,6 @@ using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryParentheses;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParentheses
@@ -39,12 +37,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
 
         internal override bool ShouldSkipMessageDescriptionVerification(DiagnosticDescriptor descriptor)
             => descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary) && descriptor.DefaultSeverity == DiagnosticSeverity.Hidden;
-
-        private DiagnosticDescription GetRemoveUnnecessaryParenthesesDiagnostic(string text, int line, int column)
-            => TestHelpers.Diagnostic(IDEDiagnosticIds.RemoveUnnecessaryParenthesesDiagnosticId, text, startLocation: new LinePosition(line, column));
-
-        private DiagnosticDescription GetRemoveUnnecessaryParenthesesDiagnostic(string text, int line, int column, DiagnosticSeverity severity)
-            => GetRemoveUnnecessaryParenthesesDiagnostic(text, line, column).WithEffectiveSeverity(severity);
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
         public async Task TestArithmeticRequiredForClarity2()

--- a/src/Analyzers/CSharp/Tests/UseIsNullCheck/UseIsNullCheckForReferenceEqualsTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseIsNullCheck/UseIsNullCheckForReferenceEqualsTests.cs
@@ -5,7 +5,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseIsNullCheck;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
@@ -13,12 +12,18 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
+#if !CODE_STYLE
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
+#endif
+
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseIsNullCheck
 {
     public partial class UseIsNullCheckForReferenceEqualsTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         private static readonly ParseOptions CSharp7 = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7);
+#if !CODE_STYLE
         private static readonly ParseOptions CSharp9 = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharp9);
+#endif
 
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (new CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer(), new CSharpUseIsNullCheckForReferenceEqualsCodeFixProvider());

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -484,6 +484,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static bool IsCanceled(Exception ex, CancellationToken cancellationToken)
             => (ex as OperationCanceledException)?.CancellationToken == cancellationToken;
 
+#if DEBUG
         private static async Task VerifyDiagnosticLocationsAsync(ImmutableArray<Diagnostic> diagnostics, Project project, CancellationToken cancellationToken)
         {
             foreach (var diagnostic in diagnostics)
@@ -564,6 +565,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return null;
             }
         }
+#endif
 
         public static IEnumerable<DiagnosticData> ConvertToLocalDiagnostics(this IEnumerable<Diagnostic> diagnostics, Document targetDocument, TextSpan? span = null)
         {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -271,20 +271,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     GC.KeepAlive(wholeMethodBodyDiagnostics);
                     GC.KeepAlive(wholeDiagnostics);
                 }
-#endif
-            }
 
-            private static bool IsUnusedImportDiagnostic(Diagnostic d)
-            {
-                switch (d.Id)
+                static bool IsUnusedImportDiagnostic(Diagnostic d)
                 {
-                    case "CS8019":
-                    case "BC50000":
-                    case "BC50001":
-                        return true;
-                    default:
-                        return false;
+                    switch (d.Id)
+                    {
+                        case "CS8019":
+                        case "BC50000":
+                        case "BC50001":
+                            return true;
+                        default:
+                            return false;
+                    }
                 }
+#endif
             }
 
             private static TextSpan AdjustSpan(Document document, SyntaxNode root, TextSpan span)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -562,14 +562,6 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 return typeSymbol.RemoveUnnamedErrorTypes(compilation);
             }
 
-            private ICodeGenerationService GetCodeGenerationService()
-            {
-                var language = _state.TypeToGenerateInOpt == null
-                    ? _state.SimpleName.Language
-                    : _state.TypeToGenerateInOpt.Language;
-                return _semanticDocument.Project.Solution.Workspace.Services.GetLanguageServices(language).GetService<ICodeGenerationService>();
-            }
-
             private bool TryFindMatchingField(
                 ParameterName parameterName,
                 ITypeSymbol parameterType,

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v1/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v1/Interop/SqlConnection.cs
@@ -31,10 +31,12 @@ namespace Microsoft.CodeAnalysis.SQLite.v1.Interop
         /// </summary>
         private readonly SafeSqliteHandle _handle;
 
+#pragma warning disable IDE0052 // Remove unread private members - TODO: Can this field be removed?
         /// <summary>
         /// For testing purposes to simulate failures during testing.
         /// </summary>
         private readonly IPersistentStorageFaultInjector _faultInjector;
+#pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
         /// Our cache of prepared statements for given sql strings.

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/SqlConnection.cs
@@ -31,10 +31,12 @@ namespace Microsoft.CodeAnalysis.SQLite.v2.Interop
         /// </summary>
         private readonly SafeSqliteHandle _handle;
 
+#pragma warning disable IDE0052 // Remove unread private members - TODO: Can this field be removed?
         /// <summary>
         /// For testing purposes to simulate failures during testing.
         /// </summary>
         private readonly IPersistentStorageFaultInjector _faultInjector;
+#pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
         /// Our cache of prepared statements for given sql strings.

--- a/src/Workspaces/CoreTestUtilities/TestDynamicFileInfoProviderThatProducesFiles.cs
+++ b/src/Workspaces/CoreTestUtilities/TestDynamicFileInfoProviderThatProducesFiles.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
         }
 
-        public event EventHandler<string> Updated;
+        event EventHandler<string> IDynamicFileInfoProvider.Updated { add { } remove { } }
 
         public Task<DynamicFileInfo> GetDynamicFileInfoAsync(ProjectId projectId, string projectFilePath, string filePath, CancellationToken cancellationToken)
         {
@@ -48,8 +48,5 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public Task RemoveDynamicFileInfoAsync(ProjectId projectId, string projectFilePath, string filePath, CancellationToken cancellationToken)
             => Task.CompletedTask;
-
-        private void OnUpdate()
-            => Updated?.Invoke(this, "test");
     }
 }

--- a/src/Workspaces/CoreTestUtilities/TestDynamicFileInfoProviderThatProducesNoFiles.cs
+++ b/src/Workspaces/CoreTestUtilities/TestDynamicFileInfoProviderThatProducesNoFiles.cs
@@ -22,15 +22,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
         }
 
-        public event EventHandler<string> Updated;
+        event EventHandler<string> IDynamicFileInfoProvider.Updated { add { } remove { } }
 
         public Task<DynamicFileInfo> GetDynamicFileInfoAsync(ProjectId projectId, string projectFilePath, string filePath, CancellationToken cancellationToken)
             => Task.FromResult<DynamicFileInfo>(null);
 
         public Task RemoveDynamicFileInfoAsync(ProjectId projectId, string projectFilePath, string filePath, CancellationToken cancellationToken)
             => Task.CompletedTask;
-
-        private void OnUpdate()
-            => Updated?.Invoke(this, "test");
     }
 }


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn/commit/7878df970abb67156d33ef007a19ea67f171b847: #42166 has been implemented and Roslyn repo is currently using a toolset which has the compiler with this feature. Additionally, we no longer run analyzers on local builds, so there is no performance impact with this change.
2. https://github.com/dotnet/roslyn/commit/b75f8f0791f3b36bd78de1364fbf08e762967055: Removing the workaround for #42166 identified that IDE0051/IDE0052 were not getting enforced on the build. I will file a follow-up issue to investigate it, but this commit fixes the existing IDE0051/IDE0052 violations in IDE projects where they are set to warning.


