### PR TITLE
Dogfood the new .NET analyzers NuGet package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <!-- Versions used by several individual references below -->
     <RoslynDiagnosticsNugetPackageVersion>3.3.0-beta1.20262.5</RoslynDiagnosticsNugetPackageVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>3.3.0-beta1.20305.4</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <CodeStyleLayerCodeAnalysisVersion>3.6.0-2.final</CodeStyleLayerCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20210.2</MicrosoftCodeAnalysisTestingVersion>
     <CodeStyleAnalyzerVersion>3.7.0-1.20210.7</CodeStyleAnalyzerVersion>
@@ -69,7 +70,6 @@
     <MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>3.0.0</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
-    <MicrosoftCodeQualityAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeQualityAnalyzersVersion>
     <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>
     <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>
@@ -88,7 +88,6 @@
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta3.20174.1</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
-    <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETTestSdkVersion>16.0.1</MicrosoftNETTestSdkVersion>
     <MicrosoftNETCoreTestHostVersion>1.1.0</MicrosoftNETCoreTestHostVersion>

--- a/eng/config/rulesets/NonShipping.ruleset
+++ b/eng/config/rulesets/NonShipping.ruleset
@@ -2,28 +2,14 @@
 <RuleSet Name="Common diagnostic rules for all non-shipping projects" Description="Enables/disable rules specific to all non-shipping projects." ToolsVersion="14.0">
   <Include Path=".\Shipping.ruleset" Action="Default" />
 
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
     <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
          thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
          where we want to marshal the continuations back to it. -->
     <Rule Id="CA2007" Action="None" />
 
-    <!-- Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007) -->
-    <Rule Id="CA1825" Action="None" />
-
-    <!-- Do not use Enumerable methods on indexable collections (originally RS0014) - suppressed because we have lot of violations in non-shipping/test projects.
-         We can fix all violations once we have a code fix with fix all, and then remove this suppression.
-    -->
-    <Rule Id="CA1826" Action="None" />
-
     <!-- Mark constant field as 'const' instead of static readonly - not useful for tests -->
     <Rule Id="CA1802" Action="None" />
-
-    <!-- Properties should not return arrays - not useful for tests -->
-    <Rule Id="CA1819" Action="None" />
-
-    <!-- Use Length/Count property instead of Count() when available - lot of violations for tests -->
-    <Rule Id="CA1829" Action="None" />
   </Rules>
 
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
@@ -46,14 +32,6 @@
 
     <!-- Do not call 'GetTestAccessor()' from production code: does not apply to tests -->
     <Rule Id="RS0043" Action="None" />
-  </Rules>
-
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers.Exp" RuleNamespace="Microsoft.CodeQuality.Analyzers.Exp">
-    <!-- Dispose rules turned off for non-shipping projects due to large number of violation count -->
-    <!-- https://github.com/dotnet/roslyn/issues/25129 tracks fixing/suppressing these violations and removing the below entries -->
-    <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA2213" Action="None" />
-    <Rule Id="CA1063" Action="None" />
   </Rules>
 
   <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -1,80 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Common diagnostic rules to run during build for all shipping Roslyn projects" Description="This file contains diagnostic settings used by all Roslyn projects. Projects that need specific settings should have their own rule set files that Include this one, and then make the necessary adjustments." ToolsVersion="14.0">
   <IncludeAll Action="Hidden" />
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
-    <Rule Id="CA1000" Action="None" />
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1010" Action="None" />
-    <Rule Id="CA1016" Action="None" />
-    <Rule Id="CA1018" Action="None" />
-    <Rule Id="CA1028" Action="None" />
-    <Rule Id="CA1030" Action="None" />
-    <Rule Id="CA1031" Action="None" /> <!-- Do not catch general exception types -->
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1034" Action="None" />
-    <Rule Id="CA1036" Action="None" />
-    <Rule Id="CA1040" Action="None" />
-    <Rule Id="CA1041" Action="None" />
-    <Rule Id="CA1043" Action="None" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1052" Action="None" />
-    <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1055" Action="None" />
-    <Rule Id="CA1056" Action="None" />
-    <Rule Id="CA1061" Action="None" /> <!-- "do not hide base class methods": currently violations in the compiler -->
-    <Rule Id="CA1062" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
-    <Rule Id="CA1063" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25134: Enable rule CA1063 (Implement IDisposable correctly) for Roslyn.sln -->
-    <Rule Id="CA1064" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1066" Action="None" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
     <Rule Id="CA1067" Action="Warning" />
     <Rule Id="CA1068" Action="Warning" />
