### PR TITLE
Ensure analyzer actions are invoked for SimpleProgramNamedTypeSymbol.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4954,6 +4954,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Include only global statements at the top level
                         return (node) => node.Parent != unit || node.Kind() == SyntaxKind.GlobalStatement;
 
+                    case SymbolKind.NamedType:
+                        Debug.Assert((object)declaredSymbol.GetSymbol() == (object)entryPoint.ContainingSymbol);
+                        return (node) => false;
+
                     default:
                         ExceptionUtilities.UnexpectedValue(declaredSymbol.Kind);
                         break;

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             _cancellationToken.ThrowIfCancellationRequested();
 
-            if (symbol.IsImplicitlyDeclared || symbol.IsAccessor() || symbol is SynthesizedSimpleProgramEntryPointSymbol)
+            if (ShouldSkip(symbol))
             {
                 return;
             }
@@ -371,6 +371,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+        }
+
+        private static bool ShouldSkip(Symbol symbol)
+        {
+            return symbol.IsImplicitlyDeclared || symbol.IsAccessor() || symbol is SynthesizedSimpleProgramEntryPointSymbol || symbol is SimpleProgramNamedTypeSymbol;
         }
 
         /// <summary>
@@ -548,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert((object)symbol != null);
 
-            if (symbol.IsImplicitlyDeclared || symbol.IsAccessor() || symbol is SynthesizedSimpleProgramEntryPointSymbol)
+            if (ShouldSkip(symbol))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
 
             // do not generate attributes for members of compiler-generated types:
-            if (ContainingType.IsImplicitlyDeclared)
+            if (ContainingType.IsImplicitlyDeclared || ContainingType is SimpleProgramNamedTypeSymbol)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                               instanceInitializersSyntaxLength: 0);
         }
 
-        public override bool IsImplicitlyDeclared => true;
+        public override bool IsImplicitlyDeclared => false;
 
         internal override bool IsDefinedInSourceTree(SyntaxTree tree, TextSpan? definedWithinSpan, CancellationToken cancellationToken)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -87,6 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = this.DeclaringCompilation;
 
             // do not emit CompilerGenerated attributes for fields inside compiler generated types:
