### PR TITLE
Fix wrong reporting for removing parenthesis for stackalloc

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
@@ -82,6 +82,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        [WorkItem(44629, "https://github.com/dotnet/roslyn/issues/44629")]
+        public async Task TestStackAlloc()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M()
+    {
+        var span = (stackalloc byte[8]);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
         public async Task TestArithmeticRequiredForClarity2()
         {
             await TestInRegularAndScript1Async(

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
 {
     void M()
     {
-        var span = (stackalloc byte[8]);
+        var span = $$(stackalloc byte[8]);
     }
 }");
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 // https://github.com/dotnet/roslyn/issues/44629
                 return false;
             }
-            
 
             // The 'direct' expression that contains this parenthesized node.  Note: in the case
             // of code like: ```x is (y)``` there is an intermediary 'no-syntax' 'ConstantPattern'

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             // Simplest cases:
             //   ((x)) -> (x)
-            if (expression.IsKind(SyntaxKind.ParenthesizedExpression) &&
+            if (expression.IsKind(SyntaxKind.ParenthesizedExpression) ||
                 parentExpression.IsKind(SyntaxKind.ParenthesizedExpression))
             {
                 return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -61,7 +61,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             {
                 // var span = (stackalloc byte[8]);
                 // https://github.com/dotnet/roslyn/issues/44629
-                // PR: https://github.com/dotnet/roslyn/pull/44661
+                // The code semantics changes if the parenthesis removed.
+                // With parenthesis:    variable span is of type `Span<byte>`.
+                // Without parenthesis: variable span is of type `byte*` which can only be used in unsafe context.
                 return false;
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -26,12 +26,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             var expression = node.Expression;
-            if (expression is StackAllocArrayCreationExpressionSyntax)
-            {
-                // var span = (stackalloc byte[8]);
-                // https://github.com/dotnet/roslyn/issues/44629
-                return false;
-            }
 
             // The 'direct' expression that contains this parenthesized node.  Note: in the case
             // of code like: ```x is (y)``` there is an intermediary 'no-syntax' 'ConstantPattern'
@@ -61,6 +55,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 parentExpression.IsKind(SyntaxKind.ParenthesizedExpression))
             {
                 return true;
+            }
+
+            if (expression is StackAllocArrayCreationExpressionSyntax)
+            {
+                // var span = (stackalloc byte[8]);
+                // https://github.com/dotnet/roslyn/issues/44629
+                // PR: https://github.com/dotnet/roslyn/pull/44661
+                return false;
             }
 
             // (throw ...) -> throw ...

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -57,7 +57,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
-            if (expression is StackAllocArrayCreationExpressionSyntax)
+            if (expression is StackAllocArrayCreationExpressionSyntax ||
+                expression is ImplicitStackAllocArrayCreationExpressionSyntax)
             {
                 // var span = (stackalloc byte[8]);
                 // https://github.com/dotnet/roslyn/issues/44629

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             // Simplest cases:
             //   ((x)) -> (x)
-            if (expression.IsKind(SyntaxKind.ParenthesizedExpression) ||
+            if (expression.IsKind(SyntaxKind.ParenthesizedExpression) &&
                 parentExpression.IsKind(SyntaxKind.ParenthesizedExpression))
             {
                 return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -26,6 +26,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             var expression = node.Expression;
+            if (expression is StackAllocArrayCreationExpressionSyntax)
+            {
+                // var span = (stackalloc byte[8]);
+                // https://github.com/dotnet/roslyn/issues/44629
+                return false;
+            }
+            
 
             // The 'direct' expression that contains this parenthesized node.  Note: in the case
             // of code like: ```x is (y)``` there is an intermediary 'no-syntax' 'ConstantPattern'


### PR DESCRIPTION
Fixes #44629

@CyrusNajmabadi, Opening `Compilers.sln` in Visual Studio makes my laptop hangs and unusable (perhaps because low specs and the solution is very big). So, I really cannot confirm if this fixes it.
I'll add relevant unit tests soon.