### PR TITLE
Add a simple abstract base class

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -32,6 +32,8 @@ Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.OperatorKind.get -
 Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.Value.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.ITypePatternOperation
 Microsoft.CodeAnalysis.Operations.ITypePatternOperation.MatchedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
+Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator
+Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator.AbstractSourceGenerator() -> void
 Microsoft.CodeAnalysis.SourceGeneratorContext.AnalyzerConfigOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider
 Microsoft.CodeAnalysis.Operations.IWithOperation
 Microsoft.CodeAnalysis.Operations.IWithOperation.CloneMethod.get -> Microsoft.CodeAnalysis.IMethodSymbol
@@ -40,6 +42,7 @@ Microsoft.CodeAnalysis.Operations.IWithOperation.Value.get -> Microsoft.CodeAnal
 Microsoft.CodeAnalysis.SymbolKind.FunctionPointer = 20 -> Microsoft.CodeAnalysis.SymbolKind
 Microsoft.CodeAnalysis.TypeKind.FunctionPointer = 13 -> Microsoft.CodeAnalysis.TypeKind
 abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider.GlobalOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions
+abstract Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator.Execute(Microsoft.CodeAnalysis.SourceGeneratorContext context) -> void
 static Microsoft.CodeAnalysis.AnalyzerConfigSet.Create<TList>(TList analyzerConfigs, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics) -> Microsoft.CodeAnalysis.AnalyzerConfigSet
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitBinaryPattern(Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitNegatedPattern(Microsoft.CodeAnalysis.Operations.INegatedPatternOperation operation) -> void
@@ -51,5 +54,6 @@ virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.V
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitRelationalPattern(Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitTypePattern(Microsoft.CodeAnalysis.Operations.ITypePatternOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitWith(Microsoft.CodeAnalysis.Operations.IWithOperation operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator.Initialize(Microsoft.CodeAnalysis.InitializationContext context) -> void
 virtual Microsoft.CodeAnalysis.SymbolVisitor.VisitFunctionPointerType(Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol symbol) -> void
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TResult>.VisitFunctionPointerType(Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol symbol) -> TResult

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -32,8 +32,8 @@ Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.OperatorKind.get -
 Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.Value.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.ITypePatternOperation
 Microsoft.CodeAnalysis.Operations.ITypePatternOperation.MatchedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
-Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator
-Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator.AbstractSourceGenerator() -> void
+Microsoft.CodeAnalysis.SourceGeneration.SourceGenerator
+Microsoft.CodeAnalysis.SourceGeneration.SourceGenerator.SourceGenerator() -> void
 Microsoft.CodeAnalysis.SourceGeneratorContext.AnalyzerConfigOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider
 Microsoft.CodeAnalysis.Operations.IWithOperation
 Microsoft.CodeAnalysis.Operations.IWithOperation.CloneMethod.get -> Microsoft.CodeAnalysis.IMethodSymbol
@@ -42,7 +42,7 @@ Microsoft.CodeAnalysis.Operations.IWithOperation.Value.get -> Microsoft.CodeAnal
 Microsoft.CodeAnalysis.SymbolKind.FunctionPointer = 20 -> Microsoft.CodeAnalysis.SymbolKind
 Microsoft.CodeAnalysis.TypeKind.FunctionPointer = 13 -> Microsoft.CodeAnalysis.TypeKind
 abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider.GlobalOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions
-abstract Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator.Execute(Microsoft.CodeAnalysis.SourceGeneratorContext context) -> void
+abstract Microsoft.CodeAnalysis.SourceGeneration.SourceGenerator.Execute(Microsoft.CodeAnalysis.SourceGeneratorContext context) -> void
 static Microsoft.CodeAnalysis.AnalyzerConfigSet.Create<TList>(TList analyzerConfigs, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics) -> Microsoft.CodeAnalysis.AnalyzerConfigSet
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitBinaryPattern(Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitNegatedPattern(Microsoft.CodeAnalysis.Operations.INegatedPatternOperation operation) -> void
@@ -54,6 +54,6 @@ virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.V
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitRelationalPattern(Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitTypePattern(Microsoft.CodeAnalysis.Operations.ITypePatternOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitWith(Microsoft.CodeAnalysis.Operations.IWithOperation operation, TArgument argument) -> TResult
-virtual Microsoft.CodeAnalysis.SourceGeneration.AbstractSourceGenerator.Initialize(Microsoft.CodeAnalysis.InitializationContext context) -> void
+virtual Microsoft.CodeAnalysis.SourceGeneration.SourceGenerator.Initialize(Microsoft.CodeAnalysis.InitializationContext context) -> void
 virtual Microsoft.CodeAnalysis.SymbolVisitor.VisitFunctionPointerType(Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol symbol) -> void
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TResult>.VisitFunctionPointerType(Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol symbol) -> TResult

--- a/src/Compilers/Core/Portable/SourceGeneration/AbstractSourceGenerator.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AbstractSourceGenerator.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.SourceGeneration
+{
+    /// <summary>
+    /// A base class that can be used to implement a Source Generator 
+    /// </summary>
+    public abstract class AbstractSourceGenerator : ISourceGenerator
+    {
+        public abstract void Execute(SourceGeneratorContext context);
+
+        public virtual void Initialize(InitializationContext context)
+        {
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/AbstractSourceGenerator.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AbstractSourceGenerator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
     /// <summary>
     /// A base class that can be used to implement a Source Generator 
     /// </summary>
-    public abstract class AbstractSourceGenerator : ISourceGenerator
+    public abstract class SourceGenerator : ISourceGenerator
     {
         public abstract void Execute(SourceGeneratorContext context);
 


### PR DESCRIPTION
Simple PR to add an abstract base class that can be used to create a source generator.

**Rationale**: We chose to make `ISourceGenerator` an interface as it seems plausible that people might want to make a class that is both an analyzer and generator.  However we've heard feedback a few times that people implementing simple source generators have to have an empty `Initialize` method which is just noise. This lets us change our docs / examples to use the base class, but still give users the option of implementing `ISourceGenerator` directly if they need to.

(I also expect as we add more init options and enable a more complex class of generators we'll end up adding more base classes that handle the required boilerplate, but again still let people fall back to the interface if they need to).