### PR TITLE
Record copy ctor must invoke base copy ctor

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3958,7 +3958,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     resultMember = SynthesizedRecordCopyCtor.FindCopyConstructor(baseType);
                     found = resultMember is object;
-                    argsToParamsOpt = ImmutableArray.Create<int>(0);
+                    argsToParamsOpt = default;
                     isExpanded = false;
                     candidateConstructors = ImmutableArray<MethodSymbol>.Empty;
                     analyzedArguments.Arguments.Add(new BoundParameter(constructor.GetNonNullSyntaxNode(), constructor.Parameters[0]));
@@ -4077,7 +4077,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 analyzedArguments.Free();
             }
 
-            static void validateRecordCopyConstructor(NamedTypeSymbol containingType, MethodSymbol constructor, NamedTypeSymbol baseType, MethodSymbol resultMember, Location errorLocation, DiagnosticBag diagnostics)
+            static void validateRecordCopyConstructor(NamedTypeSymbol containingType, MethodSymbol constructor, NamedTypeSymbol baseType, MethodSymbol baseCtor, Location errorLocation, DiagnosticBag diagnostics)
             {
                 // Are we dealing with a user-defined copy constructor in a record type?
                 if (containingType is SourceNamedTypeSymbol sourceType &&
@@ -4096,7 +4096,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // We'll have reported a problem with the base type of the record elsewhere
                         return;
                     }
-                    else if (!correctBaseCopyCtor.Equals(resultMember, TypeCompareKind.ConsiderEverything))
+                    else if (!correctBaseCopyCtor.Equals(baseCtor, TypeCompareKind.ConsiderEverything))
                     {
                         diagnostics.Add(ErrorCode.ERR_CopyConstructorMustInvokeBaseCopyConstructor, errorLocation, correctBaseCopyCtor);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3963,7 +3963,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     candidateConstructors = ImmutableArray<MethodSymbol>.Empty;
                     analyzedArguments.Arguments.Add(new BoundParameter(constructor.GetNonNullSyntaxNode(), constructor.Parameters[0]));
 
-                    if (!found)
+                    if (found)
+                    {
+                        HashSet<DiagnosticInfo> ignoredUseSiteDiagnostics = null;
+                        if (!this.IsAccessible(resultMember, ref ignoredUseSiteDiagnostics, accessThroughType: null))
+                        {
+                            diagnostics.Add(ErrorCode.ERR_BadAccess, errorLocation, resultMember);
+                        }
+                    }
+                    else
                     {
                         diagnostics.Add(ErrorCode.ERR_NoCopyConstructorInBaseType, errorLocation, baseType);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4052,7 +4052,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (baseType.SpecialType == SpecialType.System_Object)
                     {
-                        if (resultMember.ContainingType.SpecialType != SpecialType.System_Object)
+                        if (resultMember is null || resultMember.ContainingType.SpecialType != SpecialType.System_Object)
                         {
                             // Record deriving from object must use `base()`, not `this()`
                             diagnostics.Add(ErrorCode.ERR_CopyConstructorMustInvokeBaseCopyConstructor, errorLocation);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3356,9 +3356,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (constructor.Initializer?.IsKind(SyntaxKind.ThisConstructorInitializer) != true &&
                 ContainingType.GetMembersUnordered().OfType<SynthesizedRecordConstructor>().Any() &&
-                !SynthesizedRecordCopyCtor.FindCopyConstructor(ContainingType).Equals(this.ContainingMember(), TypeCompareKind.ConsiderEverything))
+                !SynthesizedRecordCopyCtor.IsCopyConstructor(this.ContainingMember()))
             {
-                // Note: for copy constructors, we check the constructor initializer elsewhere
+                // Note: we check the constructor initializer of copy constructors elsewhere
                 Error(diagnostics, ErrorCode.ERR_UnexpectedOrMissingConstructorInitializerInRecord, constructor.Initializer?.ThisOrBaseKeyword ?? constructor.Identifier);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3355,8 +3355,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(bodyBinder != null);
 
             if (constructor.Initializer?.IsKind(SyntaxKind.ThisConstructorInitializer) != true &&
-                ContainingType.GetMembersUnordered().OfType<SynthesizedRecordConstructor>().Any())
+                ContainingType.GetMembersUnordered().OfType<SynthesizedRecordConstructor>().Any() &&
+                !SynthesizedRecordCopyCtor.FindCopyConstructor(ContainingType).Equals(this.ContainingMember(), TypeCompareKind.ConsiderEverything))
             {
+                // Note: for copy constructors, we check the constructor initializer elsewhere
                 Error(diagnostics, ErrorCode.ERR_UnexpectedOrMissingConstructorInitializerInRecord, constructor.Initializer?.ThisOrBaseKeyword ?? constructor.Identifier);
             }
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6253,4 +6253,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_BadRecordMemberForPositionalParameter" xml:space="preserve">
     <value>Record member '{0}' must be a readable instance property of type '{1}' to match positional parameter '{2}'.</value>
   </data>
+  <data name="ERR_NoCopyConstructorInBaseType" xml:space="preserve">
+    <value>No accessible copy constructor found in base type '{0}'.</value>
+  </data>
+  <data name="ERR_CopyConstructorMustInvokeBaseCopyConstructor" xml:space="preserve">
+    <value>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6257,6 +6257,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>No accessible copy constructor found in base type '{0}'.</value>
   </data>
   <data name="ERR_CopyConstructorMustInvokeBaseCopyConstructor" xml:space="preserve">
-    <value>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</value>
+    <value>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6257,6 +6257,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>No accessible copy constructor found in base type '{0}'.</value>
   </data>
   <data name="ERR_CopyConstructorMustInvokeBaseCopyConstructor" xml:space="preserve">
-    <value>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</value>
+    <value>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1832,6 +1832,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadRecordBase = 8864,
         ERR_BadInheritanceFromRecord = 8865,
         ERR_BadRecordMemberForPositionalParameter = 8866,
+        ERR_NoCopyConstructorInBaseType = 8867,
+        ERR_CopyConstructorMustInvokeBaseCopyConstructor = 8868,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
              ConstructorDeclarationSyntax syntax,
              MethodKind methodKind,
              DiagnosticBag diagnostics) :
-             base(containingType, location, syntax, methodKind, diagnostics)
+             base(containingType, location, syntax)
         {
             bool hasBlockBody = syntax.Body != null;
             _isExpressionBodied = !hasBlockBody && syntax.ExpressionBody != null;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected SourceConstructorSymbolBase(
             SourceMemberContainerTypeSymbol containingType,
             Location location,
-            CSharpSyntaxNode syntax,
-            MethodKind methodKind,
-            DiagnosticBag diagnostics)
+            CSharpSyntaxNode syntax)
             : base(containingType, syntax.GetReference(), ImmutableArray.Create(location), SyntaxFacts.HasYieldOperations(syntax))
         {
             Debug.Assert(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -764,6 +764,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal bool IsRecord
+        {
+            get
+            {
+                return this.declaration.Declarations[0].Kind == DeclarationKind.Record;
+            }
+        }
+
         public override bool IsImplicitlyDeclared
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -105,21 +105,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region Syntax
 
-        public bool IsRecord()
-        {
-            foreach (var syntaxRef in this.SyntaxReferences)
-            {
-                var typeDecl = (CSharpSyntaxNode)syntaxRef.GetSyntax();
-                SyntaxKind typeKind = typeDecl.Kind();
-                if (typeKind == SyntaxKind.RecordDeclaration)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private static SyntaxToken GetName(CSharpSyntaxNode node)
         {
             switch (node.Kind())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -105,6 +105,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region Syntax
 
+        public bool IsRecord()
+        {
+            foreach (var syntaxRef in this.SyntaxReferences)
+            {
+                var typeDecl = (CSharpSyntaxNode)syntaxRef.GetSyntax();
+                SyntaxKind typeKind = typeDecl.Kind();
+                if (typeKind == SyntaxKind.RecordDeclaration)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static SyntaxToken GetName(CSharpSyntaxNode node)
         {
             switch (node.Kind())

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordConstructor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
              SourceMemberContainerTypeSymbol containingType,
              RecordDeclarationSyntax syntax,
              DiagnosticBag diagnostics) :
-             base(containingType, syntax.ParameterList!.GetLocation(), syntax, MethodKind.Constructor, diagnostics)
+             base(containingType, syntax.ParameterList!.GetLocation(), syntax)
         {
             this.MakeFlags(MethodKind.Constructor, containingType.IsAbstract ? DeclarationModifiers.Protected : DeclarationModifiers.Public, returnsVoid: true, isExtensionMethod: false);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static MethodSymbol? FindCopyConstructor(NamedTypeSymbol containingType)
         {
-            foreach (var member in containingType.GetMembers(WellKnownMemberNames.InstanceConstructorName))
+            foreach (var member in containingType.InstanceConstructors)
             {
                 if (member is MethodSymbol { IsStatic: false, ParameterCount: 1, Arity: 0 } method &&
                     method.Parameters[0].Type.Equals(containingType, TypeCompareKind.CLRSignatureCompareOptions) &&

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -63,6 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var member in containingType.InstanceConstructors)
             {
                 if (HasCopyConstructorSignature(member) &&
+                    !member.HasUnsupportedMetadata &&
                     AccessCheck.IsSymbolAccessible(member.OriginalDefinition, within.OriginalDefinition, ref useSiteDiagnostics))
                 {
                     return member;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (HasCopyConstructorSignature(member) &&
                     !member.HasUnsupportedMetadata &&
-                    AccessCheck.IsSymbolAccessible(member.OriginalDefinition, within.OriginalDefinition, ref useSiteDiagnostics))
+                    AccessCheck.IsSymbolAccessible(member, within, ref useSiteDiagnostics))
                 {
                     return member;
                 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Výraz typu {0} nelze zpracovat vzorem typu {1}. Použijte prosím verzi jazyka {2} nebo vyšší, aby odpovídala otevřenému typu se vzorem konstanty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Název {0} neodpovídá příslušnému parametru Deconstruct {1}.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">{0}: Typ použitý v příkazu using musí být implicitně převoditelný na System.IDisposable. Neměli jste v úmyslu použít await using místo using?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Ein Ausdruck vom Typ "{0}" kann nicht von einem Muster vom Typ "{1}" behandelt werden. Verwenden Sie Sprachversion {2} oder höher, um einen offenen Typ mit einem konstanten Muster abzugleichen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Der Name "{0}" stimmt nicht mit dem entsprechenden Deconstruct-Parameter "{1}" überein.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">"{0}": Der in einer using-Anweisung verwendete Typ muss implizit in "System.IDisposable" konvertierbar sein. Meinten Sie "await using" anstelle von "using"?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Un patrón de tipo "{0}" no se puede controlar por un patrón de tipo "{1}". Use la versión de lenguaje "{2}" o superior para buscar un tipo abierto con un patrón constante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">El nombre "{0}" no coincide con el parámetro de "Deconstruct" correspondiente, "{1}".</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">"{0}": el tipo usado en una instrucción using debe poder convertirse implícitamente en "System.IDisposable". ¿Quiso decir "await using" en lugar de "using"?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Une expression de type '{0}' ne peut pas être prise en charge par un modèle de type '{1}'. Utilisez la version de langage '{2}' ou une version ultérieure pour faire correspondre un type ouvert à un modèle de constante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Le nom '{0}' ne correspond pas au paramètre 'Deconstruct' correspondant '{1}'.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}' : le type utilisé dans une instruction using doit être implicitement convertible en 'System.IDisposable'. Est-ce qu'il ne s'agit pas plutôt de 'await using' au lieu de 'using' ?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Un'espressione di tipo '{0}' non può essere gestita da un criterio di tipo '{1}'. Usare la versione '{2}' o versioni successive del linguaggio per abbinare un tipo aperto a un criterio costante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Il nome '{0}' non corrisponde al parametro '{1}' di 'Deconstruct' corrispondente.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}': il tipo usato in un'istruzione using deve essere convertibile in modo implicito in 'System.IDisposable'. Si intendeva 'await using' invece di 'using'?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -197,6 +197,11 @@
         <target state="translated">型 '{0}' の式を型 '{1}' のパターンで処理することはできません。オープン型と定数パターンを一致させるには、言語バージョン '{2}' 以上をご使用ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">名前 '{0}' は対応する 'Deconstruct' パラメーター '{1}' と一致しません。</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}': using ステートメントで使用される型は、暗黙的に 'System.IDisposable' への変換が可能でなければなりません。'using' ではなく 'await using' ですか?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -197,6 +197,11 @@
         <target state="translated">'{0}' 형식의 식은 '{1}' 형식의 패턴으로 처리할 수 없습니다. 언어 버전 '{2}' 이상을 사용하여 개방형 형식과 상수 패턴을 일치시키세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">'{0}' 이름이 해당 'Deconstruct' 매개 변수 '{1}'과(와) 일치하지 않습니다.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}': using 문에 사용된 형식은 암시적으로 'System.IDisposable'로 변환할 수 있어야 합니다. 'using' 대신 'await using'을 사용하시겠습니까?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Wyrażenie typu „{0}” nie może być obsługiwane przez wzorzec typu „{1}”. Użyj wersji języka „{2}” lub nowszej, aby dopasować typ otwarty za pomocą wzorca stałej.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Nazwa „{0}” nie jest zgodna z odpowiednim parametrem „Deconstruct” „{1}”.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">„{0}”: typ użyty w instrukcji using musi umożliwiać niejawną konwersję na interfejs „System.IDisposable”. Czy chodziło Ci o instrukcję „await using”, a nie „using”?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Uma expressão do tipo '{0}' não pode ser manipulada por um padrão do tipo '{1}'. Use a versão de linguagem '{2}' ou superior para corresponder a um tipo aberto com um padrão constante.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">O nome '{0}' não corresponde ao parâmetro 'Deconstruct' '{1}'.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}': o tipo usado em uma instrução using deve ser implicitamente conversível em 'System.IDisposable'. Você quis dizer 'await using' em vez de 'using'?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Выражение типа "{0}" не может быть обработано шаблоном типа "{1}". Используйте версию языка "{2}" или более позднюю, чтобы сопоставить открытый тип с постоянным шаблоном.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">Имя "{0}" не соответствует указанному параметру "Deconstruct" "{1}".</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">"{0}": тип, использованный в операторе using, должен иметь возможность неявного преобразования в System.IDisposable. Вы хотели использовать "await using" вместо "using"?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -197,6 +197,11 @@
         <target state="translated">'{0}' türünde bir ifade, '{1}' türünde bir desen tarafından işlenemez. Lütfen açık bir türü sabit bir desenle eşleştirmek için '{2}' veya daha yüksek bir dil sürümü kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">'{0}' adı ilgili '{1}' 'Deconstruct' parametresiyle eşleşmiyor.</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}': using deyiminde kullanılan tür örtük olarak 'System.IDisposable' arabirimine dönüştürülebilir olmalıdır. 'using' yerine 'await using' mi kullanmak istediniz?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -197,6 +197,11 @@
         <target state="translated">"{0}" 类型的表达式不能由 "{1}" 类型的模式进行处理。请使用语言版本 "{2}" 或更高版本，将开放类型与常数模式进行匹配。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">名称“{0}”与相应 "Deconstruct" 参数“{1}”不匹配。</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">“{0}”: using 语句中使用的类型必须可隐式转换为 "System.IDisposable"。是否希望使用 "await using" 而非 "using"?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -197,6 +197,11 @@
         <target state="translated">類型 '{0}' 的運算式無法由類型 '{1}' 的模式處理。請使用語言 '{2}' 版或更新版本，以比對開放式類型與常數模式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
+        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">
         <source>The name '{0}' does not match the corresponding 'Deconstruct' parameter '{1}'.</source>
         <target state="translated">名稱 '{0}' 與對應的 'Deconstruct' 參數 '{1}' 不相符。</target>
@@ -490,6 +495,11 @@
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
         <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
         <target state="translated">'{0}': using 陳述式中使用的類型必須可以隱含轉換為 'System.IDisposable'。您指的是 'await using' 而不是 'using' 嗎?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoCopyConstructorInBaseType">
+        <source>No accessible copy constructor found in base type '{0}'.</source>
+        <target state="new">No accessible copy constructor found in base type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoOutputDirectory">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</source>
+        <target state="new">A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CopyConstructorMustInvokeBaseCopyConstructor">
-        <source>A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</source>
-        <target state="new">A copy constructor in a record type deriving from another type must invoke that base type's copy constructor '{0}'.</target>
+        <source>A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</source>
+        <target state="new">A copy constructor in a record type deriving from another record must invoke that base record's copy constructor '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DeconstructParameterNameMismatch">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -3805,6 +3805,26 @@ public record C(object P1, object P2) : B(3, 4) { }
                 "B..ctor(B )"
             };
             AssertEx.Equal(expectedMembers, actualMembers);
+
+            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
+            verifier.VerifyIL("C..ctor(C)", @"
+{
+  // Code size       32 (0x20)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  call       ""B..ctor(B)""
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.1
+  IL_0009:  ldfld      ""object C.<P1>k__BackingField""
+  IL_000e:  stfld      ""object C.<P1>k__BackingField""
+  IL_0013:  ldarg.0
+  IL_0014:  ldarg.1
+  IL_0015:  ldfld      ""object C.<P2>k__BackingField""
+  IL_001a:  stfld      ""object C.<P2>k__BackingField""
+  IL_001f:  ret
+}
+");
         }
 
         [Fact, WorkItem(44902, "https://github.com/dotnet/roslyn/issues/44902")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -3888,6 +3888,89 @@ public record C(object P1, object P2) : B(0, 1)
         }
 
         [Fact, WorkItem(44902, "https://github.com/dotnet/roslyn/issues/44902")]
+        public void CopyCtor_UserDefinedButDoesNotDelegateToBaseCopyCtor_DerivesFromObject()
+        {
+            var source =
+@"public record C(int I)
+{
+    public C(C c)
+    {
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
+            verifier.VerifyIL("C..ctor(C)", @"
+{
+  // Code size       14 (0xe)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int C.<I>k__BackingField""
+  IL_0007:  ldarg.0
+  IL_0008:  call       ""object..ctor()""
+  IL_000d:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(44902, "https://github.com/dotnet/roslyn/issues/44902")]
+        public void CopyCtor_UserDefinedButDoesNotDelegateToBaseCopyCtor_DerivesFromObject_UsesThis()
+        {
+            var source =
+@"public record C(int I)
+{
+    public C(C c) : this(c.I)
+    {
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
+            verifier.VerifyIL("C..ctor(C)", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  callvirt   ""int C.I.get""
+  IL_0007:  call       ""C..ctor(int)""
+  IL_000c:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(44902, "https://github.com/dotnet/roslyn/issues/44902")]
+        public void CopyCtor_UserDefinedButDoesNotDelegateToBaseCopyCtor_DerivesFromObject_UsesBase()
+        {
+            var source =
+@"public record C(int I)
+{
+    public C(C c) : base()
+    {
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
+            verifier.VerifyIL("C..ctor(C)", @"
+{
+  // Code size       14 (0xe)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int C.<I>k__BackingField""
+  IL_0007:  ldarg.0
+  IL_0008:  call       ""object..ctor()""
+  IL_000d:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(44902, "https://github.com/dotnet/roslyn/issues/44902")]
         public void CopyCtor_UserDefinedButDoesNotDelegateToBaseCopyCtor_NoPositionalMembers()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -3659,7 +3659,7 @@ class Program
 {
 }";
             var compA = CreateCompilation(sourceA);
-            var verifierA = CompileAndVerify(compA, verify: ExecutionConditionUtil.IsCoreClr? Verification.Skipped: Verification.Fails);
+            var verifierA = CompileAndVerify(compA, verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
 
             verifierA.VerifyIL("B..ctor(B)", @"
 {
@@ -3700,7 +3700,7 @@ class Program
             var compB = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
             compB.VerifyDiagnostics();
 
-            var verifierB = CompileAndVerify(compB, expectedOutput: "(1, 2, 3, 4) (1, 2, 3, 4) (10, 2, 30, 4)", verify: ExecutionConditionUtil.IsCoreClr? Verification.Skipped: Verification.Fails);
+            var verifierB = CompileAndVerify(compB, expectedOutput: "(1, 2, 3, 4) (1, 2, 3, 4) (10, 2, 30, 4)", verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
             // call base copy constructor B..ctor(B)
             verifierB.VerifyIL("C..ctor(C)", @"
 {
@@ -3744,7 +3744,7 @@ public record C(object P1, object P2) : B(3, 4)
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
             comp.VerifyDiagnostics();
 
-            var verifier = CompileAndVerify(comp, expectedOutput: "(1, 2, 3, 4) (10, 20, 30, 40)", verify: ExecutionConditionUtil.IsCoreClr? Verification.Skipped: Verification.Fails);
+            var verifier = CompileAndVerify(comp, expectedOutput: "(1, 2, 3, 4) (10, 20, 30, 40)", verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
             // call base copy constructor B..ctor(B)
             verifier.VerifyIL("C..ctor(C)", @"
 {
@@ -3795,7 +3795,7 @@ public record C(object P1, object P2) : B(3, 4) { }
 public record C(object P1, object P2) : B(3, 4) { }
 ";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics( );
+            comp.VerifyDiagnostics();
 
             var actualMembers = comp.GetMember<NamedTypeSymbol>("B").GetMembers().Where(m => m.Name == ".ctor").ToTestDisplayStrings();
             var expectedMembers = new[]
@@ -3819,7 +3819,7 @@ public record C(object P1, object P2) : B(3, 4) { }
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
 
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsCoreClr? Verification.Skipped: Verification.Fails);
+            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
             verifier.VerifyIL("C..ctor(C)", @"
 {
   // Code size       55 (0x37)
@@ -3966,6 +3966,7 @@ public record D(object P1, object P2) : B(0, 1)
 {
     private D(D d) : base(d) { } // 2
 }
+public record E(object P1, object P2) : B(0, 1);
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
@@ -4145,7 +4146,7 @@ public record C(object P1, object P2) : B(3, 4)
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
             comp.VerifyDiagnostics();
 
-            var verifier = CompileAndVerify(comp, expectedOutput: "(1, 2, 3, 4, 100, 200)", verify: ExecutionConditionUtil.IsCoreClr? Verification.Skipped: Verification.Fails);
+            var verifier = CompileAndVerify(comp, expectedOutput: "(1, 2, 3, 4, 100, 200)", verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
             verifier.VerifyIL("C..ctor(C)", @"
 {
   // Code size       44 (0x2c)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -3908,7 +3908,7 @@ public record C(object P1, object P2) : B(0, 1)
 ";
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, parseOptions: TestOptions.RegularPreview, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "(2, 0)", verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
+            var verifier = CompileAndVerify(comp, expectedOutput: "(2, 0)");
             verifier.VerifyIL("C..ctor(C)", @"
 {
   // Code size        9 (0x9)
@@ -3948,7 +3948,7 @@ public record C(object P1, object P2) : B(0, 1)
 ";
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, parseOptions: TestOptions.RegularPreview, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "(2, 100) RAN (0, 0)", verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails);
+            var verifier = CompileAndVerify(comp, expectedOutput: "(2, 100) RAN (0, 0)");
             verifier.VerifyIL("C..ctor(C)", @"
 {
   // Code size       20 (0x14)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
@@ -742,11 +742,7 @@ record C(int x, int y)
 {
     public C(C other) { }
 }");
-            comp.VerifyDiagnostics(
-                // (4,12): error CS8862: A constructor declared in a record with parameters must have 'this' constructor initializer.
-                //     public C(C other) { }
-                Diagnostic(ErrorCode.ERR_UnexpectedOrMissingConstructorInitializerInRecord, "C").WithLocation(4, 12)
-                );
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -758,11 +754,7 @@ record C(int x, int y)
 {
     public C(C other) : base() { }
 }");
-            comp.VerifyDiagnostics(
-                // (4,25): error CS8862: A constructor declared in a record with parameters must have 'this' constructor initializer.
-                //     public C(C other) : base() { }
-                Diagnostic(ErrorCode.ERR_UnexpectedOrMissingConstructorInitializerInRecord, "base").WithLocation(4, 25)
-                );
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1196,6 +1188,9 @@ enum G : C { }";
 
             var comp = CreateCompilation(src);
             comp.VerifyDiagnostics(
+                // (3,8): error CS8867: No accessible copy constructor found in base type 'A'.
+                // record B : A { }
+                Diagnostic(ErrorCode.ERR_NoCopyConstructorInBaseType, "B").WithArguments("A").WithLocation(3, 8),
                 // (3,12): error CS8864: Records may only inherit from object or another record
                 // record B : A { }
                 Diagnostic(ErrorCode.ERR_BadRecordBase, "A").WithLocation(3, 12),
@@ -1209,7 +1204,7 @@ enum G : C { }";
                 // struct F : C { }
                 Diagnostic(ErrorCode.ERR_NonInterfaceInInterfaceList, "C").WithArguments("C").WithLocation(7, 12),
                 // (8,10): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
-                // enum G : C
+                // enum G : C { }
                 Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "C").WithLocation(8, 10)
             );
         }
@@ -1240,17 +1235,20 @@ enum H : C { }
             });
 
             comp2.VerifyDiagnostics(
+                // (3,8): error CS8867: No accessible copy constructor found in base type 'A'.
+                // record E : A { }
+                Diagnostic(ErrorCode.ERR_NoCopyConstructorInBaseType, "E").WithArguments("A").WithLocation(3, 8),
                 // (3,12): error CS8864: Records may only inherit from object or another record
                 // record E : A { }
                 Diagnostic(ErrorCode.ERR_BadRecordBase, "A").WithLocation(3, 12),
                 // (4,15): error CS0527: Type 'C' in interface list is not an interface
-                // interface E : C { }
+                // interface F : C { }
                 Diagnostic(ErrorCode.ERR_NonInterfaceInInterfaceList, "C").WithArguments("C").WithLocation(4, 15),
                 // (5,12): error CS0527: Type 'C' in interface list is not an interface
-                // struct F : C { }
+                // struct G : C { }
                 Diagnostic(ErrorCode.ERR_NonInterfaceInInterfaceList, "C").WithArguments("C").WithLocation(5, 12),
                 // (6,10): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
-                // enum G : C
+                // enum H : C { }
                 Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "C").WithLocation(6, 10)
             );
         }


### PR DESCRIPTION
Design notes:

- don't run initializers in synthesized copy constructor
- require that user-defined copy constructor delegate to base copy constructor
- synthesized copy constructor delegates to base copy constructor, except for object
- error if delegation fails during synthesis (member not found/accessible)
- synthesized copy constructor should be protected

Corresponding spec change: https://github.com/dotnet/csharplang/pull/3554

Fixes https://github.com/dotnet/roslyn/issues/44902 (delegate to base copy ctor)
Fixes https://github.com/dotnet/roslyn/issues/44897 (synthesized as protected)