### PR TITLE
Fix for 'and' and 'or' keyword completion appearing in invalid locations

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AndKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AndKeywordRecommenderTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
@@ -512,6 +513,25 @@ namespace N
         {
             await VerifyAbsenceAsync(AddInsideMethod(InitializeObjectE +
 @"if (e is int)$$"));
+        }
+
+        [WorkItem(44396, "https://github.com/dotnet/roslyn/issues/44396")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterColonColonPatternSyntax()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(InitializeObjectE +
+@"if (e is null or global::$$) { }"));
+        }
+
+        [WorkItem(44396, "https://github.com/dotnet/roslyn/issues/44396")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterColonColonPatternSyntax_SwitchExpression()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(InitializeObjectE +
+@"var x = false;
+x = e switch
+{
+    global::$$"));
         }
 #endif
     }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/OrKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/OrKeywordRecommenderTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
@@ -512,6 +513,25 @@ namespace N
         {
             await VerifyAbsenceAsync(AddInsideMethod(InitializeObjectE +
 @"if (e is int)$$"));
+        }
+
+        [WorkItem(44396, "https://github.com/dotnet/roslyn/issues/44396")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterColonColonPatternSyntax()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(InitializeObjectE +
+@"if (e is null or global::$$) { }"));
+        }
+
+        [WorkItem(44396, "https://github.com/dotnet/roslyn/issues/44396")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterColonColonPatternSyntax_SwitchExpression()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(InitializeObjectE +
+@"var x = false;
+x = e switch
+{
+    global::$$"));
         }
 #endif
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SyntaxKindEx.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public const SyntaxKind NotPattern = (SyntaxKind)9033;
         public const SyntaxKind AndKeyword = (SyntaxKind)8439;
         public const SyntaxKind OrKeyword = (SyntaxKind)8438;
+        public const SyntaxKind NotKeyword = (SyntaxKind)8440;
 
 #if !CODE_STYLE
         private const uint ImplicitObjectCreationExpressionAssertion = -(ImplicitObjectCreationExpression - SyntaxKind.ImplicitObjectCreationExpression);
@@ -44,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         private const uint NotPatternValueAssertion = -(NotPattern - SyntaxKind.NotPattern);
         private const uint AndKeywordValueAssertion = -(AndKeyword - SyntaxKind.AndKeyword);
         private const uint OrKeywordValueAssertion = -(OrKeyword - SyntaxKind.OrKeyword);
+        private const uint NotKeywordValueAssertion = -(NotKeyword - SyntaxKind.NotKeyword);
 #endif
     }
 }


### PR DESCRIPTION
Fixes #44396.
Also removes some unnecessary CODE_STYLE checks.