### PR TITLE
Bug 11510

### DIFF
--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -56,18 +56,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 Dim expectedTags As New List(Of String)
 
                 For Each hostDocument In workspace.Documents
-                    Dim nameAndSpansList = New List(Of Tuple(Of String, TextSpan))
-                    For Each kvp As KeyValuePair(Of String, Immutable.ImmutableArray(Of TextSpan)) In hostDocument.AnnotatedSpans
-                        Dim name = kvp.Key
-                        Dim spanList = kvp.Value
-
-                        For Each span In spanList
-                            nameAndSpansList.Add(New Tuple(Of String, TextSpan)(name, span))
-                        Next
-                    Next
-
-                    For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Item2.Start)
-                        expectedTags.Add(nameAndSpan.Item1 + ":" + nameAndSpan.Item2.ToString())
+                    Dim nameAndSpansList = hostDocument.AnnotatedSpans.SelectMany(
+                        Function(name) name.Value,
+                        Function(name, spans) New With {name, spans}) _
+                        .Select(Function(nameAndSpans) _
+                                    New With {.Name = nameAndSpans.name.Key,
+                                              .Span = nameAndSpans.spans
+                                })
+                    For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Span.Start)
+                        expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.Span.ToString())
                     Next
                 Next
 

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -62,7 +62,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                         .Select(Function(nameAndSpans) _
                                     New With {.Name = nameAndSpans.name.Key,
                                               .Span = nameAndSpans.spans
-                                })
+                                    })
+
                     For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Span.Start)
                         expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.Span.ToString())
                     Next

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                         Function(name) name.Value,
                         Function(name, span) _
                         New With {.Name = name.Key,
-                                  span
+                                  .Span = span
                         })
 
                     For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Span.Start)

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -58,14 +58,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 For Each hostDocument In workspace.Documents
                     Dim nameAndSpansList = hostDocument.AnnotatedSpans.SelectMany(
                         Function(name) name.Value,
-                        Function(name, spans) New With {name, spans}) _
-                        .Select(Function(nameAndSpans) _
-                                    New With {.Name = nameAndSpans.name.Key,
-                                              .Span = nameAndSpans.spans
-                                    })
+                        Function(name, span) _
+                        New With {.Name = name.Key,
+                                  span
+                        })
 
                     For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Span.Start)
-                        expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.Span.ToString())
+                        expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.span.ToString())
                     Next
                 Next
 

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.Editor.Tagging
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities.RemoteHost
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Roslyn.Utilities
 
@@ -55,13 +56,20 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 Dim expectedTags As New List(Of String)
 
                 For Each hostDocument In workspace.Documents
-                    For Each nameAndSpans In hostDocument.AnnotatedSpans.OrderBy(Function(x) x.Value.First().Start)
-                        For Each span In nameAndSpans.Value
-                            expectedTags.Add(nameAndSpans.Key + ":" + span.ToString())
+                    Dim nameAndSpansList = New List(Of Tuple(Of String, TextSpan))
+                    For Each kvp As KeyValuePair(Of String, Immutable.ImmutableArray(Of TextSpan)) In hostDocument.AnnotatedSpans
+                        Dim name = kvp.Key
+                        Dim spanList = kvp.Value
+
+                        For Each span In spanList
+                            nameAndSpansList.Add(New Tuple(Of String, TextSpan)(name, span))
                         Next
                     Next
-                Next
 
+                    For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Item2.Start)
+                        expectedTags.Add(nameAndSpan.Item1 + ":" + nameAndSpan.Item2.ToString())
+                    Next
+                Next
                 AssertEx.Equal(expectedTags, producedTags)
             End Using
         End Function

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -70,7 +70,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                         expectedTags.Add(nameAndSpan.Item1 + ":" + nameAndSpan.Item2.ToString())
                     Next
                 Next
+
                 AssertEx.Equal(expectedTags, producedTags)
+
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                         })
 
                     For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Span.Start)
