### PR TITLE
Prefix in-scope prefix matched item over completely matched unimport item

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -197,11 +197,42 @@ namespace Microsoft.CodeAnalysis.Completion
 
         private int CompareMatches(PatternMatch match1, PatternMatch match2, CompletionItem item1, CompletionItem item2)
         {
-            // Almost always prefer non-expanded item regardless of the pattern matching result,
-            // (except when all of the non-expanded items are worse than prefix matching and there's
-            // a complete match from expanded ones.)
-            // This currently means unimported types will be treated as "2nd tier" results,
-            // which forces users to be more explicit about selecting them.
+            // *Almost* always prefer non-expanded item regardless of the pattern matching result.
+            // Except when all non-expanded items are worse than prefix matching and there's
+            // a complete match from expanded ones. 
+            //
+            // For example, In the scenarios below, `NS2.Designer` would be selected over `System.Security.Cryptography.DES`
+            //
+            //  namespace System.Security.Cryptography
+            //  {
+            //      class DES {}
+            //  }
+            //  namespace NS2
+            //  {
+            //      class Designer {}
+            //      class C
+            //      {
+            //          des$$
+            //      }
+            //  }
+            //
+            // But in this case, `System.Security.Cryptography.DES` would be selected over `NS2.MyDesigner`
+            //
+            //  namespace System.Security.Cryptography
+            //  {
+            //      class DES {}
+            //  }
+            //  namespace NS2
+            //  {
+            //      class MyDesigner {}
+            //      class C
+            //      {
+            //          des$$
+            //      }
+            //  }
+            //
+            // This currently means items from unimported namespaces (those are the only expanded items now) 
+            // are treated as "2nd tier" results, which forces users to be more explicit about selecting them.
             var expandedDiff = CompareExpandedItem(item1, match1, item2, match2);
             if (expandedDiff != 0)
             {


### PR DESCRIPTION
One small tweak on item selection to (at least partially) address the feedback on import completion being too aggressive. With this change, we would only select an unimported item if it's a complete match and all in-scope items are worse than prefix match (previously it just needs to be worse than complete match).

For example, we'd select the local `designer` over `DES`, even `DES` is a better match.

![image](https://user-images.githubusercontent.com/788783/82390260-1a907980-99f3-11ea-9e5a-f0073dc46079.png)

Related to https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1087869

@DustinCampbell @CyrusNajmabadi 