### PR TITLE
ImplementAbstractClass should trigger on records

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -20187,7 +20187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public abstract SyntaxToken? SemicolonToken { get; }
     }
 
-    /// <summary>Base class for type declaration syntax (class, struct, interface).</summary>
+    /// <summary>Base class for type declaration syntax (class, struct, interface, record).</summary>
     internal abstract partial class TypeDeclarationSyntax : BaseTypeDeclarationSyntax
     {
         internal TypeDeclarationSyntax(SyntaxKind kind, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -20205,7 +20205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
         }
 
-        /// <summary>Gets the type keyword token ("class", "struct", "interface").</summary>
+        /// <summary>Gets the type keyword token ("class", "struct", "interface", "record").</summary>
         public abstract SyntaxToken Keyword { get; }
 
         public abstract TypeParameterListSyntax? TypeParameterList { get; }

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -8612,7 +8612,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public new BaseTypeDeclarationSyntax AddModifiers(params SyntaxToken[] items) => (BaseTypeDeclarationSyntax)AddModifiersCore(items);
     }
 
-    /// <summary>Base class for type declaration syntax (class, struct, interface).</summary>
+    /// <summary>Base class for type declaration syntax (class, struct, interface, record).</summary>
     public abstract partial class TypeDeclarationSyntax : BaseTypeDeclarationSyntax
     {
         internal TypeDeclarationSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -8620,7 +8620,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
         }
 
-        /// <summary>Gets the type keyword token ("class", "struct", "interface").</summary>
+        /// <summary>Gets the type keyword token ("class", "struct", "interface", "record").</summary>
         public abstract SyntaxToken Keyword { get; }
         public TypeDeclarationSyntax WithKeyword(SyntaxToken keyword) => WithKeywordCore(keyword);
         internal abstract TypeDeclarationSyntax WithKeywordCore(SyntaxToken keyword);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override void GenerateMethodBodyStatements(SyntheticBoundNodeFactory F, ArrayBuilder<BoundStatement> statements, DiagnosticBag diagnostics)
         {
-            // PROTOTYPE: Handle inheritance
+            // Tracking issue for copy constructor in inheritance scenario: https://github.com/dotnet/roslyn/issues/44902
             // Write assignments to fields
             //
             // {

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -3197,11 +3197,11 @@
   </AbstractNode>
   <AbstractNode Name="TypeDeclarationSyntax" Base="BaseTypeDeclarationSyntax">
     <TypeComment>
-      <summary>Base class for type declaration syntax (class, struct, interface).</summary>
+      <summary>Base class for type declaration syntax (class, struct, interface, record).</summary>
     </TypeComment>
     <Field Name="Keyword" Type="SyntaxToken">
       <PropertyComment>
-        <summary>Gets the type keyword token ("class", "struct", "interface").</summary>
+        <summary>Gets the type keyword token ("class", "struct", "interface", "record").</summary>
       </PropertyComment>
     </Field>
     <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true"/>

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -1847,5 +1847,61 @@ class B : A<int
     }
 }");
         }
+
+        [WorkItem(44907, "https://github.com/dotnet/roslyn/issues/44907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        public async Task TestWithRecords()
+        {
+            await TestAllOptionsOffAsync(
+@"abstract record A
+{
+    public abstract void AbstractMethod();
+}
+
+record [|B|] : A
+{
+
+}",
+@"abstract record A
+{
+    public abstract void AbstractMethod();
+}
+
+record B : A
+{
+    public override void AbstractMethod()
+    {
+        throw new System.NotImplementedException();
+    }
+}", parseOptions: TestOptions.RegularPreview);
+        }
+
+        [WorkItem(44907, "https://github.com/dotnet/roslyn/issues/44907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        public async Task TestWithRecordsWithPositionalMembers()
+        {
+            await TestAllOptionsOffAsync(
+@"abstract record A
+{
+    public abstract void AbstractMethod();
+}
+
+record [|B|](int i) : A
+{
+
+}",
+@"abstract record A
+{
+    public abstract void AbstractMethod();
+}
+
+record B(int i) : A
+{
+    public override void AbstractMethod()
+    {
+        throw new System.NotImplementedException();
+    }
+}", parseOptions: TestOptions.RegularPreview);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ImplementAbstractClass/CSharpImplementAbstractClassCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementAbstractClass/CSharpImplementAbstractClassCodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementAbstractClass
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.ImplementAbstractClass), Shared]
     [ExtensionOrder(After = PredefinedCodeFixProviderNames.GenerateType)]
     internal class CSharpImplementAbstractClassCodeFixProvider :
-        AbstractImplementAbstractClassCodeFixProvider<ClassDeclarationSyntax>
+        AbstractImplementAbstractClassCodeFixProvider<TypeDeclarationSyntax>
     {
         private const string CS0534 = nameof(CS0534); // 'Program' does not implement inherited abstract member 'Goo.bar()'
 
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementAbstractClass
         {
         }
 
-        protected override SyntaxToken GetClassIdentifier(ClassDeclarationSyntax classNode)
+        protected override SyntaxToken GetClassIdentifier(TypeDeclarationSyntax classNode)
             => classNode.Identifier;
     }
 }


### PR DESCRIPTION
This PR is not blocking 16.7p3.

Fixes https://github.com/dotnet/roslyn/issues/44907

Notes on design: I extended the ImplementAbstractClassProvider, rather than renaming it (ImplementAbstractTypeProvider?) or duplicating (ImplementAbstractRecordProvider).
I didn't rename because records are classes. I didn't duplicate because it would just create more computation (running two fix providers) for no gain as far as I can tell.