### PR TITLE
Correctly error in function pointer scenarios:

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2738,7 +2738,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Semicolon after method or accessor block is not valid</value>
   </data>
   <data name="ERR_MethodReturnCantBeRefAny" xml:space="preserve">
-    <value>Method or delegate cannot return type '{0}'</value>
+    <value>Method, delegate, or function pointer cannot return type '{0}'</value>
   </data>
   <data name="ERR_CompileCancelled" xml:space="preserve">
     <value>Compilation cancelled by user</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2738,7 +2738,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Semicolon after method or accessor block is not valid</value>
   </data>
   <data name="ERR_MethodReturnCantBeRefAny" xml:space="preserve">
-    <value>Method, delegate, or function pointer cannot return type '{0}'</value>
+    <value>The return type of a method, delegate, or function pointer cannot be '{0}'</value>
   </data>
   <data name="ERR_CompileCancelled" xml:space="preserve">
     <value>Compilation cancelled by user</value>

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -77,7 +77,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (returnType.IsVoidType() && refKind != RefKind.None)
                 {
-                    diagnostics.Add(ErrorCode.ERR_NoVoidHere, returnTypeParameter.GetLocation());
+                    diagnostics.Add(ErrorCode.ERR_NoVoidHere, returnTypeParameter.Location);
+                }
+                else if (returnType.IsStatic)
+                {
+                    diagnostics.Add(ErrorCode.ERR_ReturnTypeIsStaticClass, returnTypeParameter.Location, returnType);
+                }
+                else if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
+                {
+                    diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, returnTypeParameter.Location, returnType);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // span-like types are returnable in general
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                // Method or delegate cannot return type '{0}'
+                // Method, delegate, or function pointer cannot return type '{0}'
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, returnTypeSyntax.Location, returnType.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // span-like types are returnable in general
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                // Method, delegate, or function pointer cannot return type '{0}'
+                // The return type of a method, delegate, or function pointer cannot be '{0}'
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, returnTypeSyntax.Location, returnType.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -450,10 +450,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // error CS0225: The params parameter must be a single dimensional array
                 diagnostics.Add(ErrorCode.ERR_ParamsMustBeArray, paramsKeyword.GetLocation());
             }
-            else if (parameter.TypeWithAnnotations.IsStatic && !parameter.ContainingSymbol.ContainingType.IsInterfaceType())
+            else if (parameter.TypeWithAnnotations.IsStatic && (parameter.ContainingSymbol is FunctionPointerMethodSymbol || !parameter.ContainingSymbol.ContainingType.IsInterfaceType()))
             {
                 // error CS0721: '{0}': static types cannot be used as parameters
-                diagnostics.Add(ErrorCode.ERR_ParameterIsStaticClass, owner.Locations[0], parameter.Type);
+                diagnostics.Add(ErrorCode.ERR_ParameterIsStaticClass, owner.Locations.IsEmpty ? parameterSyntax.GetLocation() : owner.Locations[0], parameter.Type);
             }
             else if (firstDefault != -1 && parameterIndex > firstDefault && !isDefault && !parameter.IsParams)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                // Method, delegate, or function pointer cannot return type '{0}'
+                // The return type of a method, delegate, or function pointer cannot be '{0}'
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, returnTypeSyntax.Location, returnType.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                // Method or delegate cannot return type '{0}'
+                // Method, delegate, or function pointer cannot return type '{0}'
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, returnTypeSyntax.Location, returnType.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    // Method, delegate, or function pointer cannot return type '{0}'
+                    // The return type of a method, delegate, or function pointer cannot be '{0}'
                     diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, syntax.ReturnType.Location, _lazyReturnType.Type);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    // Method or delegate cannot return type '{0}'
