### PR TITLE
Prefer 'null' over 'nuint' in completion.

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6974,6 +6974,32 @@ class C
             End Function
         End Class
 
+        <WorkItem(43439, "https://github.com/dotnet/roslyn/issues/43439")>
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSelectNullOverNuint(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    public static void Main()
+    {
+        object o = $$
+    }
+                              </Document>,
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("nu")
+                Await state.AssertSelectedCompletionItem(displayText:="null", isHardSelected:=True)
+                Await state.AssertCompletionItemsContain("nuint", "")
+
+                state.SendTypeChars("i")
+                Await state.AssertSelectedCompletionItem(displayText:="nuint", isHardSelected:=True)
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="null", isHardSelected:=True)
+            End Using
+        End Function
+
         ' Simulates a situation where IntelliCode provides items not included into the Rolsyn original list.
         ' We want to ignore these items in CommitIfUnique.
         ' This situation should not happen. Tests with this provider were added to cover protective scenarios.

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6989,14 +6989,44 @@ class C
                               </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
+                ' 'nu' should select 'null' instead of 'nuint' (even though 'nuint' sorts higher in the list textually).
                 state.SendTypeChars("nu")
                 Await state.AssertSelectedCompletionItem(displayText:="null", isHardSelected:=True)
                 Await state.AssertCompletionItemsContain("nuint", "")
 
+                ' even after 'nuint' is selected, deleting the 'i' should still take us back to 'null'.
                 state.SendTypeChars("i")
                 Await state.AssertSelectedCompletionItem(displayText:="nuint", isHardSelected:=True)
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="null", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(43439, "https://github.com/dotnet/roslyn/issues/43439")>
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSelectNuintOverNullOnceInMRU(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    public static void Main()
+    {
+        object o = $$
+    }
+                              </Document>,
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("nui")
+                Await state.AssertCompletionItemsContain("nuint", "")
+                state.SendTab()
+                Assert.Contains("nuint", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+
+                state.SendDeleteWordToLeft()
+
+                ' nuint should be in the mru now.  so typing 'nu' should select it instead of null.
+                state.SendTypeChars("nu")
+                Await state.AssertSelectedCompletionItem(displayText:="nuint", isHardSelected:=True)
             End Using
         End Function
 

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/NuintKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/NuintKeywordRecommender.cs
@@ -2,12 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
     internal sealed class NuintKeywordRecommender : AbstractNativeIntegerKeywordRecommender
     {
-        protected override RecommendedKeyword Keyword => new RecommendedKeyword("nuint");
+        /// <summary>
+        /// We set the <see cref="MatchPriority"/> of this item less than the default value so that completion selects
+        /// the <see langword="null"/> keyword over it as the user starts typing.  Being able to type <see
+        /// langword="null"/> with just <c>nu</c> is ingrained in muscle memory and is more important to maintain versus
+        /// strict adherence to our normal textual matching procedure.  The user can always still get this item simply
+        /// by typing one additional character and unambiguously referring to <c>nui</c>.
+        /// </summary>
+        protected override RecommendedKeyword Keyword => new RecommendedKeyword("nuint", matchPriority: MatchPriority.Default - 1);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/43439