### PR TITLE
Change Signature DataGrid accessibility when navigating cells with CAPS+Arrow

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -111,7 +111,6 @@
                 </DataGrid.InputBindings>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
-                        <Setter Property="AutomationProperties.Name" Value="{Binding FullAutomationText}" />
                         <Setter Property="BorderThickness" Value="0" />
                         <Setter Property="Padding" Value="2" />
                         <Setter Property="KeyboardNavigation.IsTabStop" Value="False"/>
@@ -184,6 +183,15 @@
                     </Style>
                 </DataGrid.RowStyle>
                 <DataGrid.Columns>
+                    <!-- This column appears empty to sighted users, but provides an improved screenreader 
+                    experience that avoids moving cell-by-cell through the DataGrid -->
+                    <DataGridTextColumn x:Name="automationHeader" IsReadOnly="True" Width="0">
+                        <DataGridTextColumn.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding FullAutomationText}"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
+                    </DataGridTextColumn>
                     <DataGridTextColumn x:Name="indexHeader" Binding="{Binding InitialIndex, Mode=OneWay}" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -192,6 +200,11 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                     <DataGridTextColumn x:Name="modifierHeader" Binding="{Binding Modifier, Mode=OneWay}" IsReadOnly="True">
+                        <DataGridTextColumn.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding ModifierAutomationText, Mode=OneWay}"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Padding" Value="{StaticResource ResourceKey=cellPadding}" />
@@ -199,6 +212,11 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                     <DataGridTemplateColumn x:Name="typeHeader" Width="*" IsReadOnly="True">
+                        <DataGridTemplateColumn.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Type, Mode=OneWay}" />
+                            </Style>
+                        </DataGridTemplateColumn.CellStyle>
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
@@ -206,13 +224,19 @@
                                         Moniker="{x:Static imagecatalog:KnownMonikers.StatusWarning}" 
                                         Visibility="{Binding TypeWarningVisibility}"
                                         vs2:ImageThemingUtilities.ImageBackgroundColor="White"
-                                        Margin="0,0,5,0"/>
+                                        Margin="0,0,5,0"
+                                        AutomationProperties.Name="{Binding ElementName=dialog, Path=WarningTypeDoesNotBind}"/>
                                     <TextBlock Text="{Binding Type, Mode=OneWay}"/>
                                 </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTemplateColumn x:Name="parameterHeader" Width="*" IsReadOnly="True">
+                        <DataGridTemplateColumn.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding ParameterName, Mode=OneWay}" />
+                            </Style>
+                        </DataGridTemplateColumn.CellStyle>
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
@@ -220,13 +244,19 @@
                                         Moniker="{x:Static imagecatalog:KnownMonikers.StatusWarning}" 
                                         Visibility="{Binding HasParameterNameConflict, Mode=TwoWay}"
                                         vs2:ImageThemingUtilities.ImageBackgroundColor="White"
-                                        Margin="0,0,5,0"/>
+                                        Margin="0,0,5,0"
+                                        AutomationProperties.Name="{Binding ElementName=dialog, Path=WarningDuplicateParameterName}"/>
                                     <TextBlock Text="{Binding ParameterName, Mode=OneWay}"/>
                                 </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTextColumn x:Name="defaultHeader" Binding="{Binding DefaultValue, Mode=OneWay}" Width="*" IsReadOnly="True">
+                        <DataGridTextColumn.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding DefaultAutomationText, Mode=OneWay}"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Padding" Value="{StaticResource ResourceKey=cellPadding}" />
@@ -234,6 +264,11 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                     <DataGridTextColumn x:Name="callsiteHeader" Binding="{Binding CallSite, Mode=OneWay}" Width="*" IsReadOnly="True">
+                        <DataGridTextColumn.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding CallSiteAutomationText, Mode=OneWay}"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Padding" Value="{StaticResource ResourceKey=cellPadding}" />

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -19,14 +19,27 @@
     HasDialogFrame="True"
     WindowStartupLocation="CenterOwner">
     <Window.Resources>
-        <Style x:Key="DataGridStyle" TargetType="DataGrid">
-            <Setter Property="CellStyle">
+        <Style x:Key="DataGridCellStyle" TargetType="DataGridCell">
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="2" />
+            <Setter Property="KeyboardNavigation.IsTabStop" Value="False"/>
+            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="Template">
                 <Setter.Value>
-                    <Style TargetType="DataGridCell">
-                        <Setter Property="BorderThickness" Value="0"/>
-                    </Style>
+                    <ControlTemplate TargetType="DataGridCell">
+                        <Border Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            Padding="{TemplateBinding Padding}"
+                                            KeyboardNavigation.IsTabStop="False">
+                            <ContentPresenter />
+                        </Border>
+                    </ControlTemplate>
                 </Setter.Value>
             </Setter>
+        </Style>
+        <Style x:Key="DataGridStyle" TargetType="DataGrid">
+            <Setter Property="CellStyle" Value="{StaticResource DataGridCellStyle}" />
         </Style>
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
@@ -187,7 +200,7 @@
                     experience that avoids moving cell-by-cell through the DataGrid -->
                     <DataGridTextColumn x:Name="automationHeader" IsReadOnly="True" Width="0">
                         <DataGridTextColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding FullAutomationText}"/>
                             </Style>
                         </DataGridTextColumn.CellStyle>
