### PR TITLE
Test plan followup

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -270,7 +270,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (boundExpression.Type?.Kind == SymbolKind.FunctionPointer)
             {
-                // PROTOTYPE(func-ptr): Test nullable related features
                 ReportSuppressionIfNeeded(boundExpression, diagnostics);
                 result = BindFunctionPointerInvocation(node, boundExpression, analyzedArguments, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -2966,26 +2966,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                if (!hasConversion(sourceParam.RefKind, destinationSig.Parameters[i].Type, sourceSig.Parameters[i].Type, ref useSiteDiagnostics))
+                if (!hasConversion(sourceParam.RefKind, destinationSig.Parameters[i].TypeWithAnnotations, sourceSig.Parameters[i].TypeWithAnnotations, ref useSiteDiagnostics))
                 {
                     return false;
                 }
             }
 
             return sourceSig.RefKind == destinationSig.RefKind
-                   && hasConversion(sourceSig.RefKind, sourceSig.ReturnType, destinationSig.ReturnType, ref useSiteDiagnostics);
+                   && hasConversion(sourceSig.RefKind, sourceSig.ReturnTypeWithAnnotations, destinationSig.ReturnTypeWithAnnotations, ref useSiteDiagnostics);
 
-            bool hasConversion(RefKind refKind, TypeSymbol sourceType, TypeSymbol destinationType, ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
+            bool hasConversion(RefKind refKind, TypeWithAnnotations sourceType, TypeWithAnnotations destinationType, ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
             {
                 switch (refKind)
                 {
                     case RefKind.None:
-                        return HasIdentityOrImplicitReferenceConversion(sourceType, destinationType, ref useSiteDiagnostics)
-                               || HasImplicitPointerToVoidConversion(sourceType, destinationType)
-                               || HasImplicitPointerConversion(sourceType, destinationType, ref useSiteDiagnostics);
+                        return (!IncludeNullability || HasTopLevelNullabilityImplicitConversion(sourceType, destinationType))
+                               && (HasIdentityOrImplicitReferenceConversion(sourceType.Type, destinationType.Type, ref useSiteDiagnostics)
+                                   || HasImplicitPointerToVoidConversion(sourceType.Type, destinationType.Type)
+                                   || HasImplicitPointerConversion(sourceType.Type, destinationType.Type, ref useSiteDiagnostics));
 
                     default:
-                        return HasIdentityConversion(sourceType, destinationType);
+                        return (!IncludeNullability || HasTopLevelNullabilityIdentityConversion(sourceType, destinationType))
+                               && HasIdentityConversion(sourceType.Type, destinationType.Type);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8888,7 +8888,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        // PROTOTYPE(func-ptr): Test nullable related features
         public override BoundNode VisitFunctionPointerInvocation(BoundFunctionPointerInvocation node)
         {
             _ = Visit(node.InvokedExpression);

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal int GetHashCodeNoParameters()
-            => Hash.Combine(ReturnType, Hash.Combine(CallingConvention.GetHashCode(), RefKind.GetHashCode()));
+            => Hash.Combine(ReturnType, Hash.Combine(CallingConvention.GetHashCode(), FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind).GetHashCode()));
 
         internal override CallingConvention CallingConvention { get; }
         public override bool ReturnsVoid => ReturnTypeWithAnnotations.IsVoidType();

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private bool EqualsNoParameters(FunctionPointerMethodSymbol other, TypeCompareKind compareKind, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverride)
             => CallingConvention == other.CallingConvention
-               && RefKind == other.RefKind
+               && FunctionPointerTypeSymbol.RefKindEquals(compareKind, RefKind, other.RefKind)
                && ((compareKind & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) != 0
                     || RefCustomModifiers.SequenceEqual(other.RefCustomModifiers))
                && ReturnTypeWithAnnotations.Equals(other.ReturnTypeWithAnnotations, compareKind, isValueTypeOverride);

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal int MethodHashCode()
-            => Hash.Combine(TypeWithAnnotations.GetHashCode(), RefKind.GetHashCode());
+            => Hash.Combine(TypeWithAnnotations.GetHashCode(), FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind).GetHashCode());
 
         public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                && _containingSymbol.Equals(other._containingSymbol, compareKind, isValueTypeOverride);
 
         internal bool MethodEqualityChecks(FunctionPointerParameterSymbol other, TypeCompareKind compareKind, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverride)
-            => RefKind == other.RefKind
+            => FunctionPointerTypeSymbol.RefKindEquals(compareKind, RefKind, other.RefKind)
                && ((compareKind & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) != 0
                     || RefCustomModifiers.SequenceEqual(other.RefCustomModifiers))
                && TypeWithAnnotations.Equals(other.TypeWithAnnotations, compareKind, isValueTypeOverride);

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -157,5 +157,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this;
         }
 
+        internal static bool RefKindEquals(TypeCompareKind compareKind, RefKind refKind1, RefKind refKind2)
+        {
+            if ((compareKind & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) != 0)
+            {
+                return (refKind1, refKind2) switch
+                {
+                    (RefKind.None, RefKind.None) => true,
+                    (RefKind.None, _) => false,
+                    (_, RefKind.None) => false,
+                    _ => true
+                };
+            }
+            else
+            {
+                return refKind1 == refKind2;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -175,11 +175,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// for types that only differ by the type of ref they have.
         /// </summary>
         internal static RefKind GetRefKindForHashCode(RefKind refKind)
-            => refKind switch
-            {
-                RefKind.Out => RefKind.Ref,
-                RefKind.In => RefKind.Ref,
-                _ => refKind
-            };
+            => refKind == RefKind.None ? RefKind.None : RefKind.Ref;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             considerRefKindDifferences: false,
-            typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance is used to determine if a partial method implementation matches the definition.
@@ -313,6 +313,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _considerCallingConvention = considerCallingConvention;
             _considerRefKindDifferences = considerRefKindDifferences;
             _typeComparison = typeComparison;
+            if (!considerRefKindDifferences)
+            {
+                _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
+            }
         }
 
         #region IEqualityComparer<Symbol> Members

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -313,6 +313,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _considerCallingConvention = considerCallingConvention;
             _considerRefKindDifferences = considerRefKindDifferences;
             _typeComparison = typeComparison;
+            Debug.Assert((_typeComparison & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) == 0,
+                         $"Rely on the {nameof(considerRefKindDifferences)} flag to set this to ensure all cases are handled.");
             if (!considerRefKindDifferences)
             {
                 _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
@@ -459,11 +461,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         #endregion
-
-        public static bool HaveSameReturnTypes(MethodSymbol member1, MethodSymbol member2, TypeCompareKind typeComparison)
-        {
-            return HaveSameReturnTypes(member1, GetTypeMap(member1), member2, GetTypeMap(member2), typeComparison);
-        }
 
         private static bool HaveSameReturnTypes(Symbol member1, TypeMap typeMap1, Symbol member2, TypeMap typeMap2, TypeCompareKind typeComparison)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -62,7 +62,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
     /// </code>
     /// </example>
     /// </summary>
-    // PROTOTYPE(func-ptr): Implement and test in function pointers. Also dynamic and nullable
     internal struct TupleTypeDecoder
     {
         private readonly ImmutableArray<string?> _elementNames;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -102,7 +102,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes)); // Same custom modifiers as source type.
 
-            Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic, nullability and tuple names as destination type.
+            // Same object/dynamic, nullability and tuple names as destination type.
+            Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNativeIntegers));
 
             return resultType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes)); // Same custom modifiers as source type.
 
             // Same object/dynamic, nullability and tuple names as destination type.
