### PR TITLE
[Dogfooding] Enforce IDE0007 (prefer "var") as build warning in IDE projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -225,10 +225,6 @@ dotnet_diagnostic.RS0037.severity = none
 # warning RS0005: Do not use generic CodeAction.Create to create CodeAction
 dotnet_diagnostic.RS0005.severity = none
 
-[src/**.{cs,vb}]
-# Temporary workaround to enable FixAll in solution
-dotnet_diagnostic.IDE0007.severity = none
-
 [src/{Analyzers,CodeStyle,Features,Workspaces}/**/*.{cs,vb}]
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -225,6 +225,10 @@ dotnet_diagnostic.RS0037.severity = none
 # warning RS0005: Do not use generic CodeAction.Create to create CodeAction
 dotnet_diagnostic.RS0005.severity = none
 
+[src/**.{cs,vb}]
+# Temporary workaround to enable FixAll in solution
+dotnet_diagnostic.IDE0007.severity = none
+
 [src/{Analyzers,CodeStyle,Features,Workspaces}/**/*.{cs,vb}]
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = warning
@@ -264,3 +268,9 @@ dotnet_diagnostic.IDE0060.severity = warning
 
 # CA1822: Make member static
 dotnet_diagnostic.CA1822.severity = warning
+
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
 #if !CODE_STYLE
 
