### PR TITLE
Only include compilation options in the PDB that don't have default value

### DIFF
--- a/docs/features/pdb-compilation-options.md
+++ b/docs/features/pdb-compilation-options.md
@@ -261,35 +261,35 @@ Example:
 
 See [compiler options](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/listed-alphabetically) documentation
 
-| PDB Key | Documentation   |
-| ------- | --------------- |
-| portability-policy | see [portability policy](#portability-policy) |
-| checked | [checked](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/checked-compiler-option) |
-| default-encoding | see [file encoding](#file-encoding) |
-| compiler-version | full version with SHA |
-| fallback-encoding | see see [file encoding](#file-encoding) |
-| define | [define](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/define-compiler-option) |
-| language | string for language. `CSharp` or `VisualBasic` |
-| language-version | Version of the language used, matches `[0-9]+(\.[0-9]+)?`. See [langversion](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/langversion-compiler-option) |
-| nullable | [nullable](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references) |
-| optimization | see [optimization](#optimization) |
-| runtime-version | see [runtime version](#runtime-version) |
-| unsafe | [unsafe](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/unsafe-compiler-option) |
+| PDB Key                | Format                                  | Default   | Description  |
+| ---------------------- | --------------------------------------- | --------- | ------------ |
+| language               | `CSharp`                                | required  | Language name. |
+| language-version       | `[0-9]+(\.[0-9]+)?`                     | required  | [langversion](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/langversion-compiler-option) |
+| compiler-version       | [SemVer2](https://semver.org/spec/v2.0.0.html) string | required | Full version with SHA |
+| runtime-version        | [SemVer2](https://semver.org/spec/v2.0.0.html) string | required | [runtime version](#runtime-version) |
+| optimization           | `(debug|debug-plus|release)`            | `debug`   | [optimization](#optimization) |
+| portability-policy     | `(0|1|2|3)`                             | `0`       | [portability policy](#portability-policy) |
+| default-encoding       | string                                  | none      | [file encoding](#file-encoding) |
+| fallback-encoding      | string                                  | none      | [file encoding](#file-encoding) |
+| define                 | `,`-separated identifier list           | empty     | [define](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/define-compiler-option) |
+| checked                | `(True|False)`                          | `False`   | [checked](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/checked-compiler-option) |
+| nullable               | `(Disable|Warnings|Annotations|Enable)` | `Disable` | [nullable](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references) |
+| unsafe                 | `(True|False)`                          | `False`   | [unsafe](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/unsafe-compiler-option) |
 
 #### Options For Visual Basic
 
 See [compiler options](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically) documentation
 
-| PDB Key | Documentation   |
-| ------- | --------------- |
-| compiler-version | full version with SHA |
-| define | [define](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/define) |
-| language | string for language. `CSharp` or `VisualBasic` |
-| language-version | Version of the language used, matches `[0-9]+(\.[0-9]+)?`. See [langversion](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/langversion) |
-| optimization | see [optimization](#optimization) |
-| strict | [optionstrict](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/optionstrict) |
-| runtime-version | see [runtime version](#runtime-version) |
-| checked | Opposite of [removeintchecks](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/removeintchecks) |
+| PDB Key                | Format                                     | Default  | Description |
+| ---------------------- | ------------------------------------------ | -------- | ----------- |
+| language               | `Visual Basic`                             | required | Language name. |
+| language-version       | `[0-9]+(\.[0-9]+)?`                        | required | [langversion](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/langversion) |
+| compiler-version       | [SemVer2](https://semver.org/spec/v2.0.0.html) string | required | Full version with SHA |
+| runtime-version        | [SemVer2](https://semver.org/spec/v2.0.0.html) string | required | [runtime version](#runtime-version) |
+| optimization           | `(debug|debug-plus|release)`               | `debug`  | [optimization](#optimization) |
+| define                 | `,`-separated list of name `=` value pairs | empty    | [define](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/define) |
+| strict                 | `(Off|Custom|On)`                          | `Off`    | [optionstrict](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/optionstrict) |
+| checked                | `(True|False)`                             | `False`  | Opposite of [removeintchecks](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/removeintchecks) |
 
 #### Portability Policy
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3586,13 +3586,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void SerializePdbEmbeddedCompilationOptions(BlobBuilder builder)
         {
-            WriteValue(CompilationOptionNames.Checked, Options.CheckOverflow.ToString());
-            WriteValue(CompilationOptionNames.Nullable, Options.NullableContextOptions.ToString());
-            WriteValue(CompilationOptionNames.Unsafe, Options.AllowUnsafe.ToString());
-
             // LanguageVersion should already be mapped to a specific version
             Debug.Assert(LanguageVersion == LanguageVersion.MapSpecifiedToEffectiveVersion());
             WriteValue(CompilationOptionNames.LanguageVersion, LanguageVersion.ToDisplayString());
+
+            if (Options.CheckOverflow)
+            {
+                WriteValue(CompilationOptionNames.Checked, Options.CheckOverflow.ToString());
+            }
+
+            if (Options.NullableContextOptions != NullableContextOptions.Disable)
+            {
+                WriteValue(CompilationOptionNames.Nullable, Options.NullableContextOptions.ToString());
+            }
+
+            if (Options.AllowUnsafe)
+            {
+                WriteValue(CompilationOptionNames.Unsafe, Options.AllowUnsafe.ToString());
+            }
 
             var preprocessorSymbols = GetPreprocessorSymbols();
             if (preprocessorSymbols.Any())

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -868,10 +868,15 @@ namespace Microsoft.Cci
                 WriteValue(CompilationOptionNames.PortabilityPolicy, portabilityPolicy.ToString());
             }
 
+            var optimizationLevel = module.CommonCompilation.Options.OptimizationLevel;
+            var debugPlusMode = module.CommonCompilation.Options.DebugPlusMode;
+            if (optimizationLevel != OptimizationLevel.Debug || debugPlusMode)
+            {
+                WriteValue(CompilationOptionNames.Optimization, optimizationLevel.ToPdbSerializedString(debugPlusMode));
+            }
+
             var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             WriteValue(CompilationOptionNames.RuntimeVersion, runtimeVersion);
-
-            WriteValue(CompilationOptionNames.Optimization, module.CommonCompilation.Options.OptimizationLevel.ToPdbSerializedString(module.CommonCompilation.Options.DebugPlusMode));
 
             module.CommonCompilation.SerializePdbEmbeddedCompilationOptions(builder);
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -863,7 +863,10 @@ namespace Microsoft.Cci
                 portabilityPolicy |= identityComparer.PortabilityPolicy.SuppressSilverlightPlatformAssembliesPortability ? 0b10 : 0;
             }
 
-            WriteValue(CompilationOptionNames.PortabilityPolicy, portabilityPolicy.ToString());
+            if (portabilityPolicy != 0)
+            {
+                WriteValue(CompilationOptionNames.PortabilityPolicy, portabilityPolicy.ToString());
+            }
 
             var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             WriteValue(CompilationOptionNames.RuntimeVersion, runtimeVersion);

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -709,13 +709,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Sub SerializePdbEmbeddedCompilationOptions(builder As BlobBuilder)
-            WriteValue(builder, CompilationOptionNames.Checked, Options.CheckOverflow.ToString())
-
             ' LanguageVersion should already be mapped to an effective version at this point
             Debug.Assert(LanguageVersion.MapSpecifiedToEffectiveVersion() = LanguageVersion)
             WriteValue(builder, CompilationOptionNames.LanguageVersion, LanguageVersion.ToDisplayString())
 
-            WriteValue(builder, CompilationOptionNames.Strict, Options.OptionStrict.ToString())
+            If Options.CheckOverflow Then
+                WriteValue(builder, CompilationOptionNames.Checked, Options.CheckOverflow.ToString())
+            End If
+
+            If Options.OptionStrict <> OptionStrict.Off Then
+                WriteValue(builder, CompilationOptionNames.Strict, Options.OptionStrict.ToString())
+            End If
 
             If Options.ParseOptions IsNot Nothing Then
                 Dim preprocessorStrings = Options.ParseOptions.PreprocessorSymbols.Select(Function(p)

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/VisualBasicDeterministicBuildCompilationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/VisualBasicDeterministicBuildCompilationTests.vb
@@ -24,20 +24,16 @@ Public Class VisualBasicDeterministicBuildCompilationTests
         DeterministicBuildCompilationTestHelpers.AssertCommonOptions(emitOptions, originalOptions, compilation, pdbOptions)
 
         ' See VisualBasicCompilation.SerializeForPdb for options that are added
-        Assert.Equal(originalOptions.CheckOverflow.ToString(), pdbOptions("checked"))
-        Assert.Equal(originalOptions.OptionStrict.ToString(), pdbOptions("strict"))
+        pdbOptions.VerifyPdbOption("checked", originalOptions.CheckOverflow)
+        pdbOptions.VerifyPdbOption("strict", originalOptions.OptionStrict)
+
         Assert.Equal(originalOptions.ParseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion().ToDisplayString(), pdbOptions("language-version"))
 
-
-        Dim preprocessorStrings = originalOptions.ParseOptions.PreprocessorSymbols.Select(Function(p)
-                                                                                              If (p.Value Is Nothing) Then
-                                                                                                  Return p.Key
-                                                                                              End If
-
-                                                                                              Return p.Key + "=" + p.Value.ToString()
-                                                                                          End Function)
-        Assert.Equal(String.Join(",", preprocessorStrings), pdbOptions("define"))
-
+        pdbOptions.VerifyPdbOption(
+            "define",
+            originalOptions.ParseOptions.PreprocessorSymbols,
+            isDefault:=Function(v) v.IsEmpty,
+            toString:=Function(v) String.Join(",", v.Select(Function(p) If(p.Value IsNot Nothing, $"{p.Key}={p.Value}", p.Key))))
     End Sub
 
     Private Sub TestDeterministicCompilationVB(syntaxTrees As SyntaxTree(), compilationOptions As VisualBasicCompilationOptions, emitOptions As EmitOptions, ParamArray metadataReferences() As TestMetadataReferenceInfo)

--- a/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -19,6 +19,15 @@ namespace Roslyn.Test.Utilities.PDB
 {
     internal static partial class DeterministicBuildCompilationTestHelpers
     {
+        public static void VerifyPdbOption<T>(this ImmutableDictionary<string, string> pdbOptions, string pdbName, T expectedValue, Func<T, bool> isDefault = null, Func<T, string> toString = null)
+        {
+            bool expectedIsDefault = (isDefault != null) ? isDefault(expectedValue) : EqualityComparer<T>.Default.Equals(expectedValue, default);
+            var expectedValueString = expectedIsDefault ? null : (toString != null) ? toString(expectedValue) : expectedValue.ToString();
+
+            pdbOptions.TryGetValue(pdbName, out var actualValueString);
+            Assert.Equal(expectedValueString, actualValueString);
+        }
+
         public static IEnumerable<EmitOptions> GetEmitOptions()
         {
             var emitOptions = new EmitOptions(
@@ -34,15 +43,8 @@ namespace Roslyn.Test.Utilities.PDB
 
         internal static void AssertCommonOptions(EmitOptions emitOptions, CompilationOptions compilationOptions, Compilation compilation, ImmutableDictionary<string, string> pdbOptions)
         {
-            if (emitOptions.FallbackSourceFileEncoding != null)
-            {
-                Assert.Equal(emitOptions.FallbackSourceFileEncoding.WebName, pdbOptions["fallback-encoding"]);
-            }
-
-            if (emitOptions.DefaultSourceFileEncoding != null)
-            {
-                Assert.Equal(emitOptions.DefaultSourceFileEncoding.WebName, pdbOptions["default-encoding"]);
-            }
+            pdbOptions.VerifyPdbOption("fallback-encoding", emitOptions.FallbackSourceFileEncoding, toString: v => v.WebName);
+            pdbOptions.VerifyPdbOption("default-encoding", emitOptions.DefaultSourceFileEncoding, toString: v => v.WebName);
 
             int portabilityPolicy = 0;
             if (compilationOptions.AssemblyIdentityComparer is DesktopAssemblyIdentityComparer identityComparer)
@@ -51,8 +53,7 @@ namespace Roslyn.Test.Utilities.PDB
                 portabilityPolicy |= identityComparer.PortabilityPolicy.SuppressSilverlightPlatformAssembliesPortability ? 0b10 : 0;
             }
 
-            pdbOptions.TryGetValue("portability-policy", out var actualPortabilityPolicy);
-            Assert.Equal((portabilityPolicy == 0) ? null : portabilityPolicy.ToString(), actualPortabilityPolicy);
+            pdbOptions.VerifyPdbOption("portability-policy", portabilityPolicy);
 
             var compilerVersion = typeof(Compilation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             Assert.Equal(compilerVersion.ToString(), pdbOptions["compiler-version"]);
@@ -60,7 +61,11 @@ namespace Roslyn.Test.Utilities.PDB
             var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             Assert.Equal(runtimeVersion, pdbOptions[CompilationOptionNames.RuntimeVersion]);
 
-            Assert.Equal(compilationOptions.OptimizationLevel.ToPdbSerializedString(compilationOptions.DebugPlusMode), pdbOptions["optimization"]);
+            pdbOptions.VerifyPdbOption(
+                "optimization",
+                (compilationOptions.OptimizationLevel, compilationOptions.DebugPlusMode),
+                toString: v => v.OptimizationLevel.ToPdbSerializedString(v.DebugPlusMode));
+
             Assert.Equal(compilation.Language, pdbOptions["language"]);
         }
 

--- a/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -52,7 +52,7 @@ namespace Roslyn.Test.Utilities.PDB
             }
 
             pdbOptions.TryGetValue("portability-policy", out var actualPortabilityPolicy);
-            Assert.Equal(portabilityPolicy.ToString(), actualPortabilityPolicy ?? "0");
+            Assert.Equal((portabilityPolicy == 0) ? null : portabilityPolicy.ToString(), actualPortabilityPolicy);
 
             var compilerVersion = typeof(Compilation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             Assert.Equal(compilerVersion.ToString(), pdbOptions["compiler-version"]);

--- a/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -51,7 +51,8 @@ namespace Roslyn.Test.Utilities.PDB
                 portabilityPolicy |= identityComparer.PortabilityPolicy.SuppressSilverlightPlatformAssembliesPortability ? 0b10 : 0;
             }
 
-            Assert.Equal(portabilityPolicy.ToString(), pdbOptions["portability-policy"]);
+            pdbOptions.TryGetValue("portability-policy", out var actualPortabilityPolicy);
+            Assert.Equal(portabilityPolicy.ToString(), actualPortabilityPolicy ?? "0");
 
             var compilerVersion = typeof(Compilation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             Assert.Equal(compilerVersion.ToString(), pdbOptions["compiler-version"]);


### PR DESCRIPTION
`portability-policy` emitted to PDB CompilationOptions record is only relevant for legacy Silverlight builds. It's always `0` otherwise. No reason to include it if it has the default value.