### PR TITLE
Don't generate references for built-in operators

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -466,7 +466,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         private static string GetLanguage(TestWorkspace workspace, XElement projectElement)
         {
-            var languageName = projectElement.Attribute(LanguageAttributeName).Value;
+            var languageAttribute = projectElement.Attribute(LanguageAttributeName);
+            if (languageAttribute == null)
+            {
+                throw new ArgumentException($"{projectElement} is missing a {LanguageAttributeName} attribute.");
+            }
+
+            var languageName = languageAttribute.Value;
 
             if (!workspace.Services.SupportedLanguages.Contains(languageName))
             {

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -195,6 +195,12 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 return false;
             }
 
+            // If it's a built-in operator, just skip it
+            if (symbol is IMethodSymbol { MethodKind: MethodKind.BuiltinOperator })
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
+++ b/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
@@ -13,9 +13,9 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
         <Theory>
         <InlineData("class C { [|string|] s; }", "mscorlib#T:System.String", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
-        <InlineData("class C { void M() { [|M|](); }", TestProjectAssemblyName + "#M:C.M", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
-        <InlineData("class C { void M(string s) { M([|s|]) }", TestProjectAssemblyName + "#M:C.M(System.String)#s", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
-        <InlineData("class C { void M(string s) { string local; M([|local|]) }", Nothing, Nothing)>
+        <InlineData("class C { void M() { [|M|](); } }", TestProjectAssemblyName + "#M:C.M", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
+        <InlineData("class C { void M(string s) { M([|s|]); } }", TestProjectAssemblyName + "#M:C.M(System.String)#s", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
+        <InlineData("class C { void M(string s) { string local = """"; M([|local|]); } }", Nothing, Nothing)>
         <InlineData("class C { void M(string s) { M(s [|+|] s) }", Nothing, Nothing)>
         <InlineData("using [|S|] = System.String;", Nothing, Nothing)>
         <InlineData("class C { [|global|]::System.String s; }", "<global namespace>", WellKnownSymbolMonikerSchemes.DotnetNamespace)>
@@ -49,7 +49,9 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                             <Document Name="A.cs" FilePath="Z:\A.cs">
                                 <%= code %>
                             </Document>
+                            <ProjectReference Alias="A">ReferencedWithAlias</ProjectReference>
                         </Project>
+                        <Project AssemblyName="ReferencedWithAlias" Language="C#" FilePath="Z:\ReferencedWithAlias.csproj"></Project>
                     </Workspace>))
 
             Assert.Empty(lsif.Vertices.OfType(Of Range))

--- a/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
+++ b/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <InlineData("class C { void M() { [|M|](); } }", TestProjectAssemblyName + "#M:C.M", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
         <InlineData("class C { void M(string s) { M([|s|]); } }", TestProjectAssemblyName + "#M:C.M(System.String)#s", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
         <InlineData("class C { void M(string s) { string local = """"; M([|local|]); } }", Nothing, Nothing)>
-        <InlineData("class C { void M(string s) { M(s [|+|] s) }", Nothing, Nothing)>
         <InlineData("using [|S|] = System.String;", Nothing, Nothing)>
         <InlineData("class C { [|global|]::System.String s; }", "<global namespace>", WellKnownSymbolMonikerSchemes.DotnetNamespace)>
         Public Async Sub ReferenceMoniker(code As String, expectedMoniker As String, expectedMonikerScheme As String)
@@ -130,6 +129,54 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                 ' The references vertex should point back to our range
                 Dim referencedRanges = lsif.GetLinkedVertices(Of Graph.Range)(referencesVertex, "item")
                 Assert.Contains(rangeVertex, referencedRanges)
+            Next
+        End Sub
+
+        <Theory>
+        <InlineData("class A { public const int C = 42 + 42; }", "class B { public const int C = 42 + 42; }")> ' case for built-in operators
+        <InlineData("class A { public void M() { } }",
+                    "class B
+                    {
+                        /// <see cref=""A.M()"" />
+                        public void M2() { }
+                    }")> ' case for crefs
+        Public Async Sub NoCrossDocumentReferencesWithoutAMoniker(file1 As String, file2 As String)
+            Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
+                TestWorkspace.CreateWorkspace(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                            <Document Name="File1.cs" FilePath="Z:\File1.cs"><%= file1 %></Document>
+                            <Document Name="File2.cs" FilePath="Z:\File2.cs"><%= file2 %></Document>
+                        </Project>
+                    </Workspace>))
+
+            ' If we ever emit a result set that doesn't have a moniker, some LSIF importers will make up a moniker
+            ' for us when they're importing, which can be based on the first range that they see. This is problematic if
+            ' the result set crosses multiple files, because there's no very stable moniker they can easily pick that won't
+            ' change if unrelated documents change.
+            For Each resultSetVertex In lsif.Vertices.OfType(Of Graph.ResultSet)
+                Dim monikerVertex = lsif.GetLinkedVertices(Of Graph.Moniker)(resultSetVertex, "moniker").SingleOrDefault()
+
+                ' If it's got a moniker, then no concerns
+                If monikerVertex IsNot Nothing Then
+                    Continue For
+                End If
+
+                Dim documents As New HashSet(Of Graph.Document)
+
+                ' Let's now enumerate all the documents and ranges to see which documents contain a range that links to
+                ' this resultSet
+                For Each document In lsif.Vertices.OfType(Of Graph.Document)
+                    For Each range In lsif.GetLinkedVertices(Of Graph.Range)(document, "contains")
+                        If lsif.GetLinkedVertices(Of Graph.ResultSet)(range, "next").Contains(resultSetVertex) Then
+                            documents.Add(document)
+                        End If
+                    Next
+                Next
+
+                If documents.Count > 0 Then
+                    Assert.Single(documents)
+                End If
             Next
         End Sub
     End Class

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
@@ -30,6 +30,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
 
             For Each project In workspace.CurrentSolution.Projects
                 Dim compilation = Await project.GetCompilationAsync()
+
+                ' Assert we don't have any errors to prevent any typos in the tests
+                Assert.Empty(compilation.GetDiagnostics().Where(Function(d) d.Severity = DiagnosticSeverity.Error))
+
                 generator.GenerateForCompilation(compilation, project.FilePath, project.LanguageServices)
             Next
         End Function


### PR DESCRIPTION
Since we didn't have a moniker for built-in operators, we were confusing LSIF importing tools that weren't sure what to do here. They would make up a moniker based on the first use, but that's not stable across different runs.

We _could_ make up a moniker here, but it's not clear if finding references for all uses of + in a project is really terribly useful.