+                    // Method, delegate, or function pointer cannot return type '{0}'
                     diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, syntax.ReturnType.Location, _lazyReturnType.Type);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // NOTE: Span-like types can be returned (if expression is returnable).
             if (_lazyReturnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                // Method, delegate, or function pointer cannot return type '{0}'
+                // The return type of a method, delegate, or function pointer cannot be '{0}'
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, ReturnTypeSyntax.Location, _lazyReturnType.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // NOTE: Span-like types can be returned (if expression is returnable).
             if (_lazyReturnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                // Method or delegate cannot return type '{0}'
+                // Method, delegate, or function pointer cannot return type '{0}'
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, ReturnTypeSyntax.Location, _lazyReturnType.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -6228,7 +6228,7 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Metoda nebo delegát nemůže vracet typ {0}.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -6228,8 +6228,8 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Metoda nebo delegát nemůže vracet typ {0}.</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Metoda nebo delegát nemůže vracet typ {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -6228,8 +6228,8 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Die Methode oder der Delegat kann den Typ "{0}" nicht zurückgeben.</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Die Methode oder der Delegat kann den Typ "{0}" nicht zurückgeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -6228,7 +6228,7 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Die Methode oder der Delegat kann den Typ "{0}" nicht zurückgeben.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -6228,8 +6228,8 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">El método o el delegado no pueden devolver el tipo '{0}'</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">El método o el delegado no pueden devolver el tipo '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -6228,7 +6228,7 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">El método o el delegado no pueden devolver el tipo '{0}'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -6228,7 +6228,7 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Ni la méthode, ni le délégué ne peuvent retourner un type '{0}'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -6228,8 +6228,8 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Ni la méthode, ni le délégué ne peuvent retourner un type '{0}'</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Ni la méthode, ni le délégué ne peuvent retourner un type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -6228,8 +6228,8 @@ Un blocco catch() dopo un blocco catch (System.Exception e) può rilevare eccezi
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Il metodo o il delegato non può restituire il tipo '{0}'</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Il metodo o il delegato non può restituire il tipo '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -6228,7 +6228,7 @@ Un blocco catch() dopo un blocco catch (System.Exception e) può rilevare eccezi
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Il metodo o il delegato non può restituire il tipo '{0}'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -6228,7 +6228,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">メソッドまたはデリゲートは、型 '{0}' を返すことができません。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -6228,8 +6228,8 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">メソッドまたはデリゲートは、型 '{0}' を返すことができません。</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">メソッドまたはデリゲートは、型 '{0}' を返すことができません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -6228,7 +6228,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">메서드 또는 대리자는 '{0}' 형식을 반환할 수 없습니다.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -6228,8 +6228,8 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">메서드 또는 대리자는 '{0}' 형식을 반환할 수 없습니다.</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">메서드 또는 대리자는 '{0}' 형식을 반환할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -6228,8 +6228,8 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Metoda ani delegat nie może zwracać typu „{0}”</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Metoda ani delegat nie może zwracać typu „{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -6228,7 +6228,7 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Metoda ani delegat nie może zwracać typu „{0}”</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -6226,7 +6226,7 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Método ou representante não pode retornar tipo "{0}"</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -6226,8 +6226,8 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Método ou representante não pode retornar tipo "{0}"</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Método ou representante não pode retornar tipo "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -6228,7 +6228,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Метод или делегат не могут возвращать тип "{0}".</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -6228,8 +6228,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Метод или делегат не могут возвращать тип "{0}".</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Метод или делегат не могут возвращать тип "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -6228,8 +6228,8 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">Yöntem veya temsilci '{0}' türünü döndüremiyor</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">Yöntem veya temsilci '{0}' türünü döndüremiyor</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -6228,7 +6228,7 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">Yöntem veya temsilci '{0}' türünü döndüremiyor</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -6228,7 +6228,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">方法或委托不能返回“{0}”类型</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -6228,8 +6228,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">方法或委托不能返回“{0}”类型</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">方法或委托不能返回“{0}”类型</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -6228,8 +6228,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method or delegate cannot return type '{0}'</source>
-        <target state="translated">方法或委派無法傳回類型 '{0}'</target>
+        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <target state="needs-review-translation">方法或委派無法傳回類型 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CompileCancelled">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -6228,7 +6228,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_MethodReturnCantBeRefAny">
-        <source>Method, delegate, or function pointer cannot return type '{0}'</source>
+        <source>The return type of a method, delegate, or function pointer cannot be '{0}'</source>
         <target state="needs-review-translation">方法或委派無法傳回類型 '{0}'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -30,9 +30,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             string source,
             MetadataReference[]? references = null,
             Action<ModuleSymbol>? symbolValidator = null,
-            string? expectedOutput = null)
+            string? expectedOutput = null,
+            TargetFramework targetFramework = TargetFramework.Standard)
         {
-            return CompileAndVerify(source, references, parseOptions: TestOptions.RegularPreview, options: expectedOutput is null ? TestOptions.UnsafeReleaseDll : TestOptions.UnsafeReleaseExe, symbolValidator: symbolValidator, expectedOutput: expectedOutput, verify: Verification.Skipped);
+            return CompileAndVerify(source, references, parseOptions: TestOptions.RegularPreview, options: expectedOutput is null ? TestOptions.UnsafeReleaseDll : TestOptions.UnsafeReleaseExe, symbolValidator: symbolValidator, expectedOutput: expectedOutput, verify: Verification.Skipped, targetFramework: targetFramework);
         }
 
         private CompilationVerifier CompileAndVerifyFunctionPointersWithIl(string source, string ilStub, Action<ModuleSymbol>? symbolValidator = null, string? expectedOutput = null)
@@ -7031,6 +7032,44 @@ unsafe public class C
                 //         delegate*<ref string, ref string?> ptr3 = ptr1;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ptr1").WithArguments("delegate*<ref string, string>", "delegate*<ref string, string?>").WithLocation(20, 51)
             );
+        }
+
+        [Fact]
+        public void SpanInArgumentAndReturn()
+        {
+            var comp = CompileAndVerifyFunctionPointers(@"
+using System;
+public class C
+{
+    static char[] chars = new[] { '1', '2', '3', '4' };
+
+    static Span<char> ChopSpan(Span<char> span) => span[..^1];
+
+    public static unsafe void Main()
+    {
+        delegate*<Span<char>, Span<char>> ptr = &ChopSpan;
+        Console.Write(new string(ptr(chars)));
+    }
+}
+", targetFramework: TargetFramework.NetCoreApp30, expectedOutput: "123");
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       39 (0x27)
+  .maxstack  2
+  .locals init (delegate*<System.Span<char>, System.Span<char>> V_0)
+  IL_0000:  ldftn      ""System.Span<char> C.ChopSpan(System.Span<char>)""
+  IL_0006:  stloc.0
+  IL_0007:  ldsfld     ""char[] C.chars""
+  IL_000c:  call       ""System.Span<char> System.Span<char>.op_Implicit(char[])""
+  IL_0011:  ldloc.0
+  IL_0012:  calli      ""delegate*<System.Span<char>, System.Span<char>>""
+  IL_0017:  call       ""System.ReadOnlySpan<char> System.Span<char>.op_Implicit(System.Span<char>)""
+  IL_001c:  newobj     ""string..ctor(System.ReadOnlySpan<char>)""
+  IL_0021:  call       ""void System.Console.Write(string)""
+  IL_0026:  ret
+}
+");
         }
 
         private static readonly Guid s_guid = new Guid("97F4DBD4-F6D1-4FAD-91B3-1001F92068E5");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -7034,7 +7034,7 @@ unsafe public class C
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void SpanInArgumentAndReturn()
         {
             var comp = CompileAndVerifyFunctionPointers(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -19,9 +19,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class FunctionPointerTests : CompilingTestBase
     {
-        private CSharpCompilation CreateCompilationWithFunctionPointers(string source, CSharpCompilationOptions? options = null, CSharpParseOptions? parseOptions = null, TargetFramework targetFramework = default)
+        private CSharpCompilation CreateCompilationWithFunctionPointers(string source, CSharpCompilationOptions? options = null, CSharpParseOptions? parseOptions = null, TargetFramework? targetFramework = null)
         {
-            return CreateCompilation(source, options: options ?? TestOptions.UnsafeReleaseDll, parseOptions: parseOptions ?? TestOptions.RegularPreview, targetFramework: targetFramework);
+            return CreateCompilation(source, options: options ?? TestOptions.UnsafeReleaseDll, parseOptions: parseOptions ?? TestOptions.RegularPreview, targetFramework: targetFramework ?? TargetFramework.Standard);
         }
 
         private CompilationVerifier CompileAndVerifyFunctionPointers(CSharpCompilation compilation, string? expectedOutput = null)
@@ -2499,6 +2499,9 @@ class E<T> where T : struct {}
 ");
 
             comp.VerifyDiagnostics(
+                // (6,27): error CS0722: 'S': static types cannot be used as return types
+                //     void M1(delegate*<C*, S> ptr) {}
+                Diagnostic(ErrorCode.ERR_ReturnTypeIsStaticClass, "S").WithArguments("S").WithLocation(6, 27),
                 // (6,30): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('C')
                 //     void M1(delegate*<C*, S> ptr) {}
                 Diagnostic(ErrorCode.ERR_ManagedAddr, "ptr").WithArguments("C").WithLocation(6, 30),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -2888,7 +2888,7 @@ unsafe static class C
             );
         }
 
-        [Fact, WorkItem(44953, "https://github.com/dotnet/roslyn/issues/44953")]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem(44953, "https://github.com/dotnet/roslyn/issues/44953")]
         public void RestrictedTypeInFunctionPointer()
         {
             var comp = CreateCompilationWithFunctionPointers(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -2902,7 +2902,7 @@ unsafe static class C
                 // (5,35): error CS1601: Cannot make reference to variable of type 'ArgIterator'
                 //     static delegate*<ArgIterator, ref ArgIterator, ArgIterator> Ptr;
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "ref ArgIterator").WithArguments("System.ArgIterator").WithLocation(5, 35),
-                // (5,52): error CS1599: Method, delegate, or function pointer cannot return type 'System.ArgIterator'
+                // (5,52): error CS1599: The return type of a method, delegate, or function pointer cannot be 'System.ArgIterator'
                 //     static delegate*<ArgIterator, ref ArgIterator, ArgIterator> Ptr;
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(5, 52),
                 // (5,65): warning CS0169: The field 'C.Ptr' is never used

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -531,7 +531,7 @@ class Program
                 // (39,34): error CS1601: Cannot make reference to variable of type 'TypedReference'
                 //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "ref TypedReference ss").WithArguments("System.TypedReference").WithLocation(39, 34),
-                // (39,12): error CS1599: Method or delegate cannot return type 'TypedReference'
+                // (39,12): error CS1599: Method, delegate, or function pointer cannot return type 'TypedReference'
                 //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ref TypedReference").WithArguments("System.TypedReference").WithLocation(39, 12)
             );
@@ -926,7 +926,7 @@ public class Program
             CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
 
             comp.VerifyDiagnostics(
-                // (14,19): error CS1599: Method or delegate cannot return type 'TypedReference'
+                // (14,19): error CS1599: Method, delegate, or function pointer cannot return type 'TypedReference'
                 //     public static TypedReference operator +(Span<int> x, Program y) => default(TypedReference);
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "TypedReference").WithArguments("System.TypedReference").WithLocation(14, 19)
             );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -531,7 +531,7 @@ class Program
                 // (39,34): error CS1601: Cannot make reference to variable of type 'TypedReference'
                 //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "ref TypedReference ss").WithArguments("System.TypedReference").WithLocation(39, 34),
