### PR TITLE
#3438, use standard Type Conversion Functions when possible

### DIFF
--- a/src/EditorFeatures/Test2/Expansion/ExtensionMethodExpansionRewriteTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/ExtensionMethodExpansionRewriteTests.vb
@@ -182,7 +182,7 @@ Imports System.Runtime.CompilerServices
 Public Class Program
     Public Sub Main(args As String())
         Dim p As Program = Nothing
-        Dim ss = Global.ProgramExtensions.goo((CType((Global.ProgramExtensions.goo((CType((p), Global.Program)), (CType((""), System.String)))), Global.Program)), (CType((""), System.String)))
+        Dim ss = Global.ProgramExtensions.goo((CType((Global.ProgramExtensions.goo((CType((p), Global.Program)), (CStr((""))))), Global.Program)), (CStr((""))))
     End Sub
 End Class
 

--- a/src/EditorFeatures/Test2/Expansion/ExtensionMethodExpansionRewriteTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/ExtensionMethodExpansionRewriteTests.vb
@@ -88,7 +88,7 @@ Imports System.Runtime.CompilerServices
 Public Class Program
     Public Sub Main(args As String())
         Dim p As Program = Nothing
-        Dim ss = Global.ProgramExtensions.goo((CType((p), Global.Program)), (CType((""), System.String)))
+        Dim ss = Global.ProgramExtensions.goo((CType((p), Global.Program)), (CStr((""))))
     End Sub
 End Class
 
@@ -229,7 +229,7 @@ Imports System.Runtime.CompilerServices
 Public Class Program
     Public Sub Main(args As String())
         Dim p As Program = Nothing
-        Dim ss = Global.ProgramExtensions.goo((CType((Global.ProgramExtensions.goo((CType((p), Global.Program)), (CType((""), System.String)), (CType((""), System.String)), (CType((""), System.String)))), Global.Program)), (CType((""), System.String)), (CType((""), System.String)), (CType((""), System.String)))
+        Dim ss = Global.ProgramExtensions.goo((CType((Global.ProgramExtensions.goo((CType((p), Global.Program)), (CStr((""))), (CStr((""))), (CStr((""))))), Global.Program)), (CStr((""))), (CStr((""))), (CStr((""))))
     End Sub
 End Class
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
@@ -66,14 +66,14 @@ End Module")
 "Option Strict On
 Module M1
     Sub Main()
-        Dim s As String = 0.ToString
+        Dim s As String = 0.ToString()
         Dim ch As Char = [|s|]
     End Sub
 End Module",
 "Option Strict On
 Module M1
     Sub Main()
-        Dim s As String = 0.ToString
+        Dim s As String = 0.ToString()
         Dim ch As Char = CChar(s)
     End Sub
 End Module")
@@ -85,14 +85,14 @@ End Module")
 "Option Strict On
 Module M1
     Sub Main()
-        Dim s As String = #2006-06-13#.ToString
+        Dim s As String = #2006-06-13#.ToString()
         Dim dt As Date = [|s|]
     End Sub
 End Module",
 "Option Strict On
 Module M1
     Sub Main()
-        Dim s As String = #2006-06-13#.ToString
+        Dim s As String = #2006-06-13#.ToString()
         Dim dt As Date = CDate(s)
     End Sub
 End Module")
@@ -104,14 +104,14 @@ End Module")
 "Option Strict On
 Module M1
     Sub Main()
-        Dim s As String = 1.0R.ToString
+        Dim s As String = 1.0R.ToString()
         Dim db As Double = [|s|]
     End Sub
 End Module",
 "Option Strict On
 Module M1
     Sub Main()
-        Dim s As String = 1.0R.ToString
+        Dim s As String = 1.0R.ToString()
         Dim db As Double = CDbl(s)
     End Sub
 End Module")

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
@@ -1787,7 +1787,6 @@ Class Program
 End Class")
         End Function
 
