### PR TITLE
Cleanup global analyzer config naming:

### DIFF
--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// 
     /// <see cref="PropertyItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> is the property name
     /// and have a metadata value called <c>Value</c> that contains the evaluated value of the property. Each of the ]
-    /// <see cref="PropertyItems"/> will be transformed into an <c>msbuild_property.<em>ItemSpec</em> = <em>Value</em></c> entry in the
+    /// <see cref="PropertyItems"/> will be transformed into an <c>build_property.<em>ItemSpec</em> = <em>Value</em></c> entry in the
     /// global section of the generated config file.
     /// 
     /// <see cref="MetadataItems"/> is expected to be a list of items whose <see cref="ITaskItem.ItemSpec"/> represents a file in the 
@@ -31,12 +31,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// 
     /// Each of the <see cref="MetadataItems"/> will be transformed into a new section in the generated config file. The section
     /// header will be the full path of the item (generated via its<see cref="ITaskItem.ItemSpec"/>), and each section will have a 
-    /// set of <c>msbuild_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetrievedMetadataValue</em></c>, one per <c>ItemType</c>
+    /// set of <c>build_metadata.<em>ItemType</em>.<em>MetadataName</em> = <em>RetrievedMetadataValue</em></c>, one per <c>ItemType</c>
     /// 
     /// The Microsoft.Managed.Core.targets calls this task with the collected results of the <c>AnalyzerProperty</c> and 
     /// <c>AnalyzerItemMetadata</c> item groups. 
     /// </remarks>
