### PR TITLE
Disable NuGet restore within Visual Studio

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <configuration>
+  <packageRestore>
+    <!-- NuGet Restore was observed to cause performance problems for in-IDE builds,
+         so it has been disabled. https://github.com/dotnet/arcade/issues/5550
+ 
+         ⚠ THIS IS A PERFORMANCE-CRITICAL LINE. DO NOT REMOVE. ⚠ -->
+    <add key="enabled" value="false" />
+  </packageRestore>
   <packageSources>
     <clear />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />


### PR DESCRIPTION
The in-IDE restore operation does not produce bitwise identical results to the command line **Restore.cmd** script, which results in unavoidable performance degradations during daily developer scenarios such as branch switches and merges. This change disables the IDE restore operation, so all experiences rely on the **Restore.cmd** script for uniform behavior.

Unblocks #44034
See dotnet/arcade#5172