-    <Rule Id="CA1069" Action="None" /> <!-- Enums values should not be duplicated -->
-    <Rule Id="CA1303" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
-    <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1508" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
-    <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1710" Action="None" />
-    <Rule Id="CA1713" Action="None" /> <!-- Events should not have 'Before' or 'After' prefix -->
-    <Rule Id="CA1714" Action="None" />
-    <Rule Id="CA1715" Action="None" />
-    <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1717" Action="None" />
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1721" Action="None" />
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1801" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/20405: Enable rule CA1801 (remove unused parameter) in Roslyn.sln once we have a fixer for it -->
+    <Rule Id="CA1200" Action="Warning" />
     <Rule Id="CA1802" Action="Warning" />
-    <Rule Id="CA1804" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/20406: Enable rule CA1804 (remove unused local) in Roslyn.sln once we have a fixer for it -->
-    <Rule Id="CA1806" Action="None" /> <!-- "do not ignore results": we do this in many places, for example fire-and-forget async or HRESULTs we don't care about -->
-    <Rule Id="CA1812" Action="None" /> <!-- disabled as we create many internal types via reflection-based mechanisms -->
-    <Rule Id="CA1814" Action="None" /> <!-- prefer jagged arrays to multidimensional: a silly piece of advice -->
-    <Rule Id="CA1815" Action="None" />
-    <Rule Id="CA1820" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/29038: Enable CA1820 (Test for empty strings using string length) -->
     <Rule Id="CA1821" Action="Warning" />
-    <Rule Id="CA1822" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25132: Enable rule CA1822 (Mark members as static) on Roslyn.sln -->
-    <Rule Id="CA1823" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/20404: Enable rule CA1823 (remove unused field) once we have a fixer for it -->
-    <Rule Id="CA1824" Action="None" /> <!-- mark assemblies with NeutralResourcesLanguageAttribute -->
-    <Rule Id="CA1827" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/37959: DoNotUseCountWhenAnyCanBeUsed -->
-    <Rule Id="CA1834" Action="None" /> <!-- Consider using 'StringBuilder.Append(char)' when applicable -->
-    <Rule Id="CA1835" Action="None" /> <!-- Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' -->
-    <Rule Id="CA2000" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2007" Action="Warning" />
-    <Rule Id="CA2109" Action="None" /> <!-- Review visible event handlers (legacy rule is no longer relevant) -->
-    <Rule Id="CA2211" Action="None" />
-    <Rule Id="CA2213" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
-    <Rule Id="CA2214" Action="None" /> <!-- do not call overridable methods in constructors: done in various places -->
-    <Rule Id="CA2215" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
-    <Rule Id="CA2218" Action="None" />
-    <Rule Id="CA2222" Action="None" />
-    <Rule Id="CA2224" Action="None" />
-    <Rule Id="CA2225" Action="None" />
-    <Rule Id="CA2227" Action="None" />
-    <Rule Id="CA2231" Action="None" />
-    <Rule Id="CA2234" Action="None" />
-    <Rule Id="CA2249" Action="None" /> <!-- Consider using 'String.Contains' instead of 'String.IndexOf' -->
-    <Rule Id="CA5350" Action="None" /> <!-- in some cases we must use legacy cryptographic hashes, so disable for now -->
-    <Rule Id="CA5351" Action="None" /> <!-- in some cases we must use legacy cryptographic hashes, so disable for now -->
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CodeStyle" RuleNamespace="Microsoft.CodeAnalysis.CodeStyle">
     <Rule Id="IDE0055" Action="Warning" />
@@ -96,10 +29,6 @@
     <Rule Id="RS1022" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26420: Enable rule RS1022 for Roslyn.sln -->
     <Rule Id="RS1024" Action="Hidden" /> <!-- Compare symbols correctly -->
   </Rules>
-  <Rules AnalyzerId="Microsoft.Composition.Analyzers" RuleNamespace="Microsoft.Composition.Analyzers">
-    <Rule Id="RS0006" Action="Error" />
-    <Rule Id="RS0023" Action="Error" />
-  </Rules>
   <Rules AnalyzerId="Roslyn.Core" RuleNamespace="Roslyn.Core">
     <Rule Id="AD0001" Action="Error" />
   </Rules>
@@ -107,48 +36,21 @@
     <Rule Id="RS0001" Action="Warning" />
     <Rule Id="RS0002" Action="Warning" />
     <Rule Id="RS0005" Action="Warning" />
