### PR TITLE
Replace values in EndToEndTests.DeeplyNestedGeneric

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 270,
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1290,
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 170,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 700, // PROTOTYPE(angocke): Improve stack usage
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 730,
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 


### PR DESCRIPTION
Fixes #44681 

I did not get a crash when running this test locally in release-x64, so I figured I would just PR it and if it goes green then good. (I had the branch from #44582 checked out, so it's possible that will need to merge before this will work).

See the version of the file in master for comparison: https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs#L153