-            Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNativeIntegers));
+            Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
 
             return resultType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -512,6 +512,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case SymbolKind.ArrayType:
                     case SymbolKind.PointerType:
+                    case SymbolKind.FunctionPointer:
                     case SymbolKind.Assembly:
                     case SymbolKind.DynamicType:
                     case SymbolKind.NetModule:

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -250,6 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
                 case SymbolKind.PointerType:
+                case SymbolKind.FunctionPointer:
                 case SymbolKind.TypeParameter:
                     return true;
                 case SymbolKind.Alias:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -6008,7 +6008,7 @@ unsafe class Derived : Base
             comp.VerifyDiagnostics(
             );
 
-            assertMethods(comp.SourceModule); 
+            assertMethods(comp.SourceModule);
             CompileAndVerify(comp, symbolValidator: assertMethods);
 
             static void assertMethods(ModuleSymbol module)
@@ -6172,7 +6172,7 @@ unsafe class Derived : Base
 
             comp.VerifyDiagnostics(
                 // (16,29): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     protected override void M1(delegate*<string> ptr) {{}}
+                //     protected override void M1(delegate*<string> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("ptr").WithLocation(16, 29),
                 // (19,48): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     protected override delegate*<string, void> M4() => throw null!;
@@ -6181,7 +6181,7 @@ unsafe class Derived : Base
                 //     protected override delegate*<string?> M6() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M6").WithLocation(21, 43),
                 // (22,29): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     protected override void M7(delegate*<string?, void> ptr) {{}}
+                //     protected override void M7(delegate*<string?, void> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M7").WithArguments("ptr").WithLocation(22, 29)
             );
 
