### PR TITLE
Fix descriptions for XMLDoc Triple Apostrophes in some languages.

### DIFF
--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
@@ -158,6 +158,7 @@
   </data>
   <data name="Generate_XML_documentation_comments_for" xml:space="preserve">
     <value>_Generate XML documentation comments for '''</value>
+    <comment>{Locked="'''"} "'''" is a VB keyword and should not be localized.</comment>
   </data>
   <data name="Highlighting" xml:space="preserve">
     <value>Highlighting</value>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.cs.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.cs.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Generovat komentáře dokumentace XML pro '''</target>
-        <note />
+        <target state="needs-review-translation">_Generovat komentáře dokumentace XML pro '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_XML-Dokumentationskommentare generieren für '''</target>
-        <note />
+        <target state="needs-review-translation">_XML-Dokumentationskommentare generieren für '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Generar comentarios de documentación XML con '''</target>
-        <note />
+        <target state="needs-review-translation">_Generar comentarios de documentación XML con '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.fr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.fr.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Générer des commentaires de documentation XML pour '''</target>
-        <note />
+        <target state="needs-review-translation">_Générer des commentaires de documentation XML pour '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.it.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.it.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Genera commenti in formato documentazione XML per '''</target>
-        <note />
+        <target state="needs-review-translation">_Genera commenti in formato documentazione XML per '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
@@ -89,7 +89,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">'' が入力されたときに XML ドキュメント コメントを生成する(_G)</target>
+        <target state="translated">''' が入力されたときに XML ドキュメント コメントを生成する(_G)</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">''' が入力されたときに XML ドキュメント コメントを生成する(_G)</target>
-        <note />
+        <target state="needs-review-translation">''' が入力されたときに XML ドキュメント コメントを生成する(_G)</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">'''에 대해 XML 문서 주석 생성(_G)</target>
-        <note />
+        <target state="needs-review-translation">'''에 대해 XML 문서 주석 생성(_G)</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
@@ -89,7 +89,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">''에 대해 XML 문서 주석 생성(_G)</target>
+        <target state="translated">'''에 대해 XML 문서 주석 생성(_G)</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pl.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pl.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Generuj komentarze dokumentacji XML dla '''</target>
-        <note />
+        <target state="needs-review-translation">_Generuj komentarze dokumentacji XML dla '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pt-BR.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pt-BR.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Gerar comentário da documentação XML para '''</target>
-        <note />
+        <target state="needs-review-translation">_Gerar comentário da documentação XML para '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Создавать комментарии XML-документации для '''</target>
-        <note />
+        <target state="needs-review-translation">_Создавать комментарии XML-документации для '''</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
@@ -89,7 +89,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Создавать комментарии XML-документации для """</target>
+        <target state="translated">_Создавать комментарии XML-документации для '''</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">''' için XML belge açıklamaları _oluştur</target>
-        <note />
+        <target state="needs-review-translation">''' için XML belge açıklamaları _oluştur</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
@@ -89,7 +89,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">'' için XML belge açıklamaları _oluştur</target>
+        <target state="translated">''' için XML belge açıklamaları _oluştur</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hans.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">为 ''' 生成 XML 文档注释(_G)</target>
-        <note />
+        <target state="needs-review-translation">为 ''' 生成 XML 文档注释(_G)</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hant.xlf
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">產生 ''' 的 XML 文件註解(_G)</target>
-        <note />
+        <target state="needs-review-translation">產生 ''' 的 XML 文件註解(_G)</target>
+        <note>{Locked="'''"} "'''" is a VB keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Highlighting">
         <source>Highlighting</source>


### PR DESCRIPTION
Incorrect description on how to generate XML comments in Japanese, Korean, Russian, and Turkish.