### PR TITLE
Update "Move declaration near reference" for top-level statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -44,6 +44,25 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMove1_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+int [||]x;
+{
+    Console.WriteLine(x);
+}
+",
+@"
+{
+    int x;
+    Console.WriteLine(x);
+}
+",
+                Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestMove2()
         {
             await TestInRegularAndScriptAsync(
@@ -65,6 +84,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
         Console.WriteLine(x);
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMove2_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+int [||]x;
+Console.WriteLine();
+Console.WriteLine(x);
+",
+@"
+Console.WriteLine();
+int x;
+Console.WriteLine(x);
+",
+                Options.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
@@ -102,6 +138,35 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMove3_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+int [||]x;
+Console.WriteLine();
+{
+    Console.WriteLine(x);
+}
+
+{
+    Console.WriteLine(x);
+}
+",
+@"
+Console.WriteLine();
+int x;
+{
+    Console.WriteLine(x);
+}
+
+{
+    Console.WriteLine(x);
+}
+",
+                Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestMove4()
         {
             await TestInRegularAndScriptAsync(
@@ -125,6 +190,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
             Console.WriteLine(x);
         }
     }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMove4_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+int [||]x;
+Console.WriteLine();
+{
+    Console.WriteLine(x);
+}
+",
+@"
+Console.WriteLine();
+{
+    int x;
+    Console.WriteLine(x);
+}
+",
+                Options.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
@@ -223,6 +309,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissing1_TopLevelStatement()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+int [||]x;
+Console.WriteLine(x);
+");
+        }
+
         [WorkItem(538424, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538424")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestMissingWhenReferencedInDeclaration()
@@ -253,6 +349,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
         Console.WriteLine(i);
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissingWhenInDeclarationGroup_TopLevelStatement()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+int [||]i = 5;
+int j = 10;
+Console.WriteLine(i);
+");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
@@ -294,6 +401,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestFormatting_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+int [||]i = 5; Console.WriteLine();
+Console.Write(i);
+",
+@"
+Console.WriteLine();
+int i = 5; Console.Write(i);
+",
+                Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestMissingInHiddenBlock1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -328,6 +450,21 @@ class Program
         Bar(x);
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissingInHiddenBlock2_TopLevelStatement()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"#line default
+
+int [|x|] = 0;
+Goo();
+#line hidden
+Goo();
+#line default
+Bar(x);
+");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
@@ -394,6 +531,33 @@ class Program
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestAvailableInNonHiddenBlock2_TopLevelStatement()
+        {
+            await TestAsync(
+@"#line default
+
+int [||]x = 0;
+Goo();
+#line hidden
+Goo();
+#line default
+Goo();
+Bar(x);
+",
+@"#line default
+
+Goo();
+#line hidden
+Goo();
+#line default
+Goo();
+int x = 0;
+Bar(x);
+",
+                Options.Regular);
+        }
+
         [WorkItem(545435, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545435")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestWarnOnChangingScopes1()
@@ -432,6 +596,33 @@ class Program
 
         [WorkItem(545435, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545435")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestWarnOnChangingScopes1_TopLevelStatement()
+        {
+            await TestAsync(
+@"using System.Linq;
+
+var [||]@lock = new object();
+new[] { 1 }.AsParallel().ForAll((i) => {
+    lock (@lock)
+    {
+    }
+});
+",
+@"using System.Linq;
+
+new[] { 1 }.AsParallel().ForAll((i) =>
+{
+    {|Warning:var @lock = new object();|}
+    lock (@lock)
+    {
+    }
+});
+",
+                Options.Regular);
+        }
+
+        [WorkItem(545435, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545435")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestWarnOnChangingScopes2()
         {
             await TestInRegularAndScriptAsync(
@@ -465,6 +656,34 @@ class Program
         }
     }
 }");
+        }
+
+        [WorkItem(545435, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545435")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestWarnOnChangingScopes2_TopLevelStatement()
+        {
+            await TestAsync(
+@"using System;
+using System.Linq;
+
+var [||]i = 0;
+foreach (var v in new[] { 1 })
+{
+    Console.Write(i);
+    i++;
+}
+",
+@"using System;
+using System.Linq;
+
+foreach (var v in new[] { 1 })
+{
+    {|Warning:var i = 0;|}
+    Console.Write(i);
+    i++;
+}
+",
+                Options.Regular);
         }
 
         [WorkItem(545840, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545840")]
@@ -1164,6 +1383,38 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMergeComments07_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+if (true)
+{
+}
+
+// leading trivia
+int [||]i = 5;
+Console.WriteLine();
+
+// Existing trivia
+i = 0;
+Console.Write(i);
+",
+@"
+if (true)
+{
+}
+
+Console.WriteLine();
+
+// leading trivia
+// Existing trivia
+int i = 0;
+Console.Write(i);
+",
+                Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestMergeComments08()
         {
             await TestInRegularAndScriptAsync(
@@ -1204,6 +1455,42 @@ class Program
         }
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMergeComments08_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+if (true)
+{
+}
+
+// leading trivia
+int [||]i = 5;
+Console.WriteLine();
+
+{
+    // Existing trivia
+    i = 0;
+    Console.Write(i);
+}
+",
+@"
+if (true)
+{
+}
+
+Console.WriteLine();
+
+{
+    // leading trivia
+    // Existing trivia
+    int i = 0;
+    Console.Write(i);
+}
+",
+                Options.Regular);
         }
 
         [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
@@ -1401,6 +1688,30 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMoveIntoSwitchSection_TopLevelStatement()
+        {
+            await TestAsync(
+@"
+int [||]x;
+switch (true)
+{
+    case true:
+        x = 0;
+        break;
+}
+",
+@"
+switch (true)
+{
+    case true:
+        int x = 0;
+        break;
+}
+",
+                Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestUsedInMultipleSwitchSections_MoveToSwitchStatement()
         {
             await TestInRegularAndScriptAsync(
@@ -1441,6 +1752,39 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestUsedInMultipleSwitchSections_TopLevelStatement_MoveToSwitchStatement()
+        {
+            await TestAsync(
+@"
+int [||]x;
+System.Console.WriteLine();
+switch (true)
+{
+    case true:
+        x = 0;
+        break;
+    case false:
+        x = 0;
+        break;
+}
+",
+@"
+System.Console.WriteLine();
+int x;
+switch (true)
+{
+    case true:
+        x = 0;
+        break;
+    case false:
+        x = 0;
+        break;
+}
+",
+                Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task TestUsedInMultipleSwitchSections_CannotMove()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -1460,6 +1804,24 @@ class Program
         }
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestUsedInMultipleSwitchSections_TopLevelStatement_CannotMove()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+int [||]x;
+switch (true)
+{
+    case true:
+        x = 0;
+        break;
+    case false:
+        x = 0;
+        break;
+}
+");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -54,7 +54,9 @@ int [||]x;
 }
 ",
 @"
+
 {
+
     int x;
     Console.WriteLine(x);
 }
@@ -96,7 +98,9 @@ Console.WriteLine();
 Console.WriteLine(x);
 ",
 @"
+
 Console.WriteLine();
+
 int x;
 Console.WriteLine(x);
 ",
@@ -153,10 +157,12 @@ Console.WriteLine();
 }
 ",
 @"
+
 Console.WriteLine();
+
 int x;
 {
-    Console.WriteLine(x);
+Console.WriteLine(x);
 }
 
 {
@@ -204,8 +210,10 @@ Console.WriteLine();
 }
 ",
 @"
+
 Console.WriteLine();
 {
+
     int x;
     Console.WriteLine(x);
 }
@@ -409,7 +417,9 @@ int [||]i = 5; Console.WriteLine();
 Console.Write(i);
 ",
 @"
+
 Console.WriteLine();
+
 int i = 5; Console.Write(i);
 ",
                 Options.Regular);
@@ -552,6 +562,8 @@ Goo();
 Goo();
 #line default
 Goo();
+#line default
+
 int x = 0;
 Bar(x);
 ",
@@ -612,6 +624,7 @@ new[] { 1 }.AsParallel().ForAll((i) => {
 
 new[] { 1 }.AsParallel().ForAll((i) =>
 {
+
     {|Warning:var @lock = new object();|}
     lock (@lock)
     {
@@ -678,6 +691,7 @@ using System.Linq;
 
 foreach (var v in new[] { 1 })
 {
+
     {|Warning:var i = 0;|}
     Console.Write(i);
     i++;
@@ -1769,7 +1783,9 @@ switch (true)
 }
 ",
 @"
+
 System.Console.WriteLine();
+
 int x;
 switch (true)
 {

--- a/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -700,6 +700,72 @@ foreach (var v in new[] { 1 })
                 Options.Regular);
         }
 
+        [WorkItem(44664, "https://github.com/dotnet/roslyn/pull/44664")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestWarnOnChangingScopes3()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+using System.Linq;
+
+class Program
+{
+    void Main()
+    {
+        var [||]i = 0;
+        void LocalFunction()
+        {
+            Console.Write(i);
+            i++;
+        }
+    }
+}",
+@"using System;
+using System.Linq;
+
+class Program
+{
+    void Main()
+    {
+        void LocalFunction()
+        {
+            {|Warning:var i = 0;|}
+            Console.Write(i);
+            i++;
+        }
+    }
+}");
+        }
+
+        [WorkItem(44664, "https://github.com/dotnet/roslyn/pull/44664")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestWarnOnChangingScopes3_TopLevelStatement()
+        {
+            await TestAsync(
+@"using System;
+using System.Linq;
+
+var [||]i = 0;
+void LocalFunction()
+{
+    Console.Write(i);
+    i++;
+}
+",
+@"using System;
+using System.Linq;
+
+void LocalFunction()
+{
+
+    {|Warning:var i = 0;|}
+    Console.Write(i);
+    i++;
+}
+",
+                Options.Regular);
+        }
+
         [WorkItem(545840, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545840")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public async Task InsertCastIfNecessary1()

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2788,6 +2788,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNodesBefore(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
         {
+            if (declaration.Parent.IsKind(SyntaxKind.GlobalStatement))
+            {
+                // Insert global statements before this global statement
+                declaration = declaration.Parent;
+                newDeclarations = newDeclarations.Select(declaration => declaration is StatementSyntax statement ? SyntaxFactory.GlobalStatement(statement) : declaration);
+            }
+
             if (root.Span.Contains(declaration.Span))
             {
                 return this.Isolate(root.TrackNodes(declaration), r => this.InsertNodesBeforeInternal(r, r.GetCurrentNode(declaration), newDeclarations));
@@ -2820,6 +2827,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNodesAfter(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
         {
+            if (declaration.Parent.IsKind(SyntaxKind.GlobalStatement))
+            {
+                // Insert global statements before this global statement
+                declaration = declaration.Parent;
+                newDeclarations = newDeclarations.Select(declaration => declaration is StatementSyntax statement ? SyntaxFactory.GlobalStatement(statement) : declaration);
+            }
+
             if (root.Span.Contains(declaration.Span))
             {
                 return this.Isolate(root.TrackNodes(declaration), r => this.InsertNodesAfterInternal(r, r.GetCurrentNode(declaration), newDeclarations));
@@ -2880,6 +2894,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode node, SyntaxRemoveOptions options)
         {
+            if (node.Parent.IsKind(SyntaxKind.GlobalStatement))
+            {
+                // Remove the entire global statement as part of the edit
+                node = node.Parent;
+            }
+
             if (root.Span.Contains(node.Span))
             {
                 // node exists within normal span of the root (not in trivia)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceService.State.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceService.State.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
                     return false;
                 }
 
-                OutermostBlock = DeclarationStatement.Parent;
+                OutermostBlock = syntaxFacts.GetStatementContainer(DeclarationStatement);
                 if (!syntaxFacts.IsExecutableBlock(OutermostBlock))
                 {
                     return false;


### PR DESCRIPTION
The first commit implements this change the way I expected things to work.

The second commit updates the expected test outputs to include whitespace and trivia changes which appear in the real refactoring, even though they were not desirable.