### PR TITLE
Clean up error messages for address of to non-function-pointer types.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2354,7 +2354,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.UnconvertedAddressOfOperator:
                     {
-                        diagnostics.Add(ErrorCode.ERR_AddressOfToNonFunctionPointer , syntax.Location, ((BoundUnconvertedAddressOfOperator)operand).Operand.Name, targetType);
+                        var errorCode = targetType.TypeKind switch
+                        {
+                            TypeKind.FunctionPointer => ErrorCode.ERR_MethFuncPtrMismatch,
+                            TypeKind.Delegate => ErrorCode.ERR_CannotConvertAddressOfToDelegate,
+                            _ => ErrorCode.ERR_AddressOfToNonFunctionPointer
+                        };
+
+                        diagnostics.Add(errorCode, syntax.Location, ((BoundUnconvertedAddressOfOperator)operand).Operand.Name, targetType);
                         return;
                     }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2352,6 +2352,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         GenerateImplicitConversionError(diagnostics, operand.Syntax, conversion, operand, targetType);
                         return;
                     }
+                case BoundKind.UnconvertedAddressOfOperator:
+                    {
+                        diagnostics.Add(ErrorCode.ERR_AddressOfToNonFunctionPointer , syntax.Location, ((BoundUnconvertedAddressOfOperator)operand).Operand.Name, targetType);
+                        return;
+                    }
             }
 
             Debug.Assert((object)operand.Type != null);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2138,12 +2138,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.MethodGroup:
                     {
-                        reportMethodGroupErrors((BoundMethodGroup)operand);
+                        reportMethodGroupErrors((BoundMethodGroup)operand, fromFunctionPtr: false);
                         return;
                     }
                 case BoundKind.UnconvertedAddressOfOperator:
                     {
-                        reportMethodGroupErrors(((BoundUnconvertedAddressOfOperator)operand).Operand);
+                        reportMethodGroupErrors(((BoundUnconvertedAddressOfOperator)operand).Operand, fromFunctionPtr: true);
                         return;
                     }
                 case BoundKind.Literal:
@@ -2204,7 +2204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(operand.HasAnyErrors && operand.Kind != BoundKind.UnboundLambda, "Missing a case in implicit conversion error reporting");
 
