### PR TITLE
Add support for LSP project contexts

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <CodeStyleAnalyzerVersion>3.7.0-1.20210.7</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>16.4.248</VisualStudioEditorPackagesVersion>
     <ILToolsPackageVersion>5.0.0-alpha1.19409.1</ILToolsPackageVersion>
-    <MicrosoftVisualStudioLanguageServerPackagesVersion>16.7.12-g74a1f6f85d</MicrosoftVisualStudioLanguageServerPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerPackagesVersion>16.7.29</MicrosoftVisualStudioLanguageServerPackagesVersion>
   </PropertyGroup>
   <!--
     Dependency versions

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -203,7 +203,7 @@ namespace Roslyn.Test.Utilities
             return workspace;
         }
 
-        protected Workspace CreateXmlTestWorkspace(string xmlContent, out Dictionary<string, IList<LSP.Location>> locations)
+        protected TestWorkspace CreateXmlTestWorkspace(string xmlContent, out Dictionary<string, IList<LSP.Location>> locations)
         {
             var workspace = TestWorkspace.Create(xmlContent, exportProvider: GetExportProvider());
             locations = GetAnnotatedLocations(workspace, workspace.CurrentSolution);

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -114,16 +114,23 @@ namespace Roslyn.Test.Utilities
                 ContainerName = containerName
             };
 
-        protected static LSP.TextDocumentIdentifier CreateTextDocumentIdentifier(Uri uri)
-            => new LSP.TextDocumentIdentifier()
-            {
-                Uri = uri
-            };
+        protected static LSP.TextDocumentIdentifier CreateTextDocumentIdentifier(Uri uri, ProjectId projectContext = null)
+        {
+            var documentIdentifier = new LSP.VSTextDocumentIdentifier() { Uri = uri };
 
-        protected static LSP.TextDocumentPositionParams CreateTextDocumentPositionParams(LSP.Location caret)
+            if (projectContext != null)
+            {
+                documentIdentifier.ProjectContext =
+                    new LSP.ProjectContext { Id = ProtocolConversions.ProjectIdToProjectContextId(projectContext) };
+            }
+
+            return documentIdentifier;
+        }
+
+        protected static LSP.TextDocumentPositionParams CreateTextDocumentPositionParams(LSP.Location caret, ProjectId projectContext = null)
             => new LSP.TextDocumentPositionParams()
             {
-                TextDocument = CreateTextDocumentIdentifier(caret.Uri),
+                TextDocument = CreateTextDocumentIdentifier(caret.Uri, projectContext),
                 Position = caret.Range.Start
             };
 

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -5,11 +5,13 @@
 #nullable enable
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
@@ -23,31 +25,70 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return ProtocolConversions.GetUriFromFilePath(document.FilePath);
         }
 