+            Debug.Assert(!(this.ContainingType is SimpleProgramNamedTypeSymbol));
             if (!this.ContainingType.IsImplicitlyDeclared)
             {
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
 
-            if (ContainingSymbol.Kind == SymbolKind.NamedType && ContainingSymbol.IsImplicitlyDeclared)
+            if (ContainingSymbol.Kind == SymbolKind.NamedType && (ContainingSymbol.IsImplicitlyDeclared || ContainingSymbol is SimpleProgramNamedTypeSymbol))
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var type = typeWithAnnotations.Type;
 
             // do not emit CompilerGenerated attributes for fields inside compiler generated types:
+            Debug.Assert(!(_containingType is SimpleProgramNamedTypeSymbol));
             if (!_containingType.IsImplicitlyDeclared)
             {
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -18,6 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedSimpleProgramEntryPointSymbol : SourceMemberMethodSymbol
     {
+        internal const string UnspeakableName = "$Main";
+
         /// <summary>
         /// The corresponding <see cref="SingleTypeDeclaration"/>. 
         /// </summary>
@@ -71,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return "$Main";
+                return UnspeakableName;
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -691,7 +691,7 @@ System.Console.WriteLine(s);
             Assert.Equal(SymbolKind.Method, local.ContainingSymbol.Kind);
             Assert.False(local.ContainingSymbol.IsImplicitlyDeclared);
             Assert.Equal(SymbolKind.NamedType, local.ContainingSymbol.ContainingSymbol.Kind);
-            Assert.True(local.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
+            Assert.False(local.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
             Assert.True(((INamespaceSymbol)local.ContainingSymbol.ContainingSymbol.ContainingSymbol).IsGlobalNamespace);
         }
 
@@ -4195,7 +4195,7 @@ void local()
             Assert.Equal(SymbolKind.Method, local.ContainingSymbol.Kind);
             Assert.False(local.ContainingSymbol.IsImplicitlyDeclared);
             Assert.Equal(SymbolKind.NamedType, local.ContainingSymbol.ContainingSymbol.Kind);
-            Assert.True(local.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
+            Assert.False(local.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
             Assert.True(((INamespaceSymbol)local.ContainingSymbol.ContainingSymbol.ContainingSymbol).IsGlobalNamespace);
 
             VerifyFlowGraph(comp, tree.GetRoot(),
@@ -4861,7 +4861,7 @@ label1: System.Console.WriteLine(""Hi!"");
             Assert.Equal(SymbolKind.Method, label.ContainingSymbol.Kind);
             Assert.False(label.ContainingSymbol.IsImplicitlyDeclared);
             Assert.Equal(SymbolKind.NamedType, label.ContainingSymbol.ContainingSymbol.Kind);
-            Assert.True(label.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
+            Assert.False(label.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
             Assert.True(((INamespaceSymbol)label.ContainingSymbol.ContainingSymbol.ContainingSymbol).IsGlobalNamespace);
         }
 
@@ -4946,7 +4946,7 @@ args: System.Console.WriteLine(""Hi!"");
             Assert.Equal(SymbolKind.Method, label.ContainingSymbol.Kind);
             Assert.False(label.ContainingSymbol.IsImplicitlyDeclared);
             Assert.Equal(SymbolKind.NamedType, label.ContainingSymbol.ContainingSymbol.Kind);
-            Assert.True(label.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
+            Assert.False(label.ContainingSymbol.ContainingSymbol.IsImplicitlyDeclared);
             Assert.True(((INamespaceSymbol)label.ContainingSymbol.ContainingSymbol.ContainingSymbol).IsGlobalNamespace);
         }
 
@@ -6105,10 +6105,10 @@ static extern void local1();
 
             void validate(ModuleSymbol module)
             {
-                var cClass = module.GlobalNamespace.GetMember<NamedTypeSymbol>("$Program");
+                var cClass = module.GlobalNamespace.GetMember<NamedTypeSymbol>(SimpleProgramNamedTypeSymbol.UnspeakableName);
                 Assert.Equal(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(cClass.GetAttributes().As<CSharpAttributeData>()));
 
-                Assert.Empty(cClass.GetMethod("$Main").GetAttributes());
+                Assert.Empty(cClass.GetMethod(SynthesizedSimpleProgramEntryPointSymbol.UnspeakableName).GetAttributes());
 
                 var localFn1 = cClass.GetMethod("<$Main>g__local1|0_0");
 
@@ -6501,6 +6501,12 @@ class B : A
 
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(0, analyzer.FireCount2);
+            Assert.Equal(1, analyzer.FireCount3);
+            Assert.Equal(1, analyzer.FireCount4);
+            Assert.Equal(0, analyzer.FireCount5);
+            Assert.Equal(1, analyzer.FireCount6);
+            Assert.Equal(0, analyzer.FireCount7);
+            Assert.Equal(1, analyzer.FireCount8);
 
             var text2 = @"System.Console.WriteLine(2);";
 
@@ -6510,12 +6516,24 @@ class B : A
 
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(1, analyzer.FireCount2);
+            Assert.Equal(1, analyzer.FireCount3);
+            Assert.Equal(1, analyzer.FireCount4);
+            Assert.Equal(1, analyzer.FireCount5);
+            Assert.Equal(1, analyzer.FireCount6);
+            Assert.Equal(1, analyzer.FireCount7);
+            Assert.Equal(1, analyzer.FireCount8);
         }
 
         private class AnalyzerActions_03_Analyzer : DiagnosticAnalyzer
         {
             public int FireCount1;
             public int FireCount2;
+            public int FireCount3;
+            public int FireCount4;
+            public int FireCount5;
+            public int FireCount6;
+            public int FireCount7;
+            public int FireCount8;
 
             private static readonly DiagnosticDescriptor Descriptor =
                new DiagnosticDescriptor("XY0000", "Test", "Test", "Test", DiagnosticSeverity.Warning, true, "Test", "Test");
@@ -6525,10 +6543,11 @@ class B : A
 
             public override void Initialize(AnalysisContext context)
             {
-                context.RegisterSymbolStartAction(Handle, SymbolKind.Method);
+                context.RegisterSymbolStartAction(Handle1, SymbolKind.Method);
+                context.RegisterSymbolStartAction(Handle2, SymbolKind.NamedType);
             }
 
-            private void Handle(SymbolStartAnalysisContext context)
+            private void Handle1(SymbolStartAnalysisContext context)
             {
                 Assert.Equal("<top-level-statements-entry-point>", context.Symbol.ToTestDisplayString());
 
@@ -6536,14 +6555,59 @@ class B : A
                 {
                     case "System.Console.WriteLine(1);":
                         Interlocked.Increment(ref FireCount1);
+                        context.RegisterSymbolEndAction(Handle3);
                         break;
                     case "System.Console.WriteLine(2);":
                         Interlocked.Increment(ref FireCount2);
+                        context.RegisterSymbolEndAction(Handle4);
                         break;
                     default:
                         Assert.True(false);
                         break;
                 }
+            }
+
+            private void Handle2(SymbolStartAnalysisContext context)
+            {
+                Assert.Equal(SimpleProgramNamedTypeSymbol.UnspeakableName, context.Symbol.ToTestDisplayString());
+                Interlocked.Increment(ref FireCount3);
+                context.RegisterSymbolEndAction(Handle5);
+
+                foreach (var syntaxReference in context.Symbol.DeclaringSyntaxReferences)
+                {
+                    switch (syntaxReference.GetSyntax().ToString())
+                    {
+                        case "System.Console.WriteLine(1);":
+                            Interlocked.Increment(ref FireCount4);
+                            break;
+                        case "System.Console.WriteLine(2);":
+                            Interlocked.Increment(ref FireCount5);
+                            break;
+                        default:
+                            Assert.True(false);
+                            break;
+                    }
+                }
+            }
+
+            private void Handle3(SymbolAnalysisContext context)
+            {
+                Assert.Equal("<top-level-statements-entry-point>", context.Symbol.ToTestDisplayString());
+                Interlocked.Increment(ref FireCount6);
+                Assert.Equal("System.Console.WriteLine(1);", context.Symbol.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            }
+
+            private void Handle4(SymbolAnalysisContext context)
+            {
+                Assert.Equal("<top-level-statements-entry-point>", context.Symbol.ToTestDisplayString());
+                Interlocked.Increment(ref FireCount7);
+                Assert.Equal("System.Console.WriteLine(2);", context.Symbol.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            }
+
+            private void Handle5(SymbolAnalysisContext context)
+            {
+                Assert.Equal(SimpleProgramNamedTypeSymbol.UnspeakableName, context.Symbol.ToTestDisplayString());
+                Interlocked.Increment(ref FireCount8);
             }
         }
 
@@ -7138,6 +7202,7 @@ class C1
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(1, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
+            Assert.Equal(1, analyzer.FireCount4);
 
             analyzer = new AnalyzerActions_11_Analyzer();
             comp = CreateCompilation(new[] { text1, text2 }, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);
@@ -7146,6 +7211,7 @@ class C1
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(1, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
+            Assert.Equal(1, analyzer.FireCount4);
         }
 
         private class AnalyzerActions_11_Analyzer : DiagnosticAnalyzer
@@ -7153,6 +7219,7 @@ class C1
             public int FireCount1;
             public int FireCount2;
             public int FireCount3;
+            public int FireCount4;
 
             private static readonly DiagnosticDescriptor Descriptor =
                new DiagnosticDescriptor("XY0000", "Test", "Test", "Test", DiagnosticSeverity.Warning, true, "Test", "Test");
@@ -7181,8 +7248,18 @@ class C1
 
             private void Handle3(SymbolAnalysisContext context)
             {
-                Interlocked.Increment(ref FireCount3);
-                Assert.Equal("C1", context.Symbol.ToTestDisplayString());
+                switch (context.Symbol.ToTestDisplayString())
+                {
+                    case "C1":
+                        Interlocked.Increment(ref FireCount3);
+                        break;
+                    case SimpleProgramNamedTypeSymbol.UnspeakableName:
+                        Interlocked.Increment(ref FireCount4);
+                        break;
+                    default:
+                        Assert.True(false);
+                        break;
+                }
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyCompilationsTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyCompilationsTests.cs
@@ -88,8 +88,8 @@ public void Method()
 }
 ";
 
-            var comp1 = CreateCompilation(src1);
-            var comp2 = CreateCompilation(src2);
+            var comp1 = CreateCompilation(src1, assemblyName: "C2CErrorSymbolUnchanged01");
+            var comp2 = CreateCompilation(src2, assemblyName: "C2CErrorSymbolUnchanged01");
 
             var symbol01 = comp1.SourceModule.GlobalNamespace.GetMembers().FirstOrDefault() as NamedTypeSymbol;
             var symbol02 = comp1.SourceModule.GlobalNamespace.GetMembers().FirstOrDefault() as NamedTypeSymbol;


### PR DESCRIPTION
Fixes #44663.