### PR TITLE
Revert "always partition tests assemblies"

### DIFF
--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -6,12 +6,16 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using RunTests.Cache;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 using System.Collections.Immutable;
 using Newtonsoft.Json;
+using System.Reflection;
 using System.Diagnostics;
 
 namespace RunTests
@@ -292,7 +296,23 @@ namespace RunTests
 
             foreach (var assemblyPath in options.Assemblies.OrderByDescending(x => new FileInfo(x).Length))
             {
-                list.AddRange(scheduler.Schedule(assemblyPath));
+                var name = Path.GetFileName(assemblyPath);
+
+                // As a starting point we will just schedule the items we know to be a performance
+                // bottleneck.  Can adjust as we get real data.
+                if (name == "Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll" ||
+                    name == "Microsoft.CodeAnalysis.EditorFeatures.UnitTests.dll" ||
+                    name == "Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" ||
+                    name == "Microsoft.VisualStudio.LanguageServices.UnitTests.dll" ||
+                    name == "Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll" ||
+                    name == "Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.dll")
+                {
+                    list.AddRange(scheduler.Schedule(assemblyPath));
+                }
+                else
+                {
+                    list.Add(scheduler.CreateAssemblyInfo(assemblyPath));
+                }
             }
 
             return list;


### PR DESCRIPTION
Reverts dotnet/roslyn#43539

test to see if this change was the cause of the unit test time regression.