-    public sealed class GenerateMSBuildAnalyzerConfig : Task
+    public sealed class GenerateMSBuildEditorConfig : Task
     {
         [Output]
         public string ConfigFileContents { get; set; }
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         [Required]
         public ITaskItem[] PropertyItems { get; set; }
 
-        public GenerateMSBuildAnalyzerConfig()
+        public GenerateMSBuildEditorConfig()
         {
             ConfigFileContents = string.Empty;
             MetadataItems = Array.Empty<ITaskItem>();
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // collect the properties into a global section
             foreach (var prop in PropertyItems)
             {
-                builder.Append("msbuild_property.")
+                builder.Append("build_property.")
                        .Append(prop.ItemSpec)
                        .Append(" = ")
                        .AppendLine(prop.GetMetadata("Value"));
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 foreach (var item in group)
                 {
                     string metadataName = item.GetMetadata("MetadataName");
-                    builder.Append("msbuild_item.")
+                    builder.Append("build_metadata.")
                            .Append(item.GetMetadata("ItemType"))
                            .Append(".")
                            .Append(metadataName)

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -69,63 +69,63 @@
     Property/metadata global .editorconfig Support
     ========================
     
-    Generates a global analyzer config that contains the evaluation of requested MSBuild properties and item metadata
+    Generates a global editor config that contains the evaluation of requested MSBuild properties and item metadata
     
     Requested properties/items are requested via item groups like:
    
-      <AnalyzerProperty Include="PropertyNameToEval" />
-      <AnalyzerItemMetadata Include="ItemType" MetadataName="MetadataToRetrieve" />
+      <CompilerVisibleProperty Include="PropertyNameToEval" />
+      <CompilerVisibleItemMetadata Include="ItemType" MetadataName="MetadataToRetrieve" />
     -->
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildAnalyzerConfig" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildEditorConfig" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
 
   <PropertyGroup>
-    <GeneratedMSBuildAnalyzerConfigFile Condition="'$(GeneratedMSBuildAnalyzerConfigFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).GeneratedMSBuildAnalyzerConfig.editorconfig</GeneratedMSBuildAnalyzerConfigFile>
-    <GenerateMSBuildAnalyzerConfigFile Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == ''">true</GenerateMSBuildAnalyzerConfigFile>
+    <GeneratedMSBuildEditorConfigFile Condition="'$(GeneratedMSBuildEditorConfigFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).GeneratedMSBuildEditorConfig.editorconfig</GeneratedMSBuildEditorConfigFile>
+    <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">true</GenerateMSBuildEditorConfigFile>
   </PropertyGroup>
 
-  <Target Name="GenerateMSBuildAnalyzerConfigFile"
+  <Target Name="GenerateMSBuildEditorConfigFile"
           BeforeTargets="BeforeCompile;CoreCompile"
-          DependsOnTargets="PrepareForBuild;GenerateMSBuildAnalyzerConfigFileShouldRun;GenerateMSBuildAnalyzerConfigFileCore" />
+          DependsOnTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GenerateMSBuildEditorConfigFileCore" />
 
-  <Target Name="GenerateMSBuildAnalyzerConfigFileShouldRun">
+  <Target Name="GenerateMSBuildEditorConfigFileShouldRun">
     <PropertyGroup>
-      <_GeneratedAnalyzerConfigHasItems Condition="'@(AnalyzerItemMetadata->Count())' != '0'">true</_GeneratedAnalyzerConfigHasItems>
-      <_GeneratedAnalyzerConfigShouldRun Condition="'$(GenerateMSBuildAnalyzerConfigFile)' == 'true' and ('$(_GeneratedAnalyzerConfigHasItems)' == 'true' or '@(AnalyzerProperty->Count())' != '0')">true</_GeneratedAnalyzerConfigShouldRun>
+      <_GeneratedEditorConfigHasItems Condition="'@(CompilerVisibleItemMetadata->Count())' != '0'">true</_GeneratedEditorConfigHasItems>
+      <_GeneratedEditorConfigShouldRun Condition="'$(GenerateMSBuildEditorConfigFile)' == 'true' and ('$(_GeneratedEditorConfigHasItems)' == 'true' or '@(CompilerVisibleProperty->Count())' != '0')">true</_GeneratedEditorConfigShouldRun>
     </PropertyGroup>
   </Target>
 
-  <Target Name="GenerateMSBuildAnalyzerConfigFileCore"
-          Condition="'$(_GeneratedAnalyzerConfigShouldRun)' == 'true'"
-          Outputs="$(GeneratedMSBuildAnalyzerConfigFile)">
+  <Target Name="GenerateMSBuildEditorConfigFileCore"
+          Condition="'$(_GeneratedEditorConfigShouldRun)' == 'true'"
+          Outputs="$(GeneratedMSBuildEditorConfigFile)">
 
     <ItemGroup>
       <!-- Collect requested properties, and eval their value -->
-      <_GeneratedAnalyzerConfigProperty Include="@(AnalyzerProperty)">
-        <Value>$(%(AnalyzerProperty.Identity))</Value>
-      </_GeneratedAnalyzerConfigProperty>
+      <_GeneratedEditorConfigProperty Include="@(CompilerVisibleProperty)">
+        <Value>$(%(CompilerVisibleProperty.Identity))</Value>
+      </_GeneratedEditorConfigProperty>
 
       <!-- Collect the requested items and remember which metadata is wanted -->
-      <_GeneratedAnalyzerConfigMetadata Include="@(%(AnalyzerItemMetadata.Identity))" Condition="'$(_GeneratedAnalyzerConfigHasItems)' == 'true'">
+      <_GeneratedEditorConfigMetadata Include="@(%(CompilerVisibleItemMetadata.Identity))" Condition="'$(_GeneratedEditorConfigHasItems)' == 'true'">
         <ItemType>%(Identity)</ItemType>
         <MetadataName>%(MetadataName)</MetadataName>
-      </_GeneratedAnalyzerConfigMetadata>
+      </_GeneratedEditorConfigMetadata>
 
       <!-- Record that we'll write a file, and add it to the editorconfig inputs -->
-      <FileWrites Include="$(GeneratedMSBuildAnalyzerConfigFile)" />
-      <EditorConfigFiles Include="$(GeneratedMSBuildAnalyzerConfigFile)" />
+      <FileWrites Include="$(GeneratedMSBuildEditorConfigFile)" />
+      <EditorConfigFiles Include="$(GeneratedMSBuildEditorConfigFile)" />
     </ItemGroup>
 
     <!-- Transform the collected properties and items into an editor config file -->
-    <GenerateMSBuildAnalyzerConfig
-      PropertyItems="@(_GeneratedAnalyzerConfigProperty)"
-      MetadataItems="@(_GeneratedAnalyzerConfigMetadata)">
+    <GenerateMSBuildEditorConfig
+      PropertyItems="@(_GeneratedEditorConfigProperty)"
+      MetadataItems="@(_GeneratedEditorConfigMetadata)">
 
       <Output TaskParameter="ConfigFileContents"
-          PropertyName="_GeneratedAnalyzerConfigFileContent" />
-    </GenerateMSBuildAnalyzerConfig>
+          PropertyName="_GeneratedEditorConfigFileContent" />
+    </GenerateMSBuildEditorConfig>
 
     <!-- Write the output to the generated file, if it's changed -->
-    <WriteLinesToFile Lines="$(_GeneratedAnalyzerConfigFileContent)" File="$(GeneratedMSBuildAnalyzerConfigFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
+    <WriteLinesToFile Lines="$(_GeneratedEditorConfigFileContent)" File="$(GeneratedMSBuildEditorConfigFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
   </Target>
 
   <!--

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -18,12 +18,12 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {
-    public class GenerateMSBuildAnalyzerConfigTests
+    public class GenerateMSBuildEditorConfigTests
     {
         [Fact]
         public void GlobalPropertyIsGeneratedIfEmpty()
         {
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig();
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig();
             configTask.Execute();
 
             var result = configTask.ConfigFileContents;
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             TaskItem property1 = new TaskItem("Property1", new Dictionary<string, string> { { "Value", "abc123" } });
             TaskItem property2 = new TaskItem("Property2", new Dictionary<string, string> { { "Value", "def456" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 PropertyItems = new[] { property1, property2 }
             };
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             var result = configTask.ConfigFileContents;
 
             Assert.Equal(@"is_global = true
-msbuild_property.Property1 = abc123
-msbuild_property.Property2 = def456
+build_property.Property1 = abc123
+build_property.Property2 = def456
 ", result);
         }
 
@@ -56,7 +56,7 @@ msbuild_property.Property2 = def456
         {
             TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1 }
             };
@@ -67,7 +67,7 @@ msbuild_property.Property2 = def456
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 ", result);
         }
 
@@ -78,7 +78,7 @@ msbuild_item.Compile.ToRetrieve = abc123
             TaskItem item2 = new TaskItem("c:\\file2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
             TaskItem item3 = new TaskItem("c:\\file3.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFiles" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "ghi789" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2, item3 }
             };
@@ -89,13 +89,13 @@ msbuild_item.Compile.ToRetrieve = abc123
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 
 [c:/file2.cs]
-msbuild_item.Compile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = def456
 
 [c:/file3.cs]
-msbuild_item.AdditionalFiles.ToRetrieve = ghi789
+build_metadata.AdditionalFiles.ToRetrieve = ghi789
 ", result);
         }
 
@@ -105,7 +105,7 @@ msbuild_item.AdditionalFiles.ToRetrieve = ghi789
             TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
             TaskItem item2 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2 }
             };
@@ -116,8 +116,8 @@ msbuild_item.AdditionalFiles.ToRetrieve = ghi789
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
-msbuild_item.AdditionalFile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = abc123
+build_metadata.AdditionalFile.ToRetrieve = def456
 ", result);
         }
 
@@ -126,7 +126,7 @@ msbuild_item.AdditionalFile.ToRetrieve = def456
         {
             TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1 }
             };
@@ -137,7 +137,7 @@ msbuild_item.AdditionalFile.ToRetrieve = def456
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = 
+build_metadata.Compile.ToRetrieve = 
 ", result);
         }
 
@@ -148,7 +148,7 @@ msbuild_item.Compile.ToRetrieve =
             TaskItem item2 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" } });
             TaskItem item3 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "MetadataName", "ToRetrieve" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2, item3 }
             };