-
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
         Public Async Function GenericType2() As Task
             Await TestMissingInRegularAndScriptAsync(

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
@@ -237,15 +237,34 @@ End Module")
 "Option Strict On
 Module M1
     Sub Main()
-        Dim i As integer = 1
+        Dim i As Integer = 1
         Dim s As String = [|i|]
     End Sub
 End Module",
 "Option Strict On
 Module M1
     Sub Main()
-        Dim i As integer = 1
+        Dim i As Integer = 1
         Dim s As String = CStr(i)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentObjectToStringCStr() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim o As Object = 1.ToString()
+        Dim s As String = [|o|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim o As Object = 1.ToString()
+        Dim s As String = CStr(o)
     End Sub
 End Module")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
@@ -21,7 +21,26 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.AddExp
         End Function
 
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
-        Public Async Function TestPredefinedAssignment() As Task
+        Public Async Function TestPredefinedAssignmentCBool() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = 0
+        Dim b As Boolean = [|i|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = 0
+        Dim b As Boolean = CBool(i)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCByte() As Task
             Await TestInRegularAndScriptAsync(
 "Option Strict On
 Module M1
@@ -37,6 +56,253 @@ Module M1
         Dim b As Byte = 1
         Dim c As Byte = 2
         b = CByte(b & c)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCChar() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim s As String = 0.ToString
+        Dim ch As Char = [|s|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim s As String = 0.ToString
+        Dim ch As Char = CChar(s)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCDate() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim s As String = #2006-06-13#.ToString
+        Dim dt As Date = [|s|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim s As String = #2006-06-13#.ToString
+        Dim dt As Date = CDate(s)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCDbl() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim s As String = 1.0R.ToString
+        Dim db As Double = [|s|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim s As String = 1.0R.ToString
+        Dim db As Double = CDbl(s)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCDec() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim dc As Decimal = [|db|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim dc As Decimal = CDec(db)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCInt() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim i As Integer = [|db|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim i As Integer = CInt(db)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCLng() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim lg As Long = [|db|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim lg As Long = CLng(db)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCSByte() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim dc As Decimal = -14.02D
+        Dim sb As SByte = [|dc|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim dc As Decimal = -14.02D
+        Dim sb As SByte = CSByte(dc)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCShort() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = 2
+        Dim sh As Short = [|i|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = 2
+        Dim sh As Short = CShort(i)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCSng() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim sn As Single = [|db|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim db As Double = 1.0R
+        Dim sn As Single = CSng(db)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCStr() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As integer = 1
+        Dim s As String = [|i|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As integer = 1
+        Dim s As String = CStr(i)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCUInt() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = -1
+        Dim ui As UInteger = [|i|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = -1
+        Dim ui As UInteger = CUInt(i)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCULng() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim l As Long = -1
+        Dim ul As ULong =[|l|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim l As Long = -1
+        Dim ul As ULong = CULng(l)
+    End Sub
+End Module")
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
+        Public Async Function TestPredefinedAssignmentCUShort() As Task
+            Await TestInRegularAndScriptAsync(
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = -2
+        Dim us As UShort = [|i|]
+    End Sub
+End Module",
+"Option Strict On
+Module M1
+    Sub Main()
+        Dim i As Integer = -2
+        Dim us As UShort = CUShort(i)
     End Sub
 End Module")
         End Function
@@ -1520,6 +1786,7 @@ Class Program
     End Sub
 End Class")
         End Function
+
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddExplicitCast)>
         Public Async Function GenericType2() As Task

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests.vb
@@ -3197,17 +3197,17 @@ Class Program
 
     Private Sub M()
         Dim b As Base = New Base()
-        Foo(s:="""", i:=1, d:=CType(b, {0}))
+        Foo(s:="""", i:=1, d:={0})
     End Sub
 End Class"
 
-            Await TestInRegularAndScriptAsync(initialMarkup, String.Format(expect_format, "String"), index:=0,
+            Await TestInRegularAndScriptAsync(initialMarkup, String.Format(expect_format, "CStr(b)"), index:=0,
                 title:=String.Format(FeaturesResources.Convert_type_to_0, "String"))
 
-            Await TestInRegularAndScriptAsync(initialMarkup, String.Format(expect_format, "Derived"), index:=1,
+            Await TestInRegularAndScriptAsync(initialMarkup, String.Format(expect_format, "CType(b, Derived)"), index:=1,
                 title:=String.Format(FeaturesResources.Convert_type_to_0, "Derived"))
 
-            Await TestInRegularAndScriptAsync(initialMarkup, String.Format(expect_format, "Derived2"), index:=2,
+            Await TestInRegularAndScriptAsync(initialMarkup, String.Format(expect_format, "CType(b, Derived2)"), index:=2,
                 title:=String.Format(FeaturesResources.Convert_type_to_0, "Derived2"))
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddExplicitCast/AddExplicitCastTests_FixAllTests.vb
@@ -1270,7 +1270,7 @@ Public Class Program1
         Foo4(i:=1, j:="", CType(b1, Derived1))
         Foo5("", 1, b1)
         Foo5(d:=CType(b1, Derived2), i:=1, j:="", x:=1)
-        Foo5(CType(1, String), "", x:=1, d:=b1)
+        Foo5(CStr(1), "", x:=1, d:=b1)
         Foo5(1, "", d:=b1, b2, b3, d1)
         Foo5("", 1, d:=b1, b2, b3, d1)
         Dim d2list = New Derived2() {}
@@ -1475,7 +1475,7 @@ Public Class Program1
         Foo4(i:=1, j:="", CType(b1, Derived1))
         Foo5("", 1, b1)
         Foo5(d:=CType(b1, Derived2), i:=1, j:="", x:=1)
-        Foo5(CType(1, String), "", x:=1, d:=b1)
+        Foo5(CStr(1), "", x:=1, d:=b1)
         Foo5(1, "", d:=b1, b2, b3, d1)
         Foo5("", 1, d:=b1, b2, b3, d1)
         Dim d2list = New Derived2() {}
@@ -1680,7 +1680,7 @@ Public Class Program1
         Foo4(i:=1, j:="", CType(b1, Derived1))
         Foo5("", 1, b1)
         Foo5(d:=CType(b1, Derived2), i:=1, j:="", x:=1)
-        Foo5(CType(1, String), "", x:=1, d:=b1)
+        Foo5(CStr(1), "", x:=1, d:=b1)
         Foo5(1, "", d:=b1, b2, b3, d1)
         Foo5("", 1, d:=b1, b2, b3, d1)
         Dim d2list = New Derived2() {}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ITypeSymbolExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ITypeSymbolExtensions.vb
@@ -42,6 +42,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return SyntaxKind.CSngKeyword
                 Case specialType.System_Int16
                     Return SyntaxKind.CShortKeyword
+                Case SpecialType.System_String
+                    Return SyntaxKind.CStrKeyword
                 Case specialType.System_UInt32
                     Return SyntaxKind.CUIntKeyword
                 Case specialType.System_UInt64


### PR DESCRIPTION
use standard Type Conversion Functions when possible (including CStr), and not CType.