### PR TITLE
Fix serialization/deserialization of SymbolUsageInfo in SerializableS…

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/IRemoteFindUsagesService.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
     {
         public int DefinitionId;
         public SerializableDocumentSpan SourceSpan;
-        public SymbolUsageInfo SymbolUsageInfo;
+        public SerializableSymbolUsageInfo SymbolUsageInfo;
         public (string Key, string Value)[] AdditionalProperties;
 
         public static SerializableSourceReferenceItem Dehydrate(
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             {
                 DefinitionId = definitionId,
                 SourceSpan = SerializableDocumentSpan.Dehydrate(item.SourceSpan),
-                SymbolUsageInfo = item.SymbolUsageInfo,
+                SymbolUsageInfo = SerializableSymbolUsageInfo.Dehydrate(item.SymbolUsageInfo),
                 AdditionalProperties = item.AdditionalProperties.Select(kvp => (kvp.Key, kvp.Value)).ToArray(),
             };
         }
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             return new SourceReferenceItem(
                 definition,
                 SourceSpan.Rehydrate(solution),
-                SymbolUsageInfo,
+                SymbolUsageInfo.Rehydrate(),
                 AdditionalProperties.ToImmutableDictionary(t => t.Key, t => t.Value));
         }
     }


### PR DESCRIPTION
…ourceReferenceItem

Fixes #44184
Find References `Kind` column uses `SymbolUsageInfo` for its data, and needs it to be properly serialized/deserialized for OOP calls to correctly show its values.

`SymbolUsageInfo` is correctly serialized/deserialized when Find References is invoked via [SymbolFinder.FindReferencesServerCallback](https://github.com/dotnet/roslyn/blob/b8585be8e9ff9e30dbe64980e2c9156ae8b6c2bf/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs#L72-L84), as it uses [SerializableReferenceLocation](https://github.com/dotnet/roslyn/blob/a65653a77b2862329052d84816b5fb324f8bc8bd/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs#L156) which uses `SerializableSymbolUsageInfo`.

With https://github.com/dotnet/roslyn/pull/43914/, we added a new [FindUsagesServerCallback](https://github.com/dotnet/roslyn/blob/0852232f315e952fee1dc63a0b374614b55c1c69/src/EditorFeatures/Core/FindUsages/IRemoteFindUsagesService.cs#L32) and switched to it for Find references serialization/deserialization. This callback does not use `SerializableSymbolUsageInfo`, hence loses the SymbolUsageInfo for "Kind" column. This PR fixes this part.