### PR TITLE
Fix null reference exception with convert tuple with inaccessible System.HashCode

### DIFF
--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -744,7 +744,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             // help create members like Equals/GetHashCode.  Then, once we have all the members we
             // create the final type.
             var namedTypeWithoutMembers = CreateNamedType(
-                scope, structName, typeParameters, members: default);
+                semanticModel.Compilation.Assembly, scope, structName, typeParameters, members: default);
 
             var generator = SyntaxGenerator.GetGenerator(document);
             var constructor = CreateConstructor(semanticModel, structName, fields, generator);
@@ -768,7 +768,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             members.Add(GenerateDeconstructMethod(semanticModel, generator, tupleType, constructor));
             AddConversions(generator, members, tupleType, namedTypeWithoutMembers);
 
-            var namedTypeSymbol = CreateNamedType(scope, structName, typeParameters, members.ToImmutableAndFree());
+            var namedTypeSymbol = CreateNamedType(semanticModel.Compilation.Assembly, scope, structName, typeParameters, members.ToImmutableAndFree());
             return namedTypeSymbol;
         }
 
@@ -834,6 +834,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
         }
 
         private static INamedTypeSymbol CreateNamedType(
+            IAssemblySymbol containingAssembly,
             Scope scope, string structName,
             ImmutableArray<ITypeParameterSymbol> typeParameters, ImmutableArray<ISymbol> members)
         {
@@ -842,7 +843,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 : Accessibility.Internal;
             return CodeGenerationSymbolFactory.CreateNamedTypeSymbol(
                 attributes: default, accessibility, modifiers: default,
-                TypeKind.Struct, structName, typeParameters, members: members);
+                TypeKind.Struct, structName, typeParameters, members: members, containingAssembly: containingAssembly);
         }
 
         private static IMethodSymbol CreateConstructor(

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -383,12 +383,13 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<INamedTypeSymbol> interfaces = default,
             SpecialType specialType = SpecialType.None,
             ImmutableArray<ISymbol> members = default,
-            NullableAnnotation nullableAnnotation = NullableAnnotation.None)
+            NullableAnnotation nullableAnnotation = NullableAnnotation.None,
+            IAssemblySymbol containingAssembly = null)
         {
             members = members.NullToEmpty();
 
             return new CodeGenerationNamedTypeSymbol(
-                null, attributes, accessibility, modifiers, typeKind, name,
+                containingAssembly, null, attributes, accessibility, modifiers, typeKind, name,
                 typeParameters, baseType, interfaces, specialType, nullableAnnotation,
                 members.WhereAsArray(m => !(m is INamedTypeSymbol)),
                 members.OfType<INamedTypeSymbol>().Select(n => n.ToCodeGenerationSymbol()).ToImmutableArray(),
@@ -421,6 +422,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 parameters: parameters);
 
             return new CodeGenerationNamedTypeSymbol(
+                containingAssembly: null,
                 containingType: null,
                 attributes: attributes,
                 declaredAccessibility: accessibility,

--- a/src/Workspaces/Core/Portable/CodeGeneration/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/INamedTypeSymbolExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
 
             return new CodeGenerationNamedTypeSymbol(
+                namedType.ContainingAssembly,
                 namedType.ContainingType,
                 namedType.GetAttributes(),
                 namedType.DeclaredAccessibility,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             DeclarationModifiers modifiers,
             string name,
             ImmutableArray<AttributeData> returnTypeAttributes)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name)
+            : base(containingType?.ContainingAssembly, containingType, attributes, declaredAccessibility, modifiers, name)
         {
             _returnTypeAttributes = returnTypeAttributes.NullToEmpty();
         }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         internal readonly ImmutableArray<CodeGenerationAbstractNamedTypeSymbol> TypeMembers;
 
         protected CodeGenerationAbstractNamedTypeSymbol(
+            IAssemblySymbol containingAssembly,
             INamedTypeSymbol containingType,
             ImmutableArray<AttributeData> attributes,
             Accessibility declaredAccessibility,
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             SpecialType specialType,
             NullableAnnotation nullableAnnotation,
             ImmutableArray<CodeGenerationAbstractNamedTypeSymbol> typeMembers)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name, specialType, nullableAnnotation)
