### PR TITLE
Add support for language server exit & shutdown.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractLanguageServerClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractLanguageServerClient.cs
@@ -68,8 +68,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         public Task<Connection> ActivateAsync(CancellationToken token)
         {
-            Contract.ThrowIfFalse(_languageServer == null, "This language server has already been initialized");
-
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
             _languageServer = new InProcLanguageServer(serverStream, serverStream, _languageServerProtocol, _workspace, _diagnosticService, clientName: _diagnosticsClientName);
             return Task.FromResult(new Connection(clientStream, clientStream));

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractLanguageServerClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractLanguageServerClient.cs
@@ -68,6 +68,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         public Task<Connection> ActivateAsync(CancellationToken token)
         {
+            Contract.ThrowIfTrue(_languageServer?.Running == true, "The language server has not yet shutdown.");
+
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
             _languageServer = new InProcLanguageServer(serverStream, serverStream, _languageServerProtocol, _workspace, _diagnosticService, clientName: _diagnosticsClientName);
             return Task.FromResult(new Connection(clientStream, clientStream));

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -120,12 +120,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
             try
             {
-                if (!_jsonRpc.IsDisposed)
-                {
-                    _jsonRpc.Dispose();
-                }
+                _jsonRpc.Dispose();
             }
-            catch (Exception)
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {
                 // Swallow exceptions thrown by disposing our JsonRpc object. Disconnected events can potentially throw their own exceptions so
                 // we purposefully ignore all of those exceptions in an effort to shutdown gracefully.

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -100,7 +100,31 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         }
 
         [JsonRpcMethod(Methods.ShutdownName)]
-        public object? Shutdown(CancellationToken _) => null;
+        public Task ShutdownAsync(CancellationToken _)
+        {
+            _diagnosticService.DiagnosticsUpdated -= DiagnosticService_DiagnosticsUpdated;
+
+            return Task.CompletedTask;
+        }
+
+        [JsonRpcMethod(Methods.ExitName)]
+        public Task ExitAsync(CancellationToken _)
+        {
+            try
+            {
+                if (!_jsonRpc.IsDisposed)
+                {
+                    _jsonRpc.Dispose();
+                }
+            }
+            catch (Exception)
+            {
+                // Swallow exceptions thrown by disposing our JsonRpc object. Disconnected events can potentially throw their own exceptions so
+                // we purposefully ignore all of those exceptions in an effort to shutdown gracefully.
+            }
+
+            return Task.CompletedTask;
+        }
 
         [JsonRpcMethod(Methods.ExitName)]
         public void Exit()

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             _clientCapabilities = new VSClientCapabilities();
         }
 
-        public bool Running => !_shuttingDown && !_jsonRpc.IsDisposed
+        public bool Running => !_shuttingDown && !_jsonRpc.IsDisposed;
 
         /// <summary>
         /// Handle the LSP initialize request by storing the client capabilities


### PR DESCRIPTION
- The language server platform is properly implementing solution close understanding for local language servers and I found that when testing their bits Roslyn would explode gloriously. Turns out shutdown and exit support just wasn't fully enabled yet.
![image](https://user-images.githubusercontent.com/2008729/83904754-49a62b00-a715-11ea-9967-3acabce3ef03.png)

- When the language server platform reboots language servers it re-invokes Activate and because of that Roslyn explodes because the language client has already been activated and there was previously a contract throws check on already being initialized.
- Implemented the `ShutdownAsync` target on the `InProcLanguageServer` to detach from the diagnostic service.
- Implemented the `ExitAsync` target on the `InProcLanguageServer` to properly dispose our `JsonRpc` object.