@@ -159,9 +159,9 @@ msbuild_item.Compile.ToRetrieve =
             Assert.Equal(@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.. = 
-msbuild_item.Compile. = 
-msbuild_item..ToRetrieve = 
+build_metadata.. = 
+build_metadata.Compile. = 
+build_metadata..ToRetrieve = 
 ", result);
         }
 
@@ -176,7 +176,7 @@ msbuild_item..ToRetrieve =
             TaskItem property1 = new TaskItem("Property1", new Dictionary<string, string> { { "Value", "abc123" } });
             TaskItem property2 = new TaskItem("Property2", new Dictionary<string, string> { { "Value", "def456" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2, item3, item4 },
                 PropertyItems = new[] { property1, property2 }
@@ -186,18 +186,18 @@ msbuild_item..ToRetrieve =
             var result = configTask.ConfigFileContents;
 
             Assert.Equal(@"is_global = true
-msbuild_property.Property1 = abc123
-msbuild_property.Property2 = def456
+build_property.Property1 = abc123
+build_property.Property2 = def456
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
-msbuild_item.AdditionalFiles.ToRetrieve = jkl012
+build_metadata.Compile.ToRetrieve = abc123
+build_metadata.AdditionalFiles.ToRetrieve = jkl012
 
 [c:/file2.cs]
-msbuild_item.Compile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = def456
 
 [c:/file3.cs]
-msbuild_item.AdditionalFiles.ToRetrieve = ghi789
+build_metadata.AdditionalFiles.ToRetrieve = ghi789
 ", result);
         }
 
@@ -208,7 +208,7 @@ msbuild_item.AdditionalFiles.ToRetrieve = ghi789
             TaskItem item2 = new TaskItem("subDir\\file2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
             TaskItem item3 = new TaskItem("someDir\\otherDir\\thirdDir\\..\\file3.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2, item3 }
             };
@@ -226,13 +226,13 @@ msbuild_item.AdditionalFiles.ToRetrieve = ghi789
             Assert.Equal($@"is_global = true
 
 [{expectedPath1}]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 
 [{expectedPath2}]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 
 [{expectedPath3}]
-msbuild_item.Compile.ToRetrieve = abc123
+build_metadata.Compile.ToRetrieve = abc123
 ", result);
         }
 
@@ -242,7 +242,7 @@ msbuild_item.Compile.ToRetrieve = abc123
             TaskItem item1 = new TaskItem("c:\\file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
             TaskItem item2 = new TaskItem("c:\\someDir\\..\\file1.cs", new Dictionary<string, string> { { "ItemType", "AdditionalFile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2 }
             };
@@ -253,8 +253,8 @@ msbuild_item.Compile.ToRetrieve = abc123
             Assert.Equal($@"is_global = true
 
 [c:/file1.cs]
-msbuild_item.Compile.ToRetrieve = abc123
-msbuild_item.AdditionalFile.ToRetrieve = def456
+build_metadata.Compile.ToRetrieve = abc123
+build_metadata.AdditionalFile.ToRetrieve = def456
 ", result);
         }
 
@@ -280,7 +280,7 @@ values
             TaskItem property1 = new TaskItem("Property1", new Dictionary<string, string> { { "Value", longPropertyValue } });
             TaskItem property2 = new TaskItem("Property2", new Dictionary<string, string> { { "Value", "def456" } });
 
-            GenerateMSBuildAnalyzerConfig configTask = new GenerateMSBuildAnalyzerConfig()
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 PropertyItems = new[] { property1, property2 }
             };
@@ -289,7 +289,7 @@ values
             var result = configTask.ConfigFileContents;
 
             Assert.Equal(@"is_global = true
-msbuild_property.Property1 = this is 
+build_property.Property1 = this is 
 a 
 property
 with  
@@ -299,7 +299,7 @@ and
 property = looking
 values
 
-msbuild_property.Property2 = def456
+build_property.Property2 = def456
 ", result);
         }
     }

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -733,7 +733,7 @@ namespace Roslyn.Utilities
         /// in the given string with '/'. Otherwise, returns the string.
         /// </summary>
         /// <remarks>
-        /// This method is equivalent to Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildAnalyzerConfig.NormalizeWithForwardSlash
+        /// This method is equivalent to Microsoft.CodeAnalysis.BuildTasks.GenerateMSBuildEditorConfig.NormalizeWithForwardSlash
         /// Both methods should be kept in sync.
         /// </remarks>
         public static string NormalizeWithForwardSlash(string p)


### PR DESCRIPTION
- Rename msbuild_* to build_*
- Rename Analyzer{Property/Metadata} to CompilerVisible{Property/Metadata}
- Rename GenerateMSBuildAnalyzerConfig -> GenerateMSBuildEditorConfig