### PR TITLE
Workaround for analyzerconfig + sg crash:

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTestBase.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTestBase.cs
@@ -51,15 +51,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
-        internal MockCSharpCompiler CreateCSharpCompiler(string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, AnalyzerAssemblyLoader loader = null)
+        internal MockCSharpCompiler CreateCSharpCompiler(string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
         {
-            return CreateCSharpCompiler(null, WorkingDirectory, args, analyzers, loader);
+            return CreateCSharpCompiler(null, WorkingDirectory, args, analyzers, generators, loader);
         }
 
-        internal MockCSharpCompiler CreateCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, AnalyzerAssemblyLoader loader = null)
+        internal MockCSharpCompiler CreateCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
         {
             var buildPaths = RuntimeUtilities.CreateBuildPaths(workingDirectory, sdkDirectory: SdkDirectory);
-            return new MockCSharpCompiler(responseFile, buildPaths, args, analyzers, loader);
+            return new MockCSharpCompiler(responseFile, buildPaths, args, analyzers, generators, loader);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12378,6 +12378,9 @@ key = value");
     {
         private readonly string _sourceToAdd;
 
+        /// <remarks>
+        /// Required for reflection based tests
+        /// </remarks>
         public SimpleGenerator()
         {
             _sourceToAdd = string.Empty;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -18,6 +18,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -9608,6 +9609,7 @@ public class Program
                                            int expectedWarningCount = 0,
                                            int expectedErrorCount = 0,
                                            bool errorlog = false,
+                                           IEnumerable<ISourceGenerator> generators = null,
                                            params DiagnosticAnalyzer[] analyzers)
         {
             var args = new[] {
@@ -9629,7 +9631,7 @@ public class Program
                 args = args.Append(additionalFlags);
             }
 
-            var csc = CreateCSharpCompiler(null, sourceDir.Path, args, analyzers: analyzers.ToImmutableArrayOrEmpty());
+            var csc = CreateCSharpCompiler(null, sourceDir.Path, args, analyzers: analyzers.ToImmutableArrayOrEmpty(), generators: generators.ToImmutableArrayOrEmpty());
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             var exitCode = csc.Run(outWriter);
             var output = outWriter.ToString();
@@ -12188,6 +12190,24 @@ generated_code = auto");
             }
         }
 
+        [Fact]
+        [WorkItem(44087, "https://github.com/dotnet/roslyn/issues/44087")]
+        public void SourceGeneratorsAndAnalyzerConfig()
+        {
+            var dir = Temp.CreateDirectory();
+            var src = dir.CreateFile("temp.cs").WriteAllText(@"
+class C
+{
+}");
+            var analyzerConfig = dir.CreateFile(".editorconfig").WriteAllText(@"
+[*.cs]
+key = value");
+
+            var generator = new SimpleGenerator("public class D {}");
+
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/langversion:preview", "/analyzerconfig:" + analyzerConfig.Path }, generators: new[] { generator }, analyzers: new HiddenDiagnosticAnalyzer() );
+        }
+
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
         private sealed class FieldAnalyzer : DiagnosticAnalyzer
         {
@@ -12350,6 +12370,26 @@ generated_code = auto");
                 },
                 SyntaxKind.PragmaWarningDirectiveTrivia
                 );
+        }
+    }
+
+    [Generator]
+    internal class SimpleGenerator : ISourceGenerator
+    {
+        private readonly string _sourceToAdd;
+
+        public SimpleGenerator(string sourceToAdd)
+        {
+            _sourceToAdd = sourceToAdd;
+        }
+
+        public void Execute(SourceGeneratorContext context)
+        {
+            context.AddSource("addedSource.cs", SourceText.From(_sourceToAdd, Encoding.UTF8));
+        }
+
+        public void Initialize(InitializationContext context)
+        {
         }
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12205,7 +12205,7 @@ key = value");
 
             var generator = new SimpleGenerator("public class D {}");
 
-            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/langversion:preview", "/analyzerconfig:" + analyzerConfig.Path }, generators: new[] { generator }, analyzers: new HiddenDiagnosticAnalyzer() );
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/langversion:preview", "/analyzerconfig:" + analyzerConfig.Path }, generators: new[] { generator }, analyzers: new HiddenDiagnosticAnalyzer());
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -12378,6 +12378,11 @@ key = value");
     {
         private readonly string _sourceToAdd;
 
+        public SimpleGenerator()
+        {
+            _sourceToAdd = string.Empty;
+        }
+
         public SimpleGenerator(string sourceToAdd)
         {
             _sourceToAdd = sourceToAdd;
@@ -12385,7 +12390,10 @@ key = value");
 
         public void Execute(SourceGeneratorContext context)
         {
-            context.AddSource("addedSource.cs", SourceText.From(_sourceToAdd, Encoding.UTF8));
+            if (!string.IsNullOrWhiteSpace(_sourceToAdd))
+            {
+                context.AddSource("addedSource.cs", SourceText.From(_sourceToAdd, Encoding.UTF8));
+            }
         }
 
         public void Initialize(InitializationContext context)

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -794,7 +794,8 @@ namespace Microsoft.CodeAnalysis
             // and add them in here.
             if (Arguments.AnalyzerConfigPaths.Length > 0 && generators.Length > 0)
             {
-                sourceFileAnalyzerConfigOptions = compilation.SyntaxTrees.SelectAsArray(f => analyzerConfigSet.GetOptionsForSourcePath(f.FilePath));
+                var generatedOptions = compilation.SyntaxTrees.Skip(sourceFileAnalyzerConfigOptions.Length).Select(f => analyzerConfigSet.GetOptionsForSourcePath(f.FilePath));
+                sourceFileAnalyzerConfigOptions = sourceFileAnalyzerConfigOptions.AddRange(generatedOptions);
             }
 
             CompileAndEmit(

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis
             // Workaround by re-getting options for *all* the syntax trees including generated ones if there were
             // any generators to run. We'll actually want to parse the generated files according to the rules of the config set
             // and add them in here.
-            if (Arguments.AnalyzerConfigPaths.Length > 0 && generators.Length > 0)
+            if (!sourceFileAnalyzerConfigOptions.IsDefault && generators.Length > 0)
             {
                 var generatedOptions = compilation.SyntaxTrees.Skip(sourceFileAnalyzerConfigOptions.Length).Select(f => analyzerConfigSet.GetOptionsForSourcePath(f.FilePath));
                 sourceFileAnalyzerConfigOptions = sourceFileAnalyzerConfigOptions.AddRange(generatedOptions);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -789,9 +789,8 @@ namespace Microsoft.CodeAnalysis
             compilation = RunGenerators(compilation, Arguments.ParseOptions, generators, additionalTexts, diagnostics);
 
             // https://github.com/dotnet/roslyn/issues/44087 
-            // Workaround by re-getting options for *all* the syntax trees including generated ones if there were
-            // any generators to run. We'll actually want to parse the generated files according to the rules of the config set
-            // and add them in here.
+            // Workaround by getting options for any generated trees that were produced.
+            // In the future we'll want to apply the config set rules at parse time, return the options, and add them in here
             if (!sourceFileAnalyzerConfigOptions.IsDefault && generators.Length > 0)
             {
                 var generatedOptions = compilation.SyntaxTrees.Skip(sourceFileAnalyzerConfigOptions.Length).Select(f => analyzerConfigSet.GetOptionsForSourcePath(f.FilePath));

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -788,6 +788,15 @@ namespace Microsoft.CodeAnalysis
             // We pass it to the generators, which will realize any symbols they require. 
             compilation = RunGenerators(compilation, Arguments.ParseOptions, generators, additionalTexts, diagnostics);
 
+            // https://github.com/dotnet/roslyn/issues/44087 
+            // Workaround by re-getting options for *all* the syntax trees including generated ones if there were
+            // any generators to run. We'll actually want to parse the generated files according to the rules of the config set
+            // and add them in here.
+            if (Arguments.AnalyzerConfigPaths.Length > 0 && generators.Length > 0)
+            {
+                sourceFileAnalyzerConfigOptions = compilation.SyntaxTrees.SelectAsArray(f => analyzerConfigSet.GetOptionsForSourcePath(f.FilePath));
+            }
+
             CompileAndEmit(
                 touchedFilesLogger,
                 ref compilation,

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -15,18 +15,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
     internal class MockCSharpCompiler : CSharpCompiler
     {
         private readonly ImmutableArray<DiagnosticAnalyzer> _analyzers;
+        private readonly ImmutableArray<ISourceGenerator> _generators;
         internal Compilation Compilation;
         internal AnalyzerOptions AnalyzerOptions;
 
-        public MockCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, AnalyzerAssemblyLoader loader = null)
-            : this(responseFile, CreateBuildPaths(workingDirectory), args, analyzers, loader)
+        public MockCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
+            : this(responseFile, CreateBuildPaths(workingDirectory), args, analyzers, generators, loader)
         {
         }
 
-        public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, AnalyzerAssemblyLoader loader = null)
+        public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
             : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), loader ?? new DefaultAnalyzerAssemblyLoader())
         {
             _analyzers = analyzers.NullToEmpty();
+            _generators = generators.NullToEmpty();
         }
 
         private static BuildPaths CreateBuildPaths(string workingDirectory, string sdkDirectory = null) => RuntimeUtilities.CreateBuildPaths(workingDirectory, sdkDirectory);
@@ -41,6 +43,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             if (!_analyzers.IsDefaultOrEmpty)
             {
                 analyzers = analyzers.InsertRange(0, _analyzers);
+            }
+            if(!_generators.IsDefaultOrEmpty)
+            {
+                generators = generators.InsertRange(0, _generators);
             }
         }
 

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             {
                 analyzers = analyzers.InsertRange(0, _analyzers);
             }
-            if(!_generators.IsDefaultOrEmpty)
+            if (!_generators.IsDefaultOrEmpty)
             {
                 generators = generators.InsertRange(0, _generators);
             }


### PR DESCRIPTION
- Workaround analyzer config options not being available for generated trees by getting new options for all trees after generation
- Add test to cover crash + fix

This is a band-aid fix for #44087 

Eventually we'll want to actually parse the generated trees with the `AnalyzerConfigSet` and when doing that we can return the options at the same time, meaning we won't do any duplicate work. That requires threading a whole bunch of stuff through the generator though, and I wanted to get a fix in first that fixed the compiler crash.