### PR TITLE
Fix change signature accessibility bugs

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -35,20 +35,24 @@
         <Thickness x:Key="textboxPadding">2</Thickness>
         <vs:NegateBooleanConverter x:Key="NegateBooleanConverter"/>
         <RoutedUICommand x:Key="MoveUp" />
+        <RoutedUICommand x:Key="MoveUpFocus" />
         <RoutedUICommand x:Key="MoveDown" />
+        <RoutedUICommand x:Key="MoveDownFocus" />
         <RoutedUICommand x:Key="MoveSelectionUp" />
         <RoutedUICommand x:Key="MoveSelectionDown" />
         <RoutedUICommand x:Key="ClickOK" />
         <RoutedUICommand x:Key="ToggleRemovedState" />
     </Window.Resources>
     <Window.CommandBindings>
+        <CommandBinding Command="{StaticResource MoveUpFocus}" Executed="MoveUp_Click_FocusRow" />
         <CommandBinding Command="{StaticResource MoveUp}" Executed="MoveUp_Click" />
+        <CommandBinding Command="{StaticResource MoveDownFocus}" Executed="MoveDown_Click_FocusRow" />
         <CommandBinding Command="{StaticResource MoveDown}" Executed="MoveDown_Click" />
         <CommandBinding Command="{StaticResource ToggleRemovedState}" Executed="ToggleRemovedState" />
     </Window.CommandBindings>
     <Window.InputBindings>
-        <KeyBinding Key="Up" Modifiers="Alt" Command="{StaticResource MoveUp}" />
-        <KeyBinding Key="Down" Modifiers="Alt" Command="{StaticResource MoveDown}" />
+        <KeyBinding Key="Up" Modifiers="Alt" Command="{StaticResource MoveUpFocus}" />
+        <KeyBinding Key="Down" Modifiers="Alt" Command="{StaticResource MoveDownFocus}" />
         <KeyBinding Key="Delete" Command="{StaticResource ToggleRemovedState}" />
         <KeyBinding Key="Return" Command="{StaticResource ClickOK}" />
     </Window.InputBindings>
@@ -260,7 +264,7 @@
                 <ScrollViewer Name="Scroller"
                               AutomationProperties.Name="{Binding SignaturePreviewAutomationText}"
                               AutomationProperties.LabeledBy="{Binding ElementName=PreviewMethodSignatureLabel}"
-                              IsTabStop="True"
+                              IsTabStop="False"
                               Padding="8, 4, 4, 4" 
                               VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" 
                               Content="{Binding SignatureDisplay}" 
@@ -270,6 +274,7 @@
             <StackPanel Name="ControlButtonsPanel" Grid.Column="1" Grid.Row="0" Height="Auto" Width="Auto" Margin="0, 3, 0, 0" >
                 <vs:DialogButton Name="UpButton" 
                                  AutomationProperties.Name="{Binding MoveUpAutomationText}"
+                                 ToolTip="{Binding MoveUpAutomationText}"
                                  Margin="9 0 0 0"
                                  IsEnabled="{Binding CanMoveUp, Mode=OneWay}" 
                                  AutomationProperties.AutomationId="UpButton"
@@ -283,6 +288,7 @@
                 </vs:DialogButton>
                 <vs:DialogButton Name="DownButton" 
                                  AutomationProperties.Name="{Binding MoveDownAutomationText}"
