### PR TITLE
Do not always add NewLine following MultiLineComments.

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/CSharpFormattingTestBase.cs
+++ b/src/Workspaces/CSharpTest/Formatting/CSharpFormattingTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         protected override SyntaxNode ParseCompilation(string text, ParseOptions parseOptions)
             => SyntaxFactory.ParseCompilationUnit(text, options: (CSharpParseOptions)parseOptions);
 
-        private protected Task AssertNoChangeInFormatAsync(
+        private protected Task AssertNoFormattingChangesAsync(
             string code,
             bool debugMode = false,
             OptionsCollection changedOptionSet = null,

--- a/src/Workspaces/CSharpTest/Formatting/CSharpFormattingTestBase.cs
+++ b/src/Workspaces/CSharpTest/Formatting/CSharpFormattingTestBase.cs
@@ -21,6 +21,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         protected override SyntaxNode ParseCompilation(string text, ParseOptions parseOptions)
             => SyntaxFactory.ParseCompilationUnit(text, options: (CSharpParseOptions)parseOptions);
 
+        private protected Task AssertNoChangeInFormatAsync(
+            string code,
+            bool debugMode = false,
+            OptionsCollection changedOptionSet = null,
+            bool testWithTransformation = true,
+            ParseOptions parseOptions = null)
+        {
+            return AssertFormatAsync(code, code, SpecializedCollections.SingletonEnumerable(new TextSpan(0, code.Length)), debugMode, changedOptionSet, testWithTransformation, parseOptions);
+        }
+
         private protected Task AssertFormatAsync(
             string expected,
             string code,

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
@@ -1790,5 +1790,32 @@ class F
             var actual = formatted.ToFullString();
             Assert.Equal(expected, actual);
         }
+
+        [WorkItem(39351, "https://github.com/dotnet/roslyn/issues/39351")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task SingleLineComment_AtEndOfFile_DoesNotAddNewLine()
+        {
+            await AssertNoChangeInFormatAsync(@"class Program { }
+
+// Test");
+        }
+
+        [WorkItem(39351, "https://github.com/dotnet/roslyn/issues/39351")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task MultiLineComment_AtEndOfFile_DoesNotAddNewLine()
+        {
+            await AssertNoChangeInFormatAsync(@"class Program { }
+
+/* Test */");
+        }
+
+        [WorkItem(39351, "https://github.com/dotnet/roslyn/issues/39351")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task DocComment_AtEndOfFile_DoesNotAddNewLine()
+        {
+            await AssertNoChangeInFormatAsync(@"class Program { }
+
+/// Test");
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
@@ -1795,7 +1795,7 @@ class F
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SingleLineComment_AtEndOfFile_DoesNotAddNewLine()
         {
-            await AssertNoChangeInFormatAsync(@"class Program { }
+            await AssertNoFormattingChangesAsync(@"class Program { }
 
 // Test");
         }
@@ -1804,7 +1804,7 @@ class F
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task MultiLineComment_AtEndOfFile_DoesNotAddNewLine()
         {
-            await AssertNoChangeInFormatAsync(@"class Program { }
+            await AssertNoFormattingChangesAsync(@"class Program { }
 
 /* Test */");
         }
@@ -1813,7 +1813,7 @@ class F
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task DocComment_AtEndOfFile_DoesNotAddNewLine()
         {
-            await AssertNoChangeInFormatAsync(@"class Program { }
+            await AssertNoFormattingChangesAsync(@"class Program { }
 
 /// Test");
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -164,7 +164,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private bool IsStartOrEndOfFile(SyntaxTrivia trivia1, SyntaxTrivia trivia2)
-            => (this.Token1.RawKind == 0 || this.Token2.IsKind(SyntaxKind.None, SyntaxKind.EndOfFileToken)) && (trivia1.Kind() == 0 || trivia2.Kind() == 0);
+        {
+            // Below represents the tokens for a file:
+            // (None) - It is the start of the file. This means there are no previous tokens.
+            // (...) - All the tokens in the compilation unit.
+            // (EndOfFileToken) - This is the synthetic end of file token. Should be treated as the end of the file.
+            // (None) - It is the end of the file. This means there are no more tokens.
+
+            var isStartOrEndOfFile = (this.Token1.RawKind == 0 || this.Token2.RawKind == 0) && (trivia1.Kind() == 0 || trivia2.Kind() == 0);
+            var isAtEndOfFileToken = (Token2.IsKind(SyntaxKind.EndOfFileToken) && trivia2.Kind() == 0);
+
+            return isStartOrEndOfFile || isAtEndOfFileToken;
+        }
 
         private static bool IsMultilineComment(SyntaxTrivia trivia1)
             => trivia1.IsMultiLineComment() || trivia1.IsMultiLineDocComment();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -72,15 +72,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // [trivia] [whitespace] [token] case
             if (trivia2.IsKind(SyntaxKind.None))
             {
-                var operation = this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2);
+                var insertNewLine = this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2) != null;
 
                 if (IsMultilineComment(trivia1))
                 {
-                    return LineColumnRule.PreserveLinesWithGivenIndentation(
-                        lines: operation is object ? operation.Line : 0);
+                    return LineColumnRule.PreserveLinesWithGivenIndentation(lines: insertNewLine ? 1 : 0);
                 }
 
-                if (operation is object)
+                if (insertNewLine)
                 {
                     return LineColumnRule.PreserveLinesWithDefaultIndentation(lines: 0);
                 }
@@ -96,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // preprocessor case
             if (SyntaxFacts.IsPreprocessorDirective(trivia2.Kind()))
             {
-                // Check for immovable preprocessor directives, which are bad directive trivia 
+                // Check for immovable preprocessor directives, which are bad directive trivia
                 // without a preceding line break
                 if (trivia2.IsKind(SyntaxKind.BadDirectiveTrivia) && existingWhitespaceBetween.Lines == 0 && !implicitLineBreak)
                 {
@@ -165,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private bool IsStartOrEndOfFile(SyntaxTrivia trivia1, SyntaxTrivia trivia2)
-            => (this.Token1.RawKind == 0 || this.Token2.RawKind == 0) && (trivia1.Kind() == 0 || trivia2.Kind() == 0);
+            => (this.Token1.RawKind == 0 || this.Token2.IsKind(SyntaxKind.None, SyntaxKind.EndOfFileToken)) && (trivia1.Kind() == 0 || trivia2.Kind() == 0);
 
         private static bool IsMultilineComment(SyntaxTrivia trivia1)
             => trivia1.IsMultiLineComment() || trivia1.IsMultiLineDocComment();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -72,14 +72,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // [trivia] [whitespace] [token] case
             if (trivia2.IsKind(SyntaxKind.None))
             {
-                var insertNewLine = this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2) != null;
+                var operation = this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2);
 
                 if (IsMultilineComment(trivia1))
                 {
-                    return LineColumnRule.PreserveLinesWithGivenIndentation(lines: insertNewLine ? 1 : 0);
+                    return LineColumnRule.PreserveLinesWithGivenIndentation(
+                        lines: operation is object ? operation.Line : 0);
                 }
 
-                if (insertNewLine)
+                if (operation is object)
                 {
                     return LineColumnRule.PreserveLinesWithDefaultIndentation(lines: 0);
                 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/39351

Allow the adjust newlines operation to dictate how many lines to add following a multiline comment.