-                // (39,12): error CS1599: Method, delegate, or function pointer cannot return type 'TypedReference'
+                // (39,12): error CS1599: The return type of a method, delegate, or function pointer cannot be 'TypedReference'
                 //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ref TypedReference").WithArguments("System.TypedReference").WithLocation(39, 12)
             );
@@ -926,7 +926,7 @@ public class Program
             CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
 
             comp.VerifyDiagnostics(
-                // (14,19): error CS1599: Method, delegate, or function pointer cannot return type 'TypedReference'
+                // (14,19): error CS1599: The return type of a method, delegate, or function pointer cannot be 'TypedReference'
                 //     public static TypedReference operator +(Span<int> x, Program y) => default(TypedReference);
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "TypedReference").WithArguments("System.TypedReference").WithLocation(14, 19)
             );

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -14697,16 +14697,16 @@ class C
 }
 ";
             CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-// (5,5): error CS1599: Method, delegate, or function pointer cannot return type 'System.ArgIterator'
+// (5,5): error CS1599: The return type of a method, delegate, or function pointer cannot be 'System.ArgIterator'
 //     ArgIterator M(); // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator"),
-// (11,12): error CS1599: Method, delegate, or function pointer cannot return type 'System.RuntimeArgumentHandle'
+// (11,12): error CS1599: The return type of a method, delegate, or function pointer cannot be 'System.RuntimeArgumentHandle'
 //     public RuntimeArgumentHandle Test2() // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "RuntimeArgumentHandle").WithArguments("System.RuntimeArgumentHandle"),
