### PR TITLE
Ensure correct binder is used to bind constructor initializers for synthesized parameter-less and copy constructors in records.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal InMethodBinder GetRecordConstructorInMethodBinder(SynthesizedRecordConstructor constructor)
         {
-            TypeDeclarationSyntax typeDecl = constructor.GetSyntax();
+            RecordDeclarationSyntax typeDecl = constructor.GetSyntax();
 
             var extraInfo = NodeUsage.ConstructorBodyOrInitializer;
             var key = BinderFactoryVisitor.CreateBinderCacheKey(typeDecl, extraInfo);
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (InMethodBinder)resultBinder;
         }
 
-        internal Binder GetInRecordBodyBinder(TypeDeclarationSyntax typeDecl)
+        internal Binder GetInRecordBodyBinder(RecordDeclarationSyntax typeDecl)
         {
             BinderFactoryVisitor visitor = _binderFactoryVisitorPool.Allocate();
             visitor.Initialize(position: typeDecl.SpanStart, memberDeclarationOpt: null, memberOpt: null);

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1867,8 +1867,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // The constructor is implicit. We need to get the binder for the body
                 // of the enclosing class. 
                 CSharpSyntaxNode containerNode = constructor.GetNonNullSyntaxNode();
-                SyntaxToken bodyToken = GetImplicitConstructorBodyToken(containerNode);
-                outerBinder = compilation.GetBinderFactory(containerNode.SyntaxTree).GetBinder(containerNode, bodyToken.Position);
+                BinderFactory binderFactory = compilation.GetBinderFactory(containerNode.SyntaxTree);
+
+                if (containerNode is RecordDeclarationSyntax recordDecl)
+                {
+                    outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
+                }
+                else
+                {
+                    SyntaxToken bodyToken = GetImplicitConstructorBodyToken(containerNode);
+                    outerBinder = binderFactory.GetBinder(containerNode, bodyToken.Position);
+                }
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -1140,6 +1140,134 @@ record C(int X)
         }
 
         [Fact]
+        public void AccessibilityOfBaseCtor_01()
+        {
+            var src = @"
+using System;
+
+record Base
+{
+    protected Base(int X, int Y)
+    {
+        Console.WriteLine(X);
+        Console.WriteLine(Y);
+    }
+
+    public Base() {}
+
+    public static void Main()
+    {
+        var c = new C(1, 2);
+    }
+}
+
+record C(int X, int Y) : Base(X, Y);
+";
+            CompileAndVerify(src, expectedOutput: @"
+1
+2
+");
+        }
+
+        [Fact]
+        public void AccessibilityOfBaseCtor_02()
+        {
+            var src = @"
+using System;
+
+record Base
+{
+    protected Base(int X, int Y)
+    {
+        Console.WriteLine(X);
+        Console.WriteLine(Y);
+    }
+
+    public Base() {}
+
+    public static void Main()
+    {
+        var c = new C(1, 2);
+    }
+}
+
+record C(int X, int Y) : Base(X, Y) {}
+";
+            CompileAndVerify(src, expectedOutput: @"
+1
+2
+");
+        }
+
+        [Fact]
+        [WorkItem(44898, "https://github.com/dotnet/roslyn/issues/44898")]
+        public void AccessibilityOfBaseCtor_03()
+        {
+            var src = @"
+abstract record A
+{
+    protected A() {}
+    protected A(A x) {}
+};
+record B(object P) : A;
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(44898, "https://github.com/dotnet/roslyn/issues/44898")]
+        public void AccessibilityOfBaseCtor_04()
+        {
+            var src = @"
+abstract record A
+{
+    protected A() {}
+    protected A(A x) {}
+};
+record B(object P) : A {}
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(44898, "https://github.com/dotnet/roslyn/issues/44898")]
+        public void AccessibilityOfBaseCtor_05()
+        {
+            var src = @"
+abstract record A
+{
+    protected A() {}
+    protected A(A x) {}
+};
+record B : A;
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(44898, "https://github.com/dotnet/roslyn/issues/44898")]
+        public void AccessibilityOfBaseCtor_06()
+        {
+            var src = @"
+abstract record A
+{
+    protected A() {}
+    protected A(A x) {}
+};
+record B : A {}
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void WithExprNestedErrors()
         {
             var src = @"


### PR DESCRIPTION
Fixes #44898.