### PR TITLE
Disallow module initializers in VB

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1572,6 +1572,10 @@ lReportErrorOnTwoTokens:
                 arguments.Diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
+            If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
+                arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
+            End If
+
             If arguments.SymbolPart = AttributeLocation.Return Then
                 ' Decode well-known attributes applied to return value
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1572,10 +1572,6 @@ lReportErrorOnTwoTokens:
                 arguments.Diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
-                arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
-            End If
-
             If arguments.SymbolPart = AttributeLocation.Return Then
                 ' Decode well-known attributes applied to return value
 
@@ -1725,6 +1721,8 @@ lReportErrorOnTwoTokens:
                 End If
             ElseIf VerifyObsoleteAttributeAppliedToMethod(arguments, AttributeDescription.ObsoleteAttribute) Then
             ElseIf VerifyObsoleteAttributeAppliedToMethod(arguments, AttributeDescription.DeprecatedAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
+                arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
             Else
                 Dim methodImpl As MethodSymbol = If(Me.IsPartial, PartialImplementationPart, Me)
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -198,6 +198,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.SkipLocalsInitAttribute) Then
                 arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.SkipLocalsInitAttribute.FullName)
             End If
+
+            If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
+                arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
+            End If
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -198,10 +198,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.SkipLocalsInitAttribute) Then
                 arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.SkipLocalsInitAttribute.FullName)
             End If
-
-            If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
-                arguments.Diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
-            End If
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -5873,7 +5873,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -5905,7 +5905,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -5968,7 +5968,7 @@ End Namespace
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -5990,7 +5990,7 @@ End Namespace
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6015,7 +6015,7 @@ End Enum
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6042,7 +6042,7 @@ End Enum
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6067,7 +6067,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6092,7 +6092,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6116,7 +6116,7 @@ End Interface
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6140,7 +6140,7 @@ End Structure
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6166,12 +6166,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    Function F() As <System.Runtime.CompilerServices.ModuleInitializerAttribute> Integer
-                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6196,7 +6191,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
         <Fact>
@@ -6221,7 +6216,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
+            CompilationUtils.AssertNoDiagnostics(comp)
         End Sub
 
 #End Region

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -5814,6 +5814,39 @@ BC30657: 'sc1_method' has a return type that is not supported or parameter types
 
 #End Region
 
+#Region "ModuleInitializerAttribute"
+        <Fact, WorkItem(40500, "https://github.com/dotnet/roslyn/issues/40500")>
+        Public Sub TestModuleInitializerAttributeOnMethod()
+            Dim source =
+            <compilation>
+                <file name="attr.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Class Program
+    <ModuleInitializer>
+    Sub M1()
+    End Sub
+End Class
+
+Namespace System.Runtime.CompilerServices
+    Public Class ModuleInitializerAttribute
+        Inherits Attribute
+    End Class
+End Namespace
+]]>
+                </file>
+            </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib40(source)
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <ModuleInitializer>
+     ~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+#End Region
+
         <Fact, WorkItem(807, "https://github.com/dotnet/roslyn/issues/807")>
         Public Sub TestAttributePropagationForAsyncAndIterators_01()
             Dim source =

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -5815,24 +5815,27 @@ BC30657: 'sc1_method' has a return type that is not supported or parameter types
 #End Region
 
 #Region "ModuleInitializerAttribute"
-        <Fact, WorkItem(40500, "https://github.com/dotnet/roslyn/issues/40500")>
-        Public Sub TestModuleInitializerAttributeOnMethod()
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnMethod()
             Dim source =
             <compilation>
                 <file name="attr.vb"><![CDATA[
-Imports System.Runtime.CompilerServices
-
-Class Program
-    <ModuleInitializer>
-    Sub M1()
-    End Sub
-End Class
-
 Namespace System.Runtime.CompilerServices
     Public Class ModuleInitializerAttribute
         Inherits Attribute
     End Class
 End Namespace
+
+Class Program
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Sub S()
+    End Sub
+
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Function F() As Integer
+        Return 1
+    End Function
+End Class
 ]]>
                 </file>
             </compilation>
