### PR TITLE
Fix exception in declare-as-nullable code fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -833,6 +833,22 @@ class Program
         }
 
         [Fact]
+        [WorkItem(44338, "https://github.com/dotnet/roslyn/issues/44338")]
+        public async Task NoFixInvocationOfExternalMethod_NamedArgument()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"#nullable enable
+class Program
+{
+    void M()
+    {
+        var list = new System.Collections.Generic.List<string>();
+        list.Add(item: [|null|]);
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task FixInvocation_NamedArgument_OutOfOrder()
         {
             await TestInRegularAndScript1Async(
@@ -853,6 +869,22 @@ class Program
         M2(x: null, i: 1);
     }
     void M2(int i, string? x) { }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        [WorkItem(44338, "https://github.com/dotnet/roslyn/issues/44338")]
+        public async Task NoFixInvocationOfExternalMethod_NamedArgument_OutOfOrder()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"#nullable enable
+class Program
+{
+    void M()
+    {
+        var dict = new System.Collections.Generic.Dictionary<string, int>();
+        dict.Add(value: 0, key: [|null|]);
+    }
 }", parameters: s_nullableFeature);
         }
 
@@ -893,6 +925,22 @@ class Program
         M2(null);
     }
     void M2(string? x) { }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        [WorkItem(44338, "https://github.com/dotnet/roslyn/issues/44338")]
+        public async Task NoFixInvocationOfExternalMethod_PositionArgument()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"#nullable enable
+class Program
+{
+    void M()
+    {
+        var list = new System.Collections.Generic.List<string>();
+        list.Add([|null|]);
+    }
 }", parameters: s_nullableFeature);
         }
 

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -332,7 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
             static TypeSyntax? TryGetParameterTypeSyntax(IParameterSymbol? parameterSymbol)
             {
                 if (parameterSymbol is object &&
-                    parameterSymbol.DeclaringSyntaxReferences[0].GetSyntax() is ParameterSyntax parameterSyntax &&
+                    parameterSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is ParameterSyntax parameterSyntax &&
                     parameterSymbol.ContainingSymbol is IMethodSymbol method &&
                     method.GetAllMethodSymbolsOfPartialParts().Length == 1)
                 {


### PR DESCRIPTION
Fixes #44338

`IParameterSymbol.DeclaringSyntaxReferences` will be empty if the analyzed method call is targeting a method with no source code available (external assembly).