### PR TITLE
Only switch find-refs progress bar on when we have made progress.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 Debug.Assert(_tableDataSink != null);
 
                 // https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=359162
-                // VS actually responds to each SetProgess call by enqueueing a UI task to do the
+                // VS actually responds to each SetProgess call by queuing a UI task to do the
                 // progress bar update.  This can made FindReferences feel extremely slow when
                 // thousands of SetProgress calls are made.
                 //
@@ -404,7 +404,19 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 if (!nextBatch.IsEmpty)
                 {
                     var (current, maximum) = nextBatch.Last();
-                    _findReferencesWindow.SetProgress(current, maximum);
+
+                    // Do not update the UI if the current progress is zero.  It will switch us from the indeterminate
+                    // progress bar (which conveys to the user that we're working) to showing effectively nothing (which
+                    // makes it appear as if the search is complete).  So the user sees:
+                    //
+                    //      indeterminate->complete->progress
+                    //
+                    // instead of:
+                    //
+                    //      indeterminate->progress
+
+                    if (current > 0)
+                        _findReferencesWindow.SetProgress(current, maximum);
                 }
 
                 return Task.CompletedTask;


### PR DESCRIPTION
I observed this while dogfooding.  You could occasionally see a flash with find-refs progress, or have a brief pause where find-refs looked like it was doing nothing (say because it was syncing with OOP) before actual results came in. 

This simple change fixes thigns so you can always see that findrefs is working.  It will either be in the initial indeterminate state:

![image](https://user-images.githubusercontent.com/4564579/82428181-fb1f3e00-9a3e-11ea-92f8-deeddf169079.png)


or it will transition from that directly to the in-progress state:

![image](https://user-images.githubusercontent.com/4564579/82428209-07a39680-9a3f-11ea-9aa2-329234ff9c1c.png)