@@ -6238,25 +6238,25 @@ unsafe class Derived : Base
 
             comp.VerifyDiagnostics(
                 // (16,29): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     protected override void M1(delegate*<ref string> ptr) {{}}
+                //     protected override void M1(delegate*<ref string> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("ptr").WithLocation(16, 29),
                 // (17,46): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     protected override delegate*<ref string> M2() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M2").WithLocation(17, 46),
                 // (18,29): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     protected override void M3(delegate*<ref string, void> ptr) {{}}
+                //     protected override void M3(delegate*<ref string, void> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("ptr").WithLocation(18, 29),
                 // (19,52): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     protected override delegate*<ref string, void> M4() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(19, 52),
                 // (20,29): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     protected override void M5(delegate*<ref string?> ptr) {{}}
+                //     protected override void M5(delegate*<ref string?> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("ptr").WithLocation(20, 29),
                 // (21,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     protected override delegate*<ref string?> M6() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M6").WithLocation(21, 47),
                 // (22,29): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     protected override void M7(delegate*<ref string?, void> ptr) {{}}
+                //     protected override void M7(delegate*<ref string?, void> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M7").WithArguments("ptr").WithLocation(22, 29),
                 // (23,53): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     protected override delegate*<ref string?, void> M8() => throw null!;
@@ -6316,25 +6316,25 @@ public unsafe class Derived : Base
 
             comp.VerifyDiagnostics(
                 // (16,26): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     public override void M1(ref delegate*<string> ptr) {{}}
+                //     public override void M1(ref delegate*<string> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("ptr").WithLocation(16, 26),
                 // (17,43): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     public override ref delegate*<string> M2() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M2").WithLocation(17, 43),
                 // (18,26): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     public override void M3(ref delegate*<string, void> ptr) {{}}
+                //     public override void M3(ref delegate*<string, void> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("ptr").WithLocation(18, 26),
                 // (19,49): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     public override ref delegate*<string, void> M4() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(19, 49),
                 // (20,26): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     public override void M5(ref delegate*<string?> ptr) {{}}
+                //     public override void M5(ref delegate*<string?> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("ptr").WithLocation(20, 26),
                 // (21,44): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     public override ref delegate*<string?> M6() => throw null!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M6").WithLocation(21, 44),
                 // (22,26): warning CS8610: Nullability of reference types in type of parameter 'ptr' doesn't match overridden member.
-                //     public override void M7(ref delegate*<string?, void> ptr) {{}}
+                //     public override void M7(ref delegate*<string?, void> ptr) {}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M7").WithArguments("ptr").WithLocation(22, 26),
                 // (23,50): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     public override ref delegate*<string?, void> M8() => throw null!;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -5861,16 +5861,16 @@ unsafe class Derived : Base
         }
 
         [Theory]
-        [InlineData(" ", "ref ")]
-        [InlineData(" ", "out ")]
-        [InlineData(" ", "in ")]
+        [InlineData("", "ref ")]
+        [InlineData("", "out ")]
+        [InlineData("", "in ")]
         [InlineData("ref ", "")]
         [InlineData("ref ", "out ")]
         [InlineData("ref ", "in ")]
-        [InlineData("out ", " ")]
+        [InlineData("out ", "")]
         [InlineData("out ", "ref ")]
         [InlineData("out ", "in ")]
-        [InlineData("in ", " ")]
+        [InlineData("in ", "")]
         [InlineData("in ", "ref ")]
         [InlineData("in ", "out ")]
         public void Override_RefnessMustMatch_Parameters(string refKind1, string refKind2)
@@ -5890,13 +5890,11 @@ unsafe class Derived : Base
             comp.VerifyDiagnostics(
                 // (9,29): error CS0115: 'Derived.M1(delegate*<{refKind2} string, void>)': no suitable method found to override
                 //     protected override void M1(delegate*<{refKind2} string, void> ptr) {}
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M1").WithArguments($"Derived.M1(delegate*<{refKindString(refKind2)}string, void>)").WithLocation(9, 29),
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M1").WithArguments($"Derived.M1(delegate*<{refKind2}string, void>)").WithLocation(9, 29),
                 // (10,49): error CS0508: 'Derived.M2()': return type must be 'delegate*<{refKind1} string, void>' to match overridden member 'Base.M2()'
                 //     protected override delegate*<{refKind2} string, void> M2() => throw null;
-                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M2").WithArguments("Derived.M2()", "Base.M2()", $"delegate*<{refKindString(refKind1)}string, void>").WithLocation(10, 48 + refKind2.Length)
+                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M2").WithArguments("Derived.M2()", "Base.M2()", $"delegate*<{refKind1}string, void>").WithLocation(10, 48 + refKind2.Length)
             );
-
-            static string refKindString(string orig) => orig == " " ? "" : orig;
         }
 
         [Theory]
@@ -6063,7 +6061,7 @@ unsafe class Derived : Base
             comp.VerifyDiagnostics(
             );
 
-            assertMethods(comp.SourceModule); 
+            assertMethods(comp.SourceModule);
             CompileAndVerify(comp, symbolValidator: assertMethods);
 
             static void assertMethods(ModuleSymbol module)
