### PR TITLE
Remove prototype comments

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_WithExpression.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnose: false,
                     ref useSiteDiagnostics);
 
-                // PROTOTYPE: Should handle hiding/overriding
+                // https://github.com/dotnet/roslyn/issues/44908 - Should handle hiding/overriding
                 if (lookupResult.IsMultiViable)
                 {
                     foreach (var symbol in lookupResult.Symbols)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9690,7 +9690,7 @@ tryAgain:
                 case SyntaxKind.IsPatternExpression:
                     return Precedence.Relational;
                 case SyntaxKind.SwitchExpression:
-                // PROTOTYPE: Is this the right precedence?
+                // https://github.com/dotnet/roslyn/issues/44675 Is this the right precedence?
                 case SyntaxKind.WithExpression:
                     return Precedence.Switch;
                 case SyntaxKind.LeftShiftExpression:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2972,8 +2972,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(builder.RecordDeclarationWithParameters is object);
                 Debug.Assert(builder.InstanceInitializersForRecordDeclarationWithParameters is object);
 
-                // PROTOTYPE: The semantics of an empty parameter list have not been decided. Error
-                // for now
+                // https://github.com/dotnet/roslyn/issues/44677
+                // The semantics of an empty parameter list have not been decided. Error for now
                 if (paramList.ParameterCount == 0)
                 {
                     diagnostics.Add(ErrorCode.ERR_BadRecordDeclaration, paramList.Location);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             var F = new SyntheticBoundNodeFactory(this, ContainingType.GetNonNullSyntaxNode(), compilationState, diagnostics);
-            // PROTOYPE: We can do better :)
+            // https://github.com/dotnet/roslyn/issues/44683 We can do better :)
             F.CloseMethod(F.Return(F.Literal(0)));
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPropertySymbol.cs
@@ -224,7 +224,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Name = SourcePropertyAccessorSymbol.GetAccessorName(
                     paramName,
                     getNotSet: false,
-                    isWinMdOutput: false /* PROTOTYPE */);
+                    // https://github.com/dotnet/roslyn/issues/44684
+                    isWinMdOutput: false);
 
                 var comp = property.DeclaringCompilation;
                 var type = TypeWithAnnotations.Create(comp.GetSpecialType(SpecialType.System_Void));

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             // Add nodes that are not yet in AllInOneCSharpCode to this list.
             var missingSyntaxKinds = new HashSet<SyntaxKind>();
-            // PROTOTYPE: Add to all in one
+            // https://github.com/dotnet/roslyn/issues/44682 Add to all in one
             missingSyntaxKinds.Add(SyntaxKind.WithExpression);
             missingSyntaxKinds.Add(SyntaxKind.RecordDeclaration);
             missingSyntaxKinds.Add(SyntaxKind.FunctionPointerType);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
@@ -1136,7 +1136,7 @@ class C
         public void WithParsing16()
         {
             var text = @"x with { X = ""2"" };";
-            // PROTOTYPE
+            // https://github.com/dotnet/roslyn/issues/44688
             // The parser doesn't see this as an invalid expression
             // statement, but as a broken declaration, e.g.
             //      x with <missing ,> { X = ""2 "" <missing ;> };

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -1218,7 +1218,7 @@ tryAgain:
 
             if (isReturn)
             {
-                // PROTOTYPE(init-only): make this more restrictive (ie. disallow aside from the return value of an instance setter)
+                // https://github.com/dotnet/roslyn/issues/44671 make this more restrictive (ie. disallow aside from the return value of an instance setter)
                 allowedAttributes |= AllowedRequiredModifierType.System_Runtime_CompilerServices_IsExternalInit;
             }
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Friend Overrides Function IsAcceptedIsExternalInitModifierType(type As TypeSymbol) As Boolean
-            ' PROTOTYPE(init-only): VB doesn't deal with init-only members yet.
+            ' https://github.com/dotnet/roslyn/issues/44870 VB doesn't deal with init-only members yet.
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        ' PROTOTYPE(init-only) VB will be able to consume 'init' set accessors
+        ' https://github.com/dotnet/roslyn/issues/44870 VB will be able to consume 'init' set accessors
         Private ReadOnly Property IMethodSymbol_IsInitOnly As Boolean Implements IMethodSymbol.IsInitOnly
             Get
                 Return False

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
             symbolKindsWithNoCodeBlocks.Add(SymbolKind.NamedType);
 
             var missingSyntaxNodes = new HashSet<SyntaxKind>();
-            // PROTOTYPE: Add to all in one
+            // https://github.com/dotnet/roslyn/issues/44682 - Add to all in one
             missingSyntaxNodes.Add(SyntaxKind.WithExpression);
             missingSyntaxNodes.Add(SyntaxKind.RecordDeclaration);
             missingSyntaxNodes.Add(SyntaxKind.FunctionPointerType);


### PR DESCRIPTION
Removes most PROTOTYPE comments from the feature branch.

To reduce conflicts, PROTOTYPE comments removed by the following PRs are not modified in this PR:
#44906
#44852