### PR TITLE
Properly unwrap faulted tasks in AsyncLazy<T>

### DIFF
--- a/src/EditorFeatures/Test/Utilities/AsyncLazyTests.cs
+++ b/src/EditorFeatures/Test/Utilities/AsyncLazyTests.cs
@@ -45,15 +45,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 includeSynchronousComputation ? synchronousComputation : null,
                 cacheResult: true);
 
-            var thrownException = Assert.ThrowsAny<Exception>(() =>
+            var thrownException = Assert.Throws<OperationCanceledException>(() =>
                 {
                     // Do a first request. Even though we will get a cancellation during the evaluation,
                     // since we handed a result back, that result must be cached.
                     doGetValue(lazy, requestCancellationTokenSource.Token);
                 });
-
-            // Assert it's either cancellation or aggregate exception
-            Assert.True(thrownException is OperationCanceledException || ((AggregateException)thrownException).InnerException is OperationCanceledException);
 
             // And a second request. We'll let this one complete normally.
             var secondRequestResult = doGetValue(lazy, CancellationToken.None);

--- a/src/EditorFeatures/Test/Utilities/AsyncLazyTests.cs
+++ b/src/EditorFeatures/Test/Utilities/AsyncLazyTests.cs
@@ -12,10 +12,9 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
-    public partial class AsyncLazyTests
+    public class AsyncLazyTests
     {
-        // This probably shouldn't need WpfFact, but the failure is being tracked by https://github.com/dotnet/roslyn/issues/7438
-        [WpfFact, Trait(Traits.Feature, Traits.Features.AsyncLazy)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AsyncLazy)]
         public void CancellationDuringInlinedComputationFromGetValueStillCachesResult()
         {
             CancellationDuringInlinedComputationFromGetValueOrGetValueAsyncStillCachesResultCore((lazy, ct) => lazy.GetValue(ct), includeSynchronousComputation: true);
@@ -64,7 +63,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(1, computations);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.AsyncLazy)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AsyncLazy)]
         public void SynchronousRequestShouldCacheValueWithAsynchronousComputeFunction()
         {
             var lazy = new AsyncLazy<object>(c => Task.FromResult(new object()), cacheResult: true);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -574,7 +574,13 @@ namespace Roslyn.Utilities
                 }
                 else if (task.IsFaulted)
                 {
-                    this.TrySetException(task.Exception!);
+                    // TrySetException wraps its argument in an AggregateException, so we pass the inner exceptions from
+                    // the antecedent to avoid wrapping in two layers of AggregateException.
+                    RoslynDebug.AssertNotNull(task.Exception);
+                    if (task.Exception.InnerExceptions.Count > 0)
+                        this.TrySetException(task.Exception.InnerExceptions);
+                    else
+                        this.TrySetException(task.Exception);
                 }
                 else
                 {


### PR DESCRIPTION
Also closes #7438