### PR TITLE
Binder Check for Unbound Generics in Methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5942,9 +5942,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     options |= LookupOptions.MustBeInvocableIfMember;
                 }
 
-                SeparatedSyntaxList<TypeSyntax> typeArgumentsSyntax = right is GenericNameSyntax genericName ? genericName.TypeArgumentList.Arguments : default;
+                var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName ? ((GenericNameSyntax)right).TypeArgumentList.Arguments : default(SeparatedSyntaxList<TypeSyntax>);
                 bool rightHasTypeArguments = typeArgumentsSyntax.Count > 0;
-                ImmutableArray<TypeWithAnnotations> typeArguments = rightHasTypeArguments ? BindTypeArguments(typeArgumentsSyntax, diagnostics) : default;
+                var typeArguments = rightHasTypeArguments ? BindTypeArguments(typeArgumentsSyntax, diagnostics) : default(ImmutableArray<TypeWithAnnotations>);
 
                 // A member-access consists of a primary-expression, a predefined-type, or a 
                 // qualified-alias-member, followed by a "." token, followed by an identifier, 
@@ -6207,9 +6207,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         lookupResult,
                         flags);
 
-                    if (!boundMethodGroup.HasErrors && (boundMethodGroup.ResultKind == LookupResultKind.Empty ||
-                        (right is GenericNameSyntax genericNameRight && !IsUnboundTypeAllowed(genericNameRight))) &&
-                        typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument))
+                    if (!boundMethodGroup.HasErrors && typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) &&
+                        (boundMethodGroup.ResultKind == LookupResultKind.Empty || boundMethodGroup.ResultKind == LookupResultKind.WrongArity))
                     {
                         Error(diagnostics, ErrorCode.ERR_BadArity, node, rightName, MessageID.IDS_MethodGroup.Localize(), typeArgumentsSyntax.Count);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6062,11 +6062,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     default:
                         {
-                            // Ensure that there is an error thrown when an Unbound Generic is found.
-                            if (right is GenericNameSyntax genericNameRight && rightHasTypeArguments && typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) && !IsUnboundTypeAllowed(genericNameRight))
-                            {
-                                diagnostics.Add(ErrorCode.ERR_UnexpectedUnboundGenericName, genericNameRight.Location);
-                            }
                             // Can't dot into the null literal
                             if (boundLeft.Kind == BoundKind.Literal && ((BoundLiteral)boundLeft).ConstantValueOpt == ConstantValue.Null)
                             {
@@ -6079,6 +6074,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else if ((object)leftType != null)
                             {
+                                // Ensure that an error is thrown when an unbound generic is found.
+                                if (right is GenericNameSyntax genericNameRight && rightHasTypeArguments &&
+                                    typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) && !IsUnboundTypeAllowed(genericNameRight))
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_UnexpectedUnboundGenericName, genericNameRight.Location);
+                                }
+
                                 // NB: We don't know if we really only need RValue access, or if we are actually
                                 // passing the receiver implicitly by ref (e.g. in a struct instance method invocation).
                                 // These checks occur later.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6074,13 +6074,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else if ((object)leftType != null)
                             {
-                                // Ensure that an error is thrown when an unbound generic is found.
-                                if (right is GenericNameSyntax genericNameRight && rightHasTypeArguments &&
-                                    typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) && !IsUnboundTypeAllowed(genericNameRight))
-                                {
-                                    diagnostics.Add(ErrorCode.ERR_UnexpectedUnboundGenericName, genericNameRight.Location);
-                                }
-
                                 // NB: We don't know if we really only need RValue access, or if we are actually
                                 // passing the receiver implicitly by ref (e.g. in a struct instance method invocation).
                                 // These checks occur later.
@@ -6214,7 +6207,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         lookupResult,
                         flags);
 
-                    if (!boundMethodGroup.HasErrors && boundMethodGroup.ResultKind == LookupResultKind.Empty && typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument))
+                    if (!boundMethodGroup.HasErrors && (boundMethodGroup.ResultKind == LookupResultKind.Empty ||
+                        (right is GenericNameSyntax genericNameRight && !IsUnboundTypeAllowed(genericNameRight))) &&
+                        typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument))
                     {
                         Error(diagnostics, ErrorCode.ERR_BadArity, node, rightName, MessageID.IDS_MethodGroup.Localize(), typeArgumentsSyntax.Count);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5942,9 +5942,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                     options |= LookupOptions.MustBeInvocableIfMember;
                 }
 
-                var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName ? ((GenericNameSyntax)right).TypeArgumentList.Arguments : default(SeparatedSyntaxList<TypeSyntax>);
-                bool rightHasTypeArguments = typeArgumentsSyntax.Count > 0;
-                var typeArguments = rightHasTypeArguments ? BindTypeArguments(typeArgumentsSyntax, diagnostics) : default(ImmutableArray<TypeWithAnnotations>);
+                ImmutableArray<TypeWithAnnotations> typeArguments = default;
+                SeparatedSyntaxList<TypeSyntax> typeArgumentsSyntax = default;
+                bool rightHasTypeArguments = false;
+                if (right is GenericNameSyntax genericName)
+                {
+                    typeArgumentsSyntax = genericName.TypeArgumentList.Arguments;
+                    if (typeArgumentsSyntax.Count > 0)
+                    {
+                        rightHasTypeArguments = true;
+                        typeArguments = BindTypeArguments(typeArgumentsSyntax, diagnostics);
+
+                        if (typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) && !IsUnboundTypeAllowed(genericName))
+                        {
+                            diagnostics.Add(ErrorCode.ERR_UnexpectedUnboundGenericName, genericName.Location);
+                            return BadExpression(node, boundLeft);
+                        }
+                    }
+                }
 
                 // A member-access consists of a primary-expression, a predefined-type, or a 
                 // qualified-alias-member, followed by a "." token, followed by an identifier, 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6207,10 +6207,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         lookupResult,
                         flags);
 
