### PR TITLE
Fix parsing of nested verbatim interpolated strings started with @$

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -602,6 +602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             }
                             else if (lexer.TextWindow.PeekChar(1) == '$' && lexer.TextWindow.PeekChar(2) == '"')
                             {
+                                lexer.CheckFeatureAvailability(MessageID.IDS_FeatureAltInterpolatedVerbatimStrings);
                                 var interpolations = (ArrayBuilder<Interpolation>)null;
                                 var info = default(TokenInfo);
                                 bool wasVerbatim = this.isVerbatim;

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -600,6 +600,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 ScanInterpolatedStringLiteralNestedVerbatimString();
                                 continue;
                             }
+                            else if (lexer.TextWindow.PeekChar(1) == '$' && lexer.TextWindow.PeekChar(2) == '"')
+                            {
+                                var interpolations = (ArrayBuilder<Interpolation>)null;
+                                var info = default(TokenInfo);
+                                bool wasVerbatim = this.isVerbatim;
+                                bool wasAllowNewlines = this.allowNewlines;
+                                try
+                                {
+                                    this.isVerbatim = true;
+                                    this.allowNewlines = true;
+                                    bool closeQuoteMissing;
+                                    ScanInterpolatedStringLiteralTop(interpolations, ref info, out closeQuoteMissing);
+                                }
+                                finally
+                                {
+                                    this.isVerbatim = wasVerbatim;
+                                    this.allowNewlines = wasAllowNewlines;
+                                }
+                                continue;
+                            }
 
                             goto default;
                         case '/':

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -86,6 +86,79 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 N(SyntaxKind.InterpolatedStringText);
                 {
                     N(SyntaxKind.InterpolatedStringTextToken);
+                }
+                N(SyntaxKind.InterpolatedStringEndToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestNestedAltInterpolatedVerbatimString_CSharp73()
+        {
+            UsingExpression("$@\"aaa{@$\"bbb\nccc\"}ddd\"", TestOptions.Regular7_3,
+                // (1,8): error CS8401: To use '@$' instead of '$@' for an interpolated verbatim string, please use language version '8.0' or greater.
+                // $@"aaa{@$"bbb
+                Diagnostic(ErrorCode.ERR_AltInterpolatedVerbatimStringsNotAvailable, @"@$""").WithArguments("8.0").WithLocation(1, 8)
+                );
+
+            N(SyntaxKind.InterpolatedStringExpression);
+            {
+                N(SyntaxKind.InterpolatedVerbatimStringStartToken);
+                N(SyntaxKind.InterpolatedStringText);
+                {
+                    N(SyntaxKind.InterpolatedStringTextToken, "aaa");
+                }
+                N(SyntaxKind.Interpolation);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.InterpolatedStringExpression);
+                    {
+                        N(SyntaxKind.InterpolatedVerbatimStringStartToken);
+                        N(SyntaxKind.InterpolatedStringText);
+                        {
+                            N(SyntaxKind.InterpolatedStringTextToken, "bbb\nccc");
+                        }
+                        N(SyntaxKind.InterpolatedStringEndToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.InterpolatedStringText);
+                {
+                    N(SyntaxKind.InterpolatedStringTextToken, "ddd");
+                }
+                N(SyntaxKind.InterpolatedStringEndToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestNestedAltInterpolatedVerbatimString_CSharp8()
+        {
+            UsingExpression("$@\"aaa{@$\"bbb\nccc\"}ddd\"", TestOptions.Regular8);
+            N(SyntaxKind.InterpolatedStringExpression);
+            {
+                N(SyntaxKind.InterpolatedVerbatimStringStartToken);
+                N(SyntaxKind.InterpolatedStringText);
+                {
+                    N(SyntaxKind.InterpolatedStringTextToken, "aaa");
+                }
+                N(SyntaxKind.Interpolation);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.InterpolatedStringExpression);
+                    {
+                        N(SyntaxKind.InterpolatedVerbatimStringStartToken);
+                        N(SyntaxKind.InterpolatedStringText);
+                        {
+                            N(SyntaxKind.InterpolatedStringTextToken, "bbb\nccc");
+                        }
+                        N(SyntaxKind.InterpolatedStringEndToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.InterpolatedStringText);
+                {
+                    N(SyntaxKind.InterpolatedStringTextToken, "ddd");
                 }
                 N(SyntaxKind.InterpolatedStringEndToken);
             }
@@ -200,25 +273,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotEqual(default, us.Token);
             Assert.Equal(SyntaxKind.StringLiteralToken, us.Token.Kind());
             Assert.Equal("\"stuff\"", us.Token.ValueText);
-        }
-
-        [Fact]
-        public void TestNestedInterpolatedStringLiteralExpression()
-        {
-            test("$@\"aaa{@$\"bbb\nccc\"}ddd\"");
-            test("$@\"aaa{$@\"bbb\nccc\"}ddd\"");
-            void test(string text)
-            {
-                var expr = (InterpolatedStringExpressionSyntax)this.ParseExpression(text);
-                Assert.NotNull(expr);
-                Assert.Equal(SyntaxKind.InterpolatedStringExpression, expr.Kind());
-                Assert.Equal(0, expr.Errors().Length);
-
-                Assert.Equal("aaa", ((InterpolatedStringTextSyntax)expr.Contents[0]).TextToken.Text);
-                var innerStr = (InterpolatedStringExpressionSyntax)((InterpolationSyntax)expr.Contents[1]).Expression;
-                Assert.Equal("bbb\nccc", ((InterpolatedStringTextSyntax)innerStr.Contents[0]).TextToken.Text);
-                Assert.Equal("ddd", ((InterpolatedStringTextSyntax)expr.Contents[2]).TextToken.Text);
-            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -203,6 +203,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void TestNestedInterpolatedStringLiteralExpression()
+        {
+            test("$@\"aaa{@$\"bbb\nccc\"}ddd\"");
+            test("$@\"aaa{$@\"bbb\nccc\"}ddd\"");
+            void test(string text)
+            {
+                var expr = (InterpolatedStringExpressionSyntax)this.ParseExpression(text);
+                Assert.NotNull(expr);
+                Assert.Equal(SyntaxKind.InterpolatedStringExpression, expr.Kind());
+                Assert.Equal(0, expr.Errors().Length);
+
+                Assert.Equal("aaa", ((InterpolatedStringTextSyntax)expr.Contents[0]).TextToken.Text);
+                var innerStr = (InterpolatedStringExpressionSyntax)((InterpolationSyntax)expr.Contents[1]).Expression;
+                Assert.Equal("bbb\nccc", ((InterpolatedStringTextSyntax)innerStr.Contents[0]).TextToken.Text);
+                Assert.Equal("ddd", ((InterpolatedStringTextSyntax)expr.Contents[2]).TextToken.Text);
+            }
+        }
+
+        [Fact]
         public void TestCharacterLiteralExpression()
         {
             var text = "'c'";


### PR DESCRIPTION
When parsing an interpolated string, the function that scans to find the end of an interpolated hole, `ScanInterpolatedStringLiteralHoleBalancedText`, does not correctly account for the possibility of a nested string starting with @$.

This PR fixes this by copying the code already present for the $@ case just a few `case`s earlier.

I've included a unit test which fails without this patch.