@@ -6092,24 +6090,24 @@ unsafe class Derived : Base
             var comp = CreateCompilationWithFunctionPointers(@"
 unsafe class Base
 {
-    protected virtual void M1(delegate*<(int, string)> ptr) {{}}
+    protected virtual void M1(delegate*<(int, string)> ptr) {}
     protected virtual delegate*<(int, string)> M2() => throw null;
-    protected virtual void M3(delegate*<(int, string), void> ptr) {{}}
+    protected virtual void M3(delegate*<(int, string), void> ptr) {}
     protected virtual delegate*<(int, string), void> M4() => throw null;
-    protected virtual void M5(delegate*<(int i, string s)> ptr) {{}}
+    protected virtual void M5(delegate*<(int i, string s)> ptr) {}
     protected virtual delegate*<(int i, string s)> M6() => throw null;
-    protected virtual void M7(delegate*<(int i, string s), void> ptr) {{}}
+    protected virtual void M7(delegate*<(int i, string s), void> ptr) {}
     protected virtual delegate*<(int i, string s), void> M8() => throw null;
 }
 unsafe class Derived : Base
 {
-    protected override void M1(delegate*<(int i, string s)> ptr) {{}}
+    protected override void M1(delegate*<(int i, string s)> ptr) {}
     protected override delegate*<(int i, string s)> M2() => throw null;
-    protected override void M3(delegate*<(int i, string s), void> ptr) {{}}
+    protected override void M3(delegate*<(int i, string s), void> ptr) {}
     protected override delegate*<(int i, string s), void> M4() => throw null;
-    protected override void M5(delegate*<(int, string)> ptr) {{}}
+    protected override void M5(delegate*<(int, string)> ptr) {}
     protected override delegate*<(int, string)> M6() => throw null;
-    protected override void M7(delegate*<(int, string), void> ptr) {{}}
+    protected override void M7(delegate*<(int, string), void> ptr) {}
     protected override delegate*<(int, string), void> M8() => throw null;
 }");
 
@@ -6151,24 +6149,24 @@ unsafe class Derived : Base
 #nullable enable
 unsafe class Base
 {
-    protected virtual void M1(delegate*<string?> ptr) {{}}
+    protected virtual void M1(delegate*<string?> ptr) {}
     protected virtual delegate*<string?> M2() => throw null!;
-    protected virtual void M3(delegate*<string?, void> ptr) {{}}
+    protected virtual void M3(delegate*<string?, void> ptr) {}
     protected virtual delegate*<string?, void> M4() => throw null!;
-    protected virtual void M5(delegate*<string> ptr) {{}}
+    protected virtual void M5(delegate*<string> ptr) {}
     protected virtual delegate*<string> M6() => throw null!;
-    protected virtual void M7(delegate*<string, void> ptr) {{}}
+    protected virtual void M7(delegate*<string, void> ptr) {}
     protected virtual delegate*<string, void> M8() => throw null!;
 }
 unsafe class Derived : Base
 {
-    protected override void M1(delegate*<string> ptr) {{}}
+    protected override void M1(delegate*<string> ptr) {}
     protected override delegate*<string> M2() => throw null!;
-    protected override void M3(delegate*<string, void> ptr) {{}}
+    protected override void M3(delegate*<string, void> ptr) {}
     protected override delegate*<string, void> M4() => throw null!;
-    protected override void M5(delegate*<string?> ptr) {{}}
+    protected override void M5(delegate*<string?> ptr) {}
     protected override delegate*<string?> M6() => throw null!;
-    protected override void M7(delegate*<string?, void> ptr) {{}}
+    protected override void M7(delegate*<string?, void> ptr) {}
     protected override delegate*<string?, void> M8() => throw null!;
 }");
 
@@ -6187,7 +6185,7 @@ unsafe class Derived : Base
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M7").WithArguments("ptr").WithLocation(22, 29)
             );
 
-            assertMethods(comp.SourceModule); 
+            assertMethods(comp.SourceModule);
             CompileAndVerify(comp, symbolValidator: assertMethods);
 
             static void assertMethods(ModuleSymbol module)
@@ -6217,24 +6215,24 @@ unsafe class Derived : Base
 #nullable enable
 unsafe class Base
 {
-    protected virtual void M1(delegate*<ref string?> ptr) {{}}
+    protected virtual void M1(delegate*<ref string?> ptr) {}
     protected virtual delegate*<ref string?> M2() => throw null!;
-    protected virtual void M3(delegate*<ref string?, void> ptr) {{}}
+    protected virtual void M3(delegate*<ref string?, void> ptr) {}
     protected virtual delegate*<ref string?, void> M4() => throw null!;
-    protected virtual void M5(delegate*<ref string> ptr) {{}}
+    protected virtual void M5(delegate*<ref string> ptr) {}
     protected virtual delegate*<ref string> M6() => throw null!;
-    protected virtual void M7(delegate*<ref string, void> ptr) {{}}
+    protected virtual void M7(delegate*<ref string, void> ptr) {}
     protected virtual delegate*<ref string, void> M8() => throw null!;
 }
 unsafe class Derived : Base
 {
-    protected override void M1(delegate*<ref string> ptr) {{}}
+    protected override void M1(delegate*<ref string> ptr) {}
     protected override delegate*<ref string> M2() => throw null!;
-    protected override void M3(delegate*<ref string, void> ptr) {{}}
+    protected override void M3(delegate*<ref string, void> ptr) {}
     protected override delegate*<ref string, void> M4() => throw null!;
-    protected override void M5(delegate*<ref string?> ptr) {{}}
+    protected override void M5(delegate*<ref string?> ptr) {}
     protected override delegate*<ref string?> M6() => throw null!;
-    protected override void M7(delegate*<ref string?, void> ptr) {{}}
+    protected override void M7(delegate*<ref string?, void> ptr) {}
     protected override delegate*<ref string?, void> M8() => throw null!;
 }");
 
@@ -6265,7 +6263,7 @@ unsafe class Derived : Base
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M8").WithLocation(23, 53)
             );
 
-            assertMethods(comp.SourceModule); 
+            assertMethods(comp.SourceModule);
             CompileAndVerify(comp, symbolValidator: assertMethods);
 
             static void assertMethods(ModuleSymbol module)
