### PR TITLE
For for assertion failure when invoking Find All References on client side in Liveshare 

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
@@ -48,16 +48,14 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             }
         }
 
-        async Task IFindUsagesLSPService.FindReferencesAsync(
+        Task IFindUsagesLSPService.FindReferencesAsync(
             Document document, int position, IFindUsagesContext context)
         {
             // We don't need to get third party definitions when finding references in LSP.
             // Currently, 3rd party definitions = XAML definitions, and XAML will provide
             // references via LSP instead of hooking into Roslyn.
             // This also means that we don't need to be on the UI thread.
-            var definitionTrackingContext = new DefinitionTrackingContext(context);
-            await FindLiteralOrSymbolReferencesAsync(
-                document, position, definitionTrackingContext).ConfigureAwait(false);
+            return FindLiteralOrSymbolReferencesAsync(document, position, new DefinitionTrackingContext(context));
         }
 
         private async Task FindLiteralOrSymbolReferencesAsync(

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 {
     internal abstract partial class AbstractFindUsagesService
     {
-        public async Task FindReferencesAsync(
+        async Task IFindUsagesService.FindReferencesAsync(
             Document document, int position, IFindUsagesContext context)
         {
             var definitionTrackingContext = new DefinitionTrackingContext(context);
@@ -46,6 +46,18 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 // Don't need ConfigureAwait(true) here 
                 await context.OnDefinitionFoundAsync(definition).ConfigureAwait(false);
             }
+        }
+
+        async Task IFindUsagesLSPService.FindReferencesAsync(
+            Document document, int position, IFindUsagesContext context)
+        {
+            // We don't need to get third party definitions when finding references in LSP.
+            // Currently, 3rd party definitions = XAML definitions, and XAML will provide
+            // references via LSP instead of hooking into Roslyn.
+            // This also means that we don't need to be on the UI thread.
+            var definitionTrackingContext = new DefinitionTrackingContext(context);
+            await FindLiteralOrSymbolReferencesAsync(
+                document, position, definitionTrackingContext).ConfigureAwait(false);
         }
 
         private async Task FindLiteralOrSymbolReferencesAsync(

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -9,7 +9,6 @@ using System.Composition;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;


### PR DESCRIPTION
Fixes #44170

It looks like moving parts of FAR OOP in #43914 may have deleted some of the existing code in the master-vs-deps branch and caused LSP FAR to try to search for 3rd party references.