### PR TITLE
Few more IDE scenarios for top-level statements

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -81,8 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     declaratorToRemoveTypeOpt = semanticModel.GetDeclaredSymbol(declaratorToRemoveNodeOpt).GetSymbolType();
                 }
 
-                var switchNode = switchLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
-                var switchStatement = (SwitchStatementSyntax)(switchNode);
+                var switchStatement = (SwitchStatementSyntax)switchLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
                 var switchExpression = Rewriter.Rewrite(
                     switchStatement, declaratorToRemoveTypeOpt, nodeToGenerate,
                     shouldMoveNextStatementToSwitchExpression: shouldRemoveNextStatement,
@@ -100,11 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     // Already morphed into the top-level switch expression.
                     SyntaxNode nextStatement = switchStatement.GetNextStatement();
                     Debug.Assert(nextStatement.IsKind(SyntaxKind.ThrowStatement, SyntaxKind.ReturnStatement));
-                    if (nextStatement.IsParentKind(SyntaxKind.GlobalStatement))
-                    {
-                        nextStatement = nextStatement.Parent;
-                    }
-                    editor.RemoveNode(nextStatement);
+                    editor.RemoveNode(nextStatement.IsParentKind(SyntaxKind.GlobalStatement) ? nextStatement.Parent : nextStatement);
                 }
             }
         }

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -1913,13 +1913,18 @@ return i switch
 };
 ";
 
-            await VerifyCS.VerifyCodeFixAsync(source, new[] {
-                    // error CS9004: Program using top-level statements must be an executable.
-                    DiagnosticResult.CompilerError("CS9004"),
-                    // error CS8652: The feature 'top-level statements' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    DiagnosticResult.CompilerError("CS8652").WithSpan(2, 1, 2, 11).WithArguments("top-level statements"),
-                },
-                fixedSource);
+            var test = new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                LanguageVersion = LanguageVersion.Preview,
+            };
+
+            test.ExpectedDiagnostics.Add(
+                // error CS9004: Program using top-level statements must be an executable.
+                DiagnosticResult.CompilerError("CS9004"));
+
+            await test.RunAsync();
         }
 
         [WorkItem(44449, "https://github.com/dotnet/roslyn/issues/44449")]
@@ -1928,7 +1933,6 @@ return i switch
         {
             // We should be rewriting the declaration for 'j' to get 'var j = i switch ...'
             string source = @"
-int ignored = 0;
 int i = 0;
 int j;
 [|switch|] (i)
@@ -1944,7 +1948,6 @@ throw null;
 ";
 
             string fixedSource = @"
-int ignored = 0;
 int i = 0;
 int j;
 j = i switch
@@ -1955,13 +1958,18 @@ j = i switch
 };
 ";
 
-            await VerifyCS.VerifyCodeFixAsync(source, new DiagnosticResult[] {
-                    // error CS9004: Program using top-level statements must be an executable.
-                    DiagnosticResult.CompilerError("CS9004"),
-                    // error CS8652: The feature 'top-level statements' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    DiagnosticResult.CompilerError("CS8652").WithSpan(2, 1, 2, 17).WithArguments("top-level statements"),
-                },
-                fixedSource);
+            var test = new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                LanguageVersion = LanguageVersion.Preview,
+            };
+
+            test.ExpectedDiagnostics.Add(
+                // error CS9004: Program using top-level statements must be an executable.
+                DiagnosticResult.CompilerError("CS9004"));
+
+            await test.RunAsync();
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -2282,18 +2282,15 @@ class C
 }");
         }
 
+        [WorkItem(44429, "https://github.com/dotnet/roslyn/issues/44429")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
         public async Task TopLevelStatement()
         {
-            await TestAsync(@"
+            await TestMissingAsync(@"
 [|int|] i;
 if (int.TryParse(v, out i))
 {
-}",
-@"
-if (int.TryParse(v, out int i))
-{
-}", TestOptions.Regular);
+}", new TestParameters(TestOptions.Regular));
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.InlineDeclaration;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitType;
@@ -2279,6 +2280,20 @@ class C
         c2 = c;
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TopLevelStatement()
+        {
+            await TestAsync(@"
+[|int|] i;
+if (int.TryParse(v, out i))
+{
+}",
+@"
+if (int.TryParse(v, out int i))
+{
+}", TestOptions.Regular);
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseThrowExpression/UseThrowExpressionTests.cs
@@ -541,18 +541,5 @@ class A<T> where T: struct
     }
 }");
         }
-
-        [WorkItem(44454, "https://github.com/dotnet/roslyn/issues/44454")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
-        public async Task TopLevelStatement()
-        {
-            await TestMissingAsync(
-@"using System;
-string s = null;
-string x = null;
-if (s == null) [|throw|] new ArgumentNullException();
-x = s;
-");
-        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseThrowExpression/UseThrowExpressionTests.cs
@@ -541,5 +541,18 @@ class A<T> where T: struct
     }
 }");
         }
+
+        [WorkItem(44454, "https://github.com/dotnet/roslyn/issues/44454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task TopLevelStatement()
+        {
+            await TestMissingAsync(
+@"using System;
+string s = null;
+string x = null;
+if (s == null) [|throw|] new ArgumentNullException();
+x = s;
+");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedLocalFunction/RemoveUnusedLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedLocalFunction/RemoveUnusedLocalFunctionTests.cs
@@ -5,9 +5,11 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedLocalFunction;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedLocalFunction
@@ -112,6 +114,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedLocalFuncti
     {
     }
 }");
+        }
+
+        [WorkItem(44272, "https://github.com/dotnet/roslyn/issues/44272")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedLocalFunction)]
+        public async Task TopLevelStatement()
+        {
+            await TestAsync(@"
+void [|local()|] { }
+",
+@"
+", TestOptions.Regular);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedVariable/RemoveUnusedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedVariable/RemoveUnusedVariableTests.cs
@@ -5,6 +5,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -702,6 +703,17 @@ class C
         }
     }
 }");
+        }
+
+        [WorkItem(44273, "https://github.com/dotnet/roslyn/issues/44273")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedVariable)]
+        public async Task TopLevelStatement()
+        {
+            await TestAsync(@"
+[|int i = 0|];
+",
+@"
+", TestOptions.Regular);
         }
     }
 }