@@ -6295,24 +6293,24 @@ unsafe class Derived : Base
 #nullable enable
 public unsafe class Base
 {
-    public virtual void M1(ref delegate*<string?> ptr) {{}}
+    public virtual void M1(ref delegate*<string?> ptr) {}
     public virtual ref delegate*<string?> M2() => throw null!;
-    public virtual void M3(ref delegate*<string?, void> ptr) {{}}
+    public virtual void M3(ref delegate*<string?, void> ptr) {}
     public virtual ref delegate*<string?, void> M4() => throw null!;
-    public virtual void M5(ref delegate*<string> ptr) {{}}
+    public virtual void M5(ref delegate*<string> ptr) {}
     public virtual ref delegate*<string> M6() => throw null!;
-    public virtual void M7(ref delegate*<string, void> ptr) {{}}
+    public virtual void M7(ref delegate*<string, void> ptr) {}
     public virtual ref delegate*<string, void> M8() => throw null!;
 }
 public unsafe class Derived : Base
 {
-    public override void M1(ref delegate*<string> ptr) {{}}
+    public override void M1(ref delegate*<string> ptr) {}
     public override ref delegate*<string> M2() => throw null!;
-    public override void M3(ref delegate*<string, void> ptr) {{}}
+    public override void M3(ref delegate*<string, void> ptr) {}
     public override ref delegate*<string, void> M4() => throw null!;
-    public override void M5(ref delegate*<string?> ptr) {{}}
+    public override void M5(ref delegate*<string?> ptr) {}
     public override ref delegate*<string?> M6() => throw null!;
-    public override void M7(ref delegate*<string?, void> ptr) {{}}
+    public override void M7(ref delegate*<string?, void> ptr) {}
     public override ref delegate*<string?, void> M8() => throw null!;
 }");
 
@@ -6370,7 +6368,6 @@ public unsafe class Derived : Base
         [Fact]
         public void Override_SingleDimensionArraySizesInMetadata()
         {
-
             var il = @"
 .class public auto ansi abstract beforefieldinit Base
     extends [mscorlib]System.Object

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
@@ -709,6 +709,10 @@ class A
     private A[] aarray;
     private K* kptr;
     private A* aptr;
+    private delegate*<A, A, K> kinreturnfuncptr;
+    private delegate*<K, A, A> kinparamfuncptr1;
+    private delegate*<A, K, A> kinparamfuncptr2;
+    private delegate*<A, A> afuncptr;
     private IEnumerable<K> kenum;
     private IEnumerable<A> aenum;
     void M()
@@ -746,6 +750,10 @@ class ADerived2: A
             ITypeSymbol aarrayType = (classA.GetMembers("aarray").Single() as IFieldSymbol).Type;
             ITypeSymbol kptrType = (classA.GetMembers("kptr").Single() as IFieldSymbol).Type;
             ITypeSymbol aptrType = (classA.GetMembers("aptr").Single() as IFieldSymbol).Type;
+            ITypeSymbol kinreturnfuncptrType = (classA.GetMembers("kinreturnfuncptr").Single() as IFieldSymbol).Type;
+            ITypeSymbol kinparamfuncptr1Type = (classA.GetMembers("kinparamfuncptr1").Single() as IFieldSymbol).Type;
+            ITypeSymbol kinparamfuncptr2Type = (classA.GetMembers("kinparamfuncptr2").Single() as IFieldSymbol).Type;
+            ITypeSymbol afuncptrType = (classA.GetMembers("afuncptr").Single() as IFieldSymbol).Type;
             ITypeSymbol kenumType = (classA.GetMembers("kenum").Single() as IFieldSymbol).Type;
             ITypeSymbol aenumType = (classA.GetMembers("aenum").Single() as IFieldSymbol).Type;
             var discards = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(i => i.Identifier.ContextualKind() == SyntaxKind.UnderscoreToken).ToArray();
@@ -774,6 +782,14 @@ class ADerived2: A
             Assert.False(compilation.IsSymbolAccessibleWithin(kptrType, classB));
             Assert.True(Symbol.IsSymbolAccessible(aptrType.GetSymbol(), classB.GetSymbol()));
             Assert.True(compilation.IsSymbolAccessibleWithin(aptrType, classB));
+            Assert.False(Symbol.IsSymbolAccessible(kinreturnfuncptrType.GetSymbol(), classB.GetSymbol()));
+            Assert.False(compilation.IsSymbolAccessibleWithin(kinreturnfuncptrType, classB));
+            Assert.False(Symbol.IsSymbolAccessible(kinparamfuncptr1Type.GetSymbol(), classB.GetSymbol()));
+            Assert.False(compilation.IsSymbolAccessibleWithin(kinparamfuncptr1Type, classB));
+            Assert.False(Symbol.IsSymbolAccessible(kinparamfuncptr2Type.GetSymbol(), classB.GetSymbol()));
+            Assert.False(compilation.IsSymbolAccessibleWithin(kinparamfuncptr2Type, classB));
+            Assert.True(Symbol.IsSymbolAccessible(afuncptrType.GetSymbol(), classB.GetSymbol()));
+            Assert.True(compilation.IsSymbolAccessibleWithin(afuncptrType, classB));
             Assert.False(Symbol.IsSymbolAccessible(kdiscard.GetSymbol(), classB.GetSymbol()));
             Assert.False(compilation.IsSymbolAccessibleWithin(kdiscard, classB));
             Assert.True(Symbol.IsSymbolAccessible(adiscard.GetSymbol(), classB.GetSymbol()));
@@ -811,8 +827,16 @@ class ADerived2: A
             Assert.False(compilation.IsSymbolAccessibleWithin(karrayType, sourceAssem));
             Assert.True(Symbol.IsSymbolAccessible(aptrType.GetSymbol(), sourceAssem.GetSymbol()));
             Assert.True(compilation.IsSymbolAccessibleWithin(aptrType, sourceAssem));
+            Assert.True(Symbol.IsSymbolAccessible(afuncptrType.GetSymbol(), sourceAssem.GetSymbol()));
+            Assert.True(compilation.IsSymbolAccessibleWithin(afuncptrType, sourceAssem));
             Assert.False(Symbol.IsSymbolAccessible(kptrType.GetSymbol(), sourceAssem.GetSymbol()));
             Assert.False(compilation.IsSymbolAccessibleWithin(kptrType, sourceAssem));
+            Assert.False(Symbol.IsSymbolAccessible(kinreturnfuncptrType.GetSymbol(), sourceAssem.GetSymbol()));
+            Assert.False(compilation.IsSymbolAccessibleWithin(kinreturnfuncptrType, sourceAssem));
+            Assert.False(Symbol.IsSymbolAccessible(kinparamfuncptr1Type.GetSymbol(), sourceAssem.GetSymbol()));
+            Assert.False(compilation.IsSymbolAccessibleWithin(kinparamfuncptr1Type, sourceAssem));
+            Assert.False(Symbol.IsSymbolAccessible(kinparamfuncptr2Type.GetSymbol(), sourceAssem.GetSymbol()));
+            Assert.False(compilation.IsSymbolAccessibleWithin(kinparamfuncptr2Type, sourceAssem));
             Assert.True(Symbol.IsSymbolAccessible(adiscard.GetSymbol(), sourceAssem.GetSymbol()));
             Assert.True(compilation.IsSymbolAccessibleWithin(adiscard, sourceAssem));
             Assert.False(Symbol.IsSymbolAccessible(kdiscard.GetSymbol(), sourceAssem.GetSymbol()));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -1353,7 +1353,7 @@ unsafe class C
         }
 
         [Fact]