-// (17,19): error CS1599: Method, delegate, or function pointer cannot return type 'System.ArgIterator'
+// (17,19): error CS1599: The return type of a method, delegate, or function pointer cannot be 'System.ArgIterator'
 //     public static ArgIterator operator +(C c1, C c2) // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator"),
-// (9,21): error CS1599: Method, delegate, or function pointer cannot return type 'System.TypedReference'
+// (9,21): error CS1599: The return type of a method, delegate, or function pointer cannot be 'System.TypedReference'
 //     public delegate TypedReference Test1(); // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "TypedReference").WithArguments("System.TypedReference")
                 );
@@ -14741,13 +14741,13 @@ class C
 }
 ";
             CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-                // (6,9): error CS1599: Method, delegate, or function pointer cannot return type 'TypedReference'
+                // (6,9): error CS1599: The return type of a method, delegate, or function pointer cannot be 'TypedReference'
                 //         System.TypedReference local1() // 1599
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(6, 9),
-                // (12,9): error CS1599: Method, delegate, or function pointer cannot return type 'RuntimeArgumentHandle'
+                // (12,9): error CS1599: The return type of a method, delegate, or function pointer cannot be 'RuntimeArgumentHandle'
                 //         System.RuntimeArgumentHandle local2() // 1599
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "System.RuntimeArgumentHandle").WithArguments("System.RuntimeArgumentHandle").WithLocation(12, 9),
-                // (18,9): error CS1599: Method, delegate, or function pointer cannot return type 'ArgIterator'
+                // (18,9): error CS1599: The return type of a method, delegate, or function pointer cannot be 'ArgIterator'
                 //         System.ArgIterator local3() // 1599
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "System.ArgIterator").WithArguments("System.ArgIterator").WithLocation(18, 9));
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -14697,16 +14697,16 @@ class C
 }
 ";
             CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-// (5,5): error CS1599: Method or delegate cannot return type 'System.ArgIterator'