-                        expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.span.ToString())
+                        expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.Span.ToString())
                     Next
                 Next
 

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -741,33 +741,6 @@ class C
         {
             get
             {
-                return 0;
-            }
-        }
-}
-                    </Document>
-                </Project>
-            </Workspace>
-
-            Await VerifyHighlightsAsync(input)
-        End Function
-
-        <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
-        Public Async Function TestHighlightParamAndComments3() As Task
-            Dim input =
-            <Workspace>
-                <Project Language="C#" CommonReferences="true">
-                    <Document>
-class C
-{
-        /// &lt; summary &gt;
-        /// &lt; paramref name="$${|Reference:x|}"/ &gt;
-        /// &lt; /summary &gt;
-        /// &lt; param name="{|Reference:x|}" &gt; &lt; /param &gt;
-        public int this[int {|Definition:x|}]
-        {
-            get
-            {
                 return {|Reference:x|};
             }
         }

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -741,6 +741,33 @@ class C
         {
             get
             {
+                return 0;
+            }
+        }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestHighlightParamAndComments3() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+        /// &lt; summary &gt;
+        /// &lt; paramref name="$${|Reference:x|}"/ &gt;
+        /// &lt; /summary &gt;
+        /// &lt; param name="{|Reference:x|}" &gt; &lt; /param &gt;
+        public int this[int {|Definition:x|}]
+        {
+            get
+            {
                 return {|Reference:x|};
             }
         }

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -699,7 +699,7 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
-        Public Async Function TestHighlightParamAndComments1() As Task
+        Public Async Function TestHighlightParamAndCommentsCursorOnDefinition() As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferences="true">
@@ -726,7 +726,7 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
-        Public Async Function TestHighlightParamAndComments2() As Task
+        Public Async Function TestHighlightParamAndCommentsCursorOnReference() As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferences="true">
@@ -753,7 +753,7 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
-        Public Async Function TestHighlightParamAndComments3() As Task
+        Public Async Function TestHighlightParamAndCommentsDefinitionNestedBetweenReferences() As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferences="true">

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -697,5 +697,86 @@ class C
 
             Await VerifyHighlightsAsync(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestHighlightParamAndComments1() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+        /// &lt; summary &gt;
+        /// &lt; paramref name="{|Reference:x|}"/ &gt;
+        /// &lt; /summary &gt;
+        /// &lt; param name="{|Reference:x|}" &gt; &lt; /param &gt;
+        public int this[int $${|Definition:x|}]
+        {
+            get
+            {
+                return 0;
+            }
+        }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestHighlightParamAndComments2() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+        /// &lt; summary &gt;
+        /// &lt; paramref name="$${|Reference:x|}"/ &gt;
+        /// &lt; /summary &gt;
+        /// &lt; param name="{|Reference:x|}" &gt; &lt; /param &gt;
+        public int this[int {|Definition:x|}]
+        {
+            get
+            {
+                return 0;
+            }
+        }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestHighlightParamAndComments3() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+        /// &lt; summary &gt;
+        /// &lt; paramref name="$${|Reference:x|}"/ &gt;
+        /// &lt; /summary &gt;
+        /// &lt; param name="{|Reference:x|}" &gt; &lt; /param &gt;
+        public int this[int {|Definition:x|}]
+        {
+            get
+            {
+                return {|Reference:x|};
+            }
+        }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -294,20 +294,6 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
 
                 case SymbolKind.NamedType:
                     return !((INamedTypeSymbol)symbol).IsScriptClass;
-
-                case SymbolKind.Parameter:
-
-                    // If it's an indexer parameter, we will determine by the property 
-                    // symbols instead of the accessor symbols because accessor 
-                    // symbols with no references are filtered out
-                    if (symbol.ContainingSymbol is IMethodSymbol methodSymbol
-                        && methodSymbol.AssociatedSymbol is IPropertySymbol containingProperty
-                        && containingProperty.IsIndexer)
-                    {
-                        return false;
-                    }
-
-                    break;
             }
 
             return true;

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -296,8 +296,13 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                     return !((INamedTypeSymbol)symbol).IsScriptClass;
 
                 case SymbolKind.Parameter:
-                    // If it's an indexer parameter, we will determine by the property symbols
-                    if (symbol.ContainingSymbol is IMethodSymbol methodSymbol && methodSymbol.AssociatedSymbol is IPropertySymbol containingProperty && containingProperty.IsIndexer)
+
+                    // If it's an indexer parameter, we will determine by the property 
+                    // symbols instead of the accessor symbols because accessor 
+                    // symbols with no references are filtered out
+                    if (symbol.ContainingSymbol is IMethodSymbol methodSymbol
+                        && methodSymbol.AssociatedSymbol is IPropertySymbol containingProperty
+                        && containingProperty.IsIndexer)
                     {
                         return false;
                     }

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -167,7 +167,6 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             var solution = startingDocument.Project.Solution;
-
             references = references.FilterToItemsToShow(options);
             references = references.FilterNonMatchingMethodNames(solution, symbol);
             references = references.FilterToAliasMatches(symbol as IAliasSymbol);
@@ -297,9 +296,8 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                     return !((INamedTypeSymbol)symbol).IsScriptClass;
 
                 case SymbolKind.Parameter:
-                    // If it's an indexer parameter, we will have also cascaded to the accessor
-                    // one that actually receives the references
-                    if (symbol.ContainingSymbol is IPropertySymbol containingProperty && containingProperty.IsIndexer)
+                    // If it's an indexer parameter, we will determine by the property symbols
+                    if (symbol.ContainingSymbol is IMethodSymbol methodSymbol && methodSymbol.AssociatedSymbol is IPropertySymbol containingProperty && containingProperty.IsIndexer)
                     {
                         return false;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11510

Issue:
The issue here was that reference highlighting did not work on an indexer that had no references. The issue was occurring because the referenced symbol was being filtered out since it was implicitly declared and had no references. However, in the ```AbstractDocumentHighlightsService.cs``` file, the ```ShouldIncludeDefinition(ISymbol symbol)``` function was waiting for the parameter symbol with accessor methods. However, the parameter symbol for the accessor methods got filtered out.

There was also an issue with the ```AbstractReferenceHighlightingTests```. The issue here was that when sorting the expected tags, the code implicitly assumed that definitions and references would never get intermixed.

Fix:
To fix the highlighting issue, I needed to modify the ```ShouldIncludeDefinition(ISymbol symbol)``` method. I removed the case dealing with parameters entirely. I tested that duplicate definition highlight spans did not have unintended consequences. It did not have duplicate highlighting and the highlight-navigation flow did not get altered with the change.

To fix the issue with the test, I flattened the dictionary to a list of tuples of (name, span). From there I sorted the entire list rather than sorting based on references and definition groups.