### PR TITLE
[Dogfooding] Enforce IDE0011 (Add braces) as a build warning for some…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -231,6 +231,8 @@ dotnet_diagnostic.IDE0005.severity = warning
 
 # IDE0011: Add braces
 csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
 # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0035.severity = warning

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -72,7 +72,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.NamespaceDeclaration:
                     {
                         var ns = (NamespaceDeclarationSyntax)node;
-                        foreach (var decl in ns.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        foreach (var decl in ns.Members)
+                        {
+                            ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        }
+
                         var declInfo = GetDeclarationInfo(model, node, getSymbol, cancellationToken);
                         builder.Add(declInfo);
 
@@ -94,7 +98,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.InterfaceDeclaration:
                     {
                         var t = (TypeDeclarationSyntax)node;
-                        foreach (var decl in t.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        foreach (var decl in t.Members)
+                        {
+                            ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        }
+
                         var attributes = GetAttributes(t.AttributeLists).Concat(GetTypeParameterListAttributes(t.TypeParameterList));
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
                         return;
@@ -103,7 +111,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.EnumDeclaration:
                     {
                         var t = (EnumDeclarationSyntax)node;
-                        foreach (var decl in t.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        foreach (var decl in t.Members)
+                        {
+                            ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        }
+
                         var attributes = GetAttributes(t.AttributeLists);
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
                         return;
@@ -133,7 +145,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var t = (EventDeclarationSyntax)node;
                         if (t.AccessorList != null)
                         {
-                            foreach (var decl in t.AccessorList.Accessors) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                            foreach (var decl in t.AccessorList.Accessors)
+                            {
+                                ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                            }
                         }
                         var attributes = GetAttributes(t.AttributeLists);
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
@@ -170,7 +185,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var t = (PropertyDeclarationSyntax)node;
                         if (t.AccessorList != null)
                         {
-                            foreach (var decl in t.AccessorList.Accessors) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                            foreach (var decl in t.AccessorList.Accessors)
+                            {
+                                ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                            }
                         }
 
                         if (t.ExpressionBody != null)
@@ -259,7 +277,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.CompilationUnit:
                     {
                         var t = (CompilationUnitSyntax)node;
-                        foreach (var decl in t.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        foreach (var decl in t.Members)
+                        {
+                            ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        }
 
                         if (t.AttributeLists.Any())
                         {

--- a/src/Features/CSharp/Portable/ConvertLinq/CSharpConvertLinqQueryToForEachProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertLinq/CSharpConvertLinqQueryToForEachProvider.cs
@@ -98,8 +98,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertLinq
                 {
                     if (!documentUpdateInfo.Source.IsParentKind(SyntaxKind.Block) &&
                         documentUpdateInfo.Destinations.Length > 1)
-
+                    {
                         documentUpdateInfo = new DocumentUpdateInfo(documentUpdateInfo.Source, SyntaxFactory.Block(documentUpdateInfo.Destinations));
+                    }
+
                     return true;
                 }
 

--- a/src/Features/CSharp/Portable/DisambiguateSameVariable/CSharpDisambiguateSameVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/DisambiguateSameVariable/CSharpDisambiguateSameVariableCodeFixProvider.cs
@@ -155,7 +155,9 @@ namespace Microsoft.CodeAnalysis.CSharp.DisambiguateSameVariable
             {
                 if (!CanFix(semanticModel, diagnostic, cancellationToken,
                         out var nameNode, out var matchingMember, out _))
+                {
                     continue;
+                }
 
                 var newNameNode = matchingMember.Name.ToIdentifierName();
                 var newExpr = (ExpressionSyntax)newNameNode;

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -419,8 +419,10 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             var nextStatementLeading = nextStatement.GetLeadingTrivia();
             var precedingEndOfLine = nextStatementLeading.LastOrDefault(t => t.Kind() == SyntaxKind.EndOfLineTrivia);
             if (precedingEndOfLine == default)
+            {
                 return oldStatements.ReplaceRange(
                     nextStatement, new[] { newStatement, nextStatement });
+            }
 
             var endOfLineIndex = nextStatementLeading.IndexOf(precedingEndOfLine) + 1;
 

--- a/src/Features/CSharp/Portable/ReverseForStatement/CSharpReverseForStatementCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReverseForStatement/CSharpReverseForStatementCodeRefactoringProvider.cs
@@ -53,7 +53,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ReverseForStatement
             if (declaration == null ||
                 declaration.Variables.Count != 1 ||
                 forStatement.Incrementors.Count != 1)
+            {
                 return;
+            }
 
             var variable = declaration.Variables[0];
             var after = forStatement.Incrementors[0];

--- a/src/Features/Core/Portable/ConflictMarkerResolution/AbstractConflictMarkerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/ConflictMarkerResolution/AbstractConflictMarkerCodeFixProvider.cs
@@ -93,7 +93,9 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
                 // issue there.
                 if (startTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia ||
                     middleTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia)
+                {
                     return false;
+                }
             }
 
             return true;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexCharClass.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexCharClass.cs
@@ -269,7 +269,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
             // reverse this check.
             Debug.Assert((SETSTART & 0x1) == 1, "If SETSTART is not odd, the calculation below this will be reversed");
             if ((min & 0x1) == (start & 0x1))
+            {
                 return true;
+            }
             else
             {
                 if (myCategoryLength == 0)
@@ -302,7 +304,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
                     if (curcat == SpaceConst)
                     {
                         if (char.IsWhiteSpace(ch))
+                        {
                             return true;
+                        }
                         else
                         {
                             i++;
@@ -320,7 +324,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
                     if (curcat == NotSpaceConst)
                     {
                         if (!char.IsWhiteSpace(ch))
+                        {
                             return true;
+                        }
                         else
                         {
                             i++;

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -237,8 +237,10 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             var builder = ImmutableDictionary.CreateBuilder<DocumentId, ImmutableArray<ComplexifiedSpan>>();
 
             foreach (var (docId, spans) in _documentToComplexifiedSpansMap)
+            {
                 builder.Add(docId, spans.SelectAsArray(
                     s => new ComplexifiedSpan(s.OriginalSpan, s.NewSpan, s.ModifiedSubSpans.ToImmutableArray())));
+            }
 
             return builder.ToImmutable();
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SelectedMembers/AbstractSelectedMembers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SelectedMembers/AbstractSelectedMembers.cs
@@ -102,7 +102,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             {
                 if (!(member is TFieldDeclarationSyntax) &&
                     !(member is TPropertyDeclarationSyntax))
+                {
                     return;
+                }
 
                 // first, check if entire member is selected.  If so, we definitely include this member.
                 if (textSpan.Contains(member.Span))


### PR DESCRIPTION
… IDE projects

My prior attempt to enable _IDE0011: Add Braces when multiline_ as a build warning in https://github.com/dotnet/roslyn/pull/44164 did not work due to #44201. This PR actually adds the build enforcement and fixes the violations.

```ini
[src/{Analyzers,CodeStyle,Features,Workspaces}/**/*.{cs,vb}]

# IDE0011: Add braces
csharp_prefer_braces = when_multiline:warning
# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
dotnet_diagnostic.IDE0011.severity = warning
```