+// (5,5): error CS1599: Method, delegate, or function pointer cannot return type 'System.ArgIterator'
 //     ArgIterator M(); // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator"),
-// (11,12): error CS1599: Method or delegate cannot return type 'System.RuntimeArgumentHandle'
+// (11,12): error CS1599: Method, delegate, or function pointer cannot return type 'System.RuntimeArgumentHandle'
 //     public RuntimeArgumentHandle Test2() // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "RuntimeArgumentHandle").WithArguments("System.RuntimeArgumentHandle"),
-// (17,19): error CS1599: Method or delegate cannot return type 'System.ArgIterator'
+// (17,19): error CS1599: Method, delegate, or function pointer cannot return type 'System.ArgIterator'
 //     public static ArgIterator operator +(C c1, C c2) // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator"),
-// (9,21): error CS1599: Method or delegate cannot return type 'System.TypedReference'
+// (9,21): error CS1599: Method, delegate, or function pointer cannot return type 'System.TypedReference'
 //     public delegate TypedReference Test1(); // 1599
 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "TypedReference").WithArguments("System.TypedReference")
                 );
@@ -14741,13 +14741,13 @@ class C
 }
 ";
             CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-                // (6,9): error CS1599: Method or delegate cannot return type 'TypedReference'
+                // (6,9): error CS1599: Method, delegate, or function pointer cannot return type 'TypedReference'
                 //         System.TypedReference local1() // 1599
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(6, 9),
-                // (12,9): error CS1599: Method or delegate cannot return type 'RuntimeArgumentHandle'
+                // (12,9): error CS1599: Method, delegate, or function pointer cannot return type 'RuntimeArgumentHandle'
                 //         System.RuntimeArgumentHandle local2() // 1599
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "System.RuntimeArgumentHandle").WithArguments("System.RuntimeArgumentHandle").WithLocation(12, 9),
-                // (18,9): error CS1599: Method or delegate cannot return type 'ArgIterator'
+                // (18,9): error CS1599: Method, delegate, or function pointer cannot return type 'ArgIterator'
                 //         System.ArgIterator local3() // 1599
                 Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "System.ArgIterator").WithArguments("System.ArgIterator").WithLocation(18, 9));
         }


### PR DESCRIPTION
* When a static type is used as a parameter or return type.
* When a restricted type is used as a parameter or return type.

Fixes https://github.com/dotnet/roslyn/issues/44953