-            void reportMethodGroupErrors(BoundMethodGroup methodGroup)
+            void reportMethodGroupErrors(BoundMethodGroup methodGroup, bool fromFunctionPtr)
             {
                 if (!Conversions.ReportDelegateOrFunctionPointerMethodGroupDiagnostics(this, methodGroup, targetType, diagnostics))
                 {
@@ -2230,19 +2230,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     switch (targetType.TypeKind)
                     {
-                        case TypeKind.FunctionPointer:
-                            if (operand.Kind == BoundKind.MethodGroup)
-                            {
-                                Error(diagnostics, ErrorCode.ERR_MissingAddressOf, location);
-                                return;
-                            }
+                        case TypeKind.FunctionPointer when fromFunctionPtr:
                             errorCode = ErrorCode.ERR_MethFuncPtrMismatch;
+                            break;
+                        case TypeKind.FunctionPointer:
+                            Error(diagnostics, ErrorCode.ERR_MissingAddressOf, location);
+                            return;
+                        case TypeKind.Delegate when fromFunctionPtr:
+                            errorCode = ErrorCode.ERR_CannotConvertAddressOfToDelegate;
                             break;
                         case TypeKind.Delegate:
                             errorCode = ErrorCode.ERR_MethDelegateMismatch;
                             break;
                         default:
-                            errorCode = ErrorCode.ERR_MethGrpToNonDel;
+                            errorCode = fromFunctionPtr ? ErrorCode.ERR_AddressOfToNonFunctionPointer : ErrorCode.ERR_MethGrpToNonDel;
                             break;
                     }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2138,12 +2138,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.MethodGroup:
                     {
-                        reportMethodGroupErrors((BoundMethodGroup)operand, fromFunctionPtr: false);
+                        reportMethodGroupErrors((BoundMethodGroup)operand, fromAddressOf: false);
                         return;
                     }
                 case BoundKind.UnconvertedAddressOfOperator:
                     {
-                        reportMethodGroupErrors(((BoundUnconvertedAddressOfOperator)operand).Operand, fromFunctionPtr: true);
+                        reportMethodGroupErrors(((BoundUnconvertedAddressOfOperator)operand).Operand, fromAddressOf: true);
                         return;
                     }
                 case BoundKind.Literal:
@@ -2204,7 +2204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(operand.HasAnyErrors && operand.Kind != BoundKind.UnboundLambda, "Missing a case in implicit conversion error reporting");
 
-            void reportMethodGroupErrors(BoundMethodGroup methodGroup, bool fromFunctionPtr)
+            void reportMethodGroupErrors(BoundMethodGroup methodGroup, bool fromAddressOf)
             {
                 if (!Conversions.ReportDelegateOrFunctionPointerMethodGroupDiagnostics(this, methodGroup, targetType, diagnostics))
                 {
@@ -2230,20 +2230,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     switch (targetType.TypeKind)
                     {
-                        case TypeKind.FunctionPointer when fromFunctionPtr:
+                        case TypeKind.FunctionPointer when fromAddressOf:
                             errorCode = ErrorCode.ERR_MethFuncPtrMismatch;
                             break;
                         case TypeKind.FunctionPointer:
                             Error(diagnostics, ErrorCode.ERR_MissingAddressOf, location);
                             return;
-                        case TypeKind.Delegate when fromFunctionPtr:
+                        case TypeKind.Delegate when fromAddressOf:
                             errorCode = ErrorCode.ERR_CannotConvertAddressOfToDelegate;
                             break;
                         case TypeKind.Delegate:
                             errorCode = ErrorCode.ERR_MethDelegateMismatch;
                             break;
                         default:
-                            errorCode = fromFunctionPtr ? ErrorCode.ERR_AddressOfToNonFunctionPointer : ErrorCode.ERR_MethGrpToNonDel;
+                            errorCode = fromAddressOf ? ErrorCode.ERR_AddressOfToNonFunctionPointer : ErrorCode.ERR_MethGrpToNonDel;
                             break;
                     }
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6146,7 +6146,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Cannot convert method group to function pointer (Are you missing a '&amp;'?)</value>
   </data>
   <data name="ERR_CannotUseReducedExtensionMethodInAddressOf" xml:space="preserve">
-    <value>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</value>
+    <value>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</value>
   </data>
   <data name="ERR_CannotUseFunctionPointerAsFixedLocal" xml:space="preserve">
     <value>The type of a local declared in a fixed statement cannot be a function pointer type.</value>
@@ -6159,5 +6159,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="OutIsNotValidForReturn" xml:space="preserve">
     <value>'RefKind.Out' is not a valid ref kind for a return type.</value>
+  </data>
+  <data name="ERR_CannotConvertAddressOfToDelegate" xml:space="preserve">
+    <value>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</value>
+  </data>
+  <data name="ERR_AddressOfToNonFunctionPointer" xml:space="preserve">
+    <value>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -2115,6 +2115,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     type = null;
                     nullability = new NullabilityInfo(CodeAnalysis.NullableAnnotation.NotAnnotated, CodeAnalysis.NullableFlowState.NotNull);
                 }
+                else if (boundExpr == highestBoundNode && boundExpr is BoundUnconvertedAddressOfOperator && boundNodeForSyntacticParent is BoundConversion { ExplicitCastInCode: true })
+                {
+                    // There was an explicit cast of an address of to a type it wasn't compatible with.
+                    type = null;
+                    convertedType = null;
+                    convertedNullability = nullability;
+                    conversion = Conversion.NoConversion;
+                }
                 else
                 {
                     convertedType = type;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -2115,14 +2115,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     type = null;
                     nullability = new NullabilityInfo(CodeAnalysis.NullableAnnotation.NotAnnotated, CodeAnalysis.NullableFlowState.NotNull);
                 }
-                else if (boundExpr == highestBoundNode && boundExpr is BoundUnconvertedAddressOfOperator && boundNodeForSyntacticParent is BoundConversion { ExplicitCastInCode: true })
-                {
-                    // There was an explicit cast of an address of to a type it wasn't compatible with.
-                    type = null;
-                    convertedType = null;
-                    convertedNullability = nullability;
-                    conversion = Conversion.NoConversion;
-                }
                 else
                 {
                     convertedType = type;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1806,6 +1806,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidFuncPointerReturnTypeModifier = 8797,
         ERR_DupReturnTypeMod = 8798,
         ERR_AddressOfMethodGroupInExpressionTree = 8799,
+        ERR_CannotConvertAddressOfToDelegate = 8800,
+        ERR_AddressOfToNonFunctionPointer = 8801,
 
         #endregion
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Pokud chcete pro interpolovaný doslovný řetězec použít @$ místo $@, použijte verzi jazyka {0} nebo vyšší.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Chyba syntaxe příkazového řádku: {0} není platná hodnota možnosti {1}. Hodnota musí mít tvar {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Um für eine interpolierte ausführliche Zeichenfolge "@$" anstelle von "$@" zu verwenden, benötigen Sie Sprachversion {0} oder höher.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Fehler in der Befehlszeilensyntax: "{0}" ist kein gültiger Wert für die Option "{1}". Der Wert muss im Format "{2}" vorliegen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Para usar "@$" en lugar de "$@" para una cadena textual interpolada, use la versión "{0}" del lenguaje o una posterior.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Error de sintaxis de la línea de comandos: "{0}" no es un valor válido para la opción "{1}". El valor debe tener el formato "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Pour utiliser '@$' à la place de '$@' pour une chaîne verbatim interpolée, utilisez la version de langage '{0}' ou une version ultérieure.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Erreur de syntaxe de ligne de commande : '{0}' est une valeur non valide pour l'option '{1}'. La valeur doit se présenter sous la forme '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Per usare '@$' invece di '$@' per una stringa verbatim interpolata, usare la versione '{0}' o versioni successive del linguaggio.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Errore di sintassi della riga di comando: '{0}' non è un valore valido per l'opzione '{1}'. Il valore deve essere espresso nel formato '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">挿入される逐語的文字列で '$@' の代わりに '@$' を使用するには、言語バージョン '{0}' 以上をご使用ください。</target>
@@ -117,14 +122,19 @@
         <target state="translated">コマンドライン構文エラー: '{0}' は、'{1}' オプションの有効な値ではありません。値は '{2}' の形式にする必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">보간된 축자 문자열에 '$@' 대신 '@$'를 사용하려면 언어 버전 '{0}' 이상을 사용하세요.</target>
@@ -117,14 +122,19 @@
         <target state="translated">명령줄 구문 오류: '{0}'은(는) '{1}' 옵션에 유효한 값이 아닙니다. 값은 '{2}' 형식이어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Aby użyć elementu „@$” zamiast elementu „$@” w interpolowanym ciągu dosłownym, użyj wersji języka „{0}” lub nowszej.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Błąd składni wiersza polecenia: „{0}” nie jest prawidłową wartością dla opcji „{1}”. Wartość musi mieć postać „{2}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Para usar '@$' em vez de '$@' em uma cadeia de caracteres verbatim interpolada, use a versão de linguagem {0} ou superior.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Erro de sintaxe de linha de comando: '{0}' não é um valor válido para a opção '{1}'. O valor precisa estar no formato '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">Чтобы применять "@$" вместо "$@" для интерполированной буквальной строки, следует использовать версию языка "{0}" или более позднюю.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Ошибка в синтаксисе командной строки: "{0}" не является допустимым значением для параметра "{1}". Значение должно иметь форму "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">İlişkilendirilmiş tam bir dize için '$@' yerine '@$' kullanmak amacıyla lütfen '{0}' veya daha yüksek bir dil sürümü kullanın.</target>
@@ -117,14 +122,19 @@
         <target state="translated">Komut satırı söz dizimi hatası: '{0}', '{1}' seçeneği için geçerli bir değer değil. Değer '{2}' biçiminde olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">若要对内插逐字字符串使用 "@$" 而不是 "$@"，请使用语言版本 {0} 或更高版本。</target>
@@ -117,14 +122,19 @@
         <target state="translated">命令行语法错误:“{0}”不是“{1}”选项的有效值。值的格式必须为 "{2}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="new">'&amp;' on method groups cannot be used in expression trees</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AddressOfToNonFunctionPointer">
+        <source>Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</source>
+        <target state="new">Cannot convert &amp; method group '{0}' to non-function pointer type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AltInterpolatedVerbatimStringsNotAvailable">
         <source>To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '{0}' or greater.</source>
         <target state="translated">若要在插入的逐字字串使用 '@$' 而不是 '$@'，請使用 '{0}' 或更高的語言版本。</target>
@@ -117,14 +122,19 @@
         <target state="translated">命令列語法錯誤: '{0}' 對 '{1}' 選項而言不是有效的值。此值的格式必須是 '{2}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
+        <source>Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</source>
+        <target state="new">Cannot convert a &amp; method group '{0}' to delegate type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotUseFunctionPointerAsFixedLocal">
         <source>The type of a local declared in a fixed statement cannot be a function pointer type.</source>
         <target state="new">The type of a local declared in a fixed statement cannot be a function pointer type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CannotUseReducedExtensionMethodInAddressOf">
-        <source>Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</source>
-        <target state="new">Cannot use a an extension method with a receiver as the target of a '&amp;' operator.</target>
+        <source>Cannot use an extension method with a receiver as the target of a '&amp;' operator.</source>
+        <target state="new">Cannot use an extension method with a receiver as the target of a '&amp;' operator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -3721,9 +3721,9 @@ class C
                 // (8,24): error CS0119: 'Action' is a type, which is not valid in the given context
                 //         Action ptr1 = (Action)&M;
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "Action").WithArguments("System.Action", "type").WithLocation(8, 24),
-                // (9,23): error CS8800: Cannot convert a '& method group' to delegate type 'Action'.
+                // (9,23): error CS8800: Cannot convert a & method group 'M' to delegate type 'M'.
                 //         Action ptr2 = &M;
-                Diagnostic(ErrorCode.ERR_CannotConvertAddressOfToDelegate, "&M").WithArguments("System.Action").WithLocation(9, 23)
+                Diagnostic(ErrorCode.ERR_CannotConvertAddressOfToDelegate, "&M").WithArguments("M", "System.Action").WithLocation(9, 23)
             );
 
 
@@ -3956,7 +3956,7 @@ unsafe class C
                 // (10,35): error CS8757: No overload for 'M1' matches function pointer 'delegate*<C, void>'
                 //         delegate*<C, void> ptr1 = &c.M1;
                 Diagnostic(ErrorCode.ERR_MethFuncPtrMismatch, "&c.M1").WithArguments("M1", "delegate*<C, void>").WithLocation(10, 35),
-                // (11,32): error CS8788: Cannot use a an extension method with a receiver as the target of a '&amp;' operator.
+                // (11,32): error CS8788: Cannot use an extension method with a receiver as the target of a '&amp;' operator.
                 //         delegate*<void> ptr2 = &c.M1;
                 Diagnostic(ErrorCode.ERR_CannotUseReducedExtensionMethodInAddressOf, "&c.M1").WithLocation(11, 32)
             );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -3598,9 +3598,9 @@ enum Color
                 // (40,15): error CS0211: Cannot take the address of the given expression
                 //         p = &(() => 1); //CS0211
                 Diagnostic(ErrorCode.ERR_InvalidAddrOp, "() => 1").WithLocation(40, 15),
-                // (41,13): error CS0428: Cannot convert method group 'M' to non-delegate type 'int*'. Did you intend to invoke the method?
+                // (41,13): error CS8801: Cannot convert & method group 'M' to non-function pointer type 'int*'.
                 //         p = &M; //CS0211
-                Diagnostic(ErrorCode.ERR_MethGrpToNonDel, "&M").WithArguments("M", "int*").WithLocation(41, 13),
+                Diagnostic(ErrorCode.ERR_AddressOfToNonFunctionPointer, "&M").WithArguments("M", "int*").WithLocation(41, 13),
                 // (42,15): error CS0211: Cannot take the address of the given expression
                 //         p = &(new System.Int32()); //CS0211
                 Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new System.Int32()").WithLocation(42, 15),

--- a/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     Assert.Empty(semanticInfo.MemberGroup);
                     var expectedConversionKind = (expectedType, expectedConvertedType, expectedSymbol) switch
                     {
-                        (null, null, object _) => ConversionKind.Identity,
+                        (null, null, _) => ConversionKind.Identity,
                         (_, _, null) => ConversionKind.NoConversion,
                         (_, _, _) => ConversionKind.MethodGroup,
                     };

--- a/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
@@ -181,7 +181,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.AddressOfExpression, Operand: var operand }:
                     // Members should only be accessible from the underlying operand
                     Assert.Empty(semanticInfo.MemberGroup);
-                    Assert.Equal(expectedSymbol is null ? ConversionKind.NoConversion : ConversionKind.MethodGroup, semanticInfo.ImplicitConversion.Kind);
+                    var expectedConversionKind = (expectedType, expectedConvertedType, expectedSymbol) switch
+                    {
+                        (null, null, object _) => ConversionKind.Identity,
+                        (_, _, null) => ConversionKind.NoConversion,
+                        (_, _, _) => ConversionKind.MethodGroup,
+                    };
+                    Assert.Equal(expectedConversionKind, semanticInfo.ImplicitConversion.Kind);
 
                     semanticInfo = model.GetSemanticInfoSummary(operand);
                     Assert.Null(semanticInfo.Type);


### PR DESCRIPTION
* Correctly error on direct cast to non-func ptr type
* Use better error message test.

Fixes https://github.com/dotnet/roslyn/issues/44489.
