### PR TITLE
SymbolMatcher Support

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -783,11 +783,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 var sig = type.Signature;
                 var otherSig = other.Signature;
 
-                ValidateFunctionPointerParamOrReturn(
-                    sig.ReturnTypeWithAnnotations, otherSig.ReturnTypeWithAnnotations,
-                    sig.RefKind, otherSig.RefKind,
-                    sig.RefCustomModifiers, otherSig.RefCustomModifiers,
-                    allowOut: false);
+                ValidateFunctionPointerParamOrReturn(sig.ReturnTypeWithAnnotations, sig.RefKind, sig.RefCustomModifiers, allowOut: false);
+                ValidateFunctionPointerParamOrReturn(otherSig.ReturnTypeWithAnnotations, otherSig.RefKind, otherSig.RefCustomModifiers, allowOut: false);
                 if (sig.RefKind != otherSig.RefKind || !AreTypesEqual(sig.ReturnTypeWithAnnotations, otherSig.ReturnTypeWithAnnotations))
                 {
                     return false;
@@ -798,23 +795,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             private bool AreFunctionPointerParametersEqual(ParameterSymbol param, ParameterSymbol otherParam)
             {
-                ValidateFunctionPointerParamOrReturn(
-                    param.TypeWithAnnotations, otherParam.TypeWithAnnotations,
-                    param.RefKind, otherParam.RefKind,
-                    param.RefCustomModifiers, otherParam.RefCustomModifiers,
-                    allowOut: false);
+                ValidateFunctionPointerParamOrReturn(param.TypeWithAnnotations, param.RefKind, param.RefCustomModifiers, allowOut: true);
+                ValidateFunctionPointerParamOrReturn(otherParam.TypeWithAnnotations, otherParam.RefKind, otherParam.RefCustomModifiers, allowOut: true);
 
                 return param.RefKind == otherParam.RefKind && AreTypesEqual(param.TypeWithAnnotations, otherParam.TypeWithAnnotations);
             }
 
             [Conditional("DEBUG")]
-            private void ValidateFunctionPointerParamOrReturn(TypeWithAnnotations type, TypeWithAnnotations otherType, RefKind refKind, RefKind otherRefKind, ImmutableArray<CustomModifier> refCustomModifiers, ImmutableArray<CustomModifier> otherRefCustomModifiers, bool allowOut)
+            private static void ValidateFunctionPointerParamOrReturn(TypeWithAnnotations type, RefKind refKind, ImmutableArray<CustomModifier> refCustomModifiers, bool allowOut)
             {
-
                 Debug.Assert(type.CustomModifiers.IsEmpty);
-                Debug.Assert(otherType.CustomModifiers.IsEmpty);
                 Debug.Assert(verifyRefModifiers(refCustomModifiers, refKind, allowOut));
-                Debug.Assert(verifyRefModifiers(otherRefCustomModifiers, otherRefKind, allowOut));
 
                 static bool verifyRefModifiers(ImmutableArray<CustomModifier> modifiers, RefKind refKind, bool allowOut)
                 {

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -816,7 +816,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                         case RefKind.Out when allowOut:
                             return modifiers.Length == 1;
                         default:
-                            return modifiers.IsDefaultOrEmpty;
+                            return modifiers.IsEmpty;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -1272,5 +1272,136 @@ interface I
             Assert.Same(e0, matcher.MapDefinition(e1));
             Assert.Same(f0, matcher.MapDefinition(f1));
         }
+
+        [Fact]
+        public void FunctionPointerMembersTranslated()
+        {
+            var source = @"
+unsafe class C
+{
+    delegate*<void> f1;
+    delegate*<C, C, C> f2;
+    delegate*<ref C> f3;
+    delegate*<ref readonly C> f4;
+    delegate*<ref C, void> f5;
+    delegate*<in C, void> f6;
+    delegate*<out C, void> f7;
+}
+class D {}
+";
+
+            var compilation0 = CreateCompilation(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            var compilation1 = compilation0.WithSource(source);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default,
+                compilation0.SourceAssembly,
+                default,
+                null);
+
+            for (int i = 1; i <= 7; i++)
+            {
+                var f_0 = compilation0.GetMember<FieldSymbol>($"C.f{i}");
+                var f_1 = compilation1.GetMember<FieldSymbol>($"C.f{i}");
+
+                Assert.Same(f_0, matcher.MapDefinition(f_1));
+            }
+        }
+
+        [Theory]
+        [InlineData("C", "void")]
+        [InlineData("C", "object")]
+        [InlineData("C", "ref C")]
+        [InlineData("C", "ref readonly C")]
+        [InlineData("ref C", "ref readonly C")]
+        public void FunctionPointerMembers_ReturnMismatch(string return1, string return2)
+        {
+            var source1 = $@"
+unsafe class C
+{{
+    delegate*<C, {return1}> f1;
+}}";
+
+            var source2 = $@"
+unsafe class C
+{{
+    delegate*<C, {return2}> f1;
+}}";
+
+            var compilation0 = CreateCompilation(source1, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            var compilation1 = compilation0.WithSource(source2);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default,
+                compilation0.SourceAssembly,
+                default,
+                null);
+
+            var f_1 = compilation1.GetMember<FieldSymbol>($"C.f1");
+
+            Assert.Null(matcher.MapDefinition(f_1));
+        }
+
+        [Theory]
+        [InlineData("C", "object")]
+        [InlineData("C", "ref C")]
+        [InlineData("C", "out C")]
+        [InlineData("C", "in C")]
+        [InlineData("ref C", "out C")]
+        [InlineData("ref C", "in C")]
+        [InlineData("out C", "in C")]
+        [InlineData("C, C", "C")]
+        public void FunctionPointerMembers_ParamMismatch(string param1, string param2)
+        {
+            var source1 = $@"
+unsafe class C
+{{
+    delegate*<{param1}, C, void>* f1;
+}}";
+
+            var source2 = $@"
+unsafe class C
+{{
+    delegate*<{param2}, C, void>* f1;
+}}";
+
+            verify(source1, source2);
+
+            source1 = $@"
+unsafe class C
+{{
+    delegate*<C, {param1}, void> f1;
+}}";
+
+            source2 = $@"
+unsafe class C
+{{
+    delegate*<C, {param2}, void> f1;
+}}";
+
+            verify(source1, source2);
+
+            static void verify(string source1, string source2)
+            {
+                var compilation0 = CreateCompilation(source1, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+                var compilation1 = compilation0.WithSource(source2);
+
+                var matcher = new CSharpSymbolMatcher(
+                    null,
+                    compilation1.SourceAssembly,
+                    default,
+                    compilation0.SourceAssembly,
+                    default,
+                    null);
+
+                var f_1 = compilation1.GetMember<FieldSymbol>($"C.f1");
+
+                Assert.Null(matcher.MapDefinition(f_1));
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -1287,7 +1287,6 @@ unsafe class C
     delegate*<in C, void> f6;
     delegate*<out C, void> f7;
 }
-class D {}
 ";
 
             var compilation0 = CreateCompilation(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);


### PR DESCRIPTION
Adds support for function pointers to the SymbolMatcher.

Relates to #43321 (test plan for function pointers)