### PR TITLE
Restore strings used in RenameDocumentAsync

### DIFF
--- a/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
+++ b/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
             context.RegisterRefactoring(nestedCodeAction, selectedMemberNode.Span);
         }
 
+
         private ImmutableArray<INamedTypeSymbol> FindAllValidDestinations(
             ISymbol selectedMember,
             Solution solution,

--- a/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
+++ b/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
@@ -70,7 +70,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
             context.RegisterRefactoring(nestedCodeAction, selectedMemberNode.Span);
         }
 
-
         private ImmutableArray<INamedTypeSymbol> FindAllValidDestinations(
             ISymbol selectedMember,
             Solution solution,

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -559,4 +559,10 @@
   <data name="Symbols_project_could_not_be_found_in_the_provided_solution" xml:space="preserve">
     <value>Symbol's project could not be found in the provided solution</value>
   </data>
+  <data name="Rename_0_to_1" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="Sync_namespace_to_folder_structure" xml:space="preserve">
+    <value>Sync namespace to folder structure</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Odebírání dokumentů konfigurace analyzátoru se nepodporuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Das Entfernen von Konfigurationsdokumenten des Analysetools wird nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -97,6 +97,11 @@
         <target state="translated">No se permite quitar documentos de configuración del analizador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -97,6 +97,11 @@
         <target state="translated">La suppression de documents de configuration de l'analyseur n'est pas prise en charge.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -97,6 +97,11 @@
         <target state="translated">La rimozione di documenti di configurazione dell'analizzatore non è supportata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -97,6 +97,11 @@
         <target state="translated">アナライザー構成ドキュメントの削除はサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -97,6 +97,11 @@
         <target state="translated">분석기 구성 문서 제거는 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Usuwanie dokumentów z konfiguracją analizatora nie jest obsługiwane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Não há suporte para a remoção de documentos da configuração do analisador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Удаление документов конфигурации анализатора не поддерживается.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Çözümleyici yapılandırma belgelerinin kaldırılması desteklenmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -97,6 +97,11 @@
         <target state="translated">不支持删除分析器配置文档。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -97,6 +97,11 @@
         <target state="translated">不支援移除分析器組態文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Rename_0_to_1">
+        <source>Rename '{0}' to '{1}'</source>
+        <target state="new">Rename '{0}' to '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Solution_does_not_contain_specified_reference">
         <source>Solution does not contain specified reference</source>
         <target state="new">Solution does not contain specified reference</target>
@@ -180,6 +185,11 @@
       <trans-unit id="Symbols_project_could_not_be_found_in_the_provided_solution">
         <source>Symbol's project could not be found in the provided solution</source>
         <target state="new">Symbol's project could not be found in the provided solution</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_namespace_to_folder_structure">
+        <source>Sync namespace to folder structure</source>
+        <target state="new">Sync namespace to folder structure</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_already_contains_the_specified_reference">

--- a/src/Workspaces/CoreTest/Renamer/RenamerTests.cs
+++ b/src/Workspaces/CoreTest/Renamer/RenamerTests.cs
@@ -75,6 +75,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Renamer
                         Assert.True(remainingErrors.Contains(error), $"Error '{error}' was unexpected");
                         remainingErrors.Remove(error);
                     }
+
+                    // https://github.com/dotnet/roslyn/issues/44220
+                    Assert.NotNull(action.GetDescription());
                 }
 
                 solution = await documentRenameResult.UpdateSolutionAsync(solution, CancellationToken.None);


### PR DESCRIPTION
Looks like somewhere in merge/changes they got lost. Added them back and add a check in the tests that `GetDescription()` doesn't throw/return null

Fixes https://github.com/dotnet/roslyn/issues/44220 