+            : base(containingAssembly, containingType, attributes, declaredAccessibility, modifiers, name, specialType, nullableAnnotation)
         {
             this.TypeMembers = typeMembers;
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     internal class CodeGenerationArrayTypeSymbol : CodeGenerationTypeSymbol, IArrayTypeSymbol
     {
         public CodeGenerationArrayTypeSymbol(ITypeSymbol elementType, int rank, NullableAnnotation nullableAnnotation)
-            : base(null, default, Accessibility.NotApplicable, default, string.Empty, SpecialType.None, nullableAnnotation)
+            : base(null, null, default, Accessibility.NotApplicable, default, string.Empty, SpecialType.None, nullableAnnotation)
         {
             this.ElementType = elementType;
             this.Rank = rank;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             CodeGenerationNamedTypeSymbol constructedFrom,
             ImmutableArray<ITypeSymbol> typeArguments,
             ImmutableArray<CodeGenerationAbstractNamedTypeSymbol> typeMembers)
-            : base(constructedFrom.ContainingType, constructedFrom.GetAttributes(),
+            : base(constructedFrom.ContainingAssembly, constructedFrom.ContainingType, constructedFrom.GetAttributes(),
                    constructedFrom.DeclaredAccessibility, constructedFrom.Modifiers,
                    constructedFrom.Name, constructedFrom.SpecialType, constructedFrom.NullableAnnotation, typeMembers)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             IMethodSymbol addMethod,
             IMethodSymbol removeMethod,
             IMethodSymbol raiseMethod)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name)
+            : base(containingType?.ContainingAssembly, containingType, attributes, declaredAccessibility, modifiers, name)
         {
             this.Type = type;
             this.ExplicitInterfaceImplementations = explicitInterfaceImplementations.NullToEmpty();

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             string name,
             bool hasConstantValue,
             object constantValue)
-            : base(containingType, attributes, accessibility, modifiers, name)
+            : base(containingType?.ContainingAssembly, containingType, attributes, accessibility, modifiers, name)
         {
             this.Type = type;
             this.HasConstantValue = hasConstantValue;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private readonly INamedTypeSymbol _enumUnderlyingType;
 
         public CodeGenerationNamedTypeSymbol(
+            IAssemblySymbol containingAssembly,
             INamedTypeSymbol containingType,
             ImmutableArray<AttributeData> attributes,
             Accessibility declaredAccessibility,
@@ -35,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<ISymbol> members,
             ImmutableArray<CodeGenerationAbstractNamedTypeSymbol> typeMembers,
             INamedTypeSymbol enumUnderlyingType)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name, specialType, nullableAnnotation, typeMembers)
+            : base(containingAssembly, containingType, attributes, declaredAccessibility, modifiers, name, specialType, nullableAnnotation, typeMembers)
         {
             _typeKind = typeKind;
             _typeParameters = typeParameters.NullToEmpty();
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         protected override CodeGenerationTypeSymbol CloneWithNullableAnnotation(NullableAnnotation nullableAnnotation)
         {
             return new CodeGenerationNamedTypeSymbol(
-                this.ContainingType, this.GetAttributes(), this.DeclaredAccessibility,
+                this.ContainingAssembly, this.ContainingType, this.GetAttributes(), this.DeclaredAccessibility,
                 this.Modifiers, this.TypeKind, this.Name, _typeParameters, _baseType,
                 _interfaces, this.SpecialType, nullableAnnotation, _members, this.TypeMembers,
                 this.EnumUnderlyingType);

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceOrTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceOrTypeSymbol.cs
@@ -10,12 +10,13 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     internal abstract class CodeGenerationNamespaceOrTypeSymbol : CodeGenerationSymbol, INamespaceOrTypeSymbol
     {
         protected CodeGenerationNamespaceOrTypeSymbol(
+            IAssemblySymbol containingAssembly,
             INamedTypeSymbol containingType,
             ImmutableArray<AttributeData> attributes,
             Accessibility declaredAccessibility,
             DeclarationModifiers modifiers,
             string name)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name)
+            : base(containingAssembly, containingType, attributes, declaredAccessibility, modifiers, name)
         {
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceSymbol.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private readonly IList<INamespaceOrTypeSymbol> _members;
 
         public CodeGenerationNamespaceSymbol(string name, IList<INamespaceOrTypeSymbol> members)
-            : base(null, default, Accessibility.NotApplicable, default, name)
+            : base(null, null, default, Accessibility.NotApplicable, default, name)
         {
             _members = members ?? SpecializedCollections.EmptyList<INamespaceOrTypeSymbol>();
         }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             bool isOptional,
             bool hasDefaultValue,
             object defaultValue)
-            : base(containingType, attributes, Accessibility.NotApplicable, new DeclarationModifiers(), name)
+            : base(containingType?.ContainingAssembly, containingType, attributes, Accessibility.NotApplicable, new DeclarationModifiers(), name)
         {
             this.RefKind = refKind;
             this.IsParams = isParams;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPointerTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPointerTypeSymbol.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public ITypeSymbol PointedAtType { get; }
 
         public CodeGenerationPointerTypeSymbol(ITypeSymbol pointedAtType)
-            : base(null, default, Accessibility.NotApplicable, default, string.Empty, SpecialType.None, NullableAnnotation.None)
+            : base(null, null, default, Accessibility.NotApplicable, default, string.Empty, SpecialType.None, NullableAnnotation.None)
         {
             this.PointedAtType = pointedAtType;
         }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<IParameterSymbol> parametersOpt,
             IMethodSymbol getMethod,
             IMethodSymbol setMethod)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name)
+            : base(containingType?.ContainingAssembly, containingType, attributes, declaredAccessibility, modifiers, name)
         {
             this.Type = type;
             this._refKind = refKind;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationSymbol.cs
@@ -25,12 +25,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public INamedTypeSymbol ContainingType { get; protected set; }
 
         protected CodeGenerationSymbol(
+            IAssemblySymbol containingAssembly,
             INamedTypeSymbol containingType,
             ImmutableArray<AttributeData> attributes,
             Accessibility declaredAccessibility,
             DeclarationModifiers modifiers,
             string name)
         {
+            this.ContainingAssembly = containingAssembly;
             this.ContainingType = containingType;
             _attributes = attributes.NullToEmpty();
             this.DeclaredAccessibility = declaredAccessibility;
@@ -70,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public virtual ISymbol ContainingSymbol => null;
 
-        public IAssemblySymbol ContainingAssembly => null;
+        public IAssemblySymbol ContainingAssembly { get; }
 
         public static IMethodSymbol ContainingMethod => null;
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             bool hasUnmanagedConstraint,
             bool hasNotNullConstraint,
             int ordinal)
-            : base(containingType, attributes, Accessibility.NotApplicable, default, name, SpecialType.None, nullableAnnotation)
+            : base(containingType?.ContainingAssembly, containingType, attributes, Accessibility.NotApplicable, default, name, SpecialType.None, nullableAnnotation)
         {
             this.Variance = varianceKind;
             this.ConstraintTypes = constraintTypes;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public SpecialType SpecialType { get; protected set; }
 
         protected CodeGenerationTypeSymbol(
+            IAssemblySymbol containingAssembly,
             INamedTypeSymbol containingType,
             ImmutableArray<AttributeData> attributes,
             Accessibility declaredAccessibility,
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             string name,
             SpecialType specialType,
             NullableAnnotation nullableAnnotation)
-            : base(containingType, attributes, declaredAccessibility, modifiers, name)
+            : base(containingAssembly, containingType, attributes, declaredAccessibility, modifiers, name)
         {
             this.SpecialType = specialType;
             this.NullableAnnotation = nullableAnnotation;


### PR DESCRIPTION
ConvertTupleToStruct invokes our existing services for generating GetHashCode methods; that service checks whether System.HashCode is available, and if so uses it rather than implementing the hash code combining manually. The code to generate GetHashCode correctly not just grabs the type but also tries to check whether type is accessible to the struct being generated. It's possible for System.HashCode to be internal if some library you're referencing has embedded it's own copy; in this case we were trying to check if the System.HashCode was accessible to the code generation symbol; if the System.HashCode was internal it then checks the assembly symbols for InternalsVisibleTo, but since the code generation symbol never had a ContainingAssembly this would crash with a null reference.

Much of this code is null annotated, but unfortunately we have yet to annotate ContainingAssembly, so the line of code that let a null get into the system was here:

https://github.com/dotnet/roslyn/blob/884fdff6f8a87faa7f6e65d762bd6d7b2025da74/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions_Accessibility.cs#L230

My fix is to create the code generation INamedTypeSymbol with a containing assembly, which allows the rest of the checks to work correctly.