-        public void MergeVariantAnnotations()
+        public void MergeVariantAnnotations_ReturnTypes()
         {
             var comp = CreateCompilationWithFunctionPointers(@"
 #nullable enable
@@ -1420,6 +1420,79 @@ unsafe class C
                "?",
                "?",
                "delegate*<ref System.String>"
+            };
+
+            AssertEx.Equal(expectedTypes, invocationTypes);
+        }
+
+        [Fact]
+        public void MergeVariantAnnotations_ParamTypes()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+#nullable enable
+unsafe class C
+{
+    void M(bool b)
+    {
+        delegate*<string, void> ptr1 = null;
+        delegate*<string?, void> ptr2 = null;
+        delegate*<ref string, void> ptr3 = null;
+        delegate*<ref string?, void> ptr4 = null;
+        _ = b ? ptr1 : ptr2;
+        _ = b ? ptr1 : ptr3;
+        _ = b ? ptr1 : ptr4;
+        _ = b ? ptr3 : ptr4;
+
+        delegate*<string, void> ptr5 = null;
+        delegate*<string?, void> ptr6 = null;
+        delegate*<ref string, void> ptr7 = null;
+        delegate*<ref string?, void> ptr8 = null;
+        _ = b ? ptr5 : ptr6;
+        _ = b ? ptr5 : ptr7;
+        _ = b ? ptr5 : ptr8;
+        _ = b ? ptr7 : ptr8;
+    }
+}");
+
+            comp.VerifyDiagnostics(
+                // (12,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string, void>' and 'delegate*<ref string, void>'
+                //         _ = b ? ptr1 : ptr3;
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr1 : ptr3").WithArguments("delegate*<string, void>", "delegate*<ref string, void>").WithLocation(12, 13),
+                // (13,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string, void>' and 'delegate*<ref string?, void>'
+                //         _ = b ? ptr1 : ptr4;
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr1 : ptr4").WithArguments("delegate*<string, void>", "delegate*<ref string?, void>").WithLocation(13, 13),
+                // (14,24): warning CS8619: Nullability of reference types in value of type 'delegate*<ref string?, void>' doesn't match target type 'delegate*<ref string, void>'.
+                //         _ = b ? ptr3 : ptr4;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ptr4").WithArguments("delegate*<ref string?, void>", "delegate*<ref string, void>").WithLocation(14, 24),
+                // (21,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string, void>' and 'delegate*<ref string, void>'
+                //         _ = b ? ptr5 : ptr7;
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr5 : ptr7").WithArguments("delegate*<string, void>", "delegate*<ref string, void>").WithLocation(21, 13),
+                // (22,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string, void>' and 'delegate*<ref string?, void>'
+                //         _ = b ? ptr5 : ptr8;
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr5 : ptr8").WithArguments("delegate*<string, void>", "delegate*<ref string?, void>").WithLocation(22, 13),
+                // (23,24): warning CS8619: Nullability of reference types in value of type 'delegate*<ref string?, void>' doesn't match target type 'delegate*<ref string, void>'.
+                //         _ = b ? ptr7 : ptr8;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ptr8").WithArguments("delegate*<ref string?, void>", "delegate*<ref string, void>").WithLocation(23, 24)
+            );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var invocationTypes = tree.GetRoot()
+                                      .DescendantNodes()
+                                      .OfType<ConditionalExpressionSyntax>()
+                                      .Select(s => model.GetTypeInfo(s).Type.ToTestDisplayString())
+                                      .ToList();
+
+            var expectedTypes = new string[] {
+               "delegate*<System.String, System.Void>",
+               "?",
+               "?",
+               "delegate*<ref System.String, System.Void>",
+               "delegate*<System.String, System.Void>",
+               "?",
+               "?",
+               "delegate*<ref System.String, System.Void>"
             };
 
             AssertEx.Equal(expectedTypes, invocationTypes);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -1381,7 +1381,6 @@ unsafe class C
     }
 }");
 
