### PR TITLE
Do not complexify extension method calls if that would introduce an error into the code.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -7729,5 +7729,51 @@ class Program
     }
 }");
         }
+
+        [WorkItem(44291, "https://github.com/dotnet/roslyn/issues/44291")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceWithAmbiguousExtensionClass()
+        {
+            await TestInRegularAndScriptAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" Name=""P1"" CommonReferences=""true"">
+        <Document>
+public static class Extensions
+{
+    public static void Goo(this string s) { }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" Name=""P2"" CommonReferences=""true"">
+        <Document>
+public static class Extensions
+{
+    public static void Bar(this string s) { }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly3"" Name=""P3"" CommonReferences=""true"">
+        <ProjectReference>P1</ProjectReference>
+        <ProjectReference>P2</ProjectReference>
+        <Document>
+public class P
+{
+    public void M(string s)
+    {
+        s.Bar([|$""""|]);
+    }
+}</Document>
+    </Project>
+</Workspace>",
+@"
+public class P
+{
+    public void M(string s)
+    {
+        string {|Rename:v|} = $"""";
+        s.Bar(v);
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -39,17 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     typeQualificationStyle:
                         SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 
-            private static readonly SymbolDisplayFormat s_typeNameFormatWithoutGenerics =
-                new SymbolDisplayFormat(
-                    globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
-                    genericsOptions: SymbolDisplayGenericsOptions.None,
-                    memberOptions:
-                        SymbolDisplayMemberOptions.IncludeContainingType,
-                    localOptions: SymbolDisplayLocalOptions.IncludeType,
-                    miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.ExpandNullable,
-                    typeQualificationStyle:
-                        SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
-
             private readonly SemanticModel _semanticModel;
             private readonly Func<SyntaxNode, bool> _expandInsideNode;
             private readonly CancellationToken _cancellationToken;
@@ -1074,37 +1063,43 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 IMethodSymbol reducedExtensionMethod)
             {
                 var originalMemberAccess = (MemberAccessExpressionSyntax)originalNode.Expression;
-                if (originalMemberAccess.GetParentConditionalAccessExpression() != null)
+
+                // Bail out on extension method invocations in conditional access expression.
+                // Note that this is a temporary workaround for https://github.com/dotnet/roslyn/issues/2593.
+                // Issue https://github.com/dotnet/roslyn/issues/3260 tracks fixing this workaround.
+                if (originalMemberAccess.GetParentConditionalAccessExpression() == null)
                 {
-                    // Bail out on extension method invocations in conditional access expression.
-                    // Note that this is a temporary workaround for https://github.com/dotnet/roslyn/issues/2593.
-                    // Issue https://github.com/dotnet/roslyn/issues/3260 tracks fixing this workaround.
-                    return rewrittenNode;
+                    var expression = RewriteExtensionMethodInvocation(rewrittenNode, thisExpression, reducedExtensionMethod);
+
+                    // Let's rebind this and verify the original method is being called properly
+                    var binding = _semanticModel.GetSpeculativeSymbolInfo(originalNode.SpanStart, expression, SpeculativeBindingOption.BindAsExpression);
+                    if (binding.Symbol != null)
+                        return expression;
                 }
 
-                var expression = RewriteExtensionMethodInvocation(rewrittenNode, thisExpression, reducedExtensionMethod, s_typeNameFormatWithoutGenerics);
-
-                // Let's rebind this and verify the original method is being called properly
-                var binding = _semanticModel.GetSpeculativeSymbolInfo(originalNode.SpanStart, expression, SpeculativeBindingOption.BindAsExpression);
-
-                if (binding.Symbol != null)
-                {
-                    return expression;
-                }
-
-                // We'll probably need generic type arguments as well
-                return RewriteExtensionMethodInvocation(rewrittenNode, thisExpression, reducedExtensionMethod, s_typeNameFormatWithGenerics);
+                return rewrittenNode;
             }
 
             private InvocationExpressionSyntax RewriteExtensionMethodInvocation(
                 InvocationExpressionSyntax originalNode,
                 ExpressionSyntax thisExpression,
-                IMethodSymbol reducedExtensionMethod,
-                SymbolDisplayFormat symbolDisplayFormat)
+                IMethodSymbol reducedExtensionMethod)
             {
-                var containingType = reducedExtensionMethod.ContainingType.ToDisplayString(symbolDisplayFormat);
-                var newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ParseExpression(containingType), ((MemberAccessExpressionSyntax)originalNode.Expression).OperatorToken, ((MemberAccessExpressionSyntax)originalNode.Expression).Name)
-                    .WithLeadingTrivia(thisExpression.GetFirstToken().LeadingTrivia);
+                // It may be the case that this extension method cannot be called in static form.  For example, if the
+                // qualified name for the type containing the extension would be ambiguous.  In that case, just return
+                // the original call as is.
+                var containingTypeString = reducedExtensionMethod.ContainingType.ToDisplayString(s_typeNameFormatWithGenerics);
+
+                // We use .ParseExpression here, and not .GenerateTypeSyntax as we want this to be a property
+                // MemberAccessExpression, and not a QualifiedNameSyntax.
+                var containingTypeSyntax = SyntaxFactory.ParseExpression(containingTypeString);
+                var newContainingType = _semanticModel.GetSpeculativeSymbolInfo(originalNode.SpanStart, containingTypeSyntax, SpeculativeBindingOption.BindAsExpression).Symbol;
+                if (newContainingType == null || !newContainingType.Equals(reducedExtensionMethod.ContainingType))
+                    return originalNode;
+
+                var originalMemberAccess = (MemberAccessExpressionSyntax)originalNode.Expression;
+                var newMemberAccess = originalMemberAccess.WithExpression(containingTypeSyntax)
+                                                          .WithLeadingTrivia(thisExpression.GetFirstToken().LeadingTrivia);
 
                 // Copies the annotation for the member access expression
                 newMemberAccess = originalNode.Expression.CopyAnnotationsTo(newMemberAccess).WithAdditionalAnnotations(Simplifier.Annotation);
@@ -1112,7 +1107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 var thisArgument = SyntaxFactory.Argument(thisExpression).WithLeadingTrivia(SyntaxTriviaList.Empty);
 
                 // Copies the annotation for the left hand side of the member access expression to the first argument in the complexified form
-                thisArgument = ((MemberAccessExpressionSyntax)originalNode.Expression).Expression.CopyAnnotationsTo(thisArgument);
+                thisArgument = originalMemberAccess.Expression.CopyAnnotationsTo(thisArgument);
 
                 var arguments = originalNode.ArgumentList.Arguments.Insert(0, thisArgument);
                 var replacementNode = SyntaxFactory.InvocationExpression(
@@ -1120,7 +1115,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     originalNode.ArgumentList.WithArguments(arguments));
 
                 // This Annotation copy is for the InvocationExpression
-                return originalNode.CopyAnnotationsTo(replacementNode).WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
+                return originalNode.CopyAnnotationsTo(replacementNode)
+                                   .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44291

It's legal in C# to be able to call some extensions using 'instance' syntax that would be otherwise illegal to call with 'static' syntax.  Specifically, the language determines all the extension methods in scope and does overload resolution for them regardless of the name of their containing type.  However, trying to directly reference the containing type might not be legal (due to things like ambiguity).  In that case, do not complexify such calls as we will then not simplify them later due to the error.