### PR TITLE
Log telemetry on servicehub process start.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         public static async Task<RemoteHostClient> CreateAsync(HostWorkspaceServices services, CancellationToken cancellationToken)
         {
-            using (Logger.LogBlock(FunctionId.ServiceHubRemoteHostClient_CreateAsync, cancellationToken))
+            using (Logger.LogBlock(FunctionId.ServiceHubRemoteHostClient_CreateAsync, KeyValueLogMessage.NoProperty, cancellationToken))
             {
                 Logger.Log(FunctionId.RemoteHost_Bitness, KeyValueLogMessage.Create(LogType.Trace, m => m["64bit"] = RemoteHostOptions.IsServiceHubProcess64Bit(services)));
 


### PR DESCRIPTION
Was trying to investigate timeouts on starting the LSP server (which starts on solution load and waits for the OOP to start).  Wanted to get an idea of how long in general it takes to better inform the timeouts in the LSP client, but this data point was not being included in VS telemetry.