### PR TITLE
Remove build enforcement of unused usings in IDE layers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -226,9 +226,6 @@ dotnet_diagnostic.RS0037.severity = none
 dotnet_diagnostic.RS0005.severity = none
 
 [src/{Analyzers,CodeStyle,Features,Workspaces}/**/*.{cs,vb}]
-# IDE0005: Remove unnecessary usings/imports
-dotnet_diagnostic.IDE0005.severity = warning
-
 # IDE0011: Add braces
 csharp_prefer_braces = when_multiline:warning
 # NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201


### PR DESCRIPTION
We had enabled this rule as a build time enforcement for IDE projects, but it has caused a bunch of build breaks and is turning out to be too onerous to enforce. It was decided that this would be better implemented as a post-build code cleanup bot.