### PR TITLE
Tweak .editorconfig legacy engine controls

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -64,7 +64,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
 
         private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
-            // Bail out if NativeEditorConfigSupport experiment is not enabled.
             if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
             {
                 return ImmutableArray<CodeFix>.Empty;

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -34,7 +34,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string PartialLoadMode = "Roslyn.PartialLoadMode";
         public const string TypeImportCompletion = "Roslyn.TypeImportCompletion";
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
-        public const string NativeEditorConfigSupport = "Roslyn.NativeEditorConfigSupport";
         public const string TriggerCompletionInArgumentLists = "Roslyn.TriggerCompletionInArgumentLists";
         public const string SQLiteInMemoryWriteCache = "Roslyn.SQLiteInMemoryWriteCache";
 

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigDocumentOptionsProviderFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Options.EditorConfig
 
         public static readonly Option2<bool> UseLegacyEditorConfigSupport =
             new Option2<bool>(nameof(EditorConfigDocumentOptionsProviderFactory), nameof(UseLegacyEditorConfigSupport), defaultValue: false,
-                storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "UseLegacySupport"));
+                storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "UseLegacySupport16.7"));
 
         public static bool ShouldUseNativeEditorConfigSupport(Workspace workspace)
             => !workspace.Options.GetOption(UseLegacyEditorConfigSupport);


### PR DESCRIPTION
Two small changes:

1. Remove some unused bits for the experiment that is no longer active.
2. Change the storage location for the option to use legacy .editorconfig.

To explain the second bit:

We originally offered this checkbox as a way for users who were broken by our .editorconfig support to have an opt-out while we diagnosed what issues they were running into. At this point we aren't tracking any bugs, so we want anybody who had checked this checkbox to get the new experience again in hopes that their problems are now addressed. If we don't hear any additional feedback, we'll remove the legacy engine entirely in 16.8.