### PR TITLE
Code fix for CS1615 (Remove 'in' keyword)

### DIFF
--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -74,5 +74,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string PreferFrameworkType = nameof(PreferFrameworkType);
         public const string MakeStructFieldsWritable = nameof(MakeStructFieldsWritable);
         public const string AddExplicitCast = nameof(AddExplicitCast);
+        public const string RemoveIn = nameof(RemoveIn);
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveInKeyword/RemoveInKeywordCodeFixProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveInKeyword/RemoveInKeywordCodeFixProviderTests.cs
@@ -1,0 +1,244 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveInKeyword;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveInKeyword
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveInKeyword)]
+    public class RemoveInKeywordCodeFixProviderTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (null, new RemoveInKeywordCodeFixProvider());
+
+        [Fact]
+        public async Task TestRemoveInKeyword()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void M(int i) { }
+    void N(int i)
+    {
+        M(in [|i|]);
+    }
+}",
+@"class Class
+{
+    void M(int i) { }
+    void N(int i)
+    {
+        M(i);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRemoveInKeywordMultipleArguments1()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void M(int i, string s) { }
+    void N(int i, string s)
+    {
+        M(in [|i|], s);
+    }
+}",
+@"class Class
+{
+    void M(int i, string s) { }
+    void N(int i, string s)
+    {
+        M(i, s);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRemoveInKeywordMultipleArguments2()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void M(int i, int j) { }
+    void N(int i, int j)
+    {
+        M(in [|i|], in j);
+    }
+}",
+@"class Class
+{
+    void M(int i, int j) { }
+    void N(int i, int j)
+    {
+        M(i, in j);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRemoveInKeywordMultipleArgumentsWithDifferentRefKinds()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void M(in int i, string s) { }
+    void N(int i, string s)
+    {
+        M(in i, in [|s|]);
+    }
+}",
+@"class Class
+{
+    void M(in int i, string s) { }
+    void N(int i, string s)
+    {
+        M(in i, s);
+    }
+}");
+        }
+
+        [Theory]
+        [InlineData("in    [|i|]", "i")]
+        [InlineData("  in  [|i|]", "  i")]
+        [InlineData("/* start */in [|i|]", "/* start */i")]
+        [InlineData("/* start */ in [|i|]", "/* start */ i")]
+        [InlineData(
+            "/* start */ in [|i|] /* end */",
+            "/* start */ i /* end */")]
+        [InlineData(
+            "/* start */ in /* middle */ [|i|] /* end */",
+            "/* start */ i /* end */")]
+        [InlineData(
+            "/* start */ in    /* middle */ [|i|] /* end */",
+            "/* start */ i /* end */")]
+        [InlineData(
+            "/* start */in /* middle */ [|i|] /* end */",
+            "/* start */i /* end */")]
+        public async Task TestRemoveInKeywordWithTrivia(string original, string expected)
+        {
+            await TestInRegularAndScript1Async(
+$@"class App
+{{
+    void M(int i) {{ }}
+    void N(int i)
+    {{
+        M({original});
+    }}
+
+}}",
+$@"class App
+{{
+    void M(int i) {{ }}
+    void N(int i)
+    {{
+        M({expected});
+    }}
+
+}}");
+        }
+
+        [Fact]
+        public async Task TestRemoveInKeywordFixAllInDocument1()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void M1(int i) { }
+    void M2(int i, string s) { }
+
+    void N1(int i)
+    {
+        M1(in {|FixAllInDocument:i|});
+    }
+
+    void N2(int i, string s)
+    {
+        M2(in i, in s);
+    }
+
+    void N3(int i, string s)
+    {
+        M1(in i);
+        M2(in i, in s);
+    }
+}",
+@"class Class
+{
+    void M1(int i) { }
+    void M2(int i, string s) { }
+
+    void N1(int i)
+    {
+        M1(i);
+    }
+
+    void N2(int i, string s)
+    {
+        M2(i, s);
+    }
+
+    void N3(int i, string s)
+    {
+        M1(i);
+        M2(i, s);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRemoveInKeywordFixAllInDocument2()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void M1(int i) { }
+    void M2(in int i, string s) { }
+
+    void N1(int i)
+    {
+        M1(in {|FixAllInDocument:i|});
+    }
+
+    void N2(int i, string s)
+    {
+        M2(in i, in s);
+    }
+
+    void N3(int i, string s)
+    {
+        M1(in i);
+        M2(in i, in s);
+    }
+}",
+@"class Class
+{
+    void M1(int i) { }
+    void M2(in int i, string s) { }
+
+    void N1(int i)
+    {
+        M1(i);
+    }
+
+    void N2(int i, string s)
+    {
+        M2(in i, s);
+    }
+
+    void N3(int i, string s)
+    {
+        M1(i);
+        M2(in i, s);
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveInKeyword/RemoveInKeywordCodeFixProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveInKeyword/RemoveInKeywordCodeFixProviderTests.cs
@@ -105,6 +105,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveInKey
 }");
         }
 
+        [Fact]
+        public async Task TestDontRemoveInKeyword()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Class
+{
+    void M(in int i) { }
+    void N(int i)
+    {
+        M(in [|i|]);
+    }
+}");
+        }
+
         [Theory]
         [InlineData("in    [|i|]", "i")]
         [InlineData("  in  [|i|]", "  i")]

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -623,5 +623,6 @@
   </data>
   <data name="Remove_in_keyword" xml:space="preserve">
     <value>Remove 'in' keyword</value>
+    <comment>{Locked="in"} "in" is a C# keyword and should not be localized.</comment>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -621,4 +621,7 @@
     <value>Apply preferred 'using' placement preferences</value>
     <comment>'using' is a C# keyword and should not be localized</comment>
   </data>
+  <data name="Remove_in_keyword" xml:space="preserve">
+    <value>Remove 'in' keyword</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/CodeFixes/RemoveInKeyword/RemoveInKeywordCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/RemoveInKeyword/RemoveInKeywordCodeFixProvider.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveInKeyword
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.RemoveIn), Shared]
+    internal class RemoveInKeywordCodeFixProvider : CodeFixProvider
+    {
+        private const string CS1615 = nameof(CS1615); // Argument 1 may not be passed with the 'in' keyword
+
+        [ImportingConstructor]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        public RemoveInKeywordCodeFixProvider()
+        {
+        }
+
+        public override FixAllProvider GetFixAllProvider()
+            => WellKnownFixAllProviders.BatchFixer;
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CS1615);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var token = root.FindToken(diagnosticSpan.Start);
+
+            var argumentSyntax = token.GetAncestor<ArgumentSyntax>();
+            if (argumentSyntax == null || argumentSyntax.GetRefKind() != RefKind.In)
+                return;
+
+            var generator = context.Document.GetRequiredLanguageService<SyntaxGenerator>();
+
+            context.RegisterCodeFix(
+                new MyCodeAction(ct => FixAsync(context.Document, generator, argumentSyntax, ct)),
+                context.Diagnostics);
+        }
+
+        private static async Task<Document> FixAsync(
+            Document document,
+            SyntaxGenerator generator,
+            ArgumentSyntax argumentSyntax,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            return document.WithSyntaxRoot(root.ReplaceNode(
+                argumentSyntax,
+                generator.Argument(generator.SyntaxFacts.GetExpressionOfArgument(argumentSyntax))));
+        }
+
+        private class MyCodeAction : CustomCodeActions.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Remove_in_keyword,
+                    createChangedDocument,
+                    CSharpFeaturesResources.Remove_in_keyword)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeFixes/RemoveInKeyword/RemoveInKeywordCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/RemoveInKeyword/RemoveInKeywordCodeFixProvider.cs
@@ -47,20 +47,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveInKeyword
             if (argumentSyntax == null || argumentSyntax.GetRefKind() != RefKind.In)
                 return;
 
