### PR TITLE
Fix equivalence key for Populate-Switch

### DIFF
--- a/src/Analyzers/Core/CodeFixes/PopulateSwitch/AbstractPopulateSwitchCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/PopulateSwitch/AbstractPopulateSwitchCodeFixProvider.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
         private class MyCodeAction : CustomCodeActions.DocumentChangeAction
         {
             public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
-                : base(title, createChangedDocument)
+                : base(title, createChangedDocument, title)
             {
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44634