@@ -5841,10 +5844,449 @@ End Namespace
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected><![CDATA[
 BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <ModuleInitializer>
-     ~~~~~~~~~~~~~~~~~
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ]]></expected>)
         End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnClass()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+Class C
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnProperty()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Property P As Integer
+        Get
+            Return 1
+        End Get
+
+        Set
+        End Set
+    End Property
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnAccessors()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    Property P As Integer
+        <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+        Get
+            Return 1
+        End Get
+
+        <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+        Set
+        End Set
+    End Property
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+        <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+        <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnModule()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+<Module: System.Runtime.CompilerServices.ModuleInitializerAttribute>
+
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+<Module: System.Runtime.CompilerServices.ModuleInitializerAttribute>
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnAssembly()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+<Assembly: System.Runtime.CompilerServices.ModuleInitializerAttribute>
+
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+<Assembly: System.Runtime.CompilerServices.ModuleInitializerAttribute>
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnEnum()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+Enum E
+    Member
+End Enum
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnEnumMember()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Enum E
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Member1
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Member2
+End Enum
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnEvent()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Event E(ByVal i As Integer)
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnDelegate()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Delegate Sub D()
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnInterface()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+Interface I
+End Interface
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnStructure()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+Structure S
+End Structure
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+<System.Runtime.CompilerServices.ModuleInitializerAttribute>
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnReturnValue()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    Function F() As <System.Runtime.CompilerServices.ModuleInitializerAttribute> Integer
+        Return 1
+    End Function
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    Function F() As <System.Runtime.CompilerServices.ModuleInitializerAttribute> Integer
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnParameter()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    Sub M(<System.Runtime.CompilerServices.ModuleInitializerAttribute> ByVal i As Integer)
+    End Sub
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    Sub M(<System.Runtime.CompilerServices.ModuleInitializerAttribute> ByVal i As Integer)
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
+        Public Sub ModuleInitializerAttributeOnField()
+            Dim source = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Namespace System.Runtime.CompilerServices
+    Class ModuleInitializerAttribute
+        Inherits System.Attribute
+    End Class
+End Namespace
+
+Class C
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+    Dim i As Integer
+End Class
+]]>
+
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40(source)
+
+            CompilationUtils.AssertTheseDiagnostics(comp,
+<expected><![CDATA[
+BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
+    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
 #End Region
 
         <Fact, WorkItem(807, "https://github.com/dotnet/roslyn/issues/807")>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -5873,12 +5873,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-<System.Runtime.CompilerServices.ModuleInitializerAttribute>
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -5910,12 +5905,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -5978,12 +5968,7 @@ End Namespace
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-<Module: System.Runtime.CompilerServices.ModuleInitializerAttribute>
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6005,12 +5990,7 @@ End Namespace
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-<Assembly: System.Runtime.CompilerServices.ModuleInitializerAttribute>
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6035,12 +6015,7 @@ End Enum
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-<System.Runtime.CompilerServices.ModuleInitializerAttribute>
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6067,15 +6042,7 @@ End Enum
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6100,12 +6067,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6130,12 +6092,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6159,12 +6116,7 @@ End Interface
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-<System.Runtime.CompilerServices.ModuleInitializerAttribute>
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6188,12 +6140,7 @@ End Structure
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-<System.Runtime.CompilerServices.ModuleInitializerAttribute>
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6249,12 +6196,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    Sub M(<System.Runtime.CompilerServices.ModuleInitializerAttribute> ByVal i As Integer)
-           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
         <Fact>
@@ -6279,12 +6221,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source)
 
-            CompilationUtils.AssertTheseDiagnostics(comp,
-<expected><![CDATA[
-BC42381: 'System.Runtime.CompilerServices.ModuleInitializerAttribute' is not supported in VB.
-    <System.Runtime.CompilerServices.ModuleInitializerAttribute>
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-]]></expected>)
+            CompilationUtils.AssertTheseDiagnostics(comp, <expected></expected>)
         End Sub
 
 #End Region


### PR DESCRIPTION
Related to #40500

Module initializers are not supported in VB. See https://github.com/dotnet/roslyn/pull/43281#issuecomment-619170321

Tests are heavily based on the SkipLocalsInit tests in VB.