-            // Implicit pointer conversions are not currently handled, ptr3/4 and ptr7/8 should warn: https://github.com/dotnet/roslyn/issues/39865
             comp.VerifyDiagnostics(
                 // (12,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string>' and 'delegate*<string>'
                 //         _ = b ? ptr1 : ptr3;
@@ -1389,12 +1388,18 @@ unsafe class C
                 // (13,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string>' and 'delegate*<string?>'
                 //         _ = b ? ptr1 : ptr4;
                 Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr1 : ptr4").WithArguments("delegate*<string>", "delegate*<string?>").WithLocation(13, 13),
+                // (14,24): warning CS8619: Nullability of reference types in value of type 'delegate*<string?>' doesn't match target type 'delegate*<string>'.
+                //         _ = b ? ptr3 : ptr4;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ptr4").WithArguments("delegate*<string?>", "delegate*<string>").WithLocation(14, 24),
                 // (21,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string>' and 'delegate*<string>'
                 //         _ = b ? ptr5 : ptr7;
                 Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr5 : ptr7").WithArguments("delegate*<string>", "delegate*<string>").WithLocation(21, 13),
                 // (22,13): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'delegate*<string>' and 'delegate*<string?>'
                 //         _ = b ? ptr5 : ptr8;
-                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr5 : ptr8").WithArguments("delegate*<string>", "delegate*<string?>").WithLocation(22, 13)
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? ptr5 : ptr8").WithArguments("delegate*<string>", "delegate*<string?>").WithLocation(22, 13),
+                // (23,24): warning CS8619: Nullability of reference types in value of type 'delegate*<string?>' doesn't match target type 'delegate*<string>'.
+                //         _ = b ? ptr7 : ptr8;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ptr8").WithArguments("delegate*<string?>", "delegate*<string>").WithLocation(23, 24)
             );
 
             var tree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -846,7 +846,6 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
         [Fact]
         public void NormalizeTaskTypes_FunctionPointers()
         {
-
             string source =
 @"
 using System.Runtime.CompilerServices;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -844,6 +844,94 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
         }
 
         [Fact]
