### PR TITLE
Adjust baseline

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -154,14 +154,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
         {
             int nestingLevel = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
             {
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) when ExecutionConditionUtil.IsMacOS => 200,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) when ExecutionConditionUtil.IsMacOS => 520,
-                _ when ExecutionConditionUtil.IsCoreClrUnix => 1200,
-                _ when ExecutionConditionUtil.IsMonoDesktop => 730,
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 460,
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1360,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 260,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 750,
+                // Legacy baselines are indicated by comments
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) when ExecutionConditionUtil.IsMacOS => 200, // 100
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) when ExecutionConditionUtil.IsMacOS => 520, // 100
+                _ when ExecutionConditionUtil.IsCoreClrUnix => 1200, // 1200
+                _ when ExecutionConditionUtil.IsMonoDesktop => 730, // 730
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 460, // 270
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1350, // 1290
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 260, // 170
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 750, // 730
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 


### PR DESCRIPTION
Resolves #44982 

This PR slightly decreases the release/x86 baseline. Also adds the legacy baseline values from preview2 branch so we know what the minimums need to be.