+                                 ToolTip="{Binding MoveDownAutomationText}"
                                  Margin="9 9 0 0"
                                  IsEnabled="{Binding CanMoveDown, Mode=OneWay}" 
                                  AutomationProperties.AutomationId="DownButton"

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -8,10 +8,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ChangeSignature;
 using Microsoft.VisualStudio.PlatformUI;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 {
@@ -84,6 +82,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 
         private void MoveUp_Click(object sender, EventArgs e)
         {
+            MoveUp_UpdateSelectedIndex();
+            SetFocusToSelectedRow(false);
+        }
+
+        private void MoveUp_Click_FocusRow(object sender, EventArgs e)
+        {
+            MoveUp_UpdateSelectedIndex();
+            SetFocusToSelectedRow(true);
+        }
+
+        private void MoveUp_UpdateSelectedIndex()
+        {
             var oldSelectedIndex = Members.SelectedIndex;
             if (_viewModel.CanMoveUp && oldSelectedIndex >= 0)
             {
@@ -91,11 +101,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 Members.Items.Refresh();
                 Members.SelectedIndex = oldSelectedIndex - 1;
             }
-
-            SetFocusToSelectedRow();
         }
 
         private void MoveDown_Click(object sender, EventArgs e)
+        {
+            MoveDown_UpdateSelectedIndex();
+            SetFocusToSelectedRow(false);
+        }
+
+        private void MoveDown_Click_FocusRow(object sender, EventArgs e)
+        {
+            MoveDown_UpdateSelectedIndex();
+            SetFocusToSelectedRow(true);
+        }
+
+        private void MoveDown_UpdateSelectedIndex()
         {
             var oldSelectedIndex = Members.SelectedIndex;
             if (_viewModel.CanMoveDown && oldSelectedIndex >= 0)
@@ -104,8 +124,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 Members.Items.Refresh();
                 Members.SelectedIndex = oldSelectedIndex + 1;
             }
-
-            SetFocusToSelectedRow();
         }
 
         private void Remove_Click(object sender, RoutedEventArgs e)
@@ -116,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 Members.Items.Refresh();
             }
 
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         private void Restore_Click(object sender, RoutedEventArgs e)
@@ -127,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 Members.Items.Refresh();
             }
 
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         private void Add_Click(object sender, RoutedEventArgs e)
@@ -155,7 +173,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 _viewModel.AddParameter(addedParameter);
             }
 
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         private CallSiteKind GetCallSiteKind(AddParameterDialogViewModel addParameterViewModel)
@@ -176,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 : CallSiteKind.Value;
         }
 
-        private void SetFocusToSelectedRow()
+        private void SetFocusToSelectedRow(bool focusRow)
         {
             if (Members.SelectedIndex >= 0)
             {
@@ -186,7 +204,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                     row = Members.ItemContainerGenerator.ContainerFromIndex(Members.SelectedIndex) as DataGridRow;
                 }
 
-                if (row != null)
+                if (row != null && focusRow)
                 {
                     FocusRow(row);
                 }
@@ -214,7 +232,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 }
             }
 
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         private void MoveSelectionDown_Click(object sender, EventArgs e)
@@ -225,7 +243,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 Members.SelectedIndex = oldSelectedIndex + 1;
             }
 
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         private void Members_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
@@ -235,7 +253,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 Members.SelectedIndex = _viewModel.GetStartingSelectionIndex();
             }
 
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         private void ToggleRemovedState(object sender, ExecutedRoutedEventArgs e)
@@ -250,7 +268,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             }
 
             Members.Items.Refresh();
-            SetFocusToSelectedRow();
+            SetFocusToSelectedRow(true);
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -171,9 +171,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                     addParameterViewModel.TypeBinds);
 
                 _viewModel.AddParameter(addedParameter);
-            }
 
-            SetFocusToSelectedRow(true);
+                SetFocusToSelectedRow(true);
+            }
+            else
+            {
+                // Cancel/esc was pressed.
+                AddButton.Focus();
+            }
         }
 
         private CallSiteKind GetCallSiteKind(AddParameterDialogViewModel addParameterViewModel)

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -171,14 +171,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                     addParameterViewModel.TypeBinds);
 
                 _viewModel.AddParameter(addedParameter);
+            }
 
-                SetFocusToSelectedRow(true);
-            }
-            else
-            {
-                // Cancel/esc was pressed.
-                AddButton.Focus();
-            }
+            SetFocusToSelectedRow(false);
         }
 
         private CallSiteKind GetCallSiteKind(AddParameterDialogViewModel addParameterViewModel)


### PR DESCRIPTION
Fixes 3 of the 4 Change Signature accessibility bugs:
1. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1135711/ - Keyboard tab focus goes to non-actionable preview pane in Change Signature dialog
2. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1135715/ - Clicking Cancel button in Add Parameter dialog doesn't subsequently set focus on Add button in Change Signature dialog.
Also addresses issue where focus isn't staying on up/down buttons after pressing the enter key when either the up/down buttons is selected.
3. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1135728/ - Lack of tooltip for up and down arrow buttons in Change Signature dialog

Thanks @dpoeschl for the help with these!
