### PR TITLE
Simplify and make our code for resolving body-level symbols more resilient

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -552,6 +552,10 @@ namespace Microsoft.CodeAnalysis
                 {
                     var node = location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, CancellationToken);
                     var semanticModel = Compilation.GetSemanticModel(location.SourceTree);
+                    var symbol = semanticModel.GetDeclaredSymbol(node, CancellationToken);
+                    if (symbol != null)
+                        return new SymbolKeyResolution(symbol);
+
                     var info = semanticModel.GetSymbolInfo(node, CancellationToken);
                     if (info.Symbol != null)
                         return new SymbolKeyResolution(info.Symbol);

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis
                 _idToResult.Clear();
                 Compilation = null;
                 IgnoreAssemblyKey = false;
-                _resolveLocations = false;
+                _resolveLocations = true;
                 Comparer = null;
                 _methodSymbolStack.Clear();
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static SymbolKeyResolution ResolveString(
             string symbolKey, Compilation compilation,
-            bool ignoreAssemblyKey = false, bool resolveLocations = false,
+            bool ignoreAssemblyKey = false, bool resolveLocations = true,
             CancellationToken cancellationToken = default)
         {
             using var reader = SymbolKeyReader.GetReader(
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis
         /// the locations resolved may not actually be correct in the final compilation.
         /// </summary>
         public SymbolKeyResolution Resolve(
-            Compilation compilation, bool ignoreAssemblyKey = false, bool resolveLocations = false, CancellationToken cancellationToken = default)
+            Compilation compilation, bool ignoreAssemblyKey = false, bool resolveLocations = true, CancellationToken cancellationToken = default)
         {
             return ResolveString(_symbolKeyData, compilation, ignoreAssemblyKey, resolveLocations, cancellationToken);
         }


### PR DESCRIPTION
Previous code depended on things like orders of partial. i can't find anything that necessarily guarantees that, and it's not necessary here, so i've simplified things greatly so that isn't even something we need to care about.