### PR TITLE
Relax dedupe logic in code fix service

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -314,11 +314,17 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             var extensionManager = document.Project.Solution.Workspace.Services.GetService<IExtensionManager>();
 
-            // Run each CodeFixProvider to gather individual CodeFixes for reported diagnostics
-            // Ensure that each diagnostic only has a unique registered code action for any given equivalance key.
+            // Run each CodeFixProvider to gather individual CodeFixes for reported diagnostics.
+            // Ensure that no diagnostic has registered code actions from different code fix providers with same equivalance key.
             // This prevents duplicate registered code actions from NuGet and VSIX code fix providers.
             // See https://github.com/dotnet/roslyn/issues/18818 for details.
             var uniqueDiagosticToEquivalenceKeysMap = new Dictionary<Diagnostic, PooledHashSet<string?>>();
+
+            // NOTE: For backward compatibility, we allow multiple registered code actions from the same code fix provider
+            // to have the same equivalence key. See https://github.com/dotnet/roslyn/issues/44553 for details.
+            // To ensure this, we track the fixer that first registered a code action to fix a diagnostic with a specific equivalence key.
+            var diagnosticAndEquivalenceKeyToFixersMap = new Dictionary<(Diagnostic diagnostic, string? equivalenceKey), CodeFixProvider>();
+
             try
             {
                 foreach (var fixer in allFixers.Distinct())
@@ -338,11 +344,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                                 {
                                     var primaryDiagnostic = dxs.First();
                                     return GetCodeFixesAsync(document, primaryDiagnostic.Location.SourceSpan, fixer, isBlocking,
-                                        ImmutableArray.Create(primaryDiagnostic), uniqueDiagosticToEquivalenceKeysMap, cancellationToken);
+                                        ImmutableArray.Create(primaryDiagnostic), uniqueDiagosticToEquivalenceKeysMap,
+                                        diagnosticAndEquivalenceKeyToFixersMap, cancellationToken);
                                 }
                                 else
                                 {
-                                    return GetCodeFixesAsync(document, span, fixer, isBlocking, dxs, uniqueDiagosticToEquivalenceKeysMap, cancellationToken);
+                                    return GetCodeFixesAsync(document, span, fixer, isBlocking, dxs,
+                                        uniqueDiagosticToEquivalenceKeysMap, diagnosticAndEquivalenceKeyToFixersMap, cancellationToken);
                                 }
                             }
                         },
@@ -366,6 +374,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             Document document, TextSpan span, CodeFixProvider fixer, bool isBlocking,
             ImmutableArray<Diagnostic> diagnostics,
             Dictionary<Diagnostic, PooledHashSet<string?>> uniqueDiagosticToEquivalenceKeysMap,
+            Dictionary<(Diagnostic diagnostic, string? equivalenceKey), CodeFixProvider> diagnosticAndEquivalenceKeyToFixersMap,
             CancellationToken cancellationToken)
         {
             using var fixesDisposer = ArrayBuilder<CodeFix>.GetInstance(out var fixes);
@@ -377,7 +386,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     lock (fixes)
                     {
                         // Filter out applicable diagnostics which already have a registered code action with same equivalence key.
-                        applicableDiagnostics = FilterApplicableDiagnostics(applicableDiagnostics, action.EquivalenceKey, uniqueDiagosticToEquivalenceKeysMap);
+                        applicableDiagnostics = FilterApplicableDiagnostics(applicableDiagnostics, action.EquivalenceKey,
+                            fixer, uniqueDiagosticToEquivalenceKeysMap, diagnosticAndEquivalenceKeyToFixersMap);
 
                         if (!applicableDiagnostics.IsEmpty)
                         {
@@ -396,20 +406,33 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             static ImmutableArray<Diagnostic> FilterApplicableDiagnostics(
                 ImmutableArray<Diagnostic> applicableDiagnostics,
                 string? equivalenceKey,
-                Dictionary<Diagnostic, PooledHashSet<string?>> uniqueDiagosticToEquivalenceKeysMap)
+                CodeFixProvider fixer,
+                Dictionary<Diagnostic, PooledHashSet<string?>> uniqueDiagosticToEquivalenceKeysMap,
+                Dictionary<(Diagnostic diagnostic, string? equivalenceKey), CodeFixProvider> diagnosticAndEquivalenceKeyToFixersMap)
             {
                 using var disposer = ArrayBuilder<Diagnostic>.GetInstance(out var newApplicableDiagnostics);
                 foreach (var diagnostic in applicableDiagnostics)
                 {
                     if (!uniqueDiagosticToEquivalenceKeysMap.TryGetValue(diagnostic, out var equivalenceKeys))
                     {
+                        // First code action registered to fix this diagnostic with any equivalenceKey.
+                        // Record the equivalence key and the fixer that registered this action.
                         equivalenceKeys = PooledHashSet<string?>.GetInstance();
                         equivalenceKeys.Add(equivalenceKey);
                         uniqueDiagosticToEquivalenceKeysMap[diagnostic] = equivalenceKeys;
+                        diagnosticAndEquivalenceKeyToFixersMap.Add((diagnostic, equivalenceKey), fixer);
                     }
-                    else if (!equivalenceKeys.Add(equivalenceKey))
+                    else if (equivalenceKeys.Add(equivalenceKey))
                     {
-                        // Diagnostic already has a registered code action with same equivalence key.
+                        // First code action registered to fix this diagnostic with the given equivalenceKey.
+                        // Record the the fixer that registered this action.
+                        diagnosticAndEquivalenceKeyToFixersMap.Add((diagnostic, equivalenceKey), fixer);
+                    }
+                    else if (diagnosticAndEquivalenceKeyToFixersMap[(diagnostic, equivalenceKey)] != fixer)
+                    {
+                        // Diagnostic already has a registered code action with same equivalence key from a different fixer.
+                        // Note that we allow same fixer to register multiple such code actions with the same equivalence key
+                        // for backward compatibility. See https://github.com/dotnet/roslyn/issues/44553 for details.
                         continue;
                     }
 


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn/commit/449b96528f3ad55a15b08039511caaaa8e4c8248: Add unit test to demonstrate the breaking change introduced in #41768, and described in https://github.com/dotnet/roslyn/issues/44553#issuecomment-636305256. Verified the test failed without any product change.
2. https://github.com/dotnet/roslyn/commit/97d5d269b62d8e6079d942772fd3f11254d0a878: Relax the de-duplication logic in CodeFixService to allow a code fix provider to register multiple code actions with same equivalence key for backward compatibility.