### PR TITLE
Remove unused usings

### DIFF
--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -9,7 +9,6 @@ using System.Composition;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;


### PR DESCRIPTION
This unbreaks the master-vs-deps correctness leg.