### PR TITLE
Update PublishData.json

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -96,7 +96,7 @@
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
       "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
       "channels": [ "dev16.8", "dev16.8p1" ],
-      "vsBranch": null,
+      "vsBranch": "master",
       "vsMajorVersion": 16
     },
     "features/NullableReferenceTypes": {


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/roslyn/pull/45054#issuecomment-642310145.

I think `null` is wrong here, but because I do not know every way `vsBranch` is used, I cannot be confident that repeating `"master"` is the right thing here. Please take a look @dotnet/roslyn-infrastructure.