### PR TITLE
Change RichNav to run daily

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -1,10 +1,9 @@
-# Run on master CI builds
-trigger:
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight RichNav indexer run
   branches:
     include:
     - master
-
-pr: none
 
 jobs:
 - job: RichCodeNav_Indexing

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -1,6 +1,9 @@
+trigger: none
+pr: none
+
 schedules:
 - cron: "0 0 * * *"
-  displayName: Daily midnight RichNav indexer run
+  displayName: Daily midnight (UTC) RichNav indexer run
   branches:
     include:
     - master


### PR DESCRIPTION
As we are resolving some document deduping scenarios on our side, it would be helpful to reduce Roslyn to index daily for now.