-        public static Document? GetDocumentFromURI(this Solution solution, Uri fileName, string? clientName = null)
+        public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri uri, string? clientName = null)
         {
             // TODO: we need to normalize this. but for now, we check both absolute and local path
             //       right now, based on who calls this, solution might has "/" or "\\" as directory
             //       separator
-            var documentId = solution.GetDocumentIdsWithFilePath(fileName.AbsolutePath).FirstOrDefault() ??
-                             solution.GetDocumentIdsWithFilePath(fileName.LocalPath).FirstOrDefault();
+            var documentIds = solution.GetDocumentIdsWithFilePath(uri.AbsolutePath);
 
-            var document = solution.GetDocument(documentId);
-
-            if (clientName != null)
+            if (!documentIds.Any())
             {
-                var documentPropertiesService = document?.Services.GetService<DocumentPropertiesService>();
+                documentIds = solution.GetDocumentIdsWithFilePath(uri.LocalPath);
+            }
+
+            var documents = documentIds.SelectAsArray(id => solution.GetRequiredDocument(id));
+
+            // If we don't have a client name, then we're done filtering
+            if (clientName == null)
+            {
+                return documents;
+            }
+
+            // We have a client name, so we need to filter to only documents that match that name
+            return documents.WhereAsArray(document =>
+            {
+                var documentPropertiesService = document.Services.GetService<DocumentPropertiesService>();
+
                 // When a client name is specified, only return documents that have a matching client name.
                 // Allows the razor lsp server to return results only for razor documents.
                 // This workaround should be removed when https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1106064/
                 // is fixed (so that the razor language server is only asked about razor buffers).
-                if (!Equals(documentPropertiesService?.DiagnosticsLspClientName, clientName))
+                return Equals(documentPropertiesService?.DiagnosticsLspClientName, clientName);
+            });
+        }
+
+        public static Document? GetDocument(this Solution solution, TextDocumentIdentifier documentIdentifier, string? clientName = null)
+        {
+            var documents = solution.GetDocuments(documentIdentifier.Uri, clientName);
+
+            if (documents.Length == 0)
+            {
+                return null;
+            }
+
+            if (documents.Length > 1)
+            {
+                // We have more than one document; try to find the one that matches the right context
+                if (documentIdentifier is VSTextDocumentIdentifier vsDocumentIdentifier)
                 {
-                    return null;
+                    if (vsDocumentIdentifier.ProjectContext != null)
+                    {
+                        var projectId = ProtocolConversions.ProjectContextToProjectId(vsDocumentIdentifier.ProjectContext);
+                        var matchingDocument = documents.FirstOrDefault(d => d.Project.Id == projectId);
+
+                        if (matchingDocument != null)
+                        {
+                            return matchingDocument;
+                        }
+                    }
                 }
             }
 
-            return document;
-
+            // We either have only one document or have multiple, but none of them  matched our context. In the
+            // latter case, we'll just return the first one arbitrarily since this might just be some temporary mis-sync
+            // of client and server state.
+            return documents[0];
         }
 
         public static async Task<int> GetPositionFromLinePositionAsync(this Document document, LinePosition linePosition, CancellationToken cancellationToken)

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
@@ -447,6 +448,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static string ProjectIdToProjectContextId(ProjectId id)
         {
             return id.Id + "|" + id.DebugName;
+        }
+
+        public static ProjectId ProjectContextToProjectId(ProjectContext projectContext)
+        {
+            int delimiter = projectContext.Id.IndexOf('|');
+
+            return ProjectId.CreateFromSerialized(
+                Guid.Parse(projectContext.Id.Substring(0, delimiter)),
+                debugName: projectContext.Id.Substring(delimiter + 1));
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -443,5 +443,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
             return referenceKinds.ToArrayAndFree();
         }
