### PR TITLE
Add history to move to namespace

### DIFF
--- a/src/EditorFeatures/TestUtilities/MoveToNamespace/TestMoveToNamespaceOptionsService.cs
+++ b/src/EditorFeatures/TestUtilities/MoveToNamespace/TestMoveToNamespaceOptionsService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
         {
         }
 
-        public MoveToNamespaceOptionsResult GetChangeNamespaceOptions(string defaultNamespace, ImmutableArray<string> availableNamespaces, ISyntaxFactsService syntaxFactsService)
+        public MoveToNamespaceOptionsResult GetChangeNamespaceOptions(string defaultNamespace, ImmutableArray<string> availableNamespaces, ISyntaxFacts syntaxFactsService)
             => OptionsResult;
 
         internal void SetOptions(MoveToNamespaceOptionsResult moveToNamespaceOptions)

--- a/src/Features/Core/Portable/MoveToNamespace/IMoveToNamespaceOptionsService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/IMoveToNamespaceOptionsService.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         MoveToNamespaceOptionsResult GetChangeNamespaceOptions(
             string defaultNamespace,
             ImmutableArray<string> availableNamespaces,
-            ISyntaxFactsService syntaxFactsService);
+            ISyntaxFacts syntaxFactsService);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
@@ -8,6 +8,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"
              MinWidth="400" MinHeight="166"
@@ -49,7 +50,28 @@
                           Text="{Binding NamespaceName, Mode=TwoWay, ValidatesOnDataErrors=True}"
                           ItemsSource="{Binding AvailableNamespaces, Mode=OneTime}"
                           BorderThickness="0" 
-                          MaxDropDownHeight="200" />
+                          Margin="0 0 20 0"
+                          MaxDropDownHeight="200">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate DataType="Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace.NamespaceItem">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <imaging:CrispImage 
+                                Grid.Column="0" 
+                                Visibility="{Binding IsFromHistory, Converter={StaticResource BooleanToVisibilityConverter}}" 
+                                Margin="0 0 5 0" 
+                                 Moniker="{x:Static imagecatalog:KnownMonikers.History}" />
+                            
+                            <TextBlock Grid.Column="1" Text="{Binding Namespace}" />
+                        </Grid>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            
         </StackPanel>
 
         <StackPanel Grid.Row="1">
@@ -64,7 +86,8 @@
 
                 <vs:LiveTextBlock x:Name="MessageText"
                            Text="{Binding Message}"
-                           Margin="7, 0, 0, 0" />
+                           Margin="7, 0, 0, 0"
+                           Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}" />
             </StackPanel>
         </StackPanel>
 

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialog.xaml
@@ -16,7 +16,9 @@
              ResizeMode="CanResizeWithGrip"
              ShowInTaskbar="False"
              HasDialogFrame="True"
-             WindowStartupLocation="CenterOwner">
+             WindowStartupLocation="CenterOwner"
+             vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+             Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
 
     <Window.Resources>
         <Thickness x:Key="verticalLabelMargin">0, 0, 0, 5</Thickness>

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
@@ -4,14 +4,14 @@
 
 #nullable enable
 
-using System.Collections.Immutable;
-using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
-using Microsoft.VisualStudio.Imaging;
 using System;
-using Microsoft.CodeAnalysis.LanguageServices;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 {

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
@@ -9,21 +11,25 @@ using Microsoft.VisualStudio.Imaging;
 using System;
 using Microsoft.CodeAnalysis.LanguageServices;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 {
-    class MoveToNamespaceDialogViewModel : AbstractNotifyPropertyChanged, IDataErrorInfo
+    internal class MoveToNamespaceDialogViewModel : AbstractNotifyPropertyChanged, IDataErrorInfo
     {
         private readonly ISyntaxFacts _syntaxFacts;
 
         public MoveToNamespaceDialogViewModel(
             string defaultNamespace,
             ImmutableArray<string> availableNamespaces,
-            ISyntaxFacts syntaxFacts)
+            ISyntaxFacts syntaxFacts,
+            ImmutableArray<string> namespaceHistory)
         {
             _syntaxFacts = syntaxFacts ?? throw new ArgumentNullException(nameof(syntaxFacts));
-            NamespaceName = defaultNamespace;
-            AvailableNamespaces = availableNamespaces;
+            _namespaceName = defaultNamespace;
+            AvailableNamespaces = namespaceHistory.Select(n => new NamespaceItem(true, n))
+                .Concat(availableNamespaces.Except(namespaceHistory).Select(n => new NamespaceItem(false, n)))
+                .ToImmutableArray();
 
             PropertyChanged += MoveToNamespaceDialogViewModel_PropertyChanged;
         }
@@ -40,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 
         public void OnNamespaceUpdated()
         {
-            var isNewNamespace = !AvailableNamespaces.Contains(NamespaceName);
+            var isNewNamespace = !AvailableNamespaces.Any(i => i.Namespace == NamespaceName);
             var isValidName = !isNewNamespace || IsValidNamespace(NamespaceName);
 
             if (isNewNamespace && isValidName)
@@ -91,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
             set => SetProperty(ref _namespaceName, value);
         }
 
-        public ImmutableArray<string> AvailableNamespaces { get; }
+        public ImmutableArray<NamespaceItem> AvailableNamespaces { get; }
 
         private ImageMoniker _icon;
         public ImageMoniker Icon
@@ -100,8 +106,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
             private set => SetProperty(ref _icon, value);
         }
 
-        private string _message;
-        public string Message
+        private string? _message;
+        public string? Message
         {
             get => _message;
             private set => SetProperty(ref _message, value);
@@ -121,12 +127,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
             private set => SetProperty(ref _canSubmit, value);
         }
 
-        public string Error => CanSubmit ? string.Empty : Message;
+        public string Error => CanSubmit ? string.Empty : Message ?? string.Empty;
 
         public string this[string columnName] =>
             columnName switch
             {
-                nameof(NamespaceName) => CanSubmit ? string.Empty : Message,
+                nameof(NamespaceName) => Error,
                 _ => string.Empty
             };
 

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
             PropertyChanged += MoveToNamespaceDialogViewModel_PropertyChanged;
         }
 
-        private void MoveToNamespaceDialogViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void MoveToNamespaceDialogViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/NamespaceItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/NamespaceItem.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
+{
+    internal class NamespaceItem
+    {
+        public string Namespace { get; }
+        public bool IsFromHistory { get; }
+
+        public NamespaceItem(bool isFromHistory, string @namespace)
+        {
+            IsFromHistory = isFromHistory;
+            Namespace = @namespace;
+        }
+
+        public override string ToString() => Namespace;
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
@@ -62,11 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 
         private void OnSelected(string namespaceName)
         {
-            if (History.Contains(namespaceName))
-            {
-                History.Remove(namespaceName);
-            }
-
+            History.Remove(namespaceName);
             History.AddFirst(namespaceName);
 
             if (History.Count > HistorySize)

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
@@ -11,7 +11,6 @@ using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.MoveToNamespace;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
@@ -21,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
     {
         private const int HistorySize = 3;
 
-        public readonly LinkedList<string?> History = new LinkedList<string?>();
+        public readonly LinkedList<string> History = new LinkedList<string>();
         private readonly Func<MoveToNamespaceDialogViewModel, bool?> _showDialog;
 
         [ImportingConstructor]

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
@@ -24,8 +24,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioMoveToNamespaceOptionsService()
-            : this(new string[3], (viewModel) => new MoveToNamespaceDialog(viewModel).ShowModal())
         {
+            _history = new string[3];
+            _showDialog = viewModel => new MoveToNamespaceDialog(viewModel).ShowModal();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should be marked with 'ImportingConstructorAttribute'", Justification = "Test constructor")]
@@ -69,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 
             for (var i = _history.Length - 1; i > 0; i--)
             {
-                if (_history[i-1] == null)
+                if (_history[i - 1] == null)
                 {
                     continue;
                 }

--- a/src/VisualStudio/Core/Test/MoveToNamespace/MoveToNamespaceDialogViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/MoveToNamespace/MoveToNamespaceDialogViewModelTests.vb
@@ -3,13 +3,9 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
-Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.CSharp.LanguageServices
-Imports Microsoft.CodeAnalysis.MoveToNamespace
 Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Imaging
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 
@@ -40,7 +36,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
             Assert.True(viewModel.ShowMessage)
             Assert.Equal(viewModel.Icon, KnownMonikers.StatusInvalid)
 
-            viewModel.NamespaceName = viewModel.AvailableNamespaces.First()
+            viewModel.NamespaceName = viewModel.AvailableNamespaces.First().Namespace
 
             Assert.True(viewModel.CanSubmit)
             Assert.False(viewModel.ShowMessage)
@@ -59,7 +55,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
             monitor.AddExpectation(Function() viewModel.Message)
             monitor.AddExpectation(Function() viewModel.Icon)
 
-            viewModel.NamespaceName = viewModel.AvailableNamespaces.Last() & ".NewNamespace"
+            viewModel.NamespaceName = viewModel.AvailableNamespaces.Last().Namespace & ".NewNamespace"
 
             monitor.VerifyExpectations()
             monitor.Detach()
@@ -68,7 +64,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
             Assert.True(viewModel.ShowMessage)
             Assert.Equal(viewModel.Icon, KnownMonikers.StatusInformation)
 
-            viewModel.NamespaceName = viewModel.AvailableNamespaces.First()
+            viewModel.NamespaceName = viewModel.AvailableNamespaces.First().Namespace
 
             Assert.True(viewModel.CanSubmit)
             Assert.False(viewModel.ShowMessage)
@@ -86,7 +82,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
                                                             defaultNamespace & "2"})
             End If
 
-            Return New MoveToNamespaceDialogViewModel(defaultNamespace, availableNamespaces, CSharpSyntaxFacts.Instance)
+            Return New MoveToNamespaceDialogViewModel(defaultNamespace, availableNamespaces, CSharpSyntaxFacts.Instance, ImmutableArray(Of String).Empty)
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/MoveToNamespace/VisualStudioMoveToNamespaceServiceTests.vb
+++ b/src/VisualStudio/Core/Test/MoveToNamespace/VisualStudioMoveToNamespaceServiceTests.vb
@@ -1,0 +1,37 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
+
+    Public Class VisualStudioMoveToNamespaceServiceTests
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveToNamespace)>
+        Public Sub TestMoveNamespace_History()
+            Dim history(2) As String
+            Dim service = New VisualStudioMoveToNamespaceOptionsService(history, Function(viewModel As MoveToNamespaceDialogViewModel) True)
+
+            Dim namespaces = {"namespaceone", "namespacetwo", "namespaces.two", "namespaces.three"}
+            Dim result = service.GetChangeNamespaceOptions(namespaces(0), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
+
+            AssertEx.SetEqual({namespaces(0), Nothing, Nothing}, history)
+
+            result = service.GetChangeNamespaceOptions(namespaces(1), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
+            AssertEx.SetEqual({namespaces(1), namespaces(0), Nothing}, history)
+
+            result = service.GetChangeNamespaceOptions(namespaces(2), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
+            AssertEx.SetEqual({namespaces(2), namespaces(1), namespaces(0)}, history)
+
+            result = service.GetChangeNamespaceOptions(namespaces(3), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
+            AssertEx.SetEqual({namespaces(3), namespaces(2), namespaces(1)}, history)
+
+            result = service.GetChangeNamespaceOptions(namespaces(2), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
+            AssertEx.SetEqual({namespaces(2), namespaces(3), namespaces(1)}, history)
+        End Sub
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/MoveToNamespace/VisualStudioMoveToNamespaceServiceTests.vb
+++ b/src/VisualStudio/Core/Test/MoveToNamespace/VisualStudioMoveToNamespaceServiceTests.vb
@@ -13,25 +13,24 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveToNamespace
     Public Class VisualStudioMoveToNamespaceServiceTests
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveToNamespace)>
         Public Sub TestMoveNamespace_History()
-            Dim history(2) As String
-            Dim service = New VisualStudioMoveToNamespaceOptionsService(history, Function(viewModel As MoveToNamespaceDialogViewModel) True)
+            Dim service = New VisualStudioMoveToNamespaceOptionsService(Function(viewModel As MoveToNamespaceDialogViewModel) True)
 
             Dim namespaces = {"namespaceone", "namespacetwo", "namespaces.two", "namespaces.three"}
             Dim result = service.GetChangeNamespaceOptions(namespaces(0), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
 
-            AssertEx.SetEqual({namespaces(0), Nothing, Nothing}, history)
+            AssertEx.Equal({namespaces(0)}, service.History)
 
             result = service.GetChangeNamespaceOptions(namespaces(1), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
-            AssertEx.SetEqual({namespaces(1), namespaces(0), Nothing}, history)
+            AssertEx.Equal({namespaces(1), namespaces(0)}, service.History)
 
             result = service.GetChangeNamespaceOptions(namespaces(2), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
-            AssertEx.SetEqual({namespaces(2), namespaces(1), namespaces(0)}, history)
+            AssertEx.Equal({namespaces(2), namespaces(1), namespaces(0)}, service.History)
 
             result = service.GetChangeNamespaceOptions(namespaces(3), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
-            AssertEx.SetEqual({namespaces(3), namespaces(2), namespaces(1)}, history)
+            AssertEx.Equal({namespaces(3), namespaces(2), namespaces(1)}, service.History)
 
             result = service.GetChangeNamespaceOptions(namespaces(2), namespaces.AsImmutable(), syntaxFactsService:=VisualBasicSyntaxFacts.Instance)
-            AssertEx.SetEqual({namespaces(2), namespaces(3), namespaces(1)}, history)
+            AssertEx.Equal({namespaces(2), namespaces(3), namespaces(1)}, service.History)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
* Add the last 3 namespaces used as historic data in the dropdown. 
* Theme the dialog
* Add test for historic data 

Historic Data: 

![image](https://user-images.githubusercontent.com/475144/84329927-df3d2280-ab3a-11ea-8eb4-fb2b3125f2c2.png)


New Namespace Created: 
![image](https://user-images.githubusercontent.com/475144/84329846-ab61fd00-ab3a-11ea-8d22-1eb4c1ac0f24.png)

Invalid Namespace Created:
![image](https://user-images.githubusercontent.com/475144/84329878-bb79dc80-ab3a-11ea-957f-8a80c44ece89.png)


Fixes #43086