### PR TITLE
Don't call abstract override in base class when generating Equals/GetHashCode

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -3190,5 +3190,51 @@ partial class Goo
 chosenSymbols: new[] { "bar" },
 index: 1);
         }
+
+        [WorkItem(43290, "https://github.com/dotnet/roslyn/issues/43290")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestAbstractBase()
+        {
+            await TestInRegularAndScript1Async(
+@"namespace System { public struct HashCode { } }
+
+abstract class Base
+{
+    public abstract override bool Equals(object? obj);
+    public abstract override int GetHashCode();
+}
+
+class Derived : Base
+{
+    [|public int P { get; }|]
+}",
+@"using System;
+
+namespace System { public struct HashCode { } }
+
+abstract class Base
+{
+    public abstract override bool Equals(object? obj);
+    public abstract override int GetHashCode();
+}
+
+class Derived : Base
+{
+    public int P { get; }
+
+    public override bool Equals(object obj)
+    {
+        return obj is Derived derived &&
+               P == derived.P;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(P);
+    }
+}",
+index: 1,
+parameters: CSharpLatest);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
@@ -734,5 +734,58 @@ index:=1)
     Private [|a|] As Integer
 End Class")
         End Function
+
+        <WorkItem(43290, "https://github.com/dotnet/roslyn/issues/43290")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
+        Public Async Function TestAbstractBase() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Namespace System
+    Public Class HashCode
+    End Class
+End Namespace
+
+MustInherit Class Base
+    Public MustOverride Overrides Function Equals(obj As Object) As Boolean
+    Public MustOverride Overrides Function GetHashCode() As Integer
+End Class
+
+Class Derived
+    Inherits Base
+
+    [|Public P As Integer|]
+End Class
+",
+"
+Imports System
+
+Namespace System
+    Public Class HashCode
+    End Class
+End Namespace
+
+MustInherit Class Base
+    Public MustOverride Overrides Function Equals(obj As Object) As Boolean
+    Public MustOverride Overrides Function GetHashCode() As Integer
+End Class
+
+Class Derived
+    Inherits Base
+
+    Public P As Integer
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        Dim derived = TryCast(obj, Derived)
+        Return derived IsNot Nothing AndAlso
+               P = derived.P
+    End Function
+
+    Public Overrides Function GetHashCode() As Integer
+        Return HashCode.Combine(P)
+    End Function
+End Class
+",
+index:=1)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -382,7 +382,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                       !method.IsStatic &&
                       method.Parameters.Length == 1 &&
                       method.ReturnType.SpecialType == SpecialType.System_Boolean &&
-                      method.Parameters[0].Type.SpecialType == SpecialType.System_Object
+                      method.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
+                      !method.IsAbstract
                 select method;
 
             return existingMethods.Any();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_CreateGetHashCodeMethod.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_CreateGetHashCodeMethod.cs
@@ -208,7 +208,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                       method.DeclaredAccessibility == Accessibility.Public &&
                       !method.IsStatic &&
                       method.Parameters.Length == 0 &&
-                      method.ReturnType.SpecialType == SpecialType.System_Int32
+                      method.ReturnType.SpecialType == SpecialType.System_Int32 &&
+                      !method.IsAbstract
                 select method;
 
             return existingMethods.FirstOrDefault();


### PR DESCRIPTION
Fixes #43290