### PR TITLE
Avoid localizing Empty.resx

### DIFF
--- a/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
@@ -73,6 +73,14 @@
 
   <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets')" />
 
+  <Target Name="NoLocalizeEmptyResx" AfterTargets="EnsureResourceToMergeWithCTO">
+    <ItemGroup>
+      <EmbeddedResource Update="@(EmbeddedResource)" Condition="'%(ManifestResourceName)' == '_EmptyResource'">
+        <XlfInput>false</XlfInput>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
   <Target Name="VsixSourceItemsOutputGroup"
           Returns="@(VSIXSourceItem)"
           DependsOnTargets="GetVsixSourceItems">


### PR DESCRIPTION
Fixes a design time build error:

```
C:\Users\sam\.nuget\packages\xlifftasks\1.0.0-beta.20206.1\build\XliffTasks.targets(166,5): error MSB4018: The "TranslateSource" task failed unexpectedly.
System.IO.FileNotFoundException: File not found: C:\Users\sam\.nuget\packages\microsoft.vssdk.buildtools\16.7.2\tools\vssdk\xlf\Empty.cs.xlf
File name: 'C:\Users\sam\.nuget\packages\microsoft.vssdk.buildtools\16.7.2\tools\vssdk\xlf\Empty.cs.xlf'
   at XliffTasks.Tasks.XlfTask.LoadXlfDocument(String path, String language, Boolean createIfNonExistent) in /_/src/XliffTasks/Tasks/XlfTask.cs:line 79
   at XliffTasks.Tasks.TranslateSource.ExecuteCore()
   at XliffTasks.Tasks.XlfTask.Execute() in /_/src/XliffTasks/Tasks/XlfTask.cs:line 19
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\dev\roslyn\src\VisualStudio\VisualStudioInteractiveComponents\Roslyn.VisualStudio.InteractiveComponents.csproj]
```