### PR TITLE
Change name of record Clone method to unspeakable

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6128,13 +6128,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The receiver of a `with` expression must have a non-void type.</value>
   </data>
   <data name="ERR_NoSingleCloneMethod" xml:space="preserve">
-    <value>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</value>
-  </data>
-  <data name="ERR_ContainingTypeMustDeriveFromWithReturnType" xml:space="preserve">
-    <value>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</value>
-  </data>
-  <data name="ERR_WithMemberIsNotRecordProperty" xml:space="preserve">
-    <value>All arguments to a `with` expression must be compiler-generated record properties.</value>
+    <value>The receiver type '{0}' is not a valid record type.</value>
   </data>
   <data name="ERR_AssignmentInitOnly" xml:space="preserve">
     <value>Init-only property or indexer '{0}' can only be assigned in an object initializer, or on 'this' or 'base' in an instance constructor or an 'init' accessor.</value>
@@ -6246,5 +6240,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_MultipleRecordParameterLists" xml:space="preserve">
     <value>Only a single record partial declaration may have a parameter list</value>
+  </data>
+  <data name="ERR_BadRecordBase" xml:space="preserve">
+    <value>Records may only inherit from object or another record</value>
+  </data>
+  <data name="ERR_BadInheritanceFromRecord" xml:space="preserve">
+    <value>Only records may inherit from records.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1827,11 +1827,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadInitAccessor = 8856,
         ERR_InvalidWithReceiverType = 8857,
         ERR_NoSingleCloneMethod = 8858,
-        ERR_ContainingTypeMustDeriveFromWithReturnType = 8859,
-        ERR_WithMemberIsNotRecordProperty = 8860,
         ERR_UnexpectedArgumentList = 8861,
         ERR_UnexpectedOrMissingConstructorInitializerInRecord = 8862,
         ERR_MultipleRecordParameterLists = 8863,
+        ERR_BadRecordBase = 8864,
+        ERR_BadInheritanceFromRecord = 8865,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -111,6 +111,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 localBase.CheckAllConstraints(DeclaringCompilation, conversions, location, diagnostics);
             }
