### PR TITLE
Restore 'generate constructor (without fields)'

### DIFF
--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.CodeAction.cs
@@ -46,6 +46,8 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 => _withFields
                     ? string.Format(FeaturesResources.Generate_constructor_in_0, _state.TypeToGenerateIn.Name)
                     : string.Format(FeaturesResources.Generate_constructor_in_0_without_fields, _state.TypeToGenerateIn.Name);
+
+            public override string EquivalenceKey => Title;
         }
     }
 }


### PR DESCRIPTION
Note: looks like a hole in the testing harness.  We have tests for this feature, but it looks like it doesn't go through the normal codefixservice path that filters out actions with the same equivalence key.