### PR TITLE
Handle ValidateFormatString edge case

### DIFF
--- a/src/Analyzers/CSharp/Tests/ValidateFormatString/ValidateFormatStringTests.cs
+++ b/src/Analyzers/CSharp/Tests/ValidateFormatString/ValidateFormatStringTests.cs
@@ -134,6 +134,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)]
+        public async Task LiteralArray()
+        {
+            await TestDiagnosticMissingAsync(@" class Program
+{
+    static void Main(string[] args)
+    {
+        string.Format(""This {0[||]} {1} {2} {3} works"", new [] {""test1"", ""test2"", ""test3"", ""test4""}); 
+    }     
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)]
         public async Task StringArrayOutOfBounds_NoDiagnostic()
         {
             await TestDiagnosticMissingAsync(@" class Program

--- a/src/Analyzers/Core/Analyzers/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
             }
 
             var expression = syntaxFacts.GetExpressionOfArgument(argsArgument);
-            return semanticModel.GetTypeInfo(expression).Type;
+            return semanticModel.GetTypeInfo(expression).ConvertedType;
         }
 
         protected SyntaxNode? TryGetArgument(

--- a/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
@@ -36,6 +36,7 @@ Class C
 End Class")
         End Function
 
+        <WorkItem(42764, "https://github.com/dotnet/roslyn/issues/42764")>
         <Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)>
         Public Async Function LiteralArray() As Task
             Await TestDiagnosticMissingAsync("

--- a/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
@@ -36,6 +36,13 @@ Class C
 End Class")
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)>
+        Public Async Function StringArray() As Task
+            Await TestDiagnosticMissingAsync("
+Class C
+     Sub Main 
+        Dim strings() = {""test"", ""test2""}
+        String.Format(""This {0} {[||]1} works"", strings)
     End Sub
 End Class")
         End Function

--- a/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
@@ -27,11 +27,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ValidateFormatStri
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)>
-        Public Async Function ParamsObjectArray() As Task
+        Public Async Function ObjectArray() As Task
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(""This {0} {1} {[||]2} works"", New Object  { ""test"", ""test2"", ""test3"" })
+        string.Format(""This {0} {1} {[||]2} works"", New Object() { ""test"", ""test2"", ""test3"" })
+    End Sub
+End Class")
+        End Function
+
     End Sub
 End Class")
         End Function

--- a/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/ValidateFormatString/ValidateFormatStringTests.vb
@@ -37,6 +37,16 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)>
+        Public Async Function LiteralArray() As Task
+            Await TestDiagnosticMissingAsync("
+Class C
+     Sub Main 
+        string.Format(""This {0[||]} {1} {2} {3} works"", { ""test"", ""test2"", ""test3"", ""test4"" })
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)>
         Public Async Function StringArray() As Task
             Await TestDiagnosticMissingAsync("
 Class C


### PR DESCRIPTION
fixes #42764

Small changes, adds some test cases to cover the different ways arrays can be defined in VB.