+
+            // Records can only inherit from other records or object
+            if (declaration.Kind == DeclarationKind.Record &&
+                localBase.SpecialType != SpecialType.System_Object &&
+                SynthesizedRecordClone.FindValidCloneMethod(localBase) is null)
+            {
+                var baseLocation = FindBaseRefSyntax(localBase);
+                diagnostics.Add(ErrorCode.ERR_BadRecordBase, baseLocation);
+            }
+            else if (declaration.Kind != DeclarationKind.Record &&
+                     SynthesizedRecordClone.FindValidCloneMethod(localBase) is object)
+            {
+                var baseLocation = FindBaseRefSyntax(localBase);
+                diagnostics.Add(ErrorCode.ERR_BadInheritanceFromRecord, baseLocation);
+            }
         }
 
         protected override void CheckInterfaces(DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
@@ -17,11 +17,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedRecordClone : SynthesizedInstanceMethodSymbol
     {
+        public override TypeWithAnnotations ReturnTypeWithAnnotations { get; }
         public override NamedTypeSymbol ContainingType { get; }
+        public override bool IsOverride { get; }
 
         public SynthesizedRecordClone(NamedTypeSymbol containingType)
         {
             ContainingType = containingType;
+            var baseType = containingType.BaseTypeNoUseSiteDiagnostics;
+            if (FindValidCloneMethod(baseType) is { } baseClone)
+            {
+                // Use covariant returns when available
+                ReturnTypeWithAnnotations = baseClone.ReturnTypeWithAnnotations;
+                IsOverride = true;
+            }
+            else
+            {
+                ReturnTypeWithAnnotations = TypeWithAnnotations.Create(isNullableEnabled: true, containingType);
+                IsOverride = false;
+            }
         }
 
         public override string Name => WellKnownMemberNames.CloneMethodName;
@@ -43,10 +57,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override RefKind RefKind => RefKind.None;
 
         public override ImmutableArray<ParameterSymbol> Parameters => ImmutableArray<ParameterSymbol>.Empty;
-
-        public override TypeWithAnnotations ReturnTypeWithAnnotations => TypeWithAnnotations.Create(
-            isNullableEnabled: true,
-            ContainingType);
 
         public override FlowAnalysisAnnotations ReturnTypeFlowAnalysisAnnotations => FlowAnalysisAnnotations.None;
 
@@ -71,10 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsStatic => false;
 
-        // PROTOTYPE: Inheritance is not handled
-        public override bool IsVirtual => true;
-
-        public override bool IsOverride => false;
+        public override bool IsVirtual => !IsOverride;
 
         public override bool IsAbstract => false;
 
@@ -104,9 +111,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override IEnumerable<SecurityAttribute> GetSecurityInformation()
             => Array.Empty<SecurityAttribute>();
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
+        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => !IsOverride;
 
-        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => false;
+        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => true;
 
         internal override bool SynthesizesLoweredBoundBody => true;
 
@@ -114,7 +121,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var F = new SyntheticBoundNodeFactory(this, ContainingType.GetNonNullSyntaxNode(), compilationState, diagnostics);
 
-            // PROTOTYPE: what about base fields?
             var members = ContainingType.GetMembers(WellKnownMemberNames.InstanceConstructorName);
             foreach (var member in members)
             {
@@ -128,6 +134,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             throw ExceptionUtilities.Unreachable;
+        }
+
+        internal static MethodSymbol? FindValidCloneMethod(NamedTypeSymbol containingType)
+        {
+            for (; !(containingType is null); containingType = containingType.BaseTypeNoUseSiteDiagnostics)
+            {
+                foreach (var member in containingType.GetMembers(WellKnownMemberNames.CloneMethodName))
+                {
+                    if (member is MethodSymbol
+                    {
+                        DeclaredAccessibility: Accessibility.Public,
+                        IsStatic: false,
+                        IsAbstract: false,
+                        ParameterCount: 0,
+                        Arity: 0
+                    } method && (method.IsOverride || method.IsVirtual))
+                    {
+                        return method;
+                    }
+                }
+            }
+            return null;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -45,7 +45,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var param = F.Parameter(Parameters[0]);
             foreach (var field in ContainingType.GetFieldsToEmit())
             {
-                statements.Add(F.Assignment(F.Field(F.This(), field), F.Field(param, field)));
+                if (!field.IsStatic)
+                {
+                    statements.Add(F.Assignment(F.Field(F.This(), field), F.Field(param, field)));
+                }
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Neplatný operand pro porovnávací vzorek. Vyžaduje se hodnota, ale nalezeno: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Výraz typu {0} nelze zpracovat vzorem typu {1}. Použijte prosím verzi jazyka {2} nebo vyšší, aby odpovídala otevřenému typu se vzorem konstanty.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Výčty, třídy a struktury není možné deklarovat v rozhraní, které má parametr typu in/out.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Ungültiger Operand für die Musterübereinstimmung. Ein Wert ist erforderlich, gefunden wurde aber "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Ein Ausdruck vom Typ "{0}" kann nicht von einem Muster vom Typ "{1}" behandelt werden. Verwenden Sie Sprachversion {2} oder höher, um einen offenen Typ mit einem konstanten Muster abzugleichen.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Enumerationen, Klassen und Strukturen können nicht in Schnittstellen mit Parametern vom Typ "in" oder "out" deklariert werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Operando no válido para la coincidencia de patrones. Se requería un valor, pero se encontró '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Un patrón de tipo "{0}" no se puede controlar por un patrón de tipo "{1}". Use la versión de lenguaje "{2}" o superior para buscar un tipo abierto con un patrón constante.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Las enumeraciones, las clases y las estructuras no se pueden declarar en una interfaz que tenga un parámetro de tipo "in" o "out".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Opérande non valide pour les critères spéciaux ; la valeur nécessaire n'est pas celle trouvée, '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Une expression de type '{0}' ne peut pas être prise en charge par un modèle de type '{1}'. Utilisez la version de langage '{2}' ou une version ultérieure pour faire correspondre un type ouvert à un modèle de constante.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Les enums, les classes et les structures ne peuvent pas être déclarés dans une interface contenant un paramètre de type 'in' ou 'out'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">L'operando non è valido per i criteri di ricerca. È richiesto un valore ma è stato trovato '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Un'espressione di tipo '{0}' non può essere gestita da un criterio di tipo '{1}'. Usare la versione '{2}' o versioni successive del linguaggio per abbinare un tipo aperto a un criterio costante.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Non è possibile dichiarare enumerazioni, classi e strutture in un'interfaccia che contiene un parametro di tipo 'in' o 'out'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">パターン マッチには使用できないオペランドです。値が必要ですが、'{0}' が見つかりました。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">型 '{0}' の式を型 '{1}' のパターンで処理することはできません。オープン型と定数パターンを一致させるには、言語バージョン '{2}' 以上をご使用ください。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">'in' または 'out' の型パラメーターを持つインターフェイス内では、列挙体、クラス、および構造体を宣言することはできません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">패턴 일치에 대한 피연산자가 잘못되었습니다. 값이 필요하지만 '{0}'을(를) 찾았습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">'{0}' 형식의 식은 '{1}' 형식의 패턴으로 처리할 수 없습니다. 언어 버전 '{2}' 이상을 사용하여 개방형 형식과 상수 패턴을 일치시키세요.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">'in' 또는 'out' 형식 매개 변수가 있는 인터페이스에서 열거형, 클래스, 구조체를 선언할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Nieprawidłowy operand dla dopasowania wzorca; wymagana jest wartość, a znaleziono „{0}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Wyrażenie typu „{0}” nie może być obsługiwane przez wzorzec typu „{1}”. Użyj wersji języka „{2}” lub nowszej, aby dopasować typ otwarty za pomocą wzorca stałej.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Wyliczenia, klasy i struktury nie mogą być deklarowane w interfejsie mającym parametr typu „in” lub „out”.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Operando inválido para correspondência de padrão. Um valor era obrigatório, mas '{0}' foi encontrado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Uma expressão do tipo '{0}' não pode ser manipulada por um padrão do tipo '{1}'. Use a versão de linguagem '{2}' ou superior para corresponder a um tipo aberto com um padrão constante.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Não é possível declarar enumerações, classes e estruturas em uma interface que tenha um parâmetro de tipo 'in' ou 'out'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Недопустимый операнд для сопоставления с шаблоном. Требуется значение, но найдено "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">Выражение типа "{0}" не может быть обработано шаблоном типа "{1}". Используйте версию языка "{2}" или более позднюю, чтобы сопоставить открытый тип с постоянным шаблоном.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Перечисления, классы и структуры не могут быть объявлены в интерфейсе, имеющем параметр типа "In" или "Out".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">Desen eşleşmesi için işlenen geçersiz. Değer gerekiyordu ancak '{0}' bulundu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">'{0}' türünde bir ifade, '{1}' türünde bir desen tarafından işlenemez. Lütfen açık bir türü sabit bir desenle eşleştirmek için '{2}' veya daha yüksek bir dil sürümü kullanın.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">Sabit listeleri, sınıflar ve yapılar 'in' veya 'out' tür parametresine sahip bir arabirimde bildirilemez.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">用于模式匹配的操作数无效；需要值，但找到的是“{0}”。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">"{0}" 类型的表达式不能由 "{1}" 类型的模式进行处理。请使用语言版本 "{2}" 或更高版本，将开放类型与常数模式进行匹配。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">无法在含有 "in" 或 "out" 类型参数的接口中声明枚举、类和结构。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="new">'{0}' cannot be used as a modifier on a function pointer parameter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadInheritanceFromRecord">
+        <source>Only records may inherit from records.</source>
+        <target state="new">Only records may inherit from records.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadInitAccessor">
         <source>The 'init' accessor is not valid on static members</source>
         <target state="new">The 'init' accessor is not valid on static members</target>
@@ -125,6 +130,11 @@
       <trans-unit id="ERR_BadPatternExpression">
         <source>Invalid operand for pattern match; value required, but found '{0}'.</source>
         <target state="translated">模式比對運算元無效; 需要值，但找到 '{0}'。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_BadRecordBase">
+        <source>Records may only inherit from object or another record</source>
+        <target state="new">Records may only inherit from object or another record</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRecordDeclaration">
@@ -180,11 +190,6 @@
       <trans-unit id="ERR_ConstantPatternVsOpenType">
         <source>An expression of type '{0}' cannot be handled by a pattern of type '{1}'. Please use language version '{2}' or greater to match an open type with a constant pattern.</source>
         <target state="translated">類型 '{0}' 的運算式無法由類型 '{1}' 的模式處理。請使用語言 '{2}' 版或更新版本，以比對開放式類型與常數模式。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_ContainingTypeMustDeriveFromWithReturnType">
-        <source>The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</source>
-        <target state="new">The type of the 'with' expression receiver, '{0}', does not derive from the return type of the 'Clone' method, '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
@@ -483,8 +488,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoSingleCloneMethod">
-        <source>The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</source>
-        <target state="new">The receiver type '{0}' does not have an accessible parameterless instance method named "Clone".</target>
+        <source>The receiver type '{0}' is not a valid record type.</source>
+        <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NotNullConstraintMustBeFirst">
@@ -760,11 +765,6 @@
       <trans-unit id="ERR_VarianceInterfaceNesting">
         <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
         <target state="translated">無法在有 'in' 或 'out' 型別參數的介面中宣告列舉、類別和結構。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_WithMemberIsNotRecordProperty">
-        <source>All arguments to a `with` expression must be compiler-generated record properties.</source>
-        <target state="new">All arguments to a `with` expression must be compiler-generated record properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_WrongFuncPtrCallingConvention">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InitOnlyMemberTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InitOnlyMemberTests.cs
@@ -2173,7 +2173,7 @@ public record C(int i)
 
             var cMembers = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMembers();
             AssertEx.SetEqual(new[] {
-                "C C.Clone()",
+                "C C.<>Clone()",
                 "System.Type C.EqualityContract.get",
                 "System.Type C.EqualityContract { get; }",
                 "C..ctor(System.Int32 i)",

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -35,7 +35,6 @@ record C(int x, int y)
                     "Microsoft",
                     "C"),
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -69,7 +68,6 @@ record C(int x, int y)
                 Add( // C Type parameters
                     "T"),
                 Add( // Members
-                    "C<T> C<T>.Clone()",
                     "System.Int32 C<T>.x { get; init; }",
                     "T C<T>.t { get; init; }",
                     "System.Boolean C<T>.Equals(C<T>? )",
@@ -100,7 +98,6 @@ record C(int x, int y)
     T t { get; }
 `}";
             var members = new[] {
-                "C<T> C<T>.Clone()",
                 "System.Int32 C<T>.x { get; }",
                 "T C<T>.t { get; }",
                 "System.Boolean C<T>.Equals(C<T>? )",
@@ -1708,7 +1705,6 @@ record C(int X) : Base`(X`)
                     "Microsoft",
                     "C"),
                 Add( // Members + parameters
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1724,7 +1720,6 @@ record C(int X) : Base`(X`)
                     "void System.Object.Finalize()"),
                 s_pop,
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1758,7 +1753,6 @@ record C : Base(X)
                     "Microsoft",
                     "C"),
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1795,7 +1789,6 @@ partial record C : Base(X, Y)
                     "Microsoft",
                     "C"),
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1811,7 +1804,6 @@ partial record C : Base(X, Y)
                     "void System.Object.Finalize()"),
                 s_pop,
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1850,7 +1842,6 @@ partial record C : Base(X)
                     "Microsoft",
                     "C"),
                 Add( // Members + parameters
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1866,7 +1857,6 @@ partial record C : Base(X)
                     "void System.Object.Finalize()"),
                 s_pop,
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1882,7 +1872,6 @@ partial record C : Base(X)
                     "void System.Object.Finalize()"),
                 s_pop,
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1920,7 +1909,6 @@ partial record C(int X) : Base`(X`)
                     "Microsoft",
                     "C"),
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1936,7 +1924,6 @@ partial record C(int X) : Base`(X`)
                     "void System.Object.Finalize()"),
                 s_pop,
                 Add( // Members + parameters
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",
@@ -1952,7 +1939,6 @@ partial record C(int X) : Base`(X`)
                     "void System.Object.Finalize()"),
                 s_pop,
                 Add( // Members
-                    "C C.Clone()",
                     "System.Boolean C.Equals(C? )",
                     "System.Boolean C.Equals(System.Object? )",
                     "System.Boolean System.Object.Equals(System.Object obj)",

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6991,7 +6991,7 @@ oneMoreTime:
             IOperation cloned = operation.CloneMethod is null
                 ? MakeInvalidOperation(visitedInstance.Type, visitedInstance)
                 : new InvocationOperation(operation.CloneMethod, visitedInstance,
-                    isVirtual: false, arguments: ImmutableArray<IArgumentOperation>.Empty,
+                    isVirtual: true, arguments: ImmutableArray<IArgumentOperation>.Empty,
                     semanticModel: null, operation.Syntax, operation.Type, operation.ConstantValue, isImplicit: true);
 
             return PopStackFrame(frame, HandleObjectOrCollectionInitializer(operation.Initializer, cloned));

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public const string SliceMethodName = "Slice";
 
-        // PROTOTYPE: internal since this has yet to be approved
-        internal const string CloneMethodName = "Clone";
+        // internal until we settle on this long-term
+        internal const string CloneMethodName = "<>Clone";
     }
 }


### PR DESCRIPTION
The compiler now uses a reserved name for the clone method which only
records will generate. Some existing tests are interesting if we ever
allow user-generation of the clone method but cannot be run in the
current state. I've left them in, but marked them skipped  with the
text "unspeakable clone."