### PR TITLE
Don't default classifications if colors have been customized

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ColorSchemes/ColorSchemeApplier.ForegroundColorDefaulter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ColorSchemes/ColorSchemeApplier.ForegroundColorDefaulter.cs
@@ -247,14 +247,14 @@ namespace Microsoft.VisualStudio.LanguageServices.ColorSchemes
             /// <summary>
             /// Reverts Classifications to their default state.
             /// </summary>
-            public void DefaultClassifications()
+            public void DefaultClassifications(bool isThemeCustomized)
             {
                 AssertIsForeground();
 
                 var themeId = _settings.GetThemeId();
 
-                // Make no changes when in high contast mode, in unknown theme, or if theme has been defaulted.
-                if (SystemParameters.HighContrast || !IsSupportedTheme(themeId) || _settings.HasThemeBeenDefaulted[themeId])
+                // Make no changes when in high contast mode, in unknown theme, in customized theme, or if theme has been defaulted.
+                if (SystemParameters.HighContrast || !IsSupportedTheme(themeId) || isThemeCustomized || _settings.HasThemeBeenDefaulted[themeId])
                 {
                     return;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ColorSchemes/ColorSchemeApplier.cs
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ColorSchemes
             if (themeChanged)
             {
                 // Default Foreground colors if they match our theme colors.
-                _colorDefaulter.DefaultClassifications();
+                _colorDefaulter.DefaultClassifications(IsThemeCustomized());
             }
 
             // If the color scheme has updated, apply the scheme.


### PR DESCRIPTION
Fix for  https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1128270