--- a/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -58,12 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedLocalFunction
 
             foreach (var localFunction in localFunctions)
             {
-                SyntaxNode nodeToRemove = localFunction;
-                if (localFunction.Parent.Kind() == SyntaxKind.GlobalStatement)
-                {
-                    nodeToRemove = localFunction.Parent;
-                }
-                editor.RemoveNode(nodeToRemove);
+                editor.RemoveNode(localFunction.IsParentKind(SyntaxKind.GlobalStatement) ? localFunction.Parent : localFunction);
             }
 
             return Task.CompletedTask;

--- a/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
@@ -58,7 +58,12 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedLocalFunction
 
             foreach (var localFunction in localFunctions)
             {
-                editor.RemoveNode(localFunction);
+                SyntaxNode nodeToRemove = localFunction;
+                if (localFunction.Parent.Kind() == SyntaxKind.GlobalStatement)
+                {
+                    nodeToRemove = localFunction.Parent;
+                }
+                editor.RemoveNode(nodeToRemove);
             }
 
             return Task.CompletedTask;

--- a/src/Features/CSharp/Portable/RemoveUnusedVariable/CSharpRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedVariable/CSharpRemoveUnusedVariableCodeFixProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -59,11 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable
                     editor.ReplaceNode(node, ((AssignmentExpressionSyntax)node).Right);
                     return;
                 default:
-                    if (node.Parent.Kind() == SyntaxKind.GlobalStatement)
-                    {
-                        node = node.Parent;
-                    }
-                    RemoveNode(editor, node, syntaxFacts);
+                    RemoveNode(editor, node.IsParentKind(SyntaxKind.GlobalStatement) ? node.Parent : node, syntaxFacts);
                     return;
             }
         }

--- a/src/Features/CSharp/Portable/RemoveUnusedVariable/CSharpRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedVariable/CSharpRemoveUnusedVariableCodeFixProvider.cs
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable
                     editor.ReplaceNode(node, ((AssignmentExpressionSyntax)node).Right);
                     return;
                 default:
+                    if (node.Parent.Kind() == SyntaxKind.GlobalStatement)
+                    {
+                        node = node.Parent;
+                    }
                     RemoveNode(editor, node, syntaxFacts);
                     return;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/StatementSyntaxExtensions.cs
@@ -36,17 +36,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             static bool AreInSiblingTopLevelStatements(StatementSyntax one, StatementSyntax other)
             {
-                if (!one.IsParentKind(SyntaxKind.GlobalStatement))
-                {
-                    return false;
-                }
-
-                if (!one.IsParentKind(SyntaxKind.GlobalStatement))
-                {
-                    return false;
-                }
-
-                return one.Parent.Parent == other.Parent.Parent;
+                return one.IsParentKind(SyntaxKind.GlobalStatement) &&
+                    other.IsParentKind(SyntaxKind.GlobalStatement);
             }
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/StatementSyntaxExtensions.cs
@@ -29,10 +29,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             if (statement != null)
             {
                 var nextToken = statement.GetLastToken().GetNextToken();
-                return nextToken.GetAncestors<StatementSyntax>().FirstOrDefault(s => s.Parent == statement.Parent);
+                return nextToken.GetAncestors<StatementSyntax>().FirstOrDefault(s => s.Parent == statement.Parent || AreInSiblingTopLevelStatements(s, statement));
             }
 
             return null;
+
+            static bool AreInSiblingTopLevelStatements(StatementSyntax one, StatementSyntax other)
+            {
+                if (!one.IsParentKind(SyntaxKind.GlobalStatement))
+                {
+                    return false;
+                }
+
+                if (!one.IsParentKind(SyntaxKind.GlobalStatement))
+                {
+                    return false;
+                }
+
+                return one.Parent.Parent == other.Parent.Parent;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44272 (RemoveUnusedLocalFunction)
Fixes https://github.com/dotnet/roslyn/issues/44273 (RemoveUnusedVariable)
Fixes ConvertSwitchStatementToExpression