+    <Rule Id="RS0006" Action="Error" />
+    <Rule Id="RS0012" Action="Warning" />
+    <Rule Id="RS0014" Action="Warning" />
+    <Rule Id="RS0015" Action="Warning" />
     <Rule Id="RS0016" Action="Error" />
     <Rule Id="RS0017" Action="Error" />
+    <Rule Id="RS0018" Action="Warning" />
     <Rule Id="RS0022" Action="Error" />
+    <Rule Id="RS0023" Action="Error" />
     <Rule Id="RS0024" Action="Error" />
     <Rule Id="RS0025" Action="Error" />
     <Rule Id="RS0026" Action="Error" />
     <Rule Id="RS0027" Action="Error" />
     <Rule Id="RS0040" Action="None" /> <!-- Defaultable types should have defaultable fields -->
     <Rule Id="RS0101" Action="None" /> <!-- Avoid multiple blank lines -->
-  </Rules>
-  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers.ImmutableCollections">
-    <Rule Id="RS0012" Action="Warning" />
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
-    <Rule Id="CA1305" Action="None" />
-    <Rule Id="CA1307" Action="None" />
-    <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1810" Action="None" />
-    <Rule Id="CA1816" Action="None" />
-    <Rule Id="CA1825" Action="None" />
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2207" Action="None" />
-    <Rule Id="CA2208" Action="None" />
-    <Rule Id="CA2216" Action="None" />
-    <Rule Id="CA2219" Action="None" />
-    <Rule Id="CA2241" Action="None" />
-    <Rule Id="CA2242" Action="None" />
-    <Rule Id="RS0014" Action="Warning" />
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.InteropServices.Analyzers" RuleNamespace="System.Runtime.InteropServices.Analyzers">
-    <Rule Id="CA1401" Action="None" />
-    <Rule Id="CA2101" Action="None" />
-    <Rule Id="RS0015" Action="Warning" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers.Tasks">
-    <Rule Id="RS0018" Action="Warning" />
-  </Rules>
-  <Rules AnalyzerId="XmlDocumentationComments.Analyzers" RuleNamespace="XmlDocumentationComments.Analyzers">
-    <Rule Id="CA1200" Action="Warning" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
-    <Rule Id="CA9999" Action="None" /> <!-- We know the analyzers will fail during a bootstrap build -->
   </Rules>
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="Xunit.Analyzers">
     <Rule Id="xUnit1004" Action="Hidden" /> <!-- allow skipped tests, with a code fix to unskip them -->

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -123,8 +123,7 @@
     Analyzers
   -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(MicrosoftCodeQualityAnalyzersVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(MicrosoftNetCoreAnalyzersVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(MicrosoftVisualStudioThreadingAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="$(MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion)" PrivateAssets="all" />


### PR DESCRIPTION
Roslyn repo currently includes analyzer package references to sub-packages of FxCopAnalyzers package (`Microsoft.CodeQuality.Analyzers` and `Microsoft.NetCore.Analyzers`). Due to the high noise level for default enabled CA rules from these packages, we end up turning off majority of these rules for the repo in our ruleset files.

This change switches the repo from FxCop analyzers package to `Microsoft.CodeAnalysis.NetAnalyzers` package (NOTE: we plan to ship the analyzer assemblies from this package in the .NET SDK soon). This helps us dogfood the experience from this new analyzer package, especially from the perspective of noise from default enabled analyzers, while also cleaning up our configuration files. Some more details below:

- The new package has the same set of CA rules, but the legacy ones are now disabled by default.
- There are a handful of rules which are enabled by default as IDE suggestions (Info severity): either as part of the triage of pre-existing CA rules OR recently added by the .NET runtime team.
- There are even fewer set of rules which are enabled by default as warnings – all of these have been added by the .NET runtime team, none of the pre-existing rules are enabled as warnings in this package.

The core dogfooding aspect would be:

- Enabled by default rules:
   - Analyzer exception diagnostics (AD0001): absolute must to fix or disable these rules by default in the package.
   - Noise from false positives: It would be a higher priority issue if the false positives are from a rule which is enabled as a build warning, but we should fix even false positives from info rules. We may also want to consider bumping these rules to lower severity or disabling them by default.
   - Rules which had to be turned off for specific projects, say test projects. We should re-triage such rules and consider if they should be disabled by default.
- Disabled/Info rules which were escalated to Info/Warnings as we found these to be valuable and reliable: We can potentially re-triage each of these rules and consider if they are valuable enough to have its default severity/enabled state changed to benefit customers.