### PR TITLE
Temporarily change LSP FAR back to not using streaming

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 {
     internal abstract partial class AbstractFindUsagesService
     {
-        public async Task FindReferencesAsync(
+        async Task IFindUsagesService.FindReferencesAsync(
             Document document, int position, IFindUsagesContext context)
         {
             var definitionTrackingContext = new DefinitionTrackingContext(context);
@@ -46,6 +46,16 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 // Don't need ConfigureAwait(true) here 
                 await context.OnDefinitionFoundAsync(definition).ConfigureAwait(false);
             }
+        }
+
+        Task IFindUsagesLSPService.FindReferencesAsync(
+            Document document, int position, IFindUsagesContext context)
+        {
+            // We don't need to get third party definitions when finding references in LSP.
+            // Currently, 3rd party definitions = XAML definitions, and XAML will provide
+            // references via LSP instead of hooking into Roslyn.
+            // This also means that we don't need to be on the UI thread.
+            return FindLiteralOrSymbolReferencesAsync(document, position, new DefinitionTrackingContext(context));
         }
 
         private async Task FindLiteralOrSymbolReferencesAsync(

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;
@@ -28,9 +27,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
 {
     internal class FindUsagesLSPContext : FindUsagesContext
     {
-        private const int MaxResultsChunkSize = 32;
-
-        private readonly IProgress<object[]> _progress;
         private readonly Document _document;
         private readonly int _position;
         private readonly IMetadataAsSourceFileService _metadataAsSourceFileService;
@@ -54,13 +50,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
         public override CancellationToken CancellationToken { get; }
 
         public FindUsagesLSPContext(
-            IProgress<object[]> progress,
             Document document,
             int position,
             IMetadataAsSourceFileService metadataAsSourceFileService,
             CancellationToken cancellationToken)
         {
-            _progress = progress;
             _document = document;
             _position = position;
             _metadataAsSourceFileService = metadataAsSourceFileService;
@@ -68,27 +62,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
             CancellationToken = cancellationToken;
         }
 
-        public override async Task OnCompletedAsync()
-        {
-            using var _ = ArrayBuilder<VSReferenceItem>.GetInstance(out var referencesToReport);
-            using (await _semaphore.DisposableWaitAsync(CancellationToken).ConfigureAwait(false))
-            {
-                if (_resultsChunk.IsEmpty())
-                {
-                    return;
-                }
-
-                referencesToReport.AddRange(_resultsChunk.ToArray());
-                _resultsChunk.Clear();
-            }
-
-            // We can report outside of the lock here since _progress is thread-safe.
-            _progress.Report(referencesToReport.ToArray());
-        }
+        public List<VSReferenceItem> GetReferences() => _resultsChunk;
 
         public override async Task OnDefinitionFoundAsync(DefinitionItem definition)
         {
-            using var _ = ArrayBuilder<VSReferenceItem>.GetInstance(out var referencesToReport);
             using (await _semaphore.DisposableWaitAsync(CancellationToken).ConfigureAwait(false))
             {
                 if (_definitionToId.ContainsKey(definition))
@@ -121,16 +98,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
 
                 if (definitionItem != null)
                 {
-                    AddToReferencesToReport_MustBeCalledUnderLock(referencesToReport, definitionItem);
+                    AddToReferencesToReport_MustBeCalledUnderLock(definitionItem);
                 }
             }
-
-            ReportIfNotEmpty(referencesToReport);
         }
 
         public override async Task OnReferenceFoundAsync(SourceReferenceItem reference)
         {
-            using var _ = ArrayBuilder<VSReferenceItem>.GetInstance(out var referencesToReport);
             using (await _semaphore.DisposableWaitAsync(CancellationToken).ConfigureAwait(false))
             {
                 // Each reference should be associated with a definition. If this somehow isn't the
@@ -150,25 +124,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
 
                 if (referenceItem != null)
                 {
-                    AddToReferencesToReport_MustBeCalledUnderLock(referencesToReport, referenceItem);
+                    AddToReferencesToReport_MustBeCalledUnderLock(referenceItem);
                 }
             }
-
-            ReportIfNotEmpty(referencesToReport);
         }
 
-        private void AddToReferencesToReport_MustBeCalledUnderLock(ArrayBuilder<VSReferenceItem> referencesToReport, VSReferenceItem item)
+        private void AddToReferencesToReport_MustBeCalledUnderLock(VSReferenceItem item)
         {
             Debug.Assert(_semaphore.CurrentCount == 0);
-
             _resultsChunk.Add(item);
-            if (_resultsChunk.Count < MaxResultsChunkSize)
-            {
-                return;
-            }
-
-            referencesToReport.AddRange(_resultsChunk.ToArray());
-            _resultsChunk.Clear();
         }
 
         private static async Task<LSP.VSReferenceItem?> GenerateVSReferenceItemAsync(
@@ -288,17 +252,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
 
                 return null;
             }
-        }
-
-        private void ReportIfNotEmpty(ArrayBuilder<VSReferenceItem> referencesToReport)
-        {
-            if (referencesToReport.IsEmpty())
-            {
-                return;
-            }
-
-            // We can report outside of the lock here since _progress is thread-safe.
-            _progress.Report(referencesToReport.ToArray());
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -54,6 +54,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var context = new FindUsagesLSPContext(document, position, _metadataAsSourceFileService, cancellationToken);
 
             // Finds the references for the symbol at the specific position in the document, reporting them via streaming to the LSP client.
+            // TODO: Change back FAR to use streaming once the following LSP bug is fixed:
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1094786/
             await findUsagesService.FindReferencesAsync(document, position, context).ConfigureAwait(false);
 
             return context.GetReferences().ToArray();

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -9,7 +9,6 @@ using System.Composition;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -51,15 +51,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var position = await document.GetPositionFromLinePositionAsync(
                 ProtocolConversions.PositionToLinePosition(referenceParams.Position), cancellationToken).ConfigureAwait(false);
 
-            var context = new FindUsagesLSPContext(
-                referenceParams.PartialResultToken, document, position, _metadataAsSourceFileService, cancellationToken);
+            var context = new FindUsagesLSPContext(document, position, _metadataAsSourceFileService, cancellationToken);
 
             // Finds the references for the symbol at the specific position in the document, reporting them via streaming to the LSP client.
             await findUsagesService.FindReferencesAsync(document, position, context).ConfigureAwait(false);
-            await context.OnCompletedAsync().ConfigureAwait(false);
 
-            // The results have already been reported to the client, so we don't need to return anything here.
-            return Array.Empty<LSP.VSReferenceItem>();
+            return context.GetReferences().ToArray();
         }
     }
 }


### PR DESCRIPTION
This change is a temporary patch for 16.7p2 and should be reverted once https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1094786/ is fixed.