### PR TITLE
Parse Build_property/metadata keys into dedicated collections:

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -1076,6 +1076,224 @@ dotnet_diagnostic.cs000.severity = none", "Z:\\.editorconfig"));
 
         #endregion
 
+        #region Processing of build_* rules
+
+        [Fact]
+        public void BuildProperty()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+build_property.name = value
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("name", "value")),
+                ImmutableDictionary<string, string>.Empty,
+            }, options.Select(o => o.BuildProperties).ToArray());
+        }
+
+        [Fact]
+        public void GlobalBuildProperty()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+build_property.name = value
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("name", "value")),
+                CreateImmutableDictionary(("name", "value"))
+            }, options.Select(o => o.BuildProperties).ToArray());
+        }
+
+        [Fact]
+        public void SectionBuildPropertyOverridesGlobal()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+build_property.name = value
+
+[/test.cs]
+build_property.name = value2
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("name", "value2")),
+                CreateImmutableDictionary(("name", "value"))
+            }, options.Select(o => o.BuildProperties).ToArray());
+        }
+
+        [Fact]
+        public void LocalConfigBuildPropertyOverridesGlobal()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+build_property.name = value
+", "/.globalconfig"));
+
+            configs.Add(Parse(@"
+[*.cs]
+build_property.name = value2
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("name", "value2")),
+                CreateImmutableDictionary(("name", "value"))
+            }, options.Select(o => o.BuildProperties).ToArray());
+        }
+
+        [Fact]
+        public void MalformedBuildProperty()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+msbuild_property = value1
+build_property. = value2
+build_property.. = value3
+build_property..abc = value4
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("", "value2"), (".", "value3"), (".abc", "value4")),
+                ImmutableDictionary<string, string>.Empty,
+            }, options.Select(o => o.BuildProperties).ToArray());
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("msbuild_property", "value1")),
+                ImmutableDictionary<string, string>.Empty,
+            }, options.Select(o => o.AnalyzerOptions).ToArray());
+        }
+
+        [Fact]
+        public void BuildMetadata()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+build_metadata.compile.metadata = value
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("compile.metadata", "value")),
+                ImmutableDictionary<string, string>.Empty,
+            }, options.Select(o => o.BuildMetadata).ToArray());
+        }
+
+        [Fact]
+        public void SectionBuildMetadataOverridesGlobal()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+build_metadata.type.name = value
+
+[/test.cs]
+build_metadata.type.name = value2
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("type.name", "value2")),
+                CreateImmutableDictionary(("type.name", "value"))
+            }, options.Select(o => o.BuildMetadata).ToArray());
+        }
+
+        [Fact]
+        public void LocalConfigBuildMetadataOverridesGlobal()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+build_metadata.type.name = value
+", "/.globalconfig"));
+
+            configs.Add(Parse(@"
+[*.cs]
+build_metadata.type.name = value2
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("type.name", "value2")),
+                CreateImmutableDictionary(("type.name", "value"))
+            }, options.Select(o => o.BuildMetadata).ToArray());
+        }
+
+        [Fact]
+        public void MalformedBuildMetadata()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+build_metadata = value1
+build_metadata. = value2
+build_metadata.. = value3
+build_metadata.abc. = value4
+build_metadata..abc = value5
+
+", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("", "value2"), (".", "value3"), ("abc.", "value4"), (".abc", "value5")),
+                ImmutableDictionary<string, string>.Empty,
+            }, options.Select(o => o.BuildMetadata).ToArray());
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("msbuild_metadata", "value1")),
+                ImmutableDictionary<string, string>.Empty,
+            }, options.Select(o => o.AnalyzerOptions).ToArray());
+        }
+
+        #endregion
+
         #region Processing of Analyzer Options
 
         private AnalyzerConfigOptionsResult[] GetAnalyzerConfigOptions(string[] filePaths, ArrayBuilder<AnalyzerConfig> configs)

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildAnalyzerConfig.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// 
     /// <see cref="PropertyItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> is the property name
     /// and have a metadata value called <c>Value</c> that contains the evaluated value of the property. Each of the ]
-    /// <see cref="PropertyItems"/> will be transformed into an <c>msbuild_property.<em>ItemSpec</em> = <em>Value</em></c> entry in the
+    /// <see cref="PropertyItems"/> will be transformed into an <c>build_property.<em>ItemSpec</em> = <em>Value</em></c> entry in the
     /// global section of the generated config file.
     /// 
     /// <see cref="MetadataItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> represents a file in the 
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// 
     /// Each of the <see cref="MetadataItems"/> will be transformed into a new section in the generated config file. The section
     /// header will be the full path of the item (generated via its<see cref="ITaskItem.ItemSpec"/>), and each section will have a 
