### PR TITLE
Improve performance of SyntaxTreeIndex checksum computation.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -55,11 +55,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // We also want the checksum to change any time our serialization format changes.  If
             // the format has changed, all previous versions should be invalidated.
             var project = document.Project;
-
-            // This is the same logic the project itself uses here:
-            // https://github.com/dotnet/roslyn/blob/5e725e29186cc1b341b1a9b2baae73e34d245232/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs#L48
-            var serializer = project.Solution.Workspace.Services.GetService<ISerializerService>();
-            var parseOptionsChecksum = project.SupportsCompilation ? ChecksumCache.GetOrCreate(project.ParseOptions, _ => serializer.CreateChecksum(project.ParseOptions, cancellationToken)) : Checksum.Null;
+            var parseOptionsChecksum = project.State.GetParseOptionsChecksum(cancellationToken);
 
             var documentChecksumState = await document.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
             var textChecksum = documentChecksumState.Text;

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -54,8 +54,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             //
             // We also want the checksum to change any time our serialization format changes.  If
             // the format has changed, all previous versions should be invalidated.
-            var projectChecksumState = await document.Project.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-            var parseOptionsChecksum = projectChecksumState.ParseOptions;
+            var project = document.Project;
+
+            // This is the same logic the project itself uses here:
+            // https://github.com/dotnet/roslyn/blob/5e725e29186cc1b341b1a9b2baae73e34d245232/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs#L48
+            var serializer = project.Solution.Workspace.Services.GetService<ISerializerService>();
+            var parseOptionsChecksum = project.SupportsCompilation ? ChecksumCache.GetOrCreate(project.ParseOptions, _ => serializer.CreateChecksum(project.ParseOptions, cancellationToken)) : Checksum.Null;
 
             var documentChecksumState = await document.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
             var textChecksum = documentChecksumState.Text;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
@@ -27,6 +27,14 @@ namespace Microsoft.CodeAnalysis
             return collection.Checksum;
         }
 
+        public Checksum GetParseOptionsChecksum(CancellationToken cancellationToken)
+            => GetParseOptionsChecksum(_solutionServices.Workspace.Services.GetService<ISerializerService>(), cancellationToken);
+
+        private Checksum GetParseOptionsChecksum(ISerializerService serializer, CancellationToken cancellationToken)
+            => this.SupportsCompilation
+                ? ChecksumCache.GetOrCreate(this.ParseOptions, _ => serializer.CreateChecksum(this.ParseOptions, cancellationToken))
+                : Checksum.Null;
+
         private async Task<ProjectStateChecksums> ComputeChecksumsAsync(CancellationToken cancellationToken)
         {
             try
@@ -45,7 +53,7 @@ namespace Microsoft.CodeAnalysis
 
                     // these compiler objects doesn't have good place to cache checksum. but rarely ever get changed.
                     var compilationOptionsChecksum = SupportsCompilation ? ChecksumCache.GetOrCreate(CompilationOptions, _ => serializer.CreateChecksum(CompilationOptions, cancellationToken)) : Checksum.Null;
-                    var parseOptionsChecksum = SupportsCompilation ? ChecksumCache.GetOrCreate(ParseOptions, _ => serializer.CreateChecksum(ParseOptions, cancellationToken)) : Checksum.Null;
+                    var parseOptionsChecksum = GetParseOptionsChecksum(serializer, cancellationToken);
 
                     var projectReferenceChecksums = ChecksumCache.GetOrCreate<ProjectReferenceChecksumCollection>(ProjectReferences, _ => new ProjectReferenceChecksumCollection(ProjectReferences.Select(r => serializer.CreateChecksum(r, cancellationToken)).ToArray()));
                     var metadataReferenceChecksums = ChecksumCache.GetOrCreate<MetadataReferenceChecksumCollection>(MetadataReferences, _ => new MetadataReferenceChecksumCollection(MetadataReferences.Select(r => serializer.CreateChecksum(r, cancellationToken)).ToArray()));


### PR DESCRIPTION
This drops the checksum computation portion NavTo from around 14% of the scenario to around 8%.  It's still pretty expensive as we have to still read in the entire file and checksum it to know if we can actually use our cached index.  However, we at least don't need to also compute checksums for things like metadata/analyzers which cannot affect us.

This helps after first load when we have to load all hte indices to search them.