@@ -201,7 +214,7 @@
                     </DataGridTextColumn>
                     <DataGridTextColumn x:Name="modifierHeader" Binding="{Binding Modifier, Mode=OneWay}" IsReadOnly="True">
                         <DataGridTextColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding ModifierAutomationText, Mode=OneWay}"/>
                             </Style>
                         </DataGridTextColumn.CellStyle>
@@ -213,7 +226,7 @@
                     </DataGridTextColumn>
                     <DataGridTemplateColumn x:Name="typeHeader" Width="*" IsReadOnly="True">
                         <DataGridTemplateColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding Type, Mode=OneWay}" />
                             </Style>
                         </DataGridTemplateColumn.CellStyle>
@@ -233,7 +246,7 @@
                     </DataGridTemplateColumn>
                     <DataGridTemplateColumn x:Name="parameterHeader" Width="*" IsReadOnly="True">
                         <DataGridTemplateColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding ParameterName, Mode=OneWay}" />
                             </Style>
                         </DataGridTemplateColumn.CellStyle>
@@ -253,7 +266,7 @@
                     </DataGridTemplateColumn>
                     <DataGridTextColumn x:Name="defaultHeader" Binding="{Binding DefaultValue, Mode=OneWay}" Width="*" IsReadOnly="True">
                         <DataGridTextColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding DefaultAutomationText, Mode=OneWay}"/>
                             </Style>
                         </DataGridTextColumn.CellStyle>
@@ -265,7 +278,7 @@
                     </DataGridTextColumn>
                     <DataGridTextColumn x:Name="callsiteHeader" Binding="{Binding CallSite, Mode=OneWay}" Width="*" IsReadOnly="True">
                         <DataGridTextColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding CallSiteAutomationText, Mode=OneWay}"/>
                             </Style>
                         </DataGridTextColumn.CellStyle>

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -32,6 +32,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         public string Add { get { return ServicesVSResources.Add; } }
         public string OK { get { return ServicesVSResources.OK; } }
         public string Cancel { get { return ServicesVSResources.Cancel; } }
+        public string WarningTypeDoesNotBind { get { return ServicesVSResources.Warning_colon_type_does_not_bind; } }
+        public string WarningDuplicateParameterName { get { return ServicesVSResources.Warning_colon_duplicate_parameter_name; } }
 
         public Brush ParameterText { get; }
         public Brush RemovedParameterText { get; }

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.ParameterViewModels.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.ParameterViewModels.cs
@@ -33,9 +33,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             public abstract string Modifier { get; }
             public abstract string Default { get; }
 
+            public string ModifierAutomationText => ValueOrNone(Modifier);
+            public string DefaultAutomationText => ValueOrNone(Default);
+            public string CallSiteAutomationText => ValueOrNone(CallSite);
+
             public ParameterViewModel(ChangeSignatureDialogViewModel changeSignatureDialogViewModel)
             {
                 ChangeSignatureDialogViewModel = changeSignatureDialogViewModel;
+            }
+
+            private string ValueOrNone(string value)
+            {
+                return !string.IsNullOrEmpty(value)
+                    ? value
+                    : ServicesVSResources.None;
             }
 
             public Visibility HasParameterNameConflict { get; set; }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1520,4 +1520,13 @@ I agree to all of the foregoing:</value>
   <data name="Infer_from_context" xml:space="preserve">
     <value>Infer from context</value>
   </data>
+  <data name="None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="Warning_colon_duplicate_parameter_name" xml:space="preserve">
+    <value>Warning: duplicate parameter name</value>
+  </data>
+  <data name="Warning_colon_type_does_not_bind" xml:space="preserve">
+    <value>Warning: type does not bind</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Neveřejné metody</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Nicht öffentliche Methoden</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Miembros no públicos</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Méthodes non publiques</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Metodi non pubblici</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -497,6 +497,11 @@
         <target state="translated">パブリックでないメソッド</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -497,6 +497,11 @@
         <target state="translated">public이 아닌 메서드</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Metody niepubliczne</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Métodos não públicos</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Методы, не являющиеся открытыми</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Ortak olmayan yöntemler</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -497,6 +497,11 @@
         <target state="translated">非公共成员</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -497,6 +497,11 @@
         <target state="translated">非公用方法</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Omit_only_for_optional_parameters">
         <source>Omit (only for optional parameters)</source>
         <target state="new">Omit (only for optional parameters)</target>
@@ -825,6 +830,16 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_duplicate_parameter_name">
+        <source>Warning: duplicate parameter name</source>
+        <target state="new">Warning: duplicate parameter name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_colon_type_does_not_bind">
+        <source>Warning: type does not bind</source>
+        <target state="new">Warning: type does not bind</target>
         <note />
       </trans-unit>
       <trans-unit id="We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor">


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1135706

**For non-Narrator users:**
- There's a small "empty" column to the left of the visible data now, but nothing else changes because the table is set to `SelectionUnit="FullRow"`

**For Narrator users:**
- When the row (and therefore first cell in the row) is focused, narrator quickly reads a helpful description of the parameter. The user doesn't need to move cell-by-cell through the table.
- Despite being `SelectionUnit="FullRow"`, the user now _can_ CAPS+Arrow key through the cells in the table and receive meaningful information.

**Screenshot**

![image](https://user-images.githubusercontent.com/235241/84189779-b0e01a00-aa4a-11ea-9bdd-2e2fac8f20b7.png)
