### PR TITLE
LSP FAR: Add ClassifiedTextElement support + fix bug displaying invalid reference results

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <CodeStyleAnalyzerVersion>3.7.0-1.20210.7</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>16.4.248</VisualStudioEditorPackagesVersion>
     <ILToolsPackageVersion>5.0.0-alpha1.19409.1</ILToolsPackageVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.7.29</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.7.43</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
   </PropertyGroup>
   <!--
     Dependency versions

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -91,6 +91,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
 
                 if (definitionItem != null)
                 {
+                    // If a definition shouldn't be included in the results list if it doesn't have references, we
+                    // have to hold off on reporting it until later when we do find a reference.
                     if (definition.DisplayIfNoReferences)
                     {
                         AddToReferencesToReport_MustBeCalledUnderLock(definitionItem);

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
         /// Keeps track of definitions that cannot be reported without references and which we have
         /// not yet found a reference for.
         /// </summary>
-        private readonly List<VSReferenceItem> _definitionsWithoutReferences =
-            new List<VSReferenceItem>();
+        private readonly Dictionary<int, VSReferenceItem> _definitionsWithoutReference =
+            new Dictionary<int, VSReferenceItem>();
 
         private readonly List<VSReferenceItem> _resultsChunk =
             new List<VSReferenceItem>();
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
                     }
                     else
                     {
-                        _definitionsWithoutReferences.Add(definitionItem);
+                        _definitionsWithoutReference.Add(definitionItem.Id, definitionItem);
                     }
                 }
             }
@@ -117,11 +117,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
                 }
 
                 // If the definition hasn't been reported yet, add it to our list of references to report.
-                var definitionItem = _definitionsWithoutReferences.Where(d => d.DefinitionId == definitionId).FirstOrDefault();
-                if (definitionItem != null)
+                if (_definitionsWithoutReference.TryGetValue(definitionId, out var definition))
                 {
-                    AddToReferencesToReport_MustBeCalledUnderLock(definitionItem);
-                    _definitionsWithoutReferences.Remove(definitionItem);
+                    AddToReferencesToReport_MustBeCalledUnderLock(definition);
+                    _definitionsWithoutReference.Remove(definitionId);
                 }
 
                 _id++;

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.MetadataAsSource;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
 using Roslyn.Utilities;
@@ -40,6 +39,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
 
         private readonly Dictionary<DefinitionItem, int> _definitionToId =
             new Dictionary<DefinitionItem, int>();
+
+        /// <summary>
+        /// Keeps track of definitions that cannot be reported without references and which we have
+        /// not yet found a reference for.
+        /// </summary>
+        private readonly List<VSReferenceItem> _definitionsWithoutReferences =
+            new List<VSReferenceItem>();
 
         private readonly List<VSReferenceItem> _resultsChunk =
             new List<VSReferenceItem>();
@@ -77,28 +83,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
                 _id++;
                 _definitionToId.Add(definition, _id);
 
-                // VSReferenceItem currently doesn't support the ClassifiedTextElement type for DefinitionText,
-                // so for now we just pass in a string.
-                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
-                var classifiedText = definition.GetClassifiedText();
-
-                using var pd = PooledStringBuilder.GetInstance(out var pooledBuilder);
-                foreach (var text in classifiedText.Runs)
-                {
-                    pooledBuilder.Append(text.Text);
-                }
-
-                var definitionText = pooledBuilder.ToString();
-
                 // Creating a new VSReferenceItem for the definition
                 var definitionItem = await GenerateVSReferenceItemAsync(
                     _id, definitionId: _id, _document, _position, definition.SourceSpans.FirstOrDefault(),
-                    definition.DisplayableProperties, _metadataAsSourceFileService, definitionText,
+                    definition.DisplayableProperties, _metadataAsSourceFileService, definition.GetClassifiedText(),
                     symbolUsageInfo: null, CancellationToken).ConfigureAwait(false);
 
                 if (definitionItem != null)
                 {
-                    AddToReferencesToReport_MustBeCalledUnderLock(definitionItem);
+                    if (definition.DisplayIfNoReferences)
+                    {
+                        AddToReferencesToReport_MustBeCalledUnderLock(definitionItem);
+                    }
+                    else
+                    {
+                        _definitionsWithoutReferences.Add(definitionItem);
+                    }
                 }
             }
         }
@@ -112,6 +112,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
                 if (!_definitionToId.TryGetValue(reference.Definition, out var definitionId))
                 {
                     return;
+                }
+
+                // If the definition hasn't been reported yet, add it to our list of references to report.
+                var definitionItem = _definitionsWithoutReferences.Where(d => d.DefinitionId == definitionId).FirstOrDefault();
+                if (definitionItem != null)
+                {
+                    AddToReferencesToReport_MustBeCalledUnderLock(definitionItem);
+                    _definitionsWithoutReferences.Remove(definitionItem);
                 }
 
                 _id++;
@@ -143,7 +151,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
             DocumentSpan documentSpan,
             ImmutableDictionary<string, string> properties,
             IMetadataAsSourceFileService metadataAsSourceFileService,
-            string? definitionText,
+            ClassifiedTextElement? definitionText,
             SymbolUsageInfo? symbolUsageInfo,
             CancellationToken cancellationToken)
         {
@@ -232,7 +240,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
             static async Task<object?> ComputeTextAsync(
                 int id, int? definitionId,
                 DocumentSpan documentSpan,
-                string? definitionText,
+                ClassifiedTextElement? definitionText,
                 CancellationToken cancellationToken)
             {
                 if (id == definitionId)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_queries/edit/1133650/.

Also adds support on the Roslyn side for ClassifiedTextElement, which adds colorization for definitions. LSP support for ClassifiedTextElement was added in this PR: https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/248258
However, there is an outstanding bug when using ClassifiedTextElement that is causing all definitions to be grouped together: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1134996/