-            var generator = context.Document.GetRequiredLanguageService<SyntaxGenerator>();
-
             context.RegisterCodeFix(
-                new MyCodeAction(ct => FixAsync(context.Document, generator, argumentSyntax, ct)),
-                context.Diagnostics);
+                new MyCodeAction(ct => FixAsync(context.Document, argumentSyntax, ct)), context.Diagnostics);
         }
 
         private static async Task<Document> FixAsync(
             Document document,
-            SyntaxGenerator generator,
             ArgumentSyntax argumentSyntax,
             CancellationToken cancellationToken)
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
 
             return document.WithSyntaxRoot(root.ReplaceNode(
                 argumentSyntax,

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Nastavit jako ref struct</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -142,6 +142,11 @@
         <target state="translated">"ref struct" erstellen</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Convertir "ref struct"</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Définir 'ref struct'</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Imposta come 'ref struct'</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -142,6 +142,11 @@
         <target state="translated">'ref struct' を作成します</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -142,6 +142,11 @@
         <target state="translated">'ref struct'로 지정</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Ustaw jako „ref struct”</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Alterar 'ref struct'</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Сделать ref struct</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">'ref struct' yap</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="translated">生成 "ref struct"</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="Remove_in_keyword">
         <source>Remove 'in' keyword</source>
         <target state="new">Remove 'in' keyword</target>
-        <note />
+        <note>{Locked="in"} "in" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="translated">設為 'ref struct'</target>
         <note>{Locked="ref"}{Locked="struct"} "ref" and "struct" are C# keywords and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Remove_in_keyword">
+        <source>Remove 'in' keyword</source>
+        <target state="new">Remove 'in' keyword</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Remove_new_modifier">
         <source>Remove 'new' modifier</source>
         <target state="new">Remove 'new' modifier</target>

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -133,6 +133,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsQualifyMemberAccess = "CodeActions.QualifyMemberAccess";
             public const string CodeActionsRemoveByVal = "CodeActions.RemoveByVal";
             public const string CodeActionsRemoveDocCommentNode = "CodeActions.RemoveDocCommentNode";
+            public const string CodeActionsRemoveInKeyword = "CodeActions.RemoveInKeyword";
             public const string CodeActionsRemoveUnnecessarySuppressions = "CodeActions.RemoveUnnecessarySuppressions";
             public const string CodeActionsRemoveUnnecessaryCast = "CodeActions.RemoveUnnecessaryCast";
             public const string CodeActionsRemoveUnnecessaryImports = "CodeActions.RemoveUnnecessaryImports";


### PR DESCRIPTION
Closes #44187 

I'm not sure about handling 'in' keyword's trivia. Should we keep it and prepend to the argument or just remove the keyword with its trivia?