-                    if (!boundMethodGroup.HasErrors && typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) &&
-                        (boundMethodGroup.ResultKind == LookupResultKind.Empty || boundMethodGroup.ResultKind == LookupResultKind.WrongArity))
+                    if (!boundMethodGroup.HasErrors && typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument))
                     {
-                        Error(diagnostics, ErrorCode.ERR_BadArity, node, rightName, MessageID.IDS_MethodGroup.Localize(), typeArgumentsSyntax.Count);
+                        Error(diagnostics, ErrorCode.ERR_OmittedTypeArgument, node);
                     }
 
                     return boundMethodGroup;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5956,7 +5956,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument) && !IsUnboundTypeAllowed(genericName))
                         {
                             diagnostics.Add(ErrorCode.ERR_UnexpectedUnboundGenericName, genericName.Location);
-                            return BadExpression(node, boundLeft);
+                            return BadExpression(node);
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1221,7 +1221,7 @@
   <data name="ERR_AttributeCantBeGeneric" xml:space="preserve">
     <value>Cannot apply attribute class '{0}' because it is generic</value>
   </data>
-  <data name="ERR_DuplicateBound" xml:space="preserve">
+  <data name="ERR_DuplicateBound" xml:space="preserve">                                
     <value>Duplicate constraint '{0}' for type parameter '{1}'</value>
   </data>
   <data name="ERR_ClassBoundNotFirst" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1221,7 +1221,7 @@
   <data name="ERR_AttributeCantBeGeneric" xml:space="preserve">
     <value>Cannot apply attribute class '{0}' because it is generic</value>
   </data>
-  <data name="ERR_DuplicateBound" xml:space="preserve">                                
+  <data name="ERR_DuplicateBound" xml:space="preserve">
     <value>Duplicate constraint '{0}' for type parameter '{1}'</value>
   </data>
   <data name="ERR_ClassBoundNotFirst" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -471,6 +471,9 @@
   <data name="ERR_ThisInBadContext" xml:space="preserve">
     <value>Keyword 'this' is not available in the current context</value>
   </data>
+  <data name="ERR_OmittedTypeArgument" xml:space="preserve">
+    <value>Omitting the type argument is not allowed in the current context</value>
+  </data>
   <data name="WRN_InvalidMainSig" xml:space="preserve">
     <value>'{0}' has the wrong signature to be an entry point</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1581,6 +1581,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         WRN_TypeParameterSameAsOuterMethodTypeParameter = 8387,
         ERR_OutVariableCannotBeByRef = 8388,
+        ERR_OmittedTypeArgument = 8389,
 
         #region diagnostics introduced for C# 8.0
         ERR_FeatureNotAvailableInVersion8 = 8400,

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Parametr typu s možnou hodnotou null musí být známou hodnotou nebo musí jít o typ odkazu, který nemůže mít hodnotu null. Zvažte přidání 'class', 'struct' nebo omezení typu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Výstupní proměnná nemůže být deklarovaná jako lokální proměnná podle odkazu.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Ein Nullable-Typparameter muss als Werttyp oder als Non-Nullable-Verweistyp bekannt sein. Sie sollten eine class-, struct- oder eine Typeinschränkung hinzufügen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Eine out-Variable kann nicht als lokales ref-Element deklariert werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Debe saberse si un parámetro de tipo que acepta valores NULL es un tipo de valor o un tipo de referencia que no admite valores NULL. Considere agregar "class", "struct" o una restricción de tipo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Una variable out no se puede declarar como ref local</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Un paramètre de type nullable doit être connu pour pouvoir être un type valeur ou un type référence non-nullable. Ajoutez une contrainte 'class', 'struct' ou une contrainte de type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Impossible de déclarer une variable out en tant que variable locale ref</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Un parametro di tipo che ammette i valori Null deve essere noto per essere un tipo valore o un tipo riferimento che non ammette i valori Null. Provare ad aggiungere un vincolo di tipo, 'class' o 'struct'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Non è possibile dichiarare una variabile out come variabile locale ref</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Null 許容型パラメーターは、値の型または Null 非許容参照型として既知である必要があります。'class'、'struct'、型制約を追加することをご検討ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">out 変数を ref ローカルと宣言することはできません</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -522,6 +522,11 @@
         <target state="translated">값 형식 또는 null을 허용하지 않는 참조 형식이 되려면 nullable 형식 매개 변수를 알려야 합니다. 'class', 'struct' 또는 형식 제약 조건 추가를 고려하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">출력 변수는 참조 로컬로 선언할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Nullowalny parametr typumusi być typem wartości lub nienullowalnym typem referencyjnym. Rozważ dodanie elementu „class”, „struct” lub ograniczenia typu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Zmiennej out nie można zadeklarować jako lokalnej zmiennej ref</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Um parâmetro de tipo que permite valor nulo precisa ser um tipo de valor ou um tipo de referência não anulável. Considere a possibilidade de adicionar 'class', 'struct' ou restrição de tipo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Uma variável out não pode ser declarada como uma referência local</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Параметр типа, допускающего значение NULL, должен быть известен как тип значения или ссылочный тип, не допускающий значение NULL. Рекомендуется добавить "class", "struct" или ограничение типа.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Выходная переменная не может быть объявлена как локальная переменная ref</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Boş değer atanabilir bir tür parametresi bilinen bir değer türü veya boş değer atanamayan bir başvuru türü olmalıdır. Bir 'class', 'struct' veya tür kısıtlaması eklemeyi düşünün.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">Bir out değişkeni ref yerel değeri olarak bildirilemez</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -522,6 +522,11 @@
         <target state="translated">可为 null 的类型参数必须已知为值类型或不可为 null 引用类型。请考虑添加一个 “class”、“struct” 或类型约束。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">out 变量无法声明为 ref 局部变量</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -522,6 +522,11 @@
         <target state="translated">可為 Null 的型別參數必須已知為實值型別或不可為 Null 的參考型別。建議新增 'class'、'struct' 或型別條件約束。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OmittedTypeArgument">
+        <source>Omitting the type argument is not allowed in the current context</source>
+        <target state="new">Omitting the type argument is not allowed in the current context</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_OutVariableCannotBeByRef">
         <source>An out variable cannot be declared as a ref local</source>
         <target state="translated">out 變數不可宣告為 ref local</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3516,81 +3516,81 @@ public class Class1
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
 
             compilation.VerifyDiagnostics(
-                // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
-                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
-                // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
-                // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
-                //         var omittedArg1 = "string literal".ExtensionMethod1<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(14, 27),
-                // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
-                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
-                // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
-                // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
-                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
-                // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
-                // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
-                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
-                // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
-                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
-                // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
-                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
-                // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
-                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
-                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
-                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
-                // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
-                //         var lessArgs1 = "string literal".ExtensionMethod1();
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
-                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
-                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
-                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
-                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
-                // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
-                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
-                // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
-                // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
-                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(33, 51),
-                // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
-                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
-                // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
-                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
-                // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
+                    // (13,27): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod0<>").WithLocation(13, 27),
+                    // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
+                    // (14,27): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         var omittedArg1 = "string literal".ExtensionMethod1<>();
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod1<>").WithLocation(14, 27),
+                    // (15,27): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod2<>").WithLocation(15, 27),
+                    // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
+                    // (17,31): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod0<>").WithLocation(17, 31),
+                    // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
+                    // (18,31): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod1<>").WithLocation(18, 31),
+                    // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
+                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
+                    // (19,31): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod2<>").WithLocation(19, 31),
+                    // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
+                    // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
+                    // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
+                    // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
+                    // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                    //         var lessArgs1 = "string literal".ExtensionMethod1();
+                    Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
+                    // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
+                    // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
+                    // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
+                    // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
+                    // (32,51): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod0<>").WithLocation(32, 51),
+                    // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
+                    // (33,51): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod1<>").WithLocation(33, 51),
+                    // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
+                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
+                    // (34,51): error CS8389: Omitting the type argument is not allowed in the current context
+                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_OmittedTypeArgument, @"""string literal"".ExtensionMethod2<>").WithLocation(34, 51),
+                    // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
         }
 
         [WorkItem(22757, "https://github.com/dotnet/roslyn/issues/22757")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3519,7 +3519,7 @@ public class Class1
                 // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
                 //         var omittedArg0 = "string literal".ExtensionMethod0<>();
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
-                // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var omittedArg0 = "string literal".ExtensionMethod0<>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
                 // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
@@ -3528,55 +3528,55 @@ public class Class1
                 // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
                 //         var omittedArg2 = "string literal".ExtensionMethod2<>();
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
-                // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var omittedArg2 = "string literal".ExtensionMethod2<>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
                 // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
                 //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
-                // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
-                // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
-                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
                 // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
                 //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
+                // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
+                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
                 // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
                 //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
-                // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
-                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
-                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
-                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
                 // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         var lessArgs1 = "string literal".ExtensionMethod1();
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
-                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
-                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
-                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
-                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
                 // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
                 //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
-                // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
                 // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
@@ -3588,7 +3588,7 @@ public class Class1
                 // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
                 //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
                 Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
-                // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3516,81 +3516,57 @@ public class Class1
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
 
             compilation.VerifyDiagnostics(
-                // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                // (13,44): error CS7003: Unexpected use of an unbound generic name
                 //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
-                // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
-                // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(13, 44),
+                // (14,44): error CS7003: Unexpected use of an unbound generic name
                 //         var omittedArg1 = "string literal".ExtensionMethod1<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(14, 27),
-                // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(14, 44),
+                // (15,44): error CS7003: Unexpected use of an unbound generic name
                 //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
-                // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
-                // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(15, 44),
+                // (17,48): error CS7003: Unexpected use of an unbound generic name
                 //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
-                // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
-                // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(17, 48),
+                // (18,48): error CS7003: Unexpected use of an unbound generic name
                 //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
-                // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
-                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
-                // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(18, 48),
+                // (19,48): error CS7003: Unexpected use of an unbound generic name
                 //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
-                // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
-                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(19, 48),
+                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
-                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
-                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
                 // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         var lessArgs1 = "string literal".ExtensionMethod1();
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
-                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
-                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
-                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
-                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
-                // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                // (32,68): error CS7003: Unexpected use of an unbound generic name
                 //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
-                // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
-                // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(32, 68),
+                // (33,68): error CS7003: Unexpected use of an unbound generic name
                 //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(33, 51),
-                // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
-                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
-                // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(33, 68),
+                // (34,68): error CS7003: Unexpected use of an unbound generic name
                 //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
-                // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(34, 68));
         }
 
         [WorkItem(22757, "https://github.com/dotnet/roslyn/issues/22757")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3516,57 +3516,108 @@ public class Class1
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
 
             compilation.VerifyDiagnostics(
-                // (13,44): error CS7003: Unexpected use of an unbound generic name
-                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(13, 44),
-                // (14,44): error CS7003: Unexpected use of an unbound generic name
-                //         var omittedArg1 = "string literal".ExtensionMethod1<>();
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(14, 44),
-                // (15,44): error CS7003: Unexpected use of an unbound generic name
-                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(15, 44),
-                // (17,48): error CS7003: Unexpected use of an unbound generic name
-                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(17, 48),
-                // (18,48): error CS7003: Unexpected use of an unbound generic name
-                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(18, 48),
-                // (19,48): error CS7003: Unexpected use of an unbound generic name
-                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(19, 48),
-                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
-                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
-                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
-                // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
-                //         var lessArgs1 = "string literal".ExtensionMethod1();
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
-                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
-                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
-                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
-                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
-                // (32,68): error CS7003: Unexpected use of an unbound generic name
-                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(32, 68),
-                // (33,68): error CS7003: Unexpected use of an unbound generic name
-                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(33, 68),
-                // (34,68): error CS7003: Unexpected use of an unbound generic name
-                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(34, 68));
+                    // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
+                    // (13,44): error CS7003: Unexpected use of an unbound generic name
+                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(13, 44),
+                    // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
+                    // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                    //         var omittedArg1 = "string literal".ExtensionMethod1<>();
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(14, 27),
+                    // (14,44): error CS7003: Unexpected use of an unbound generic name
+                    //         var omittedArg1 = "string literal".ExtensionMethod1<>();
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(14, 44),
+                    // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
+                    // (15,44): error CS7003: Unexpected use of an unbound generic name
+                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(15, 44),
+                    // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
+                    // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
+                    // (17,48): error CS7003: Unexpected use of an unbound generic name
+                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(17, 48),
+                    // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
+                    // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
+                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
+                    // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
+                    // (18,48): error CS7003: Unexpected use of an unbound generic name
+                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(18, 48),
+                    // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
+                    // (19,48): error CS7003: Unexpected use of an unbound generic name
+                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(19, 48),
+                    // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
+                    // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
+                    // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
+                    // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
+                    // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                    //         var lessArgs1 = "string literal".ExtensionMethod1();
+                    Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
+                    // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
+                    // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
+                    // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
+                    // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
+                    // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
+                    // (32,68): error CS7003: Unexpected use of an unbound generic name
+                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(32, 68),
+                    // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
+                    // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(33, 51),
+                    // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
+                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
+                    // (33,68): error CS7003: Unexpected use of an unbound generic name
+                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(33, 68),
+                    // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
+                    // (34,68): error CS7003: Unexpected use of an unbound generic name
+                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(34, 68),
+                    // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
         }
 
         [WorkItem(22757, "https://github.com/dotnet/roslyn/issues/22757")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3516,108 +3516,81 @@ public class Class1
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
 
             compilation.VerifyDiagnostics(
-                    // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
-                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
-                    // (13,44): error CS7003: Unexpected use of an unbound generic name
-                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(13, 44),
-                    // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var omittedArg0 = "string literal".ExtensionMethod0<>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
-                    // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
-                    //         var omittedArg1 = "string literal".ExtensionMethod1<>();
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(14, 27),
-                    // (14,44): error CS7003: Unexpected use of an unbound generic name
-                    //         var omittedArg1 = "string literal".ExtensionMethod1<>();
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(14, 44),
-                    // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
-                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
-                    // (15,44): error CS7003: Unexpected use of an unbound generic name
-                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(15, 44),
-                    // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var omittedArg2 = "string literal".ExtensionMethod2<>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
-                    // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
-                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
-                    // (17,48): error CS7003: Unexpected use of an unbound generic name
-                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(17, 48),
-                    // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
-                    // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
-                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                    Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
-                    // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
-                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
-                    // (18,48): error CS7003: Unexpected use of an unbound generic name
-                    //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(18, 48),
-                    // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
-                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
-                    // (19,48): error CS7003: Unexpected use of an unbound generic name
-                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(19, 48),
-                    // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
-                    // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
-                    // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
-                    // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
-                    // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
-                    //         var lessArgs1 = "string literal".ExtensionMethod1();
-                    Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
-                    // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
-                    // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
-                    // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
-                    // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
-                    // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
-                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
-                    // (32,68): error CS7003: Unexpected use of an unbound generic name
-                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod0<>").WithLocation(32, 68),
-                    // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
-                    // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
-                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(33, 51),
-                    // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
-                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                    Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
-                    // (33,68): error CS7003: Unexpected use of an unbound generic name
-                    //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod1<>").WithLocation(33, 68),
-                    // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
-                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                    Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
-                    // (34,68): error CS7003: Unexpected use of an unbound generic name
-                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "ExtensionMethod2<>").WithLocation(34, 68),
-                    // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                    //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
-                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
+                // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
+                // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
+                // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                //         var omittedArg1 = "string literal".ExtensionMethod1<>();
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(14, 27),
+                // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
+                // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
+                // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
+                // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
+                // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
+                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
+                // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
+                // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
+                // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
+                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
+                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no accessible extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
+                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
+                // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         var lessArgs1 = "string literal".ExtensionMethod1();
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
+                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
+                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no accessible extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
+                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no accessible extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
+                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no accessible extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
+                // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
+                // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no accessible extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
+                // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(33, 51),
+                // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
+                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
+                // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
+                // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no accessible extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
         }
 
         [WorkItem(22757, "https://github.com/dotnet/roslyn/issues/22757")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
@@ -262,9 +262,9 @@ class Test<T>
                 // (17,66): error CS1031: Type expected
                 //         s = nameof(System.Collections.Generic.Dictionary<Program,>.KeyCollection);
                 Diagnostic(ErrorCode.ERR_TypeExpected, ">").WithLocation(17, 66),
-                // (11,27): error CS0305: Using the generic type 'Action<T>' requires 1 type arguments
+                // (11,27): error CS7003: Unexpected use of an unbound generic name
                 //         s = nameof(System.Action<>);
-                Diagnostic(ErrorCode.ERR_BadArity, "Action<>").WithArguments("System.Action<T>", "type", "1").WithLocation(11, 27),
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "Action<>").WithLocation(11, 27),
                 // (13,13): error CS0103: The name 'nameof' does not exist in the current context
                 //         s = nameof(void);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "nameof").WithArguments("nameof").WithLocation(13, 13),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
@@ -262,9 +262,9 @@ class Test<T>
                 // (17,66): error CS1031: Type expected
                 //         s = nameof(System.Collections.Generic.Dictionary<Program,>.KeyCollection);
                 Diagnostic(ErrorCode.ERR_TypeExpected, ">").WithLocation(17, 66),
-                // (11,27): error CS7003: Unexpected use of an unbound generic name
+                // (11,27): error CS0305: Using the generic type 'Action<T>' requires 1 type arguments
                 //         s = nameof(System.Action<>);
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "Action<>").WithLocation(11, 27),
+                Diagnostic(ErrorCode.ERR_BadArity, "Action<>").WithArguments("System.Action<T>", "type", "1").WithLocation(11, 27),
                 // (13,13): error CS0103: The name 'nameof' does not exist in the current context
                 //         s = nameof(void);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "nameof").WithArguments("nameof").WithLocation(13, 13),
@@ -295,7 +295,7 @@ class Test<T>
                 // (28,20): error CS0103: The name 'List2' does not exist in the current context
                 //         s = nameof(List2<>.Add);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "List2<>").WithArguments("List2").WithLocation(28, 20),
-                // (31,20): error CS8149: An alias-qualified name is not an expression.
+                // (31,20): error CS8083: An alias-qualified name is not an expression.
                 //         s = nameof(global::Program); // not an expression
                 Diagnostic(ErrorCode.ERR_AliasQualifiedNameNotAnExpression, "global::Program").WithLocation(31, 20),
                 // (32,20): error CS0305: Using the generic type 'Test<T>' requires 1 type arguments
@@ -307,7 +307,7 @@ class Test<T>
                 // (33,20): error CS0841: Cannot use local variable 'b' before it is declared
                 //         s = nameof(b); // cannot use before declaration
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "b").WithArguments("b").WithLocation(33, 20),
-                // (35,20): error CS8150: Type parameters are not allowed on a method group as an argument to 'nameof'.
+                // (35,20): error CS8084: Type parameters are not allowed on a method group as an argument to 'nameof'.
                 //         s = nameof(System.Linq.Enumerable.Select<int, int>); // type parameters not allowed on method group in nameof
                 Diagnostic(ErrorCode.ERR_NameofMethodGroupWithTypeParameters, "System.Linq.Enumerable.Select<int, int>").WithLocation(35, 20),
                 // (43,13): error CS0103: The name 'nameof' does not exist in the current context

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -22799,76 +22799,111 @@ class Program
 ";
             CreateCompilation(text).VerifyDiagnostics(
                 // (16,14): error CS0307: The variable 'l' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "l<>").WithArguments("l", "variable"),
+                //         Test(l<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "l<>").WithArguments("l", "variable").WithLocation(16, 14),
                 // (17,14): error CS0307: The variable 'object' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "p<>").WithArguments("object", "variable"),
+                //         Test(p<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "p<>").WithArguments("object", "variable").WithLocation(17, 14),
                 // (19,14): error CS0307: The field 'Program.f' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field"),
+                //         Test(f<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(19, 14),
                 // (20,14): error CS0307: The property 'Program.P' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property"),
+                //         Test(P<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(20, 14),
                 // (21,14): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method"),
-                // (23,19): error CS0307: The field 'Program.f' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field"),
-                // (24,19): error CS0307: The property 'Program.P' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property"),
-                // (25,19): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method"),
+                //         Test(M<>());
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(21, 14),
+                // (23,19): error CS7003: Unexpected use of an unbound generic name
+                //         Test(this.f<>);
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "f<>").WithLocation(23, 19),
+                // (24,19): error CS7003: Unexpected use of an unbound generic name
+                //         Test(this.P<>);
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "P<>").WithLocation(24, 19),
+                // (25,19): error CS7003: Unexpected use of an unbound generic name
+                //         Test(this.M<>());
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(25, 19),
                 // (29,13): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method"),
-                // (30,18): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method"),
+                //         m = M<>;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(29, 13),
+                // (30,18): error CS7003: Unexpected use of an unbound generic name
+                //         m = this.M<>;
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(30, 18),
                 // (32,9): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type"),
+                //         I<> i1 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(32, 9),
                 // (33,9): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         C<> c1 = new C();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(33, 9),
                 // (34,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         C c2 = new C<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(34, 20),
                 // (35,9): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         S<> s1 = new S();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(35, 9),
                 // (36,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         S s2 = new S<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(36, 20),
                 // (37,9): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type"),
+                //         D<> d1 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(37, 9),
                 // (39,17): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type"),
+                //         Program.I<> i2 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(39, 17),
                 // (40,17): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         Program.C<> c3 = new Program.C();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(40, 17),
                 // (41,36): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         Program.C c4 = new Program.C<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(41, 36),
                 // (42,17): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         Program.S<> s3 = new Program.S();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(42, 17),
                 // (43,36): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         Program.S s4 = new Program.S<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(43, 36),
                 // (44,17): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type"),
+                //         Program.D<> d2 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(44, 17),
                 // (46,22): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type"),
+                //         Test(default(I<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(46, 22),
                 // (47,22): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         Test(default(C<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(47, 22),
                 // (48,22): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         Test(default(S<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(48, 22),
                 // (50,30): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type"),
+                //         Test(default(Program.I<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(50, 30),
                 // (51,30): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         Test(default(Program.C<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(51, 30),
                 // (52,30): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         Test(default(Program.S<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(52, 30),
                 // (56,20): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type"),
+                //         s = typeof(I<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(56, 20),
                 // (57,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         s = typeof(C<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(57, 20),
                 // (58,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         s = typeof(S<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(58, 20),
                 // (60,28): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type"),
+                //         s = typeof(Program.I<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(60, 28),
                 // (61,28): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type"),
+                //         s = typeof(Program.C<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(61, 28),
                 // (62,28): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type"),
+                //         s = typeof(Program.S<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(62, 28),
                 // (4,9): warning CS0649: Field 'Program.f' is never assigned to, and will always have its default value 0
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "f").WithArguments("Program.f", "0")
-                );
+                //     int f;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "f").WithArguments("Program.f", "0").WithLocation(4, 9)
+            );
         }
 
         [WorkItem(542419, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542419")]
@@ -22918,8 +22953,8 @@ class Program
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+="),
                 // (9,14): error CS0307: The event 'Program.E' cannot be used with type arguments
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event"),
-                // (10,19): error CS0307: The event 'Program.E' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event"),
+                // (10,19): error CS7003: Unexpected use of an unbound generic name
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "E<>").WithLocation(10, 19),
                 // (13,9): error CS0079: The event 'Program.F' can only appear on the left hand side of += or -=
                 Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("Program.F"),
                 // (16,14): error CS0079: The event 'Program.F' can only appear on the left hand side of += or -=
@@ -22998,8 +23033,9 @@ class A
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (8,15): error CS0305: Using the generic type 'A.C<T>' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "C<>").WithArguments("A.C<T>", "type", "1"));
+                // (8,15): error CS7003: Unexpected use of an unbound generic name
+                //             A.C<>.M();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "C<>").WithLocation(8, 15));
         }
 
         [Fact, WorkItem(542796, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542796")]
@@ -23015,8 +23051,9 @@ class C
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (6,9): error CS0305: Using the generic method group 'M' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "C.M<>").WithArguments("M", "method group", "1"));
+                // (6,11): error CS7003: Unexpected use of an unbound generic name
+                //         C.M<>();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(6, 11));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -22798,111 +22798,123 @@ class Program
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (16,14): error CS0307: The variable 'l' cannot be used with type arguments
-                //         Test(l<>);
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "l<>").WithArguments("l", "variable").WithLocation(16, 14),
-                // (17,14): error CS0307: The variable 'object' cannot be used with type arguments
-                //         Test(p<>);
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "p<>").WithArguments("object", "variable").WithLocation(17, 14),
-                // (19,14): error CS0307: The field 'Program.f' cannot be used with type arguments
-                //         Test(f<>);
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(19, 14),
-                // (20,14): error CS0307: The property 'Program.P' cannot be used with type arguments
-                //         Test(P<>);
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(20, 14),
-                // (21,14): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                //         Test(M<>());
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(21, 14),
-                // (23,19): error CS7003: Unexpected use of an unbound generic name
-                //         Test(this.f<>);
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "f<>").WithLocation(23, 19),
-                // (24,19): error CS7003: Unexpected use of an unbound generic name
-                //         Test(this.P<>);
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "P<>").WithLocation(24, 19),
-                // (25,19): error CS7003: Unexpected use of an unbound generic name
-                //         Test(this.M<>());
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(25, 19),
-                // (29,13): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                //         m = M<>;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(29, 13),
-                // (30,18): error CS7003: Unexpected use of an unbound generic name
-                //         m = this.M<>;
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(30, 18),
-                // (32,9): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                //         I<> i1 = null;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(32, 9),
-                // (33,9): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         C<> c1 = new C();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(33, 9),
-                // (34,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         C c2 = new C<>();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(34, 20),
-                // (35,9): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         S<> s1 = new S();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(35, 9),
-                // (36,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         S s2 = new S<>();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(36, 20),
-                // (37,9): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
-                //         D<> d1 = null;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(37, 9),
-                // (39,17): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                //         Program.I<> i2 = null;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(39, 17),
-                // (40,17): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         Program.C<> c3 = new Program.C();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(40, 17),
-                // (41,36): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         Program.C c4 = new Program.C<>();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(41, 36),
-                // (42,17): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         Program.S<> s3 = new Program.S();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(42, 17),
-                // (43,36): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         Program.S s4 = new Program.S<>();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(43, 36),
-                // (44,17): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
-                //         Program.D<> d2 = null;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(44, 17),
-                // (46,22): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                //         Test(default(I<>));
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(46, 22),
-                // (47,22): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         Test(default(C<>));
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(47, 22),
-                // (48,22): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         Test(default(S<>));
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(48, 22),
-                // (50,30): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                //         Test(default(Program.I<>));
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(50, 30),
-                // (51,30): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         Test(default(Program.C<>));
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(51, 30),
-                // (52,30): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         Test(default(Program.S<>));
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(52, 30),
-                // (56,20): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                //         s = typeof(I<>).Name;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(56, 20),
-                // (57,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         s = typeof(C<>).Name;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(57, 20),
-                // (58,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         s = typeof(S<>).Name;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(58, 20),
-                // (60,28): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                //         s = typeof(Program.I<>).Name;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(60, 28),
-                // (61,28): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                //         s = typeof(Program.C<>).Name;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(61, 28),
-                // (62,28): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                //         s = typeof(Program.S<>).Name;
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(62, 28),
-                // (4,9): warning CS0649: Field 'Program.f' is never assigned to, and will always have its default value 0
-                //     int f;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "f").WithArguments("Program.f", "0").WithLocation(4, 9)
+                    // (16,14): error CS0307: The variable 'l' cannot be used with type arguments
+                    //         Test(l<>);
+                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "l<>").WithArguments("l", "variable").WithLocation(16, 14),
+                    // (17,14): error CS0307: The variable 'object' cannot be used with type arguments
+                    //         Test(p<>);
+                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "p<>").WithArguments("object", "variable").WithLocation(17, 14),
+                    // (19,14): error CS0307: The field 'Program.f' cannot be used with type arguments
+                    //         Test(f<>);
+                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(19, 14),
+                    // (20,14): error CS0307: The property 'Program.P' cannot be used with type arguments
+                    //         Test(P<>);
+                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(20, 14),
+                    // (21,14): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                    //         Test(M<>());
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(21, 14),
+                    // (23,19): error CS7003: Unexpected use of an unbound generic name
+                    //         Test(this.f<>);
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "f<>").WithLocation(23, 19),
+                    // (23,19): error CS0307: The field 'Program.f' cannot be used with type arguments
+                    //         Test(this.f<>);
+                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(23, 19),
+                    // (24,19): error CS7003: Unexpected use of an unbound generic name
+                    //         Test(this.P<>);
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "P<>").WithLocation(24, 19),
+                    // (24,19): error CS0307: The property 'Program.P' cannot be used with type arguments
+                    //         Test(this.P<>);
+                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(24, 19),
+                    // (25,19): error CS7003: Unexpected use of an unbound generic name
+                    //         Test(this.M<>());
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(25, 19),
+                    // (25,19): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                    //         Test(this.M<>());
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(25, 19),
+                    // (29,13): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                    //         m = M<>;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(29, 13),
+                    // (30,18): error CS7003: Unexpected use of an unbound generic name
+                    //         m = this.M<>;
+                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(30, 18),
+                    // (30,18): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                    //         m = this.M<>;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(30, 18),
+                    // (32,9): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                    //         I<> i1 = null;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(32, 9),
+                    // (33,9): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         C<> c1 = new C();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(33, 9),
+                    // (34,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         C c2 = new C<>();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(34, 20),
+                    // (35,9): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         S<> s1 = new S();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(35, 9),
+                    // (36,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         S s2 = new S<>();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(36, 20),
+                    // (37,9): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
+                    //         D<> d1 = null;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(37, 9),
+                    // (39,17): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                    //         Program.I<> i2 = null;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(39, 17),
+                    // (40,17): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         Program.C<> c3 = new Program.C();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(40, 17),
+                    // (41,36): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         Program.C c4 = new Program.C<>();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(41, 36),
+                    // (42,17): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         Program.S<> s3 = new Program.S();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(42, 17),
+                    // (43,36): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         Program.S s4 = new Program.S<>();
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(43, 36),
+                    // (44,17): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
+                    //         Program.D<> d2 = null;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(44, 17),
+                    // (46,22): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                    //         Test(default(I<>));
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(46, 22),
+                    // (47,22): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         Test(default(C<>));
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(47, 22),
+                    // (48,22): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         Test(default(S<>));
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(48, 22),
+                    // (50,30): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                    //         Test(default(Program.I<>));
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(50, 30),
+                    // (51,30): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         Test(default(Program.C<>));
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(51, 30),
+                    // (52,30): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         Test(default(Program.S<>));
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(52, 30),
+                    // (56,20): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                    //         s = typeof(I<>).Name;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(56, 20),
+                    // (57,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         s = typeof(C<>).Name;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(57, 20),
+                    // (58,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         s = typeof(S<>).Name;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(58, 20),
+                    // (60,28): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                    //         s = typeof(Program.I<>).Name;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(60, 28),
+                    // (61,28): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                    //         s = typeof(Program.C<>).Name;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(61, 28),
+                    // (62,28): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                    //         s = typeof(Program.S<>).Name;
+                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(62, 28),
+                    // (4,9): warning CS0649: Field 'Program.f' is never assigned to, and will always have its default value 0
+                    //     int f;
+                    Diagnostic(ErrorCode.WRN_UnassignedInternalField, "f").WithArguments("Program.f", "0").WithLocation(4, 9)
             );
         }
 
@@ -22933,32 +22945,46 @@ class Program
                 // Parser
 
                 // (12,11): error CS1525: Invalid expression term '>'
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">"),
+                //         E<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">").WithLocation(12, 11),
                 // (12,13): error CS1525: Invalid expression term '+='
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+="),
+                //         E<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+=").WithLocation(12, 13),
                 // (13,11): error CS1525: Invalid expression term '>'
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">"),
+                //         F<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">").WithLocation(13, 11),
                 // (13,13): error CS1525: Invalid expression term '+='
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+="),
+                //         F<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+=").WithLocation(13, 13),
                 // (15,16): error CS1525: Invalid expression term '>'
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">"),
+                //         this.E<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">").WithLocation(15, 16),
                 // (15,18): error CS1525: Invalid expression term '+='
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+="),
+                //         this.E<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+=").WithLocation(15, 18),
                 // (16,16): error CS1525: Invalid expression term '>'
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">"),
-
-                // Binder
-
+                //         this.F<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ">").WithArguments(">").WithLocation(16, 16),
                 // (16,18): error CS1525: Invalid expression term '+='
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+="),
+                //         this.F<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+=").WithLocation(16, 18),
+
+
                 // (9,14): error CS0307: The event 'Program.E' cannot be used with type arguments
-                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event"),
+                //         Test(E<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event").WithLocation(9, 14),
                 // (10,19): error CS7003: Unexpected use of an unbound generic name
+                //         Test(this.E<>);
                 Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "E<>").WithLocation(10, 19),
+                // (10,19): error CS0307: The event 'Program.E' cannot be used with type arguments
+                //         Test(this.E<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event").WithLocation(10, 19),
                 // (13,9): error CS0079: The event 'Program.F' can only appear on the left hand side of += or -=
-                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("Program.F"),
+                //         F<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("Program.F").WithLocation(13, 9),
                 // (16,14): error CS0079: The event 'Program.F' can only appear on the left hand side of += or -=
-                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("Program.F"));
+                //         this.F<> += null; //parse error
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("Program.F").WithLocation(16, 14));
         }
 
         [WorkItem(542419, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542419")]
@@ -23033,9 +23059,9 @@ class A
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (8,15): error CS7003: Unexpected use of an unbound generic name
+                // (8,15): error CS0305: Using the generic type 'A.C<T>' requires 1 type arguments
                 //             A.C<>.M();
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "C<>").WithLocation(8, 15));
+                Diagnostic(ErrorCode.ERR_BadArity, "C<>").WithArguments("A.C<T>", "type", "1").WithLocation(8, 15));
         }
 
         [Fact, WorkItem(542796, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542796")]
@@ -23051,9 +23077,9 @@ class C
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (6,11): error CS7003: Unexpected use of an unbound generic name
+                // (6,9): error CS0305: Using the generic method group 'M' requires 1 type arguments
                 //         C.M<>();
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(6, 11));
+                Diagnostic(ErrorCode.ERR_BadArity, "C.M<>").WithArguments("M", "method group", "1").WithLocation(6, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -22813,30 +22813,30 @@ class Program
                 // (21,14): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
                 //         Test(M<>());
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(21, 14),
-                // (23,14): error CS0305: Using the generic method group 'f' requires 1 type arguments
+                // (23,14): error CS8389: Omitting the type argument is not allowed in the current context
                 //         Test(this.f<>);
-                Diagnostic(ErrorCode.ERR_BadArity, "this.f<>").WithArguments("f", "method group", "1").WithLocation(23, 14),
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "this.f<>").WithLocation(23, 14),
                 // (23,19): error CS0307: The field 'Program.f' cannot be used with type arguments
                 //         Test(this.f<>);
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(23, 19),
-                // (24,14): error CS0305: Using the generic method group 'P' requires 1 type arguments
+                // (24,14): error CS8389: Omitting the type argument is not allowed in the current context
                 //         Test(this.P<>);
-                Diagnostic(ErrorCode.ERR_BadArity, "this.P<>").WithArguments("P", "method group", "1").WithLocation(24, 14),
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "this.P<>").WithLocation(24, 14),
                 // (24,19): error CS0307: The property 'Program.P' cannot be used with type arguments
                 //         Test(this.P<>);
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(24, 19),
-                // (25,14): error CS0305: Using the generic method group 'M' requires 1 type arguments
+                // (25,14): error CS8389: Omitting the type argument is not allowed in the current context
                 //         Test(this.M<>());
-                Diagnostic(ErrorCode.ERR_BadArity, "this.M<>").WithArguments("M", "method group", "1").WithLocation(25, 14),
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "this.M<>").WithLocation(25, 14),
                 // (25,19): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
                 //         Test(this.M<>());
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(25, 19),
                 // (29,13): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
                 //         m = M<>;
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(29, 13),
-                // (30,13): error CS0305: Using the generic method group 'M' requires 1 type arguments
+                // (30,13): error CS8389: Omitting the type argument is not allowed in the current context
                 //         m = this.M<>;
-                Diagnostic(ErrorCode.ERR_BadArity, "this.M<>").WithArguments("M", "method group", "1").WithLocation(30, 13),
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "this.M<>").WithLocation(30, 13),
                 // (30,18): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
                 //         m = this.M<>;
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(30, 18),
@@ -22974,9 +22974,9 @@ class Program
                 // (9,14): error CS0307: The event 'Program.E' cannot be used with type arguments
                 //         Test(E<>);
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event").WithLocation(9, 14),
-                // (10,14): error CS0305: Using the generic method group 'E' requires 1 type arguments
+                // (10,14): error CS8389: Omitting the type argument is not allowed in the current context
                 //         Test(this.E<>);
-                Diagnostic(ErrorCode.ERR_BadArity, "this.E<>").WithArguments("E", "method group", "1").WithLocation(10, 14),
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "this.E<>").WithLocation(10, 14),
                 // (10,19): error CS0307: The event 'Program.E' cannot be used with type arguments
                 //         Test(this.E<>);
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event").WithLocation(10, 19),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -22973,9 +22973,9 @@ class Program
                 // (9,14): error CS0307: The event 'Program.E' cannot be used with type arguments
                 //         Test(E<>);
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event").WithLocation(9, 14),
-                // (10,19): error CS7003: Unexpected use of an unbound generic name
+                // (10,14): error CS0305: Using the generic method group 'E' requires 1 type arguments
                 //         Test(this.E<>);
-                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "E<>").WithLocation(10, 19),
+                Diagnostic(ErrorCode.ERR_BadArity, "this.E<>").WithArguments("E", "method group", "1").WithLocation(10, 14),
                 // (10,19): error CS0307: The event 'Program.E' cannot be used with type arguments
                 //         Test(this.E<>);
                 Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "E<>").WithArguments("Program.E", "event").WithLocation(10, 19),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -22798,123 +22798,123 @@ class Program
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                    // (16,14): error CS0307: The variable 'l' cannot be used with type arguments
-                    //         Test(l<>);
-                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "l<>").WithArguments("l", "variable").WithLocation(16, 14),
-                    // (17,14): error CS0307: The variable 'object' cannot be used with type arguments
-                    //         Test(p<>);
-                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "p<>").WithArguments("object", "variable").WithLocation(17, 14),
-                    // (19,14): error CS0307: The field 'Program.f' cannot be used with type arguments
-                    //         Test(f<>);
-                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(19, 14),
-                    // (20,14): error CS0307: The property 'Program.P' cannot be used with type arguments
-                    //         Test(P<>);
-                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(20, 14),
-                    // (21,14): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                    //         Test(M<>());
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(21, 14),
-                    // (23,19): error CS7003: Unexpected use of an unbound generic name
-                    //         Test(this.f<>);
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "f<>").WithLocation(23, 19),
-                    // (23,19): error CS0307: The field 'Program.f' cannot be used with type arguments
-                    //         Test(this.f<>);
-                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(23, 19),
-                    // (24,19): error CS7003: Unexpected use of an unbound generic name
-                    //         Test(this.P<>);
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "P<>").WithLocation(24, 19),
-                    // (24,19): error CS0307: The property 'Program.P' cannot be used with type arguments
-                    //         Test(this.P<>);
-                    Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(24, 19),
-                    // (25,19): error CS7003: Unexpected use of an unbound generic name
-                    //         Test(this.M<>());
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(25, 19),
-                    // (25,19): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                    //         Test(this.M<>());
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(25, 19),
-                    // (29,13): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                    //         m = M<>;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(29, 13),
-                    // (30,18): error CS7003: Unexpected use of an unbound generic name
-                    //         m = this.M<>;
-                    Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "M<>").WithLocation(30, 18),
-                    // (30,18): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
-                    //         m = this.M<>;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(30, 18),
-                    // (32,9): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                    //         I<> i1 = null;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(32, 9),
-                    // (33,9): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         C<> c1 = new C();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(33, 9),
-                    // (34,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         C c2 = new C<>();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(34, 20),
-                    // (35,9): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         S<> s1 = new S();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(35, 9),
-                    // (36,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         S s2 = new S<>();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(36, 20),
-                    // (37,9): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
-                    //         D<> d1 = null;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(37, 9),
-                    // (39,17): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                    //         Program.I<> i2 = null;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(39, 17),
-                    // (40,17): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         Program.C<> c3 = new Program.C();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(40, 17),
-                    // (41,36): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         Program.C c4 = new Program.C<>();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(41, 36),
-                    // (42,17): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         Program.S<> s3 = new Program.S();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(42, 17),
-                    // (43,36): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         Program.S s4 = new Program.S<>();
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(43, 36),
-                    // (44,17): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
-                    //         Program.D<> d2 = null;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(44, 17),
-                    // (46,22): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                    //         Test(default(I<>));
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(46, 22),
-                    // (47,22): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         Test(default(C<>));
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(47, 22),
-                    // (48,22): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         Test(default(S<>));
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(48, 22),
-                    // (50,30): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                    //         Test(default(Program.I<>));
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(50, 30),
-                    // (51,30): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         Test(default(Program.C<>));
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(51, 30),
-                    // (52,30): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         Test(default(Program.S<>));
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(52, 30),
-                    // (56,20): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                    //         s = typeof(I<>).Name;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(56, 20),
-                    // (57,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         s = typeof(C<>).Name;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(57, 20),
-                    // (58,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         s = typeof(S<>).Name;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(58, 20),
-                    // (60,28): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
-                    //         s = typeof(Program.I<>).Name;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(60, 28),
-                    // (61,28): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
-                    //         s = typeof(Program.C<>).Name;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(61, 28),
-                    // (62,28): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
-                    //         s = typeof(Program.S<>).Name;
-                    Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(62, 28),
-                    // (4,9): warning CS0649: Field 'Program.f' is never assigned to, and will always have its default value 0
-                    //     int f;
-                    Diagnostic(ErrorCode.WRN_UnassignedInternalField, "f").WithArguments("Program.f", "0").WithLocation(4, 9)
+                // (16,14): error CS0307: The variable 'l' cannot be used with type arguments
+                //         Test(l<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "l<>").WithArguments("l", "variable").WithLocation(16, 14),
+                // (17,14): error CS0307: The variable 'object' cannot be used with type arguments
+                //         Test(p<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "p<>").WithArguments("object", "variable").WithLocation(17, 14),
+                // (19,14): error CS0307: The field 'Program.f' cannot be used with type arguments
+                //         Test(f<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(19, 14),
+                // (20,14): error CS0307: The property 'Program.P' cannot be used with type arguments
+                //         Test(P<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(20, 14),
+                // (21,14): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                //         Test(M<>());
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(21, 14),
+                // (23,14): error CS0305: Using the generic method group 'f' requires 1 type arguments
+                //         Test(this.f<>);
+                Diagnostic(ErrorCode.ERR_BadArity, "this.f<>").WithArguments("f", "method group", "1").WithLocation(23, 14),
+                // (23,19): error CS0307: The field 'Program.f' cannot be used with type arguments
+                //         Test(this.f<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "f<>").WithArguments("Program.f", "field").WithLocation(23, 19),
+                // (24,14): error CS0305: Using the generic method group 'P' requires 1 type arguments
+                //         Test(this.P<>);
+                Diagnostic(ErrorCode.ERR_BadArity, "this.P<>").WithArguments("P", "method group", "1").WithLocation(24, 14),
+                // (24,19): error CS0307: The property 'Program.P' cannot be used with type arguments
+                //         Test(this.P<>);
+                Diagnostic(ErrorCode.ERR_TypeArgsNotAllowed, "P<>").WithArguments("Program.P", "property").WithLocation(24, 19),
+                // (25,14): error CS0305: Using the generic method group 'M' requires 1 type arguments
+                //         Test(this.M<>());
+                Diagnostic(ErrorCode.ERR_BadArity, "this.M<>").WithArguments("M", "method group", "1").WithLocation(25, 14),
+                // (25,19): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                //         Test(this.M<>());
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(25, 19),
+                // (29,13): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                //         m = M<>;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(29, 13),
+                // (30,13): error CS0305: Using the generic method group 'M' requires 1 type arguments
+                //         m = this.M<>;
+                Diagnostic(ErrorCode.ERR_BadArity, "this.M<>").WithArguments("M", "method group", "1").WithLocation(30, 13),
+                // (30,18): error CS0308: The non-generic method 'Program.M()' cannot be used with type arguments
+                //         m = this.M<>;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M<>").WithArguments("Program.M()", "method").WithLocation(30, 18),
+                // (32,9): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                //         I<> i1 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(32, 9),
+                // (33,9): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         C<> c1 = new C();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(33, 9),
+                // (34,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         C c2 = new C<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(34, 20),
+                // (35,9): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         S<> s1 = new S();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(35, 9),
+                // (36,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         S s2 = new S<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(36, 20),
+                // (37,9): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
+                //         D<> d1 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(37, 9),
+                // (39,17): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                //         Program.I<> i2 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(39, 17),
+                // (40,17): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         Program.C<> c3 = new Program.C();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(40, 17),
+                // (41,36): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         Program.C c4 = new Program.C<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(41, 36),
+                // (42,17): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         Program.S<> s3 = new Program.S();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(42, 17),
+                // (43,36): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         Program.S s4 = new Program.S<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(43, 36),
+                // (44,17): error CS0308: The non-generic type 'Program.D' cannot be used with type arguments
+                //         Program.D<> d2 = null;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "D<>").WithArguments("Program.D", "type").WithLocation(44, 17),
+                // (46,22): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                //         Test(default(I<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(46, 22),
+                // (47,22): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         Test(default(C<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(47, 22),
+                // (48,22): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         Test(default(S<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(48, 22),
+                // (50,30): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                //         Test(default(Program.I<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(50, 30),
+                // (51,30): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         Test(default(Program.C<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(51, 30),
+                // (52,30): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         Test(default(Program.S<>));
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(52, 30),
+                // (56,20): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                //         s = typeof(I<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(56, 20),
+                // (57,20): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         s = typeof(C<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(57, 20),
+                // (58,20): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         s = typeof(S<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(58, 20),
+                // (60,28): error CS0308: The non-generic type 'Program.I' cannot be used with type arguments
+                //         s = typeof(Program.I<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "I<>").WithArguments("Program.I", "type").WithLocation(60, 28),
+                // (61,28): error CS0308: The non-generic type 'Program.C' cannot be used with type arguments
+                //         s = typeof(Program.C<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "C<>").WithArguments("Program.C", "type").WithLocation(61, 28),
+                // (62,28): error CS0308: The non-generic type 'Program.S' cannot be used with type arguments
+                //         s = typeof(Program.S<>).Name;
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "S<>").WithArguments("Program.S", "type").WithLocation(62, 28),
+                // (4,9): warning CS0649: Field 'Program.f' is never assigned to, and will always have its default value 0
+                //     int f;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "f").WithArguments("Program.f", "0").WithLocation(4, 9)
             );
         }
 
@@ -22969,6 +22969,7 @@ class Program
                 //         this.F<> += null; //parse error
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "+=").WithArguments("+=").WithLocation(16, 18),
 
+                // Binder
 
                 // (9,14): error CS0307: The event 'Program.E' cannot be used with type arguments
                 //         Test(E<>);
@@ -23060,8 +23061,7 @@ class A
 ";
             CreateCompilation(text).VerifyDiagnostics(
                 // (8,15): error CS0305: Using the generic type 'A.C<T>' requires 1 type arguments
-                //             A.C<>.M();
-                Diagnostic(ErrorCode.ERR_BadArity, "C<>").WithArguments("A.C<T>", "type", "1").WithLocation(8, 15));
+                Diagnostic(ErrorCode.ERR_BadArity, "C<>").WithArguments("A.C<T>", "type", "1"));
         }
 
         [Fact, WorkItem(542796, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542796")]
@@ -23078,8 +23078,7 @@ class C
 ";
             CreateCompilation(text).VerifyDiagnostics(
                 // (6,9): error CS0305: Using the generic method group 'M' requires 1 type arguments
-                //         C.M<>();
-                Diagnostic(ErrorCode.ERR_BadArity, "C.M<>").WithArguments("M", "method group", "1").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_BadArity, "C.M<>").WithArguments("M", "method group", "1"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -6862,5 +6862,38 @@ class Program
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "R2").WithArguments("int*").WithLocation(6, 7)
                 );
         }
+
+        [Fact]
+        public void Bug41779()
+        {
+            var source =
+@"interface I
+{
+    object GetService();
+}
+
+static class Program
+{
+    static T GetService<T>(this I obj) => default;
+    
+    static void M(I provider)
+    {
+        provider.GetService<>();
+        provider.GetService<>().ToString();
+        provider.GetService<>();
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (12,18): error CS7003: Unexpected use of an unbound generic name
+                //         provider.GetService<>();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "GetService<>").WithLocation(12, 18),
+                // (13,18): error CS7003: Unexpected use of an unbound generic name
+                //         provider.GetService<>().ToString();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "GetService<>").WithLocation(13, 18),
+                // (14,18): error CS7003: Unexpected use of an unbound generic name
+                //         provider.GetService<>();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "GetService<>").WithLocation(14, 18)
+            );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -6907,6 +6907,11 @@ static class Program
     object GetService();
 }
 
+interface J
+{
+    object GetService<T>();
+}
+
 static class Program
 {
     static void M(I provider)
@@ -6915,26 +6920,42 @@ static class Program
         provider.GetService<>().ToString();
         provider.GetService<>();
     }
+
+    static void N(J provider)
+    {
+        provider.GetService<>();
+        provider.GetService<>().ToString();
+        provider.GetService<>();
+    }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (10,9): error CS8389: Omitting the type argument is not allowed in the current context
+                // (15,9): error CS8389: Omitting the type argument is not allowed in the current context
                 //         provider.GetService<>();
-                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(10, 9),
-                // (10,18): error CS0308: The non-generic method 'I.GetService()' cannot be used with type arguments
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(15, 9),
+                // (15,18): error CS0308: The non-generic method 'I.GetService()' cannot be used with type arguments
                 //         provider.GetService<>();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetService<>").WithArguments("I.GetService()", "method").WithLocation(10, 18),
-                // (11,9): error CS8389: Omitting the type argument is not allowed in the current context
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetService<>").WithArguments("I.GetService()", "method").WithLocation(15, 18),
+                // (16,9): error CS8389: Omitting the type argument is not allowed in the current context
                 //         provider.GetService<>().ToString();
-                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(11, 9),
-                // (11,18): error CS0308: The non-generic method 'I.GetService()' cannot be used with type arguments
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(16, 9),
+                // (16,18): error CS0308: The non-generic method 'I.GetService()' cannot be used with type arguments
                 //         provider.GetService<>().ToString();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetService<>").WithArguments("I.GetService()", "method").WithLocation(11, 18),
-                // (12,9): error CS8389: Omitting the type argument is not allowed in the current context
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetService<>").WithArguments("I.GetService()", "method").WithLocation(16, 18),
+                // (17,9): error CS8389: Omitting the type argument is not allowed in the current context
                 //         provider.GetService<>();
-                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(12, 9),
-                // (12,18): error CS0308: The non-generic method 'I.GetService()' cannot be used with type arguments
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(17, 9),
+                // (17,18): error CS0308: The non-generic method 'I.GetService()' cannot be used with type arguments
                 //         provider.GetService<>();
-                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetService<>").WithArguments("I.GetService()", "method").WithLocation(12, 18)
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetService<>").WithArguments("I.GetService()", "method").WithLocation(17, 18),
+                // (22,9): error CS0305: Using the generic method group 'GetService' requires 1 type arguments
+                //         provider.GetService<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "provider.GetService<>").WithArguments("GetService", "method group", "1").WithLocation(22, 9),
+                // (23,9): error CS0305: Using the generic method group 'GetService' requires 1 type arguments
+                //         provider.GetService<>().ToString();
+                Diagnostic(ErrorCode.ERR_BadArity, "provider.GetService<>").WithArguments("GetService", "method group", "1").WithLocation(23, 9),
+                // (24,9): error CS0305: Using the generic method group 'GetService' requires 1 type arguments
+                //         provider.GetService<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "provider.GetService<>").WithArguments("GetService", "method group", "1").WithLocation(24, 9)
             );
         }
 
@@ -6948,25 +6969,71 @@ static class Program
 
 static class Program
 {
-    static T GetService<T>(this I obj) => default;
+    static void GetServiceA(this I obj){}
+    static T GetServiceB<T>(this I obj) => default;
     
     static void M(I provider)
     {
-        provider.GetService<>();
-        provider.GetService<>().ToString();
-        provider.GetService<>();
+        provider.GetServiceA<>();
+        provider.GetServiceA<>().ToString();
+        
+        provider.GetServiceB<>();
+        provider.GetServiceB<>().ToString();
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (9,9): error CS8389: Omitting the type argument is not allowed in the current context
-                //         provider.GetService<>();
-                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(9, 9),
                 // (10,9): error CS8389: Omitting the type argument is not allowed in the current context
-                //         provider.GetService<>().ToString();
-                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(10, 9),
+                //         provider.GetServiceA<>();
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetServiceA<>").WithLocation(10, 9),
+                // (10,18): error CS1061: 'I' does not contain a definition for 'GetServiceA' and no accessible extension method 'GetServiceA' accepting a first argument of type 'I' could be found (are you missing a using directive or an assembly reference?)
+                //         provider.GetServiceA<>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "GetServiceA<>").WithArguments("I", "GetServiceA").WithLocation(10, 18),
                 // (11,9): error CS8389: Omitting the type argument is not allowed in the current context
-                //         provider.GetService<>();
-                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetService<>").WithLocation(11, 9)
+                //         provider.GetServiceA<>().ToString();
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetServiceA<>").WithLocation(11, 9),
+                // (11,18): error CS1061: 'I' does not contain a definition for 'GetServiceA' and no accessible extension method 'GetServiceA' accepting a first argument of type 'I' could be found (are you missing a using directive or an assembly reference?)
+                //         provider.GetServiceA<>().ToString();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "GetServiceA<>").WithArguments("I", "GetServiceA").WithLocation(11, 18),
+                // (13,9): error CS8389: Omitting the type argument is not allowed in the current context
+                //         provider.GetServiceB<>();
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetServiceB<>").WithLocation(13, 9),
+                // (14,9): error CS8389: Omitting the type argument is not allowed in the current context
+                //         provider.GetServiceB<>().ToString();
+                Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "provider.GetServiceB<>").WithLocation(14, 9)
+            );
+        }
+
+        [Fact]
+        [WorkItem(41779, "https://github.com/dotnet/roslyn/issues/41779")]
+        public void Bug41779_Static()
+        {
+            var source =
+@"static class Program
+{
+    static T GetServiceA<T>() => default;
+    static object GetServiceB(){ return null; }
+    
+    static void M()
+    {
+        GetServiceA<>();
+        GetServiceA<>().ToString();
+        GetServiceB<>();
+        GetServiceB<>().ToString();
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (8,9): error CS0305: Using the generic method group 'GetServiceA' requires 1 type arguments
+                //         GetServiceA<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "GetServiceA<>").WithArguments("GetServiceA", "method group", "1").WithLocation(8, 9),
+                // (9,9): error CS0305: Using the generic method group 'GetServiceA' requires 1 type arguments
+                //         GetServiceA<>().ToString();
+                Diagnostic(ErrorCode.ERR_BadArity, "GetServiceA<>").WithArguments("GetServiceA", "method group", "1").WithLocation(9, 9),
+                // (10,9): error CS0308: The non-generic method 'Program.GetServiceB()' cannot be used with type arguments
+                //         GetServiceB<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetServiceB<>").WithArguments("Program.GetServiceB()", "method").WithLocation(10, 9),
+                // (11,9): error CS0308: The non-generic method 'Program.GetServiceB()' cannot be used with type arguments
+                //         GetServiceB<>().ToString();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "GetServiceB<>").WithArguments("Program.GetServiceB()", "method").WithLocation(11, 9)
             );
         }
     }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/UnboundGenericType.vb
@@ -291,7 +291,7 @@ End Class
 
         <Fact>
         <WorkItem(41779, "https://github.com/dotnet/roslyn/issues/41779")>
-        Public Sub UnboundGenericType_Bug41779()
+        Public Sub UnboundGenericType_Bug41779_Original()
 
             Dim compilation = CompilationUtils.CreateCompilation(
 <compilation name="C">
@@ -331,6 +331,286 @@ BC30182: Type expected.
         provider.GetService(Of)()
                               ~
                 </expected>)
+
+        End Sub
+
+        <Fact>
+        <WorkItem(41779, "https://github.com/dotnet/roslyn/issues/41779")>
+        Public Sub UnboundGenericType_Bug41779_DoubleArgs()
+
+            Dim compilation = CompilationUtils.CreateCompilation(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Interface I
+    Function GetService() As Object
+End Interface
+
+Module Program
+    <Extension()>
+    Private Function GetService(Of T1, T2)(ByVal obj As I) As T1
+        Return "default"
+    End Function
+
+    Private Sub M(ByVal provider As I)
+        provider.GetService(Of)()
+        provider.GetService(Of)().ToString()
+        provider.GetService(Of)()
+    End Sub
+End Module
+    ]]></file>
+</compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30311: Value of type 'String' cannot be converted to 'T1'.
+        Return "default"
+               ~~~~~~~~~
+BC32087: Overload resolution failed because no accessible 'GetService' accepts this number of type arguments.
+        provider.GetService(Of)()
+                 ~~~~~~~~~~~~~~
+BC30182: Type expected.
+        provider.GetService(Of)()
+                              ~
+BC32087: Overload resolution failed because no accessible 'GetService' accepts this number of type arguments.
+        provider.GetService(Of)().ToString()
+                 ~~~~~~~~~~~~~~
+BC30182: Type expected.
+        provider.GetService(Of)().ToString()
+                              ~
+BC32087: Overload resolution failed because no accessible 'GetService' accepts this number of type arguments.
+        provider.GetService(Of)()
+                 ~~~~~~~~~~~~~~
+BC30182: Type expected.
+        provider.GetService(Of)()
+                              ~
+            </expected>)
+
+        End Sub
+
+        <Fact>
+        <WorkItem(41779, "https://github.com/dotnet/roslyn/issues/41779")>
+        Public Sub UnboundGenericType_Bug41779_Instance()
+
+            Dim compilation = CompilationUtils.CreateCompilation(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+Interface I
+    Function GetService() As Object
+End Interface
+
+Interface J
+    Function GetService(Of T)() As Object
+End Interface
+
+Interface K
+    Function GetService(Of T1, T2)() As Object
+End Interface
+
+Module Program
+    Private Sub M(ByVal provider As I)
+        provider.GetService(Of)()
+        provider.GetService(Of)().ToString()
+    End Sub
+
+    Private Sub M(ByVal provider As J)
+        provider.GetService(Of)()
+        provider.GetService(Of)().ToString()
+    End Sub
+
+    Private Sub M(ByVal provider As K)
+        provider.GetService(Of)()
+        provider.GetService(Of)().ToString()
+    End Sub
+End Module
+    ]]></file>
+</compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC32045: 'Function GetService() As Object' has no type parameters and so cannot have type arguments.
+        provider.GetService(Of)()
+                           ~~~~
+BC30182: Type expected.
+        provider.GetService(Of)()
+                              ~
+BC32045: 'Function GetService() As Object' has no type parameters and so cannot have type arguments.
+        provider.GetService(Of)().ToString()
+                           ~~~~
+BC30182: Type expected.
+        provider.GetService(Of)().ToString()
+                              ~
+BC30182: Type expected.
+        provider.GetService(Of)()
+                              ~
+BC30182: Type expected.
+        provider.GetService(Of)().ToString()
+                              ~
+BC32042: Too few type arguments to 'Function GetService(Of T1, T2)() As Object'.
+        provider.GetService(Of)()
+                           ~~~~
+BC30182: Type expected.
+        provider.GetService(Of)()
+                              ~
+BC32042: Too few type arguments to 'Function GetService(Of T1, T2)() As Object'.
+        provider.GetService(Of)().ToString()
+                           ~~~~
+BC30182: Type expected.
+        provider.GetService(Of)().ToString()
+                              ~
+            </expected>)
+
+        End Sub
+
+        <Fact>
+        <WorkItem(41779, "https://github.com/dotnet/roslyn/issues/41779")>
+        Public Sub UnboundGenericType_Bug41779_Extension()
+
+            Dim compilation = CompilationUtils.CreateCompilation(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+
+Interface I
+End Interface
+
+Module Program
+    <Extension()>
+    Private Sub GetServiceA(ByVal obj As I)
+    End Sub
+
+    <Extension()>
+    Private Function GetServiceB(Of T)(ByVal obj As I) As T
+        Return "default"
+    End Function
+
+    <Extension()>
+    Private Function GetServiceC(Of T1, T2)(ByVal obj As I) As T1
+        Return "default"
+    End Function
+
+    Private Sub M(ByVal provider As I)
+        provider.GetServiceA(Of)()
+        provider.GetServiceA(Of)().ToString()
+        provider.GetServiceB(Of)()
+        provider.GetServiceB(Of)().ToString()
+        provider.GetServiceC(Of)()
+        provider.GetServiceC(Of)().ToString()
+    End Sub
+End Module
+    ]]></file>
+</compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30311: Value of type 'String' cannot be converted to 'T'.
+        Return "default"
+               ~~~~~~~~~
+BC30311: Value of type 'String' cannot be converted to 'T1'.
+        Return "default"
+               ~~~~~~~~~
+BC36907: Extension method 'Private Sub GetServiceA()' defined in 'Program' is not generic (or has no free type parameters) and so cannot have type arguments.
+        provider.GetServiceA(Of)()
+                            ~~~~
+BC30182: Type expected.
+        provider.GetServiceA(Of)()
+                               ~
+BC36907: Extension method 'Private Sub GetServiceA()' defined in 'Program' is not generic (or has no free type parameters) and so cannot have type arguments.
+        provider.GetServiceA(Of)().ToString()
+                            ~~~~
+BC30182: Type expected.
+        provider.GetServiceA(Of)().ToString()
+                               ~
+BC30182: Type expected.
+        provider.GetServiceB(Of)()
+                               ~
+BC30182: Type expected.
+        provider.GetServiceB(Of)().ToString()
+                               ~
+BC36590: Too few type arguments to extension method 'Private Function GetServiceC(Of T1, T2)() As T1' defined in 'Program'.
+        provider.GetServiceC(Of)()
+                            ~~~~
+BC30182: Type expected.
+        provider.GetServiceC(Of)()
+                               ~
+BC36590: Too few type arguments to extension method 'Private Function GetServiceC(Of T1, T2)() As T1' defined in 'Program'.
+        provider.GetServiceC(Of)().ToString()
+                            ~~~~
+BC30182: Type expected.
+        provider.GetServiceC(Of)().ToString()
+                               ~
+            </expected>)
+
+        End Sub
+
+        <Fact>
+        <WorkItem(41779, "https://github.com/dotnet/roslyn/issues/41779")>
+        Public Sub UnboundGenericType_Bug41779_Function()
+
+            Dim compilation = CompilationUtils.CreateCompilation(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+Module Program
+    Private Function GetServiceA() As Object
+        Return Nothing
+    End Function
+
+    Private Function GetServiceB(Of T)() As T
+        Return "default"
+    End Function
+
+    Private Function GetServiceC(Of T1, T2)() As T1
+        Return "default"
+    End Function
+
+    Private Sub M()
+        GetServiceA(Of)()
+        GetServiceA(Of)().ToString()
+        GetServiceB(Of)()
+        GetServiceB(Of)().ToString()
+        GetServiceC(Of)()
+        GetServiceC(Of)().ToString()
+    End Sub
+End Module
+    ]]></file>
+</compilation>)
+
+            compilation.AssertTheseDiagnostics(<expected>
+BC30311: Value of type 'String' cannot be converted to 'T'.
+        Return "default"
+               ~~~~~~~~~
+BC30311: Value of type 'String' cannot be converted to 'T1'.
+        Return "default"
+               ~~~~~~~~~
+BC32045: 'Private Function GetServiceA() As Object' has no type parameters and so cannot have type arguments.
+        GetServiceA(Of)()
+                   ~~~~
+BC30182: Type expected.
+        GetServiceA(Of)()
+                      ~
+BC32045: 'Private Function GetServiceA() As Object' has no type parameters and so cannot have type arguments.
+        GetServiceA(Of)().ToString()
+                   ~~~~
+BC30182: Type expected.
+        GetServiceA(Of)().ToString()
+                      ~
+BC30182: Type expected.
+        GetServiceB(Of)()
+                      ~
+BC30182: Type expected.
+        GetServiceB(Of)().ToString()
+                      ~
+BC32042: Too few type arguments to 'Private Function GetServiceC(Of T1, T2)() As T1'.
+        GetServiceC(Of)()
+                   ~~~~
+BC30182: Type expected.
+        GetServiceC(Of)()
+                      ~
+BC32042: Too few type arguments to 'Private Function GetServiceC(Of T1, T2)() As T1'.
+        GetServiceC(Of)().ToString()
+                   ~~~~
+BC30182: Type expected.
+        GetServiceC(Of)().ToString()
+                      ~
+            </expected>)
 
         End Sub
 


### PR DESCRIPTION
_Based off @RikkiGibson's #43130, a patch for issue #41779._
Thanks to @jpd30 for reporting the issue!

This patch checks for unbound types in the Binder, throwing a CS7003 error without needing to run EmitDiagnostics.

Changelog:

- Added check to Binder_Expression.cs

- Added test for issue #41799.

- Edited tests to throw new error when applicable.

_Sidenote: Apologies for the messy git changes to some of those tests. The newer outputs from the testing suite contained more information in comments that I thought would be worthwhile to leave in._