-                for (int i = 1; i < switchLabels.Count; i++)
+                for (var i = 1; i < switchLabels.Count; i++)
                 {
                     var nextPatternPart = GetPattern(switchLabels[i], out whenClauseUnused);
                     Debug.Assert(whenClauseUnused == null, "We should not have offered to convert multiple cases if any have a when clause");

--- a/src/Analyzers/CSharp/Tests/UseExplicitTupleName/UseExplicitTupleNameTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseExplicitTupleName/UseExplicitTupleNameTests.cs
@@ -231,7 +231,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTupleName)]
         public async Task TestOnRestField()
         {
-            string valueTuple8 = @"
+            var valueTuple8 = @"
 namespace System
 {
     public struct ValueTuple<T1>

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -560,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             }
             else
             {
-                BaseArgumentListSyntax? argumentList = node switch
+                var argumentList = node switch
                 {
                     InvocationExpressionSyntax invocation => invocation.ArgumentList,
                     ObjectCreationExpressionSyntax objectCreation => objectCreation.ArgumentList,

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -560,7 +560,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             }
             else
             {
-                var argumentList = node switch
+#pragma warning disable IDE0007 // Use implicit type - Using 'var' causes "error CS8506: No best type was found for the switch expression"
+                // TODO: File a bug on IDE0007 analyzer
+                BaseArgumentListSyntax? argumentList = node switch
+#pragma warning restore IDE0007 // Use implicit type
                 {
                     InvocationExpressionSyntax invocation => invocation.ArgumentList,
                     ObjectCreationExpressionSyntax objectCreation => objectCreation.ArgumentList,

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
 
             Debug.Assert(whenClause == null || section.Labels.Length == 1, "We shouldn't have guards when we're combining multiple cases into a single arm");
 
-            for (int i = 1; i < section.Labels.Length; i++)
+            for (var i = 1; i < section.Labels.Length; i++)
             {
                 var label = section.Labels[i];
                 Debug.Assert(label.Guards.Length == 0, "We shouldn't have guards when we're combining multiple cases into a single arm");

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         protected override SyntaxNode FindStatementAndPartner(SyntaxNode declarationBody, TextSpan span, SyntaxNode? partnerDeclarationBody, out SyntaxNode? partner, out int statementPart)
         {
-            int position = span.Start;
+            var position = span.Start;
 
             SyntaxUtilities.AssertIsBody(declarationBody, allowLambda: false);
 
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             while (true)
             {
-                bool isBody = node == declarationBody || LambdaUtilities.IsLambdaBodyStatementOrExpression(node);
+                var isBody = node == declarationBody || LambdaUtilities.IsLambdaBodyStatementOrExpression(node);
 
                 if (isBody || StatementSyntaxComparer.HasLabel(node))
                 {
@@ -513,7 +513,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             var root = GetEncompassingAncestor(container);
 
-            SyntaxNode? current = node;
+            var current = node;
             while (current != root && current != null)
             {
                 if (LambdaUtilities.IsLambdaBodyStatementOrExpression(current, out var body))
@@ -2981,7 +2981,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             var result = new List<SyntaxNode>();
 
-            SyntaxNode? current = node;
+            var current = node;
             while (current != null)
             {
                 var kind = current.Kind();

--- a/src/Features/CSharp/Portable/ExtractMethod/Extensions.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/Extensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         {
             Contract.ThrowIfNull(node);
 
-            for (SyntaxNode? current = node; current is object; current = current.Parent)
+            for (var current = node; current is object; current = current.Parent)
             {
                 if (current.Parent != null &&
                     current.Parent.IsStatementContainerNode())

--- a/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
 
         private static (SyntaxNode?, ExplicitInterfaceSpecifierSyntax?, SyntaxToken) GetContainer(SyntaxToken token)
         {
-            for (SyntaxNode? node = token.Parent; node != null; node = node.Parent)
+            for (var node = token.Parent; node != null; node = node.Parent)
             {
                 var result = node switch
                 {

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
         private static SyntaxNode? GetDeclaration(SyntaxNode node, UseExpressionBodyHelper helper)
         {
-            for (SyntaxNode? current = node; current != null; current = current.Parent)
+            for (var current = node; current != null; current = current.Parent)
             {
                 if (helper.SyntaxKinds.Contains(current.Kind()))
                     return current;

--- a/src/Features/Core/Portable/AddImport/References/Reference.cs
+++ b/src/Features/Core/Portable/AddImport/References/Reference.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             public int CompareTo(Document document, Reference other)
             {
-                int diff = ComparerWithState.CompareTo(this, other, document, s_comparers);
+                var diff = ComparerWithState.CompareTo(this, other, document, s_comparers);
                 if (diff != 0)
                 {
                     return diff;

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -269,8 +269,8 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 
             var declaredSymbolParametersCount = declaredSymbol.GetParameters().Length;
 
-            int telemetryNumberOfDeclarationsToUpdate = 0;
-            int telemetryNumberOfReferencesToUpdate = 0;
+            var telemetryNumberOfDeclarationsToUpdate = 0;
+            var telemetryNumberOfReferencesToUpdate = 0;
 
             foreach (var symbol in symbols)
             {
@@ -691,7 +691,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             var originalParameters = updatedSignature.OriginalConfiguration.ToListOfParameters();
             var reorderedParameters = updatedSignature.UpdatedConfiguration.ToListOfParameters();
 
-            int numAddedParameters = 0;
+            var numAddedParameters = 0;
 
             // Iterate through the list of new parameters and combine any
             // preexisting parameters with added parameters to construct
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         {
             var separators = ImmutableArray.CreateBuilder<SyntaxToken>();
 
-            for (int i = 0; i < arguments.SeparatorCount - numSeparatorsToSkip; i++)
+            for (var i = 0; i < arguments.SeparatorCount - numSeparatorsToSkip; i++)
             {
                 separators.Add(i < arguments.SeparatorCount
                     ? arguments.GetSeparator(i)
@@ -782,7 +782,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             var seenOmitted = false;
             var paramsHandled = false;
 
-            for (int i = 0; i < updatedParameters.Length; i++)
+            for (var i = 0; i < updatedParameters.Length; i++)
             {
                 // Skip this parameter in list of arguments for extension method calls but not for reduced ones.
                 if (updatedParameters[i] != signaturePermutation.UpdatedConfiguration.ThisParameter

--- a/src/Features/Core/Portable/ChangeSignature/SignatureChange.cs
+++ b/src/Features/Core/Portable/ChangeSignature/SignatureChange.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             var originalListWithoutRemovedOrAdded = originalListOfParameters.Where(p => updatedListOfParameters.Contains(p)).ToImmutableArray();
             var updatedListWithoutRemovedOrAdded = updatedListOfParameters.Where(p => originalListOfParameters.Contains(p)).ToImmutableArray();
 
-            for (int i = 0; i < originalListWithoutRemovedOrAdded.Length; i++)
+            for (var i = 0; i < originalListWithoutRemovedOrAdded.Length; i++)
             {
                 if (originalListWithoutRemovedOrAdded[i] != updatedListWithoutRemovedOrAdded[i])
                 {

--- a/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             // there could be multiple (n) tokens to the left if first n-1 are Empty -> iterate over all of them
             while (tokenToLeft != default)
             {
-                SyntaxNode? leftNode = tokenToLeft.Parent!;
+                var leftNode = tokenToLeft.Parent!;
                 do
                 {
                     // Consider either a Node that is:
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         {
             if (tokenToRightOrIn != default)
             {
-                SyntaxNode? rightNode = tokenToRightOrIn.Parent!;
+                var rightNode = tokenToRightOrIn.Parent!;
                 do
                 {
                     // Consider either a Node that is:
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 
         private void AddRelevantNodesForSelection<TSyntaxNode>(ISyntaxFactsService syntaxFacts, SyntaxNode root, TextSpan selectionTrimmed, ArrayBuilder<TSyntaxNode> relevantNodesBuilder, CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
         {
-            SyntaxNode? selectionNode = root.FindNode(selectionTrimmed, getInnermostNodeForTie: true);
+            var selectionNode = root.FindNode(selectionTrimmed, getInnermostNodeForTie: true);
             var prevNode = selectionNode;
             do
             {
@@ -483,7 +483,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             var token = root.FindTokenOnRightOfPosition(position, true);
 
             // traverse upwards and add all parents if of correct type
-            SyntaxNode? ancestor = token.Parent;
+            var ancestor = token.Parent;
             while (ancestor != null)
             {
                 if (ancestor is TSyntaxNode correctTypeNode)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             foreach (var (analyzer, telemetryInfo) in telemetry)
             {
-                bool isTelemetryCollectionAllowed = DiagnosticAnalyzerInfoCache.IsTelemetryCollectionAllowed(analyzer);
+                var isTelemetryCollectionAllowed = DiagnosticAnalyzerInfoCache.IsTelemetryCollectionAllowed(analyzer);
                 _telemetry.UpdateAnalyzerActionsTelemetry(analyzer, telemetryInfo, isTelemetryCollectionAllowed);
             }
         }

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1959,7 +1959,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private static List<SyntaxNode?>? GetAncestors(SyntaxNode? root, SyntaxNode node, Func<SyntaxNode, bool> nodeSelector)
         {
             List<SyntaxNode?>? list = null;
-            SyntaxNode? current = node;
+            var current = node;
 
             while (current is object && current != root)
             {
@@ -3802,7 +3802,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return memberBody;
             }
 
-            SyntaxNode? node = GetSymbolSyntax(localOrParameter, cancellationToken);
+            var node = GetSymbolSyntax(localOrParameter, cancellationToken);
             while (true)
             {
                 RoslynDebug.Assert(node is object);

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         private (SourceText? Source, bool? HasDocument) TryGetPdbMatchingSourceText(string sourceFilePath, Encoding? encoding, Project project)
         {
-            bool? hasDocument = TryReadSourceFileChecksumFromPdb(sourceFilePath, project, out var symChecksum, out var algorithm);
+            var hasDocument = TryReadSourceFileChecksumFromPdb(sourceFilePath, project, out var symChecksum, out var algorithm);
             if (hasDocument != true)
             {
                 return (Source: null, hasDocument);

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -309,8 +309,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         // internal for testing
         internal static IEnumerable<TextSpan> GetSpansInNewDocument(IEnumerable<TextChange> changes)
         {
-            int oldPosition = 0;
-            int newPosition = 0;
+            var oldPosition = 0;
+            var newPosition = 0;
             foreach (var change in changes)
             {
                 if (change.Span.Start < oldPosition)

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 using var builderDisposer = ArrayBuilder<ActiveStatementExceptionRegions>.GetInstance(instructionMap.Count, out var builder);
                 builder.Count = instructionMap.Count;
 
-                bool hasOutOfSyncDocuments = false;
+                var hasOutOfSyncDocuments = false;
 
                 foreach (var activeStatement in instructionMap.Values)
                 {
@@ -547,8 +547,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ImmutableArray<(Document Document, AsyncLazy<DocumentAnalysisResults> Results)> documentAnalyses,
             CancellationToken cancellationToken)
         {
-            bool hasChanges = false;
-            bool hasSignificantValidChanges = false;
+            var hasChanges = false;
+            var hasSignificantValidChanges = false;
 
             foreach (var analysis in documentAnalyses)
             {
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 var baseSolution = DebuggingSession.LastCommittedSolution;
 
-                bool isBlocked = false;
+                var isBlocked = false;
                 foreach (var project in solution.Projects)
                 {
                     await PopulateChangedAndAddedDocumentsAsync(baseSolution, project, changedDocuments, addedDocuments, cancellationToken).ConfigureAwait(false);
@@ -719,7 +719,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // we need to check with the debugger.
                     var (moduleDiagnostics, isModuleLoaded) = await GetModuleDiagnosticsAsync(mvid, project.Name, cancellationToken).ConfigureAwait(false);
 
-                    bool isModuleEncBlocked = isModuleLoaded && !moduleDiagnostics.IsEmpty;
+                    var isModuleEncBlocked = isModuleLoaded && !moduleDiagnostics.IsEmpty;
                     if (isModuleEncBlocked)
                     {
                         diagnostics.Add((project.Id, moduleDiagnostics));
@@ -907,8 +907,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             debugInfoReaderProvider = null;
             metadataReaderProvider = null;
 
-            bool success = false;
-            string fileBeingRead = compilationOutputs.PdbDisplayPath;
+            var success = false;
+            var fileBeingRead = compilationOutputs.PdbDisplayPath;
             try
             {
                 debugInfoReaderProvider = compilationOutputs.OpenPdb();

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/TypeParameterSubstitution.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/TypeParameterSubstitution.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 var commonTypes = await GetDerivedAndImplementedTypesAsync(
                     (INamedTypeSymbol)symbol.ConstraintTypes[0], projects).ConfigureAwait(false);
 
-                for (int i = 1; i < symbol.ConstraintTypes.Length; i++)
+                for (var i = 1; i < symbol.ConstraintTypes.Length; i++)
                 {
                     var currentTypes = await GetDerivedAndImplementedTypesAsync(
                         (INamedTypeSymbol)symbol.ConstraintTypes[i], projects).ConfigureAwait(false);

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             var trackedRoot = root.TrackNodes(nodesToTrack);
             var currentDocument = document.WithSyntaxRoot(trackedRoot);
 
-            for (int i = 0; i < parameters.Length; i++)
+            for (var i = 0; i < parameters.Length; i++)
             {
                 var parameter = parameters[i];
                 var fieldOrProperty = fieldsOrProperties[i];

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         public static ProjectId ProjectContextToProjectId(ProjectContext projectContext)
         {
-            int delimiter = projectContext.Id.IndexOf('|');
+            var delimiter = projectContext.Id.IndexOf('|');
 
             return ProjectId.CreateFromSerialized(
                 Guid.Parse(projectContext.Id.Substring(0, delimiter)),

--- a/src/Features/Lsif/Generator/CompilerInvocation.cs
+++ b/src/Features/Lsif/Generator/CompilerInvocation.cs
@@ -45,15 +45,15 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             // Unfortunately for us there are a few paths that get directly read by the command line parse which we need to remap,
             // such as /ruleset files. So let's go through and process them now.
-            for (int i = 0; i < splitCommandLine.Count; i++)
+            for (var i = 0; i < splitCommandLine.Count; i++)
             {
                 const string RuleSetSwitch = "/ruleset:";
 
                 if (splitCommandLine[i].StartsWith(RuleSetSwitch, StringComparison.Ordinal))
                 {
-                    string rulesetPath = splitCommandLine[i].Substring(RuleSetSwitch.Length);
+                    var rulesetPath = splitCommandLine[i].Substring(RuleSetSwitch.Length);
 
-                    bool quoted = rulesetPath.Length > 2 &&
+                    var quoted = rulesetPath.Length > 2 &&
                         rulesetPath.StartsWith("\"", StringComparison.Ordinal) &&
                         rulesetPath.EndsWith("\"", StringComparison.Ordinal);
 
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                     {
                         // Trim off any leading \, which would happen if you have a path like C:\Directory\\File.cs with a double slash, and happen to be
                         // mapping C:\Directory somewhere.
-                        string relativePath = unmappedPath.Substring(fromWithDirectorySuffix.Length).TrimStart('\\');
+                        var relativePath = unmappedPath.Substring(fromWithDirectorySuffix.Length).TrimStart('\\');
 
                         return Path.Combine(AddDirectorySuffixIfMissing(potentialPathMapping.To), relativePath);
                     }

--- a/src/Features/Lsif/Generator/Graph/Edge.cs
+++ b/src/Features/Lsif/Generator/Graph/Edge.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
 
             // Note: this is ultimately just an array copy, but in a strongly-typed way. The JIT might see through this as a memory copy,
             // but might require some more explicit code if not.
-            for (int i = 0; i < inVertices.Count; i++)
+            for (var i = 0; i < inVertices.Count; i++)
             {
                 inVerticesArray[i] = inVertices[i].As<TInVertex, Vertex>();
             }

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -38,10 +38,10 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         private static async Task GenerateAsync(FileInfo? solution, FileInfo? compilerInvocation, string? output, LsifFormat outputFormat, string? log)
         {
             // If we have an output file, we'll write to that, else we'll use Console.Out
-            using StreamWriter? outputFile = output != null ? new StreamWriter(output) : null;
-            TextWriter outputWriter = outputFile ?? Console.Out;
+            using var outputFile = output != null ? new StreamWriter(output) : null;
+            var outputWriter = outputFile ?? Console.Out;
 
-            using TextWriter logFile = log != null ? new StreamWriter(log) : TextWriter.Null;
+            using var logFile = log != null ? new StreamWriter(log) : TextWriter.Null;
             ILsifJsonWriter lsifWriter = outputFormat switch
             {
                 LsifFormat.Json => new JsonModeLsifJsonWriter(outputWriter),
@@ -111,8 +111,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             await logFile.WriteLineAsync($"Load of the solution completed in {solutionLoadStopwatch.Elapsed.ToDisplayString()}.");
             var lsifGenerator = new Generator(lsifWriter);
 
-            Stopwatch totalTimeInGenerationAndCompilationFetchStopwatch = Stopwatch.StartNew();
-            TimeSpan totalTimeInGenerationPhase = TimeSpan.Zero;
+            var totalTimeInGenerationAndCompilationFetchStopwatch = Stopwatch.StartNew();
+            var totalTimeInGenerationPhase = TimeSpan.Zero;
 
             foreach (var project in solution.Projects)
             {

--- a/src/Features/Lsif/Generator/ResultSetTracking/SymbolHoldingResultSetTracker.cs
+++ b/src/Features/Lsif/Generator/ResultSetTracking/SymbolHoldingResultSetTracker.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.ResultSetTr
                         return new Id<T>(existingId.Value.NumericId);
                     }
 
-                    T vertex = vertexCreator();
+                    var vertex = vertexCreator();
                     _edgeKindToVertexId.Add(edgeKind, vertex.GetId().As<T, Vertex>());
 
                     lsifJsonWriter.Write(vertex);

--- a/src/Features/Lsif/Generator/Writing/LineModeLsifJsonWriter.cs
+++ b/src/Features/Lsif/Generator/Writing/LineModeLsifJsonWriter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
 
         public void Write(Element element)
         {
-            string line = JsonConvert.SerializeObject(element, _settings);
+            var line = JsonConvert.SerializeObject(element, _settings);
 
             lock (_writeGate)
             {

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
         public static bool IsStaticallyDeclared(SyntaxToken token)
         {
-            SyntaxNode? parentNode = token.Parent;
+            var parentNode = token.Parent;
 
             if (parentNode.IsKind(SyntaxKind.EnumMemberDeclaration))
             {

--- a/src/Workspaces/Core/Desktop/Workspace/CommandLineProject.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/CommandLineProject.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis
             // and names the compilation after the file that contains it. We don't want to create a compilation, 
             // bind Mains etc. here. Besides the msbuild always includes /out in the command line it produces.
             // So if we don't have the /out argument we name the compilation "<anonymous>".
-            string assemblyName = (commandLineArguments.OutputFileName != null) ?
+            var assemblyName = (commandLineArguments.OutputFileName != null) ?
                 Path.GetFileNameWithoutExtension(commandLineArguments.OutputFileName) : "<anonymous>";
 
             // TODO (tomat): what should be the assemblyName when compiling a netmodule? Should it be /moduleassemblyname

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             var document = this.CurrentSolution.GetDocument(documentId);
             if (document != null)
             {
-                Encoding encoding = DetermineEncoding(text, document);
+                var encoding = DetermineEncoding(text, document);
 
                 this.SaveDocumentText(documentId, document.FilePath, text, encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 this.OnDocumentTextChanged(documentId, text, PreservationMode.PreserveValue);

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 descriptors = ImmutableArray<DiagnosticDescriptor>.Empty;
             }
 
-            bool telemetryAllowed = IsTelemetryCollectionAllowed(analyzer, descriptors);
+            var telemetryAllowed = IsTelemetryCollectionAllowed(analyzer, descriptors);
             return new DiagnosticDescriptorsInfo(descriptors, telemetryAllowed);
         }
 

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.Differencing
             {
                 Debug.Assert(previous != null);
 
-                int minDepth = previous.MaxDepth + 1;
-                int maxDepth = previous.MaxDepth * GrowFactor;
+                var minDepth = previous.MaxDepth + 1;
+                var maxDepth = previous.MaxDepth * GrowFactor;
 
                 Debug.Assert(minDepth > 0);
                 Debug.Assert(minDepth <= maxDepth);
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             public IEnumerable<(VArray Array, int Depth)> ConsumeArrays()
             {
                 var buffer = _currentBuffer;
-                for (int depth = _depth - 1; depth >= 0; depth--)
+                for (var depth = _depth - 1; depth >= 0; depth--)
                 {
                     if (depth < buffer.MinDepth)
                     {
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         // TODO: Consolidate return types between GetMatchingPairs and GetEdit to avoid duplicated code (https://github.com/dotnet/roslyn/issues/16864)
         protected IEnumerable<KeyValuePair<int, int>> GetMatchingPairs(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
-            VStack stack = ComputeEditPaths(oldSequence, oldLength, newSequence, newLength);
+            var stack = ComputeEditPaths(oldSequence, oldLength, newSequence, newLength);
 
             var x = oldLength;
             var y = newLength;
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Differencing
 
             while (x > 0 || y > 0)
             {
-                bool hasNext = varrays.MoveNext();
+                var hasNext = varrays.MoveNext();
                 Debug.Assert(hasNext);
 
                 var (currentV, d) = varrays.Current;
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.Differencing
 
             while (x > 0 || y > 0)
             {
-                bool hasNext = varrays.MoveNext();
+                var hasNext = varrays.MoveNext();
                 Debug.Assert(hasNext);
 
                 var (currentV, d) = varrays.Current;

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.Editing
             {
                 var current = root.GetCurrentNode(this.Node);
                 var newNodes = _modifier(current, generator).ToList();
-                for (int i = 0; i < newNodes.Count; i++)
+                for (var i = 0; i < newNodes.Count; i++)
                 {
                     newNodes[i] = _editor.ApplyTrackingToNewNode(newNodes[i]);
                 }

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Options
 
         public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey)
         {
-            ImmutableDictionary<string, (IOption? option, IEditorConfigStorageLocation2? storageLocation)> temporaryOptions = s_emptyEditorConfigKeysToOptions;
+            var temporaryOptions = s_emptyEditorConfigKeysToOptions;
             ref var editorConfigToOptionsStorage = ref temporaryOptions;
             switch (language)
             {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             this INamespaceSymbol globalNamespace,
             string namespaceName)
         {
-            INamespaceSymbol? namespaceSymbol = globalNamespace;
+            var namespaceSymbol = globalNamespace;
             foreach (var name in namespaceName.Split('.'))
             {
                 var members = namespaceSymbol.GetMembers(name);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             if (oldNodes != null)
             {
-                XNode[] rewritten = RewriteMany(symbol, visitedSymbols, compilation, oldNodes.ToArray(), cancellationToken);
+                var rewritten = RewriteMany(symbol, visitedSymbols, compilation, oldNodes.ToArray(), cancellationToken);
                 container.ReplaceNodes(rewritten);
             }
 
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return false;
                 }
 
-                for (int i = 0; i < left.Parameters.Length; i++)
+                for (var i = 0; i < left.Parameters.Length; i++)
                 {
                     if (!left.Parameters[i].Type.Equals(right.Parameters[i].Type))
                     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis
             // of projects. First, let's just compute the new set of transitive references. It's possible while doing so we'll discover that we don't
             // know the transitive project references for one of our new references. In that case, we'll use null as a sentinel to mean "we don't know" and
             // we propagate the not-knowingness. But let's not worry about that yet. First, let's just get the new transitive reference set.
-            HashSet<ProjectId>? newTransitiveReferences = new HashSet<ProjectId>(referencedProjectIds);
+            var newTransitiveReferences = new HashSet<ProjectId>(referencedProjectIds);
 
             foreach (var referencedProjectId in referencedProjectIds)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1908,8 +1908,8 @@ namespace Microsoft.CodeAnalysis
         {
             var projectState = _state.GetRequiredProjectState(projectId);
 
-            bool isSubmission = projectState.IsSubmission;
-            bool hasSubmissionReference = !ignoreExistingReferences && projectState.ProjectReferences.Any(p => _state.GetRequiredProjectState(p.ProjectId).IsSubmission);
+            var isSubmission = projectState.IsSubmission;
+            var hasSubmissionReference = !ignoreExistingReferences && projectState.ProjectReferences.Any(p => _state.GetRequiredProjectState(p.ProjectId).IsSubmission);
 
             foreach (var projectReference in projectReferences)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis
             filePathToDocumentIdsMap ??= _filePathToDocumentIdsMap;
             dependencyGraph ??= _dependencyGraph;
 
-            bool analyzerReferencesEqual = AnalyzerReferences.SequenceEqual(analyzerReferences);
+            var analyzerReferencesEqual = AnalyzerReferences.SequenceEqual(analyzerReferences);
 
             if (branchId == _branchId &&
                 solutionAttributes == _solutionAttributes &&

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -217,10 +217,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
         [Fact]
         public void TestPerLanguageCodeStyleOptions()
         {
-            PerLanguageOption2<CodeStyleOption2<bool>> perLanguageOption2 = new PerLanguageOption2<CodeStyleOption2<bool>>("test", "test", new CodeStyleOption2<bool>(false, NotificationOption2.Warning));
-            PerLanguageOption<CodeStyleOption<bool>> perLanguageOption = perLanguageOption2.ToPublicOption();
-            CodeStyleOption2<bool> newValueCodeStyleOption2 = new CodeStyleOption2<bool>(!perLanguageOption2.DefaultValue.Value, perLanguageOption2.DefaultValue.Notification);
-            CodeStyleOption<bool> newValueCodeStyleOption = (CodeStyleOption<bool>)newValueCodeStyleOption2!;
+            var perLanguageOption2 = new PerLanguageOption2<CodeStyleOption2<bool>>("test", "test", new CodeStyleOption2<bool>(false, NotificationOption2.Warning));
+            var perLanguageOption = perLanguageOption2.ToPublicOption();
+            var newValueCodeStyleOption2 = new CodeStyleOption2<bool>(!perLanguageOption2.DefaultValue.Value, perLanguageOption2.DefaultValue.Notification);
+            var newValueCodeStyleOption = (CodeStyleOption<bool>)newValueCodeStyleOption2!;
 
             // Test "OptionKey" based overloads for get/set options on OptionSet and OptionService using different public and internal type combinations.
 
@@ -263,10 +263,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
         [Fact]
         public void TestLanguageSpecificCodeStyleOptions()
         {
-            Option2<CodeStyleOption2<bool>> option2 = new Option2<CodeStyleOption2<bool>>("test", "test", new CodeStyleOption2<bool>(false, NotificationOption2.Warning));
-            Option<CodeStyleOption<bool>> option = option2.ToPublicOption();
-            CodeStyleOption2<bool> newValueCodeStyleOption2 = new CodeStyleOption2<bool>(!option2.DefaultValue.Value, option2.DefaultValue.Notification);
-            CodeStyleOption<bool> newValueCodeStyleOption = (CodeStyleOption<bool>)newValueCodeStyleOption2!;
+            var option2 = new Option2<CodeStyleOption2<bool>>("test", "test", new CodeStyleOption2<bool>(false, NotificationOption2.Warning));
+            var option = option2.ToPublicOption();
+            var newValueCodeStyleOption2 = new CodeStyleOption2<bool>(!option2.DefaultValue.Value, option2.DefaultValue.Notification);
+            var newValueCodeStyleOption = (CodeStyleOption<bool>)newValueCodeStyleOption2!;
 
             // Test "OptionKey" based overloads for get/set options on OptionSet and OptionService using different public and internal type combinations.
 

--- a/src/Workspaces/DesktopTest/CommandLineProjectTests.cs
+++ b/src/Workspaces/DesktopTest/CommandLineProjectTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestCommandLineProjectWithRelativePathOutsideProjectCone()
         {
-            string commandLine = @"..\goo.cs";
+            var commandLine = @"..\goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestCreateWithoutRequiredServices()
         {
-            string commandLine = @"goo.cs";
+            var commandLine = @"goo.cs";
 
             Assert.Throws<InvalidOperationException>(delegate
             {
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestCreateWithRequiredServices()
         {
-            string commandLine = @"goo.cs";
+            var commandLine = @"goo.cs";
             var ws = new AdhocWorkspace(DesktopMefHostServices.DefaultServices); // includes non-portable services too
             _ = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory", ws);
         }
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestUnrootedPathInsideProjectCone()
         {
-            string commandLine = @"goo.cs";
+            var commandLine = @"goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestUnrootedSubPathInsideProjectCone()
         {
-            string commandLine = @"subdir\goo.cs";
+            var commandLine = @"subdir\goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestRootedPathInsideProjectCone()
         {
-            string commandLine = @"c:\ProjectDirectory\goo.cs";
+            var commandLine = @"c:\ProjectDirectory\goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestRootedSubPathInsideProjectCone()
         {
-            string commandLine = @"c:\projectDirectory\subdir\goo.cs";
+            var commandLine = @"c:\projectDirectory\subdir\goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestRootedPathOutsideProjectCone()
         {
-            string commandLine = @"C:\SomeDirectory\goo.cs";
+            var commandLine = @"C:\SomeDirectory\goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestUnrootedPathOutsideProjectCone()
         {
-            string commandLine = @"..\goo.cs";
+            var commandLine = @"..\goo.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var docInfo = info.Documents.First();
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestAdditionalFiles()
         {
-            string commandLine = @"goo.cs /additionalfile:bar.cs";
+            var commandLine = @"goo.cs /additionalfile:bar.cs";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
 
             var firstDoc = info.Documents.Single();
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var pathToAssembly = typeof(object).Assembly.Location;
             var assemblyBaseDir = Path.GetDirectoryName(pathToAssembly);
             var relativePath = Path.Combine(".", Path.GetFileName(pathToAssembly));
-            string commandLine = @"goo.cs /a:" + relativePath;
+            var commandLine = @"goo.cs /a:" + relativePath;
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, assemblyBaseDir);
 
             var firstDoc = info.Documents.Single();

--- a/src/Workspaces/DesktopTest/CommandLineProjectWorkspaceTests.cs
+++ b/src/Workspaces/DesktopTest/CommandLineProjectWorkspaceTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestLoadProjectFromCommandLine()
         {
-            string commandLine = @"goo.cs subdir\bar.cs /out:goo.dll /target:library";
+            var commandLine = @"goo.cs subdir\bar.cs /out:goo.dll /target:library";
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
             var ws = new AdhocWorkspace();
             ws.AddProject(info);

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3583,7 +3583,7 @@ class C { }";
 
             CreateFiles(files);
 
-            string expectedEditorConfigPath = SolutionDirectory.CreateOrOpenFile(".editorconfig").Path;
+            var expectedEditorConfigPath = SolutionDirectory.CreateOrOpenFile(".editorconfig").Path;
 
             using (var workspace = CreateMSBuildWorkspace())
             {

--- a/src/Workspaces/Remote/ServiceHub/Shared/RemoteEndPoint.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/RemoteEndPoint.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Remote
             Contract.ThrowIfFalse(_startedListening);
 
             // if this end-point is already disconnected do not log more errors:
-            bool logError = _disconnectedReason == null;
+            var logError = _disconnectedReason == null;
 
             try
             {
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Remote
             Contract.ThrowIfFalse(_startedListening);
 
             // if this end-point is already disconnected do not log more errors:
-            bool logError = _disconnectedReason == null;
+            var logError = _disconnectedReason == null;
 
             try
             {
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Remote
             Contract.ThrowIfFalse(_startedListening);
 
             // if this end-point is already disconnected do not log more errors:
-            bool logError = _disconnectedReason == null;
+            var logError = _disconnectedReason == null;
 
             using var linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var pipe = new NamedPipeClientStream(serverName: ".", pipeName, PipeDirection.Out);
 
-                bool success = false;
+                var success = false;
                 try
                 {
                     await ConnectPipeAsync(pipe, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars
             // Second pass.  Convert those characters to Runes.
             using var _2 = ArrayBuilder<VirtualChar>.GetInstance(out var runeResults);
 
-            for (int i = 0; i < charResults.Count;)
+            for (var i = 0; i < charResults.Count;)
             {
                 var (ch, span) = charResults[i];
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static IEnumerable<SyntaxNode> GetAncestors(this SyntaxNode node)
         {
-            SyntaxNode? current = node.Parent;
+            var current = node.Parent;
 
             while (current != null)
             {
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static IEnumerable<TNode> GetAncestors<TNode>(this SyntaxNode node)
             where TNode : SyntaxNode
         {
-            SyntaxNode? current = node.Parent;
+            var current = node.Parent;
             while (current != null)
             {
                 if (current is TNode tNode)
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static TNode? GetAncestor<TNode>(this SyntaxNode node)
             where TNode : SyntaxNode
         {
-            SyntaxNode? current = node.Parent;
+            var current = node.Parent;
             while (current != null)
             {
                 if (current is TNode tNode)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PublicContract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PublicContract.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
         {
             using var _ = PooledHashSet<T>.GetInstance(out var set);
 
-            int i = 0;
+            var i = 0;
             foreach (var item in sequence)
             {
                 if (item is null || !set.Add(item))
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis
 
         private static int IndexOfNullOrDuplicateItem<T>(this IReadOnlyList<T> list) where T : class
         {
-            int length = list.Count;
+            var length = list.Count;
 
             if (length == 0)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis
 
             using var _ = PooledHashSet<T>.GetInstance(out var set);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 var item = list[i];
                 if (item is null || !set.Add(item))
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis
         private static void ThrowArgumentItemNullOrDuplicateException<T>(IEnumerable<T> sequence, string argumentName) where T : class
         {
             var list = sequence.ToList();
-            int index = list.IndexOfNullOrDuplicateItem();
+            var index = list.IndexOfNullOrDuplicateItem();
 
             argumentName = MakeIndexedArgumentName(argumentName, index);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SerializableBytes.cs
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis
                     Array.Clear(chunks[chunkIndex], chunkOffset, chunks[chunkIndex].Length - chunkOffset);
 
                     var trimIndex = chunkIndex + 1;
-                    for (int i = trimIndex; i < chunks.Count; i++)
+                    for (var i = trimIndex; i < chunks.Count; i++)
                     {
                         SharedPools.ByteArray.Free(chunks[i]);
                     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AbstractAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AbstractAddImportsService.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.AddImports
         {
             var usingDirective = contextNode.GetAncestor<TUsingOrAliasSyntax>();
 
-            SyntaxNode? node = usingDirective != null ? usingDirective.Parent! : contextNode;
+            var node = usingDirective != null ? usingDirective.Parent! : contextNode;
             return node.GetAncestor<TNamespaceDeclarationSyntax>() ??
                    (SyntaxNode?)node.GetAncestorOrThis<TCompilationUnitSyntax>();
         }


### PR DESCRIPTION
Only manual changes were done in https://github.com/dotnet/roslyn/commit/b884a4d63f08cc76f278fd7264a3a32e71c791a4, https://github.com/dotnet/roslyn/commit/8db8f7d9e50e9f8c1cc3195dc2deccb50d5bf6af and https://github.com/dotnet/roslyn/commit/bbb005e07d8c7486ca1e897ce383645445243017

```ini
[src/{Analyzers,CodeStyle,Features,Workspaces}/**/*.{cs,vb}]

# Prefer "var" everywhere
dotnet_diagnostic.IDE0007.severity = warning
csharp_style_var_for_built_in_types = true:warning
csharp_style_var_when_type_is_apparent = true:warning
csharp_style_var_elsewhere = true:warning
```