-    /// set of <c>msbuild_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetrievedMetadataValue</em></c>, one per <c>ItemType</c>
+    /// set of <c>build_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetrievedMetadataValue</em></c>, one per <c>ItemType</c>
     /// 
     /// The Microsoft.Managed.Core.targets calls this task with the collected results of the <c>AnalyzerProperty</c> and 
     /// <c>AnalyzerItemMetadata</c> item groups. 
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // collect the properties into a global section
             foreach (var prop in PropertyItems)
             {
-                builder.Append("msbuild_property.")
+                builder.Append("build_property.")
                        .Append(prop.ItemSpec)
                        .Append(" = ")
                        .AppendLine(prop.GetMetadata("Value"));
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 foreach (var item in group)
                 {
                     string metadataName = item.GetMetadata("MetadataName");
-                    builder.Append("msbuild_item.")
+                    builder.Append("build_metadata.")
                            .Append(item.GetMetadata("ItemType"))
                            .Append(".")
                            .Append(metadataName)

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildAnalyzerConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildAnalyzerConfigTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             var result = configTask.ConfigFileContents;
 
             Assert.Equal(@"is_global = true
-msbuild_property.Property1 = abc123
-msbuild_property.Property2 = def456
+build_property.Property1 = abc123
+build_property.Property2 = def456
 ", result);
         }
 
@@ -67,7 +67,7 @@ msbuild_property.Property2 = def456
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 ", result);
         }
 
@@ -89,13 +89,13 @@ msbuild_item.Compile.ToRetrieve = abc123
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 
 [c:/file2.cs]
-msbuild_item.Compile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = def456
 
 [c:/file3.cs]
-msbuild_item.AdditionalFiles.ToRetrieve = ghi789
+build_metadata.AdditionalFiles.ToRetrieve = ghi789
 ", result);
         }
 
@@ -116,8 +116,8 @@ msbuild_item.AdditionalFiles.ToRetrieve = ghi789
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
-msbuild_item.AdditionalFile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = abc123
+build_metadata.AdditionalFile.ToRetrieve = def456
 ", result);
         }
 
@@ -137,7 +137,7 @@ msbuild_item.AdditionalFile.ToRetrieve = def456
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = 
+build_metadata.Compile.ToRetrieve = 
 ", result);
         }
 
@@ -159,9 +159,9 @@ msbuild_item.Compile.ToRetrieve =
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.. = 
-msbuild_item.Compile. = 
-msbuild_item..ToRetrieve = 
+build_metadata.. = 
+build_metadata.Compile. = 
+build_metadata..ToRetrieve = 
 ", result);
         }
 
@@ -186,18 +186,18 @@ msbuild_item..ToRetrieve =
             var result = configTask.ConfigFileContents;
 
             Assert.Equal(@"is_global = true
-msbuild_property.Property1 = abc123
-msbuild_property.Property2 = def456
+build_property.Property1 = abc123
+build_property.Property2 = def456
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
-msbuild_item.AdditionalFiles.ToRetrieve = jkl012
+build_metadata.Compile.ToRetrieve = abc123
+build_metadata.AdditionalFiles.ToRetrieve = jkl012
 
 [c:/file2.cs]
-msbuild_item.Compile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = def456
 
 [c:/file3.cs]
-msbuild_item.AdditionalFiles.ToRetrieve = ghi789
+build_metadata.AdditionalFiles.ToRetrieve = ghi789
 ", result);
         }
 
@@ -226,13 +226,13 @@ msbuild_item.AdditionalFiles.ToRetrieve = ghi789
             Assert.Equal($@"is_global = true
 
 [{expectedPath1}]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 
 [{expectedPath2}]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 
 [{expectedPath3}]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 ", result);
         }
 
@@ -253,8 +253,8 @@ msbuild_item.Compile.ToRetrieve = abc123
             Assert.Equal($@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
-msbuild_item.AdditionalFile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = abc123
+build_metadata.AdditionalFile.ToRetrieve = def456
 ", result);
         }
 
@@ -289,7 +289,7 @@ values
             var result = configTask.ConfigFileContents;
 
             Assert.Equal(@"is_global = true
-msbuild_property.Property1 = this is 
+build_property.Property1 = this is 
 a 
 property
 with  
@@ -299,7 +299,7 @@ and
 property = looking
 values
 
-msbuild_property.Property2 = def456
+build_property.Property2 = def456
 ", result);
         }
     }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigOptionsResult.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigOptionsResult.cs
@@ -26,6 +26,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public AnalyzerOptions AnalyzerOptions { get; }
 
+        public AnalyzerOptions BuildProperties { get; }
+
+        public AnalyzerOptions BuildMetadata { get; }
+
         /// <summary>
         /// Any produced diagnostics while applying analyzer configuration.
         /// </summary>
@@ -34,6 +38,8 @@ namespace Microsoft.CodeAnalysis
         internal AnalyzerConfigOptionsResult(
             TreeOptions treeOptions,
             AnalyzerOptions analyzerOptions,
+            AnalyzerOptions buildProperties,
+            AnalyzerOptions buildMetadata,
             ImmutableArray<Diagnostic> diagnostics)
         {
             Debug.Assert(treeOptions != null);
@@ -41,6 +47,8 @@ namespace Microsoft.CodeAnalysis
 
             TreeOptions = treeOptions;
             AnalyzerOptions = analyzerOptions;
+            BuildProperties = buildProperties;
+            BuildMetadata = buildMetadata;
             Diagnostics = diagnostics;
         }
     }


### PR DESCRIPTION
- Rename `msbuild_*` to `build_*`
- Add dedicated collections
- Parse `build_*` options
- Add tests