+
+        public static string ProjectIdToProjectContextId(ProjectId id)
+        {
+            return id.Id + "|" + id.DebugName;
+        }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             LSP.ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
         {
             var codeActions = await GetCodeActionsAsync(solution,
-                request.TextDocument.Uri,
+                request.TextDocument,
                 request.Range,
                 clientName, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandlerBase.cs
@@ -30,9 +30,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _codeRefactoringService = codeRefactoringService ?? throw new ArgumentNullException(nameof(codeRefactoringService));
         }
 
-        public async Task<IEnumerable<CodeAction>> GetCodeActionsAsync(Solution solution, Uri documentUri, LSP.Range selection, string? clientName, CancellationToken cancellationToken)
+        public async Task<IEnumerable<CodeAction>> GetCodeActionsAsync(Solution solution, LSP.TextDocumentIdentifier documentIdentifier, LSP.Range selection, string? clientName, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocumentFromURI(documentUri, clientName);
+            var document = solution.GetDocument(documentIdentifier, clientName);
             if (document == null)
             {
                 return ImmutableArray<CodeAction>.Empty;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<LSP.CompletionItem[]> HandleRequestAsync(Solution solution, LSP.CompletionParams request, LSP.ClientCapabilities clientCapabilities,
             string? clientName, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return Array.Empty<LSP.CompletionItem>();

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var request = data.CompletionParams;
 
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return completionItem;

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandlerBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
             var locations = ArrayBuilder<LSP.Location>.GetInstance();
 
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return locations.ToArrayAndFree();

--- a/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return foldingRanges.ToArrayAndFree();

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<LSP.TextEdit[]> HandleRequestAsync(Solution solution, LSP.DocumentFormattingParams request, LSP.ClientCapabilities clientCapabilities,
             string? clientName, CancellationToken cancellationToken)
         {
-            return await GetTextEditsAsync(solution, request.TextDocument.Uri, clientName, cancellationToken).ConfigureAwait(false);
+            return await GetTextEditsAsync(solution, request.TextDocument, clientName, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandlerBase.cs
@@ -4,7 +4,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -18,10 +17,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
     internal abstract class FormatDocumentHandlerBase
     {
-        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(Solution solution, Uri documentUri, string? clientName, CancellationToken cancellationToken, LSP.Range? range = null)
+        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(Solution solution, LSP.TextDocumentIdentifier documentIdentifier, string? clientName, CancellationToken cancellationToken, LSP.Range? range = null)
         {
             var edits = new ArrayBuilder<LSP.TextEdit>();
-            var document = solution.GetDocumentFromURI(documentUri, clientName);
+            var document = solution.GetDocument(documentIdentifier, clientName);
 
             if (document != null)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             string? clientName, CancellationToken cancellationToken)
         {
             var edits = new ArrayBuilder<TextEdit>();
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document != null)
             {
                 var formattingService = document.Project.LanguageServices.GetRequiredService<IEditorFormattingService>();

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<TextEdit[]> HandleRequestAsync(Solution solution, DocumentRangeFormattingParams request, ClientCapabilities clientCapabilities,
             string? clientName, CancellationToken cancellationToken)
         {
-            return await GetTextEditsAsync(solution, request.TextDocument.Uri, clientName, cancellationToken, range: request.Range).ConfigureAwait(false);
+            return await GetTextEditsAsync(solution, request.TextDocument, clientName, cancellationToken, range: request.Range).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<DocumentHighlight[]> HandleRequestAsync(Solution solution, TextDocumentPositionParams request,
             ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return Array.Empty<DocumentHighlight>();

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<Hover?> HandleRequestAsync(Solution solution, TextDocumentPositionParams request,
             ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return null;

--- a/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             return Task.FromResult(new LSP.InitializeResult
             {
-                Capabilities = new LSP.ServerCapabilities
+                Capabilities = new LSP.VSServerCapabilities
                 {
                     DefinitionProvider = true,
                     RenameProvider = true,
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     DocumentOnTypeFormattingProvider = new LSP.DocumentOnTypeFormattingOptions { FirstTriggerCharacter = "}", MoreTriggerCharacter = new[] { ";", "\n" } },
                     DocumentHighlightProvider = true,
                     ReferencesProvider = true,
+                    ProjectContextProvider = true
                 }
             });
         }

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+    [Shared]
+    [ExportLspMethod(MSLSPMethods.ProjectContextsName)]
+    internal class GetTextDocumentWithContextHandler : IRequestHandler<GetTextDocumentWithContextParams, ActiveProjectContexts?>
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public GetTextDocumentWithContextHandler()
+        {
+        }
+
+        public Task<ActiveProjectContexts?> HandleRequestAsync(
+            Solution solution,
+            GetTextDocumentWithContextParams request,
+            ClientCapabilities clientCapabilities,
+            string? clientName,
+            CancellationToken cancellationToken)
+        {
+            var startingDocument = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+
+            if (startingDocument == null || startingDocument.FilePath == null)
+            {
+                return Task.FromResult<ActiveProjectContexts?>(null);
+            }
+
+            var allDocumentIds = solution.GetDocumentIdsWithFilePath(startingDocument.FilePath);
+            var contexts = new List<ProjectContext>();
+
+            foreach (var documentId in allDocumentIds)
+            {
+                var project = solution.GetRequiredProject(documentId.ProjectId);
+                var context = new ProjectContext
+                {
+                    Id = ProtocolConversions.ProjectIdToProjectContextId(project.Id),
+                    Label = project.Name
+                };
+
+                if (project.Language == LanguageNames.CSharp)
+                {
+                    context.Kind = ProjectContextKind.CSharp;
+                }
+                else if (project.Language == LanguageNames.VisualBasic)
+                {
+                    context.Kind = ProjectContextKind.VisualBasic;
+                }
+
+                contexts.Add(context);
+            }
+
+            // If the document is open, it doesn't matter which DocumentId we pass to GetDocumentIdInCurrentContext since
+            // all the documents are linked at that point, so we can just pass the first arbitrarily. If the document is closed
+            // GetDocumentIdInCurrentContext will just return the same ID back, which means we're going to pick the first
+            // ID in GetDocumentIdsWithFilePath, but there's really nothing we can do since we don't have contexts for
+            // close documents anyways.
+            var currentContextDocumentId = solution.Workspace.GetDocumentIdInCurrentContext(allDocumentIds.First());
+
+            return Task.FromResult<ActiveProjectContexts?>(new ActiveProjectContexts
+            {
+                ProjectContexts = contexts.ToArray(),
+                DefaultIndex = allDocumentIds.IndexOf(currentContextDocumentId)
+            });
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
             Debug.Assert(clientCapabilities.HasVisualStudioLspCapability());
 
-            var document = solution.GetDocumentFromURI(referenceParams.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(referenceParams.TextDocument, clientName);
             if (document == null)
             {
                 return Array.Empty<LSP.VSReferenceItem>();

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
             var locations = ArrayBuilder<LSP.Location>.GetInstance();
 
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return locations.ToArrayAndFree();

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<WorkspaceEdit?> HandleRequestAsync(Solution oldSolution, RenameParams request, ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
         {
             WorkspaceEdit? workspaceEdit = null;
-            var document = oldSolution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = oldSolution.GetDocument(request.TextDocument, clientName);
             if (document != null)
             {
                 var renameService = document.Project.LanguageServices.GetRequiredService<IEditorInlineRenameService>();

--- a/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<LSP.SignatureHelp> HandleRequestAsync(Solution solution, LSP.TextDocumentPositionParams request,
             LSP.ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return new LSP.SignatureHelp();

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<object[]> HandleRequestAsync(Solution solution, DocumentSymbolParams request,
             ClientCapabilities clientCapabilities, string clientName, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri, clientName);
+            var document = solution.GetDocument(request.TextDocument, clientName);
             if (document == null)
             {
                 return Array.Empty<SymbolInformation>();

--- a/src/Features/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Formatting
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var characterTyped = ";";
             var locationTyped = locations["type"].Single();
-            var documentText = await workspace.CurrentSolution.GetDocumentFromURI(locationTyped.Uri).GetTextAsync();
+            var documentText = await workspace.CurrentSolution.GetDocuments(locationTyped.Uri).Single().GetTextAsync();
 
             var results = await RunFormatDocumentOnTypeAsync(workspace.CurrentSolution, characterTyped, locationTyped);
             var actualText = ApplyTextEdits(results, documentText);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentRangeTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Formatting
 }";
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var rangeToFormat = locations["format"].Single();
-            var documentText = await workspace.CurrentSolution.GetDocumentFromURI(rangeToFormat.Uri).GetTextAsync();
+            var documentText = await workspace.CurrentSolution.GetDocuments(rangeToFormat.Uri).Single().GetTextAsync();
 
             var results = await RunFormatDocumentRangeAsync(workspace.CurrentSolution, rangeToFormat);
             var actualText = ApplyTextEdits(results, documentText);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
@@ -35,7 +35,7 @@ void M()
 }";
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var documentURI = locations["caret"].Single().Uri;
-            var documentText = await workspace.CurrentSolution.GetDocumentFromURI(documentURI).GetTextAsync();
+            var documentText = await workspace.CurrentSolution.GetDocuments(documentURI).Single().GetTextAsync();
 
             var results = await RunFormatDocumentAsync(workspace.CurrentSolution, documentURI);
             var actualText = ApplyTextEdits(results, documentText);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -136,9 +136,65 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
             Assert.Null(results);
         }
 
-        private static async Task<LSP.Hover> RunGetHoverAsync(Solution solution, LSP.Location caret)
+        // Test that if we pass a project context along to hover, the right context is chosen. We are using hover
+        // as a general proxy to test that our context tracking works in all cases, although there's nothing specific
+        // about hover that needs to be different here compared to any other feature.
+        [Fact]
+        public async Task TestGetHoverWithProjectContexts()
+        {
+            var source = @"
+using System;
+
+#if NET472
+
+class WithConstant
+{
+    public const string Target = ""Target in net472"";
+}
+
+#else
+
+class WithConstant
+{
+    public const string Target = ""Target in netcoreapp3.1"";
+}
+
+#endif
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(WithConstant.{|caret:Target|});
+    }
+}";
+
+            var workspaceXml =
+$@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Net472"" PreprocessorSymbols=""NET472"">
+        <Document FilePath=""C:\C.cs""><![CDATA[${source}]]></Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""NetCoreApp3"" PreprocessorSymbols=""NETCOREAPP3.1"">
+        <Document IsLinkFile=""true"" LinkFilePath=""C:\C.cs"" LinkAssemblyName=""Net472""></Document>
+    </Project>
+</Workspace>";
+
+            using var workspace = CreateXmlTestWorkspace(workspaceXml, out var locations);
+            var location = locations["caret"].Single();
+
+            foreach (var project in workspace.Projects)
+            {
+                var result = await RunGetHoverAsync(workspace.CurrentSolution, location, project.Id);
+
+                var expectedConstant = project.Name == "Net472" ? "Target in net472" : "Target in netcoreapp3.1";
+                var expectedHover = CreateHover(location, $"({FeaturesResources.constant}) string WithConstant.Target = \"{expectedConstant}\"");
+                AssertJsonEquals(expectedHover, result);
+            }
+        }
+
+        private static async Task<LSP.Hover> RunGetHoverAsync(Solution solution, LSP.Location caret, ProjectId projectContext = null)
             => await GetLanguageServer(solution).ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Hover>(LSP.Methods.TextDocumentHoverName,
-                solution, CreateTextDocumentPositionParams(caret), new LSP.ClientCapabilities(), null, CancellationToken.None);
+                solution, CreateTextDocumentPositionParams(caret, projectContext), new LSP.ClientCapabilities(), null, CancellationToken.None);
 
         private static LSP.Hover CreateHover(LSP.Location location, string text)
             => new LSP.Hover()

--- a/src/Features/LanguageServer/ProtocolUnitTests/Initialize/InitializeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Initialize/InitializeTests.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Initialize
             Assert.True(actual.ImplementationProvider);
             Assert.True(actual.DocumentSymbolProvider);
             Assert.True(actual.WorkspaceSymbolProvider);
-            Assert.True(actual.DocumentFormattingProvider);
-            Assert.True(actual.DocumentRangeFormattingProvider);
+            Assert.True((bool)actual.DocumentFormattingProvider.Value);
+            Assert.True((bool)actual.DocumentRangeFormattingProvider.Value);
             Assert.True(actual.DocumentHighlightProvider);
 
             Assert.True(actual.CompletionProvider.ResolveProvider);

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Xunit;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ProjectContext
+{
+    public class GetTextDocumentWithContextHandlerTests : AbstractLanguageServerProtocolTests
+    {
+        [Fact]
+        public async Task SingleDocumentReturnsSingleContext()
+        {
+            var workspaceXml =
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj"">
+        <Document FilePath = ""C:\C.cs"">{|caret:|}</Document>
+    </Project>
+</Workspace>";
+
+            using var workspace = CreateXmlTestWorkspace(workspaceXml, out var locations);
+            var documentUri = locations["caret"].Single().Uri;
+            var result = await RunGetProjectContext(workspace.CurrentSolution, documentUri);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result!.DefaultIndex);
+            var context = Assert.Single(result.ProjectContexts);
+
+            Assert.Equal(ProtocolConversions.ProjectIdToProjectContextId(workspace.CurrentSolution.ProjectIds.Single()), context.Id);
+            Assert.Equal(LSP.ProjectContextKind.CSharp, context.Kind);
+            Assert.Equal("CSProj", context.Label);
+        }
+
+        [Fact]
+        public async Task MultipleDocumentsReturnsMultipleContexts()
+        {
+            var workspaceXml =
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"">
+        <Document FilePath=""C:\C.cs"">{|caret:|}</Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj2"">
+        <Document IsLinkFile=""true"" LinkFilePath=""C:\C.cs"" LinkAssemblyName=""CSProj1"">{|caret:|}</Document>
+    </Project>
+</Workspace>";
+
+            using var workspace = CreateXmlTestWorkspace(workspaceXml, out var locations);
+            var documentUri = locations["caret"].Single().Uri;
+            var result = await RunGetProjectContext(workspace.CurrentSolution, documentUri);
+
+            Assert.NotNull(result);
+
+            Assert.Collection(result!.ProjectContexts.OrderBy(c => c.Label),
+                c => Assert.Equal("CSProj1", c.Label),
+                c => Assert.Equal("CSProj2", c.Label));
+        }
+
+        [Fact]
+        public async Task SwitchingContextsChangesDefaultContext()
+        {
+            var workspaceXml =
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"">
+        <Document FilePath=""C:\C.cs"">{|caret:|}</Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj2"">
+        <Document IsLinkFile=""true"" LinkFilePath=""C:\C.cs"" LinkAssemblyName=""CSProj1""></Document>
+    </Project>
+</Workspace>";
+
+            using var workspace = CreateXmlTestWorkspace(workspaceXml, out var locations);
+
+            // Ensure the documents are open so we can change contexts
+            foreach (var document in workspace.Documents)
+            {
+                _ = document.GetOpenTextContainer();
+            }
+
+            var documentUri = locations["caret"].Single().Uri;
+
+            foreach (var project in workspace.CurrentSolution.Projects)
+            {
+                workspace.SetDocumentContext(project.DocumentIds.Single());
+                var result = await RunGetProjectContext(workspace.CurrentSolution, documentUri);
+
+                Assert.Equal(ProtocolConversions.ProjectIdToProjectContextId(project.Id), result!.ProjectContexts[result.DefaultIndex].Id);
+                Assert.Equal(project.Name, result!.ProjectContexts[result.DefaultIndex].Label);
+            }
+        }
+
+        private static async Task<LSP.ActiveProjectContexts?> RunGetProjectContext(Solution solution, Uri uri)
+            => await GetLanguageServer(solution).ExecuteRequestAsync<LSP.GetTextDocumentWithContextParams, LSP.ActiveProjectContexts?>(LSP.MSLSPMethods.ProjectContextsName,
+                solution, CreateGetProjectContextParams(uri), new LSP.ClientCapabilities(), clientName: null, CancellationToken.None);
+
+        private static LSP.GetTextDocumentWithContextParams CreateGetProjectContextParams(Uri uri)
+            => new LSP.GetTextDocumentWithContextParams()
+            {
+                TextDocument = new LSP.TextDocumentItem { Uri = uri }
+            };
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -176,6 +176,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             => _protocol.ExecuteRequestAsync<WorkspaceSymbolParams, SymbolInformation[]>(Methods.WorkspaceSymbolName,
                 _workspace.CurrentSolution, workspaceSymbolParams, _clientCapabilities, _clientName, cancellationToken);
 
+        [JsonRpcMethod(MSLSPMethods.ProjectContextsName, UseSingleObjectParameterDeserialization = true)]
+        public Task<ActiveProjectContexts?> GetProjectContextsAsync(GetTextDocumentWithContextParams textDocumentWithContextParams, CancellationToken cancellationToken)
+            => _protocol.ExecuteRequestAsync<GetTextDocumentWithContextParams, ActiveProjectContexts?>(MSLSPMethods.ProjectContextsName,
+                _workspace.CurrentSolution, textDocumentWithContextParams, _clientCapabilities, _clientName, cancellationToken);
+
 #pragma warning disable VSTHRD100 // Avoid async void methods
         private async void DiagnosticService_DiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)
 #pragma warning restore VSTHRD100 // Avoid async void methods

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -49,7 +48,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             _protocol = protocol;
             _workspace = workspace;
 
-            _jsonRpc = new JsonRpc(outputStream, inputStream, this);
+            var jsonMessageFormatter = new JsonMessageFormatter();
+            jsonMessageFormatter.JsonSerializer.Converters.Add(new VSExtensionConverter<TextDocumentIdentifier, VSTextDocumentIdentifier>());
+
+            _jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(outputStream, inputStream, jsonMessageFormatter));
+            _jsonRpc.AddLocalRpcTarget(this);
             _jsonRpc.StartListening();
 
             _diagnosticService = diagnosticService;

--- a/src/VisualStudio/LiveShare/Impl/AbstractClassificationsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/AbstractClassificationsHandler.cs
@@ -28,8 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public async Task<object[]> HandleAsync(ClassificationParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var actualDocumentURI = requestContext.ProtocolConverter.FromProtocolUri(request.TextDocument.Uri);
-            var document = requestContext.Context.GetDocumentFromURI(actualDocumentURI);
+            var document = requestContext.Context.GetDocument(request.TextDocument);
             var classificationService = document?.Project.LanguageServices.GetService<IClassificationService>();
 
             if (document == null || classificationService == null)

--- a/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         {
             var solution = requestContext.Context;
 
-            var document = solution.GetDocumentFromURI(request.TextDocument.Uri);
+            var document = solution.GetDocument(request.TextDocument);
             if (document == null)
             {
                 return Array.Empty<LSP.Location>();

--- a/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynRemoteCodeAction.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynRemoteCodeAction.cs
@@ -105,7 +105,12 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.CodeActions
             foreach (var changePair in _codeActionWorkspaceEdit.Changes)
             {
                 var documentName = await _lspClient.ProtocolConverter.FromProtocolUriAsync(new Uri(changePair.Key), true, cancellationToken).ConfigureAwait(false);
-                var doc = newSolution.GetDocumentFromURI(documentName);
+
+                // The document name here is a document URI that we're trying to apply an edit to. The edit was already computed on the
+                // server and we're trying to create an equivalent copy on the client; we're only fetching the text of the document
+                // rather than any syntax trees, and so it doesn't matter from which context we grab if there are linked files --
+                // all the files are the same and modifying any of them is fine.
+                var doc = newSolution.GetDocuments(documentName).First();
                 if (doc == null)
                 {
                     continue;

--- a/src/VisualStudio/LiveShare/Impl/PreviewCodeActionsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/PreviewCodeActionsHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             var edits = ArrayBuilder<LSP.TextEdit>.GetInstance();
             var solution = requestContext.Context;
             var codeActions = await GetCodeActionsAsync(solution,
-                request.CodeActionParams.TextDocument.Uri,
+                request.CodeActionParams.TextDocument,
                 request.CodeActionParams.Range,
                 null, cancellationToken).ConfigureAwait(false);
 
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 var operations = await actionToRun.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
                 var applyChangesOperation = operations.OfType<ApplyChangesOperation>().FirstOrDefault();
 
-                var document = solution.GetDocumentFromURI(request.CodeActionParams.TextDocument.Uri);
+                var document = solution.GetDocument(request.CodeActionParams.TextDocument);
                 var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
                 if (applyChangesOperation != null && document != null)

--- a/src/VisualStudio/LiveShare/Impl/RunCodeActionsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/RunCodeActionsHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             {
                 var runRequest = ((JToken)request.Arguments.Single()).ToObject<RunCodeActionParams>();
                 var codeActions = await GetCodeActionsAsync(requestContext.Context,
-                    runRequest.CodeActionParams.TextDocument.Uri,
+                    runRequest.CodeActionParams.TextDocument,
                     runRequest.CodeActionParams.Range,
                     null, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Implements support for providing the list of project contexts to the LSP client, and respects the client passing the context back to the server to select the correct document.

Commit at a time might be helpful since the commits break up the separate pieces, but it's not that confusing to look at the whole thing at once.