+        public void NormalizeTaskTypes_FunctionPointers()
+        {
+
+            string source =
+@"
+using System.Runtime.CompilerServices;
+unsafe class C<T>
+{
+#pragma warning disable CS0169
+    static delegate*<int, int, C<MyTask<int>>> F0;
+    static delegate*<C<MyTask<int>>, int, int> F1;
+    static delegate*<int, C<MyTask<int>>, int> F2;
+    static delegate*<int, int, int> F3;
+#pragma warning restore CS0169
+}
+[AsyncMethodBuilder(typeof(MyTaskMethodBuilder<>))]
+struct MyTask<T> { }
+struct MyTaskMethodBuilder<T>
+{
+    public static MyTaskMethodBuilder<T> Create() => new MyTaskMethodBuilder<T>();
+}
+
+namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : System.Attribute { public AsyncMethodBuilderAttribute(System.Type t) { } } }
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            compilation.VerifyDiagnostics();
+
+            assert("F0", "delegate*<System.Int32, System.Int32, C<MyTask<System.Int32>>>", "delegate*<System.Int32, System.Int32, C<System.Threading.Tasks.Task<System.Int32>>>");
+            assert("F1", "delegate*<C<MyTask<System.Int32>>, System.Int32, System.Int32>", "delegate*<C<System.Threading.Tasks.Task<System.Int32>>, System.Int32, System.Int32>");
+            assert("F2", "delegate*<System.Int32, C<MyTask<System.Int32>>, System.Int32>", "delegate*<System.Int32, C<System.Threading.Tasks.Task<System.Int32>>, System.Int32>");
+            assert("F3", "delegate*<System.Int32, System.Int32, System.Int32>", normalized: null);
+
+            void assert(string fieldName, string original, string normalized)
+            {
+                var type = compilation.GetMember<FieldSymbol>($"C.{fieldName}").Type;
+                FunctionPointerUtilities.CommonVerifyFunctionPointer((FunctionPointerTypeSymbol)type);
+                var normalizedType = type.NormalizeTaskTypes(compilation);
+                Assert.Equal(original, type.ToTestDisplayString());
+                if (normalized is object)
+                {
+                    Assert.Equal(normalized, normalizedType.ToTestDisplayString());
+                }
+                else
+                {
+                    Assert.Same(type, normalizedType);
+                }
+            }
+        }
+
+        [Fact]
+        public void NormalizeTaskTypes_FunctionPointersCustomModifiers()
+        {
+            var ilSource =
+@".class public C
+{
+  .field public static method class MyTask modopt(class MyTask) *(class MyTask modopt(class MyTask)) F0
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+}
+.class public MyTask
+{
+  .custom instance void System.Runtime.CompilerServices.AsyncMethodBuilderAttribute::.ctor(class [mscorlib]System.Type) = { type(MyTaskMethodBuilder) }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+}
+.class public MyTaskMethodBuilder
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+}
+.namespace System.Runtime.CompilerServices
+{
+  .class public AsyncMethodBuilderAttribute extends [mscorlib]System.Attribute
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor(class [mscorlib]System.Type t) cil managed { ret }
+  }
+}
+";
+            var source =
+@"";
+            var reference = CompileIL(ilSource);
+            var compilation = CreateCompilationWithMscorlib45(source, references: new[] { reference });
+            compilation.VerifyDiagnostics();
+
+            var type = compilation.GetMember<FieldSymbol>("C.F0").Type;
+            var normalized = type.NormalizeTaskTypes(compilation);
+            Assert.Equal("delegate*<MyTask modopt(MyTask), MyTask modopt(MyTask)>", type.ToTestDisplayString());
+            Assert.Equal("delegate*<System.Threading.Tasks.Task modopt(MyTask), System.Threading.Tasks.Task modopt(MyTask)>", normalized.ToTestDisplayString());
+        }
+
+        [Fact]
         public void NormalizeTaskTypes_Errors()
         {
             string source =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -675,6 +675,9 @@ unsafe class C
             Assert.Equal(ptr1Ref.GetHashCode(), ptr1RefReadonly.GetHashCode());
             Assert.Equal(ptr2Ref.GetHashCode(), ptr2In.GetHashCode());
             Assert.Equal(ptr2Ref.GetHashCode(), ptr2Out.GetHashCode());
+            Assert.Equal(symbolEqualityComparer.GetHashCode(ptr1Ref.GetPublicSymbol()), symbolEqualityComparer.GetHashCode(ptr1RefReadonly.GetPublicSymbol()));
+            Assert.Equal(symbolEqualityComparer.GetHashCode(ptr2Ref.GetPublicSymbol()), symbolEqualityComparer.GetHashCode(ptr2In.GetPublicSymbol()));
+            Assert.Equal(symbolEqualityComparer.GetHashCode(ptr2Ref.GetPublicSymbol()), symbolEqualityComparer.GetHashCode(ptr2Out.GetPublicSymbol()));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Symbols/SymbolKindExtensions.cs
+++ b/src/Compilers/Core/Portable/Symbols/SymbolKindExtensions.cs
@@ -48,12 +48,10 @@ namespace Microsoft.CodeAnalysis
                     return 14;
                 case SymbolKind.TypeParameter:
                     return 15;
-                case SymbolKind.PointerType:
-                    return 16;
                 case SymbolKind.DynamicType:
-                    return 17;
+                    return 16;
                 case SymbolKind.Preprocessing:
-                    return 18;
+                    return 17;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(kind);
             }

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis
         IgnoreNullableModifiersForReferenceTypes = 8,
         ObliviousNullableModifierMatchesAny = 16,
         IgnoreNativeIntegers = 32,
+        FunctionPointerRefMatchesOutInRefReadonly = 64,
 
         AllNullableIgnoreOptions = IgnoreNullableModifiersForReferenceTypes | ObliviousNullableModifierMatchesAny,
         AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames | AllNullableIgnoreOptions | IgnoreNativeIntegers,

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -25,6 +25,14 @@ namespace Microsoft.CodeAnalysis
         IgnoreNullableModifiersForReferenceTypes = 8,
         ObliviousNullableModifierMatchesAny = 16,
         IgnoreNativeIntegers = 32,
+
+        // For the purposes of a few specific cases such as overload comparisons, we need to consider function pointers that only differ
+        // by ref, in, out, or ref readonly identical. For these specific scenarios, this option is available. However, it is not in
+        // in AllIgnoreOptions because except for these few specific cases, ignoring the RefKind is not the correct behavior.
+        // For overloading, we disallow overloading on just the type of refness in a function pointer parameter or return type. Technically
+        // we could emit signatures overloaded on this distinction, because we must encode the type of ref in a modreq on the appropriate
+        // parameter in metadata, which would change the type. However, this would be inconsistent with how ref vs out vs in works on
+        // top-level signatures today, so we disallow it in source.
         FunctionPointerRefMatchesOutInRefReadonly = 64,
 
         AllNullableIgnoreOptions = IgnoreNullableModifiersForReferenceTypes | ObliviousNullableModifierMatchesAny,

--- a/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Assert.False(symbol.IsAbstract);
                 Assert.False(symbol.IsSealed);
                 Assert.False(symbol.CanBeReferencedByName);
+                Assert.True(symbol.IsTypeOrTypeAlias());
 
                 Assert.True(symbol.IsValueType);
                 Assert.True(symbol.CanBeAssignedNull());

--- a/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Assert.False(symbol.IsStatic);
                 Assert.False(symbol.IsAbstract);
                 Assert.False(symbol.IsSealed);
+                Assert.False(symbol.CanBeReferencedByName);
 
                 Assert.True(symbol.IsValueType);
                 Assert.True(symbol.CanBeAssignedNull());


### PR DESCRIPTION
Added support for the remaining compiler-side required test plan work. @AlekseyTs @dotnet/roslyn-compiler for review. I recommend reviewing this PR commit-by-commit for ease of review.

Relates to https://github.com/dotnet/roslyn/issues/43321