### PR TITLE
Report better errors when multiple invalid constraints are combined

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -126,6 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!InExecutableBinder); // Cannot eagerly report diagnostics handled by LazyMissingNonNullTypesContextDiagnosticInfo 
             bool hasTypeLikeConstraint = false;
             bool reportedOverrideWithConstraints = false;
+            MessageID? firstTypeConstraintString = null;
 
             for (int i = 0, n = constraintsSyntax.Count; i < n; i++)
             {
@@ -137,7 +138,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (i != 0)
                         {
-                            diagnostics.Add(ErrorCode.ERR_RefValBoundMustBeFirst, syntax.GetFirstToken().GetLocation());
+                            if (!reportedOverrideWithConstraints)
+                            {
+                                reportNotFirstOrCannotCombine(diagnostics, syntax.GetFirstToken().GetLocation(), ErrorCode.ERR_RefValBoundMustBeFirst, MessageID.IDS_Class, firstTypeConstraintString);
+                            }
 
                             if (isForOverride && (constraints & (TypeParameterConstraintKind.ValueType | TypeParameterConstraintKind.ReferenceType)) != 0)
                             {
@@ -145,6 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
+                        firstTypeConstraintString ??= MessageID.IDS_Class;
                         var constraintSyntax = (ClassOrStructConstraintSyntax)syntax;
                         SyntaxToken questionToken = constraintSyntax.QuestionToken;
                         if (questionToken.IsKind(SyntaxKind.QuestionToken))
@@ -175,7 +180,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (i != 0)
                         {
-                            diagnostics.Add(ErrorCode.ERR_RefValBoundMustBeFirst, syntax.GetFirstToken().GetLocation());
+                            if (!reportedOverrideWithConstraints)
+                            {
+                                reportNotFirstOrCannotCombine(diagnostics, syntax.GetFirstToken().GetLocation(), ErrorCode.ERR_RefValBoundMustBeFirst, MessageID.IDS_Struct, firstTypeConstraintString);
+                            }
 
                             if (isForOverride && (constraints & (TypeParameterConstraintKind.ValueType | TypeParameterConstraintKind.ReferenceType)) != 0)
                             {
@@ -183,6 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
+                        firstTypeConstraintString ??= MessageID.IDS_Struct;
                         constraints |= TypeParameterConstraintKind.ValueType;
                         continue;
                     case SyntaxKind.ConstructorConstraint:
@@ -233,9 +242,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConstraintContextualKeyword.Unmanaged:
                                     if (i != 0)
                                     {
-                                        diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeFirst, typeSyntax.GetLocation());
+                                        reportNotFirstOrCannotCombine(diagnostics, typeSyntax.GetLocation(), ErrorCode.ERR_UnmanagedConstraintMustBeFirst, MessageID.IDS_Unmanaged, firstTypeConstraintString);
                                         continue;
                                     }
+
+                                    firstTypeConstraintString ??= MessageID.IDS_Unmanaged;
 
                                     // This should produce diagnostics if the types are missing
                                     GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType, diagnostics, typeSyntax);
@@ -247,9 +258,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConstraintContextualKeyword.NotNull:
                                     if (i != 0)
                                     {
-                                        diagnostics.Add(ErrorCode.ERR_NotNullConstraintMustBeFirst, typeSyntax.GetLocation());
+                                        reportNotFirstOrCannotCombine(diagnostics, typeSyntax.GetLocation(), ErrorCode.ERR_NotNullConstraintMustBeFirst, MessageID.IDS_Notnull, firstTypeConstraintString);
                                     }
 
+                                    firstTypeConstraintString ??= MessageID.IDS_Notnull;
                                     constraints |= TypeParameterConstraintKind.NotNull;
                                     continue;
 
@@ -284,6 +296,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     diagnostics.Add(ErrorCode.ERR_OverrideWithConstraints, syntax.GetLocation());
                     reportedOverrideWithConstraints = true;
+                }
+            }
+
+            static void reportNotFirstOrCannotCombine(DiagnosticBag diagnostics, Location constraintLocation, ErrorCode notFirstDiagnostic, MessageID currentConstraintString, MessageID? firstConstraintString)
+            {
+                if (firstConstraintString is MessageID firstConstraint)
+                {
+                    diagnostics.Add(ErrorCode.ERR_CannotCombineTypeConstraints, constraintLocation, currentConstraintString.Localize(), firstConstraint.Localize());
+                }
+                else
+                {
+                    diagnostics.Add(notFirstDiagnostic, constraintLocation);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1359,8 +1359,8 @@
   <data name="ERR_BadIncDecRetType" xml:space="preserve">
     <value>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</value>
   </data>
-  <data name="ERR_RefValBoundMustBeFirst" xml:space="preserve">
-    <value>The 'class' or 'struct' constraint must come before any other constraints</value>
+  <data name="ERR_TypeConstraintsMustBeUniqueAndFirst" xml:space="preserve">
+    <value>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</value>
   </data>
   <data name="ERR_RefValBoundWithClass" xml:space="preserve">
     <value>'{0}': cannot specify both a constraint class and the 'class' or 'struct' constraint</value>
@@ -5695,9 +5695,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_NewBoundWithUnmanaged" xml:space="preserve">
     <value>The 'new()' constraint cannot be used with the 'unmanaged' constraint</value>
   </data>
-  <data name="ERR_UnmanagedConstraintMustBeFirst" xml:space="preserve">
-    <value>The 'unmanaged' constraint must come before any other constraints</value>
-  </data>
   <data name="ERR_UnmanagedConstraintNotSatisfied" xml:space="preserve">
     <value>The type '{2}' must be a non-nullable value type, along with all fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</value>
   </data>
@@ -6019,9 +6016,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureNestedStackalloc" xml:space="preserve">
     <value>stackalloc in nested expressions</value>
   </data>
-  <data name="ERR_NotNullConstraintMustBeFirst" xml:space="preserve">
-    <value>The 'notnull' constraint must come before any other constraints</value>
-  </data>
   <data name="WRN_NullabilityMismatchInTypeParameterNotNullConstraint" xml:space="preserve">
     <value>The type '{2}' cannot be used as type parameter '{1}' in the generic type or method '{0}'. Nullability of type argument '{2}' doesn't match 'notnull' constraint.</value>
   </data>
@@ -6261,20 +6255,5 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_CopyConstructorMustInvokeBaseCopyConstructor" xml:space="preserve">
     <value>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</value>
-  </data>
-  <data name="IDS_Class" xml:space="preserve">
-    <value>class</value>
-  </data>
-  <data name="IDS_Struct" xml:space="preserve">
-    <value>struct</value>
-  </data>
-  <data name="IDS_Unmanaged" xml:space="preserve">
-    <value>unmanaged</value>
-  </data>
-  <data name="IDS_Notnull" xml:space="preserve">
-    <value>notnull</value>
-  </data>
-  <data name="ERR_CannotCombineTypeConstraints" xml:space="preserve">
-    <value>The '{0}' constraint cannot be combined with the '{1}' constraint</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6262,4 +6262,19 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_CopyConstructorMustInvokeBaseCopyConstructor" xml:space="preserve">
     <value>A copy constructor in a record must call a copy constructor of the base, or a parameterless object constructor if the record inherits from object.</value>
   </data>
+  <data name="IDS_Class" xml:space="preserve">
+    <value>class</value>
+  </data>
+  <data name="IDS_Struct" xml:space="preserve">
+    <value>struct</value>
+  </data>
+  <data name="IDS_Unmanaged" xml:space="preserve">
+    <value>unmanaged</value>
+  </data>
+  <data name="IDS_Notnull" xml:space="preserve">
+    <value>notnull</value>
+  </data>
+  <data name="ERR_CannotCombineTypeConstraints" xml:space="preserve">
+    <value>The '{0}' constraint cannot be combined with the '{1}' constraint</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1835,6 +1835,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadRecordMemberForPositionalParameter = 8866,
         ERR_NoCopyConstructorInBaseType = 8867,
         ERR_CopyConstructorMustInvokeBaseCopyConstructor = 8868,
+        ERR_CannotCombineTypeConstraints = 8869,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AnonMethGrpInForEach = 446,
         //ERR_AttrOnTypeArg = 447,      unused in Roslyn. The scenario for which this error exists should, and does generate a parse error.
         ERR_BadIncDecRetType = 448,
-        ERR_RefValBoundMustBeFirst = 449,
+        ERR_TypeConstraintsMustBeUniqueAndFirst = 449,
         ERR_RefValBoundWithClass = 450,
         ERR_NewBoundWithVal = 451,
         ERR_RefConstraintNotSatisfied = 452,
@@ -1564,7 +1564,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefAssignNarrower = 8374,
 
         ERR_NewBoundWithUnmanaged = 8375,
-        ERR_UnmanagedConstraintMustBeFirst = 8376,
+        //ERR_UnmanagedConstraintMustBeFirst = 8376,
         ERR_UnmanagedConstraintNotSatisfied = 8377,
         ERR_CantUseInOrOutInArglist = 8378,
         ERR_ConWithUnmanagedCon = 8379,
@@ -1729,7 +1729,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_DefaultInterfaceImplementationInNoPIAType = 8711,
         ERR_AbstractEventHasAccessors = 8712,
-        ERR_NotNullConstraintMustBeFirst = 8713,
+        //ERR_NotNullConstraintMustBeFirst = 8713,
         WRN_NullabilityMismatchInTypeParameterNotNullConstraint = 8714,
 
         ERR_DuplicateNullSuppression = 8715,
@@ -1835,7 +1835,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadRecordMemberForPositionalParameter = 8866,
         ERR_NoCopyConstructorInBaseType = 8867,
         ERR_CopyConstructorMustInvokeBaseCopyConstructor = 8868,
-        ERR_CannotCombineTypeConstraints = 8869,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -206,10 +206,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureInitOnlySetters = MessageBase + 12781,
         IDS_FeatureRecords = MessageBase + 12782,
         IDS_FeatureNullPointerConstantPattern = MessageBase + 12783,
-        IDS_Class = MessageBase + 12784,
-        IDS_Struct = MessageBase + 12785,
-        IDS_Unmanaged = MessageBase + 12786,
-        IDS_Notnull = MessageBase + 12787,
     }
 
     // Message IDs may refer to strings that need to be localized.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -206,6 +206,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureInitOnlySetters = MessageBase + 12781,
         IDS_FeatureRecords = MessageBase + 12782,
         IDS_FeatureNullPointerConstantPattern = MessageBase + 12783,
+        IDS_Class = MessageBase + 12784,
+        IDS_Struct = MessageBase + 12785,
+        IDS_Unmanaged = MessageBase + 12786,
+        IDS_Notnull = MessageBase + 12787,
     }
 
     // Message IDs may refer to strings that need to be localized.

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Chyba syntaxe příkazového řádku: {0} není platná hodnota možnosti {1}. Hodnota musí mít tvar {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementace výchozího rozhraní</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">omezení pro metody přepsání a explicitní implementace rozhraní</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Chyba syntaxe příkazového řádku: {0} není platná hodnota možnosti {1}. Hodnota musí mít tvar {2}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">Omezení notnull musí být zadané před všemi ostatními omezeními.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Očekávala se hodnota enable, disable nebo restore.</target>
@@ -727,6 +717,11 @@
         <target state="translated">Typy řazené kolekce členů, které se používají jako operandy operátoru == nebo !=, musí mít odpovídající kardinality. U tohoto operátoru je ale kardinalita typů řazené kolekce členů vlevo {0} a vpravo {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">{0}: Nejde zadat třídu omezení a zároveň omezení unmanaged.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">Omezení unmanaged musí být zadané před všemi ostatními omezeními.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementace výchozího rozhraní</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">omezení pro metody přepsání a explicitní implementace rozhraní</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">Typ vrácené hodnoty operátorů ++ a -- musí odpovídat danému typu parametru nebo z něho musí být odvozený.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">Omezení class nebo struct musí být zadané před všemi ostatními omezeními.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Fehler in der Befehlszeilensyntax: "{0}" ist kein gültiger Wert für die Option "{1}". Der Wert muss im Format "{2}" vorliegen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">Standardschnittstellenimplementierung</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;NULL&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">Einschränkungen für Außerkraftsetzung und explizite Schnittstellenimplementierungsmethoden</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Fehler in der Befehlszeilensyntax: "{0}" ist kein gültiger Wert für die Option "{1}". Der Wert muss im Format "{2}" vorliegen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">Die notnull-Einschränkung muss vor allen anderen Einschränkungen stehen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">"enable", "disable" oder "restore" erwartet.</target>
@@ -727,6 +717,11 @@
         <target state="translated">Tupeltypen, die als Operanden eines ==- oder !=-Operators verwendet werden, müssen übereinstimmende Kardinalitäten aufweisen. Dieser Operator enthält jedoch Tupeltypen der Kardinalität "{0}" auf der linken und "{1}" auf der rechten Seite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">"{0}": Eine Einschränkungsklasse kann nicht gleichzeitig mit einer unmanaged-Einschränkung angegeben werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">Die unmanaged-Einschränkung muss vor allen anderen Einschränkungen stehen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">Standardschnittstellenimplementierung</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;NULL&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">Einschränkungen für Außerkraftsetzung und explizite Schnittstellenimplementierungsmethoden</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">Der Rückgabetyp für den Operator ++ oder -- muss der Parametertyp sein oder vom Parametertyp abgeleitet werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">Die class- oder struct-Einschränkung muss vor allen anderen Einschränkungen stehen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Error de sintaxis de la línea de comandos: "{0}" no es un valor válido para la opción "{1}". El valor debe tener el formato "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">La restricción "notnull" debe preceder a cualquier otra restricción</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Se esperaba "enable", "disable" o "restore".</target>
@@ -727,6 +717,11 @@
         <target state="translated">Los tipos de tupla utilizados como operandos de un operador == o != deben tener cardinalidades coincidentes. Pero este operador tiene tipos de tupla de cardinalidad {0} a la izquierda y {1} a la derecha.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">"{0}": no se puede especificar a la vez una clase de restricción y la restricción "unmanaged"</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">La restricción "unmanaged" debe preceder a cualquier otra restricción</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementación de interfaz predeterminada</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;NULL&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">restricciones para métodos de implementación de interfaz explícita e invalidación</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">El tipo de valor devuelto para los operadores ++ o -- debe coincidir con el tipo de parámetro o derivarse de este</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">Las restricciones 'class' o 'struct' deben preceder a cualquier otra restricción</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Error de sintaxis de la línea de comandos: "{0}" no es un valor válido para la opción "{1}". El valor debe tener el formato "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementación de interfaz predeterminada</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;NULL&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">restricciones para métodos de implementación de interfaz explícita e invalidación</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Erreur de syntaxe de ligne de commande : '{0}' est une valeur non valide pour l'option '{1}'. La valeur doit se présenter sous la forme '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implémentation d'interface par défaut</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;Null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">contraintes des méthodes d'implémentation d'interface par remplacement et explicites</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Erreur de syntaxe de ligne de commande : '{0}' est une valeur non valide pour l'option '{1}'. La valeur doit se présenter sous la forme '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">La contrainte 'notnull' doit être placée avant toutes les autres contraintes</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable', 'disable' ou 'restore' attendu</target>
@@ -727,6 +717,11 @@
         <target state="translated">Les types de tuple utilisés en tant qu'opérandes d'un opérateur == ou != doivent avoir des cardinalités correspondantes. Toutefois, cet opérateur a des types de tuple de cardinalité {0} à gauche et {1} à droite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}' : impossible de spécifier à la fois une classe de contrainte et la contrainte 'unmanaged'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">La contrainte 'unmanaged' doit être placée avant toutes les autres contraintes</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implémentation d'interface par défaut</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;Null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">contraintes des méthodes d'implémentation d'interface par remplacement et explicites</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">Le type de retour pour l'opérateur ++ ou -- doit correspondre au type de paramètre ou en être dérivé</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">La contrainte 'class' ou 'struct' doit être placée avant toutes les autres contraintes</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Errore di sintassi della riga di comando: '{0}' non è un valore valido per l'opzione '{1}'. Il valore deve essere espresso nel formato '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementazione di interfaccia predefinita</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;Null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">vincoli per i metodi di override e di implementazione esplicita dell'interfaccia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Errore di sintassi della riga di comando: '{0}' non è un valore valido per l'opzione '{1}'. Il valore deve essere espresso nel formato '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">Il vincolo 'notnull' deve precedere gli altri vincoli</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">È previsto 'enable', 'disable' o 'restore'</target>
@@ -727,6 +717,11 @@
         <target state="translated">Le cardinalità dei tipi di tupla usati come operandi di un operatore == o != devono essere uguali, ma questo operatore presenta tipi di tupla con cardinalità {0} sulla sinistra e {1} sulla destra.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}': non è possibile specificare sia una classe constraint che il vincolo 'unmanaged'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">Il vincolo 'unmanaged' deve precedere gli altri vincoli</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementazione di interfaccia predefinita</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;Null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">vincoli per i metodi di override e di implementazione esplicita dell'interfaccia</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">Il tipo restituito per l'operatore ++ o -- deve essere uguale o derivare dal tipo che lo contiene.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">Il vincolo 'class' o 'struct' deve precedere gli altri vincoli</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">コマンドライン構文エラー: '{0}' は、'{1}' オプションの有効な値ではありません。値は '{2}' の形式にする必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">既定のインターフェイスの実装</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">オーバーライドおよび明示的なインターフェイスの実装メソッドの制約</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -152,11 +152,6 @@
         <target state="translated">コマンドライン構文エラー: '{0}' は、'{1}' オプションの有効な値ではありません。値は '{2}' の形式にする必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">'notnull' 制約は、他の制約の前に指定されなければなりません</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable'、'disable'、'restore' のいずれかが必要でした</target>
@@ -727,6 +717,11 @@
         <target state="translated">演算子 == または != のオペランドとして使用するタプルの型は、カーディナリティが一致している必要があります。しかし、この演算子は、左辺のタプルの型のカーディナリティが {0} で、右辺が {1} です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}': 制約クラスと 'unmanaged' 制約の両方を指定することはできません</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">'unmanaged' 制約は、他の制約の前に指定されなければなりません</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">既定のインターフェイスの実装</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">オーバーライドおよび明示的なインターフェイスの実装メソッドの制約</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">++ または -- 演算子の戻り値の型は、パラメーター型と一致するか、パラメーター型から派生する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">class' または 'struct' 制約は、他の制約の前に指定されなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">명령줄 구문 오류: '{0}'은(는) '{1}' 옵션에 유효한 값이 아닙니다. 값은 '{2}' 형식이어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">기본 인터페이스 구현</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">재정의 및 명시적 인터페이스 구현 메서드에 대한 제약 조건</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -152,11 +152,6 @@
         <target state="translated">명령줄 구문 오류: '{0}'은(는) '{1}' 옵션에 유효한 값이 아닙니다. 값은 '{2}' 형식이어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">'notnull' 제약 조건은 다른 모든 제약 조건보다 앞에 와야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable', 'disable' 또는 'restore'가 필요합니다.</target>
@@ -727,6 +717,11 @@
         <target state="translated">== 또는 != 연산자의 피연산자로 사용되는 튜플 형식에는 일치하는 카디널리티가 있어야 합니다. 하지만 이 연산자는 왼쪽에 {0}, 오른쪽에 {1} 카디널리티 형식의 튜플이 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}': constraint 클래스와 'unmanaged' 제약 조건을 둘 다 지정할 수는 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">'unmanaged' 제약 조건은 다른 모든 제약 조건보다 앞에 와야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">기본 인터페이스 구현</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">재정의 및 명시적 인터페이스 구현 메서드에 대한 제약 조건</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">++ 또는 -- 연산자의 반환 형식은 매개 변수 형식이거나 매개 변수 형식에서 파생되어야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">class' 또는 'struct' 제약 조건은 다른 모든 제약 조건보다 앞에 와야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Błąd składni wiersza polecenia: „{0}” nie jest prawidłową wartością dla opcji „{1}”. Wartość musi mieć postać „{2}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">domyślna implementacja interfejsu</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">ograniczenia dla przesłonięć i jawnych metod implementacji interfejsu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Błąd składni wiersza polecenia: „{0}” nie jest prawidłową wartością dla opcji „{1}”. Wartość musi mieć postać „{2}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">Ograniczenie „notnull” musi występować przed wszystkimi innymi ograniczeniami</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Oczekiwano opcji „enable”, „disable” lub „restore”</target>
@@ -727,6 +717,11 @@
         <target state="translated">Typy krotek używane jako operandy operatorów == lub != muszą mieć zgodne kardynalności. Ten operator zawiera natomiast typy krotek o kardynalności {0} z lewej strony i {1} z prawej strony.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">„{0}”: nie można jednocześnie określić klasy ograniczenia i ograniczenia „unmanaged”</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">Ograniczenie „unmanaged” musi występować przed wszystkimi innymi ograniczeniami</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">domyślna implementacja interfejsu</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">ograniczenia dla przesłonięć i jawnych metod implementacji interfejsu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">Typ zwracany przez operator ++ lub -- musi odpowiadać typowi parametru lub pochodzić od typu parametru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">Ograniczenie „class” lub „struct” musi występować przed wszystkimi innymi ograniczeniami</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Erro de sintaxe de linha de comando: '{0}' não é um valor válido para a opção '{1}'. O valor precisa estar no formato '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">A restrição 'notnull' precisa vir antes de outras restrições</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Esperava-se 'enable', 'disable' ou 'restore'</target>
@@ -727,6 +717,11 @@
         <target state="translated">Os tipos de tupla usados como operandos de um operador == ou != precisam ter cardinalidades correspondentes. No entanto, este operador tem tipos de tupla de cardinalidade {0} na esquerda e {1} na direita.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}': não é possível especificar uma classe de restrição e a restrição 'unmanaged'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">A restrição 'unmanaged' deve vir antes das outras restrições</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1117,11 +1107,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementação de interface padrão</target>
@@ -1372,19 +1357,9 @@
         <target state="translated">&lt;nulo&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">restrições para métodos de substituição e de implementação explícita da interface</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1405,11 +1380,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4050,11 +4020,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">O tipo de retorno para o operador ++ ou -- deve corresponder ao tipo de parâmetro ou ser derivado do tipo de parâmetro</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">A restrição 'class' ou 'struct' deve vir antes de qualquer outra restrição</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Erro de sintaxe de linha de comando: '{0}' não é um valor válido para a opção '{1}'. O valor precisa estar no formato '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1112,6 +1117,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">implementação de interface padrão</target>
@@ -1362,9 +1372,19 @@
         <target state="translated">&lt;nulo&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">restrições para métodos de substituição e de implementação explícita da interface</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1385,6 +1405,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Ошибка в синтаксисе командной строки: "{0}" не является допустимым значением для параметра "{1}". Значение должно иметь форму "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">Ограничение "notnull" должно предшествовать любым другим ограничениям.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Ожидается "enable", "disable" или "restore"</target>
@@ -727,6 +717,11 @@
         <target state="translated">Типы кортежей, используемые в качестве операндов оператора == или !=, должны иметь соответствующие кратности. Однако этот оператор имеет типы кортежей с кратностью {0} слева и {1} справа.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">"{0}": невозможно одновременно задать класс ограничения и ограничение "unmanaged"</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">Все другие ограничения должны следовать после ограничения "unmanaged"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">реализация интерфейса по умолчанию</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;NULL&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">ограничения для методов переопределения и явной реализации интерфейса</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">Возвращаемый тип оператора ++ или -- должен соответствовать типу параметра или быть производным от типа параметра.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">Все другие ограничения должны следовать после ограничения "class" или "struct".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Ошибка в синтаксисе командной строки: "{0}" не является допустимым значением для параметра "{1}". Значение должно иметь форму "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">реализация интерфейса по умолчанию</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;NULL&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">ограничения для методов переопределения и явной реализации интерфейса</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Komut satırı söz dizimi hatası: '{0}', '{1}' seçeneği için geçerli bir değer değil. Değer '{2}' biçiminde olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">varsayılan arabirim uygulaması</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">geçersiz kılma ve açık arabirim uygulama yöntemleri için kısıtlamalar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Komut satırı söz dizimi hatası: '{0}', '{1}' seçeneği için geçerli bir değer değil. Değer '{2}' biçiminde olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">'notnull' kısıtlaması diğer kısıtlamalardan önce gelmelidir</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable', 'disable' veya 'restore' bekleniyor</target>
@@ -727,6 +717,11 @@
         <target state="translated">== veya != işlecinin işleneni olarak kullanılan demet türlerinin kardinalitesi eşleşmelidir. Ancak bu işleç, solda {0} ve sağda {1} demet kardinalite türlerine sahip olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}': hem bir kısıtlama sınıfı hem de 'unmanaged' kısıtlaması belirtilemez</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">'unmanaged' kısıtlaması diğer kısıtlamalardan önce gelmelidir</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">varsayılan arabirim uygulaması</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">geçersiz kılma ve açık arabirim uygulama yöntemleri için kısıtlamalar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">++ veya -- işleci için dönüş türü parametre türüyle eşleşmeli ya da parametre türünden türemelidir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">class' veya 'struct' kısıtlaması diğer kısıtlamalardan önce gelmelidir</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">命令行语法错误:“{0}”不是“{1}”选项的有效值。值的格式必须为 "{2}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">默认接口实现</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">重写和显式接口实现方法的约束</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -152,11 +152,6 @@
         <target state="translated">命令行语法错误:“{0}”不是“{1}”选项的有效值。值的格式必须为 "{2}"。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">"notnull" 约束必须在其他所有约束之前</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">应为 "enable"、"disable" 或 "restore"</target>
@@ -727,6 +717,11 @@
         <target state="translated">用作 == 或 != 运算符的操作数的元组类型必须具有匹配的基数。但此运算符的基数的元组类型左侧为 {0}，右侧为 {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">“{0}”: 不能既指定约束类又指定 “unmanaged” 约束</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">"unmanaged" 约束必须在其他任何约束之前</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">默认接口实现</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">重写和显式接口实现方法的约束</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">++ 或 -- 运算符的返回类型必须与参数类型匹配或从参数类型派生</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">"class" 或 "struct" 约束必须在其他任何约束之前</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -152,11 +152,6 @@
         <target state="translated">命令列語法錯誤: '{0}' 對 '{1}' 選項而言不是有效的值。此值的格式必須是 '{2}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_CannotCombineTypeConstraints">
-        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
-        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -517,11 +512,6 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_NotNullConstraintMustBeFirst">
-        <source>The 'notnull' constraint must come before any other constraints</source>
-        <target state="translated">'notnull' 限制式必須在所有其他限制式之前</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">應為 'enable'、'disable' 或 'restore'</target>
@@ -727,6 +717,11 @@
         <target state="translated">作為 == 或 != 運算子之運算元使用的元組類型，必須具有相符的基數。但此運算子在左側的元組類型為基數 {0}，在右側則為 {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_TypeConstraintsMustBeUniqueAndFirst">
+        <source>The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</source>
+        <target state="new">The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypelessNewIllegalTargetType">
         <source>The type '{0}' may not be used as the target type of new()</source>
         <target state="new">The type '{0}' may not be used as the target type of new()</target>
@@ -755,11 +750,6 @@
       <trans-unit id="ERR_UnmanagedBoundWithClass">
         <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
         <target state="translated">'{0}': 不可在指定條件約束類型的同時，又指定 'unmanaged' 條件約束</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
-        <source>The 'unmanaged' constraint must come before any other constraints</source>
-        <target state="translated">'unmanaged' 條件約束必須在所有其他條件約束之前</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
@@ -1119,11 +1109,6 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
-      <trans-unit id="IDS_Class">
-        <source>class</source>
-        <target state="new">class</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">預設介面實作</target>
@@ -1374,19 +1359,9 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_Notnull">
-        <source>notnull</source>
-        <target state="new">notnull</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">適用於覆寫和明確介面實作方法的條件約束</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Struct">
-        <source>struct</source>
-        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1407,11 +1382,6 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_Unmanaged">
-        <source>unmanaged</source>
-        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">
@@ -4052,11 +4022,6 @@
       <trans-unit id="ERR_BadIncDecRetType">
         <source>The return type for ++ or -- operator must match the parameter type or be derived from the parameter type</source>
         <target state="translated">++ 或 -- 運算子的傳回類型，必須符合此參數類型或衍生自此參數類型。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_RefValBoundMustBeFirst">
-        <source>The 'class' or 'struct' constraint must come before any other constraints</source>
-        <target state="translated">class' 或 'struct' 條件約束必須在所有其他條件約束之前</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefValBoundWithClass">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">命令列語法錯誤: '{0}' 對 '{1}' 選項而言不是有效的值。此值的格式必須是 '{2}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotCombineTypeConstraints">
+        <source>The '{0}' constraint cannot be combined with the '{1}' constraint</source>
+        <target state="new">The '{0}' constraint cannot be combined with the '{1}' constraint</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CannotConvertAddressOfToDelegate">
         <source>Cannot convert &amp;method group '{0}' to delegate type '{0}'.</source>
         <target state="new">Cannot convert &amp;method group '{0}' to delegate type '{0}'.</target>
@@ -1114,6 +1119,11 @@
 </target>
         <note>Visual C# Compiler Options</note>
       </trans-unit>
+      <trans-unit id="IDS_Class">
+        <source>class</source>
+        <target state="new">class</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_DefaultInterfaceImplementation">
         <source>default interface implementation</source>
         <target state="translated">預設介面實作</target>
@@ -1364,9 +1374,19 @@
         <target state="translated">&lt;null&gt;</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Notnull">
+        <source>notnull</source>
+        <target state="new">notnull</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_OverrideWithConstraints">
         <source>constraints for override and explicit interface implementation methods</source>
         <target state="translated">適用於覆寫和明確介面實作方法的條件約束</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Struct">
+        <source>struct</source>
+        <target state="new">struct</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">
@@ -1387,6 +1407,11 @@
       <trans-unit id="IDS_TopLevelStatements">
         <source>top-level statements</source>
         <target state="new">top-level statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_Unmanaged">
+        <source>unmanaged</source>
+        <target state="new">unmanaged</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_XMLIGNORED">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -4715,7 +4715,7 @@ namespace ConsoleApplication24
             ERR_AnonMethGrpInForEach = 446,
             //ERR_AttrOnTypeArg = 447,      unused in Roslyn. The scenario for which this error exists should, and does generate a parse error.
             ERR_BadIncDecRetType = 448,
-            ERR_RefValBoundMustBeFirst = 449,
+            ERR_TypeConstraintsMustBeUniqueAndFirst = 449,
             ERR_RefValBoundWithClass = 450,
             ERR_NewBoundWithVal = 451,
             ERR_RefConstraintNotSatisfied = 452,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -1829,7 +1829,7 @@ public class Test2
             c.VerifyDiagnostics(
                 // (1,39): error CS8869: The 'unmanaged' constraint cannot be combined with the 'class' constraint
                 // public class Test<T> where T : class, unmanaged {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "class").WithLocation(1, 39));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(1, 39));
 
             var typeParameter = c.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
             Assert.False(typeParameter.HasUnmanagedTypeConstraint);
@@ -1847,7 +1847,7 @@ public class Test2
             c.VerifyDiagnostics(
                 // (1,40): error CS8869: The 'unmanaged' constraint cannot be combined with the 'struct' constraint
                 // public class Test<T> where T : struct, unmanaged {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "struct").WithLocation(1, 40));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(1, 40));
 
             var typeParameter = c.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
             Assert.False(typeParameter.HasUnmanagedTypeConstraint);
@@ -1882,7 +1882,7 @@ public class Test2
             CreateCompilation("public class Test<T> where T : System.Exception, unmanaged { }").VerifyDiagnostics(
                 // (1,50): error CS8380: The 'unmanaged' constraint must come before any other constraints
                 // public class Test<T> where T : System.Exception, unmanaged { }
-                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeFirst, "unmanaged").WithLocation(1, 50));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(1, 50));
         }
 
         [Fact]
@@ -1891,7 +1891,7 @@ public class Test2
             CreateCompilation("public class Test<T> where T : System.Enum, System.IDisposable, unmanaged { }").VerifyDiagnostics(
                 // (1,65): error CS8376: The 'unmanaged' constraint must come before any other constraints
                 // public class Test<T> where T : System.Enum, System.IDisposable, unmanaged { }
-                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeFirst, "unmanaged").WithLocation(1, 65));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(1, 65));
         }
 
         [Fact]
@@ -1917,7 +1917,7 @@ public class Test2
             CreateCompilation("public class Test<T, U> where T : U, unmanaged { }").VerifyDiagnostics(
                 // (1,38): error CS8380: The 'unmanaged' constraint must come before any other constraints
                 // public class Test<T, U> where T : U, unmanaged { }
-                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeFirst, "unmanaged").WithLocation(1, 38));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(1, 38));
         }
 
         [Fact]
@@ -4165,89 +4165,55 @@ class C2<T1> where T1 : struct, class, unmanaged, notnull
 {
     void M2<T2>() where T2 : struct, class, unmanaged, notnull {}
 }
-class C3<T1> where T1 : unmanaged, struct, class, notnull
+class C3<T1> where T1 : class, class
 {
-    void M3<T2>() where T2 : unmanaged, struct, class, notnull {}
-}
-class C4<T1> where T1 : notnull, struct, unmanaged, class
-{
-    void M4<T2>() where T2 : notnull, struct, unmanaged, class {}
+    void M3<T2>() where T2 : class, class {}
 }
 ");
 
             comp.VerifyDiagnostics(
-                // (2,32): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
+                // (2,32): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 // class C1<T1> where T1 : class, struct, unmanaged, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(2, 32),
-                // (2,40): error CS8869: The 'unmanaged' constraint cannot be combined with the 'class' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "struct").WithLocation(2, 32),
+                // (2,40): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 // class C1<T1> where T1 : class, struct, unmanaged, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "class").WithLocation(2, 40),
-                // (2,51): error CS8869: The 'notnull' constraint cannot be combined with the 'class' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(2, 40),
+                // (2,51): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 // class C1<T1> where T1 : class, struct, unmanaged, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "notnull").WithArguments("notnull", "class").WithLocation(2, 51),
-                // (4,37): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "notnull").WithLocation(2, 51),
+                // (4,37): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void M1<T2>() where T2 : class, struct, unmanaged, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(4, 37),
-                // (4,45): error CS8869: The 'unmanaged' constraint cannot be combined with the 'class' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "struct").WithLocation(4, 37),
+                // (4,45): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void M1<T2>() where T2 : class, struct, unmanaged, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "class").WithLocation(4, 45),
-                // (4,56): error CS8869: The 'notnull' constraint cannot be combined with the 'class' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(4, 45),
+                // (4,56): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void M1<T2>() where T2 : class, struct, unmanaged, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "notnull").WithArguments("notnull", "class").WithLocation(4, 56),
-                // (6,33): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "notnull").WithLocation(4, 56),
+                // (6,33): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 // class C2<T1> where T1 : struct, class, unmanaged, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(6, 33),
-                // (6,40): error CS8869: The 'unmanaged' constraint cannot be combined with the 'struct' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(6, 33),
+                // (6,40): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 // class C2<T1> where T1 : struct, class, unmanaged, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "struct").WithLocation(6, 40),
-                // (6,51): error CS8869: The 'notnull' constraint cannot be combined with the 'struct' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(6, 40),
+                // (6,51): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 // class C2<T1> where T1 : struct, class, unmanaged, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "notnull").WithArguments("notnull", "struct").WithLocation(6, 51),
-                // (8,38): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "notnull").WithLocation(6, 51),
+                // (8,38): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void M2<T2>() where T2 : struct, class, unmanaged, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(8, 38),
-                // (8,45): error CS8869: The 'unmanaged' constraint cannot be combined with the 'struct' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(8, 38),
+                // (8,45): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void M2<T2>() where T2 : struct, class, unmanaged, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "struct").WithLocation(8, 45),
-                // (8,56): error CS8869: The 'notnull' constraint cannot be combined with the 'struct' constraint
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "unmanaged").WithLocation(8, 45),
+                // (8,56): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void M2<T2>() where T2 : struct, class, unmanaged, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "notnull").WithArguments("notnull", "struct").WithLocation(8, 56),
-                // (10,36): error CS8869: The 'struct' constraint cannot be combined with the 'unmanaged' constraint
-                // class C3<T1> where T1 : unmanaged, struct, class, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "unmanaged").WithLocation(10, 36),
-                // (10,44): error CS8869: The 'class' constraint cannot be combined with the 'unmanaged' constraint
-                // class C3<T1> where T1 : unmanaged, struct, class, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "unmanaged").WithLocation(10, 44),
-                // (10,51): error CS8869: The 'notnull' constraint cannot be combined with the 'unmanaged' constraint
-                // class C3<T1> where T1 : unmanaged, struct, class, notnull
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "notnull").WithArguments("notnull", "unmanaged").WithLocation(10, 51),
-                // (12,41): error CS8869: The 'struct' constraint cannot be combined with the 'unmanaged' constraint
-                //     void M3<T2>() where T2 : unmanaged, struct, class, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "unmanaged").WithLocation(12, 41),
-                // (12,49): error CS8869: The 'class' constraint cannot be combined with the 'unmanaged' constraint
-                //     void M3<T2>() where T2 : unmanaged, struct, class, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "unmanaged").WithLocation(12, 49),
-                // (12,56): error CS8869: The 'notnull' constraint cannot be combined with the 'unmanaged' constraint
-                //     void M3<T2>() where T2 : unmanaged, struct, class, notnull {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "notnull").WithArguments("notnull", "unmanaged").WithLocation(12, 56),
-                // (14,34): error CS8869: The 'struct' constraint cannot be combined with the 'notnull' constraint
-                // class C4<T1> where T1 : notnull, struct, unmanaged, class
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "notnull").WithLocation(14, 34),
-                // (14,42): error CS8869: The 'unmanaged' constraint cannot be combined with the 'notnull' constraint
-                // class C4<T1> where T1 : notnull, struct, unmanaged, class
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "notnull").WithLocation(14, 42),
-                // (14,53): error CS8869: The 'class' constraint cannot be combined with the 'notnull' constraint
-                // class C4<T1> where T1 : notnull, struct, unmanaged, class
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "notnull").WithLocation(14, 53),
-                // (16,39): error CS8869: The 'struct' constraint cannot be combined with the 'notnull' constraint
-                //     void M4<T2>() where T2 : notnull, struct, unmanaged, class {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "notnull").WithLocation(16, 39),
-                // (16,47): error CS8869: The 'unmanaged' constraint cannot be combined with the 'notnull' constraint
-                //     void M4<T2>() where T2 : notnull, struct, unmanaged, class {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "unmanaged").WithArguments("unmanaged", "notnull").WithLocation(16, 47),
-                // (16,58): error CS8869: The 'class' constraint cannot be combined with the 'notnull' constraint
-                //     void M4<T2>() where T2 : notnull, struct, unmanaged, class {}
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "notnull").WithLocation(16, 58)
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "notnull").WithLocation(8, 56),
+                // (10,32): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
+                // class C3<T1> where T1 : class, class
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(10, 32),
+                // (12,37): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
+                //     void M3<T2>() where T2 : class, class {}
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(12, 37)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -9024,7 +9024,7 @@ class Derived : Base
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
                 // (8,60): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     public override void Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(8, 60));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 60));
         }
 
         [Fact]
@@ -9046,7 +9046,7 @@ class Derived : Base
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
                 // (8,59): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
                 //     public override void Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(8, 59));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 59));
         }
 
         [Fact]
@@ -9066,7 +9066,7 @@ class Derived : Base
             var comp = CreateCompilation(source).VerifyDiagnostics(
                 // (9,60): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     public override void Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(9, 60));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(9, 60));
         }
 
         [Fact]
@@ -9088,7 +9088,7 @@ class C : I
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Goo").WithArguments("C.Goo<T>(T)").WithLocation(8, 12),
                 // (8,46): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     void I.Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(8, 46)
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 46)
                 );
         }
 
@@ -9111,7 +9111,7 @@ class C : I
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Goo").WithArguments("C.Goo<T>(T)").WithLocation(8, 12),
                 // (8,45): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
                 //     void I.Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(8, 45));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 45));
         }
 
         [Fact]
@@ -9131,7 +9131,7 @@ class C : I
             var comp = CreateCompilation(source).VerifyDiagnostics(
                 // (9,46): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     void I.Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(9, 46));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(9, 46));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -9020,11 +9020,11 @@ class Derived : Base
 ";
             var comp = CreateCompilation(source).VerifyDiagnostics(
                 // (8,26): error CS0115: 'Derived.Goo<T>(T)': no suitable method found to override
-                //     public override void Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
-                // (8,60): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
                 //     public override void Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "class").WithLocation(8, 60));
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
+                // (8,60): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                //     public override void Goo<T>(T value) where T : struct, class { }
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(8, 60));
         }
 
         [Fact]
@@ -9044,9 +9044,9 @@ class Derived : Base
                 // (8,26): error CS0115: 'Derived.Goo<T>(T)': no suitable method found to override
                 //     public override void Goo<T>(T value) where T : class, struct { }
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
-                // (8,59): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                // (8,59): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
                 //     public override void Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "struct").WithLocation(8, 59));
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(8, 59));
         }
 
         [Fact]
@@ -9064,9 +9064,9 @@ class Derived : Base
 }
 ";
             var comp = CreateCompilation(source).VerifyDiagnostics(
-                // (9,60): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                // (9,60): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     public override void Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "class").WithLocation(9, 60));
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(9, 60));
         }
 
         [Fact]
@@ -9086,9 +9086,9 @@ class C : I
                 // (8,12): error CS0539: 'C.Goo<T>(T)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     void I.Goo<T>(T value) where T : struct, class { }
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Goo").WithArguments("C.Goo<T>(T)").WithLocation(8, 12),
-                // (8,46): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                // (8,46): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     void I.Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "class").WithLocation(8, 46)
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(8, 46)
                 );
         }
 
@@ -9109,9 +9109,9 @@ class C : I
                 // (8,12): error CS0539: 'C.Goo<T>(T)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     void I.Goo<T>(T value) where T : class, struct { }
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Goo").WithArguments("C.Goo<T>(T)").WithLocation(8, 12),
-                // (8,45): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                // (8,45): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
                 //     void I.Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "struct").WithLocation(8, 45));
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(8, 45));
         }
 
         [Fact]
@@ -9129,9 +9129,9 @@ class C : I
 }
 ";
             var comp = CreateCompilation(source).VerifyDiagnostics(
-                // (9,46): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                // (9,46): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
                 //     void I.Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "class").WithLocation(9, 46));
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "class").WithArguments("class", "struct").WithLocation(9, 46));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -9022,9 +9022,9 @@ class Derived : Base
                 // (8,26): error CS0115: 'Derived.Goo<T>(T)': no suitable method found to override
                 //     public override void Goo<T>(T value) where T : struct, class { }
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
-                // (8,60): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                // (8,60): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     public override void Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 60));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(8, 60));
         }
 
         [Fact]
@@ -9044,9 +9044,9 @@ class Derived : Base
                 // (8,26): error CS0115: 'Derived.Goo<T>(T)': no suitable method found to override
                 //     public override void Goo<T>(T value) where T : class, struct { }
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Goo").WithArguments("Derived.Goo<T>(T)").WithLocation(8, 26),
-                // (8,59): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
+                // (8,59): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     public override void Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 59));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "struct").WithLocation(8, 59));
         }
 
         [Fact]
@@ -9064,9 +9064,9 @@ class Derived : Base
 }
 ";
             var comp = CreateCompilation(source).VerifyDiagnostics(
-                // (9,60): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                // (9,60): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     public override void Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(9, 60));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(9, 60));
         }
 
         [Fact]
@@ -9086,10 +9086,9 @@ class C : I
                 // (8,12): error CS0539: 'C.Goo<T>(T)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     void I.Goo<T>(T value) where T : struct, class { }
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Goo").WithArguments("C.Goo<T>(T)").WithLocation(8, 12),
-                // (8,46): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                // (8,46): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void I.Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 46)
-                );
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(8, 46));
         }
 
         [Fact]
@@ -9109,9 +9108,9 @@ class C : I
                 // (8,12): error CS0539: 'C.Goo<T>(T)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     void I.Goo<T>(T value) where T : class, struct { }
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Goo").WithArguments("C.Goo<T>(T)").WithLocation(8, 12),
-                // (8,45): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
+                // (8,45): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void I.Goo<T>(T value) where T : class, struct { }
-                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(8, 45));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "struct").WithLocation(8, 45));
         }
 
         [Fact]
@@ -9129,9 +9128,9 @@ class C : I
 }
 ";
             var comp = CreateCompilation(source).VerifyDiagnostics(
-                // (9,46): error CS8869: The 'class' constraint cannot be combined with the 'struct' constraint
+                // (9,46): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //     void I.Goo<T>(T value) where T : struct, class { }
-                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst).WithLocation(9, 46));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(9, 46));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -868,13 +868,13 @@ class MyClass
         }
 
         [Fact]
-        public void CS0449ERR_RefValBoundMustBeFirst()
+        public void CS0449ERR_TypeConstraintsMustBeUniqueAndFirst()
         {
             var test = @"
 interface I {}
 class C4 
 {
-   public void F1<T>() where T : class, struct, I {}   // CS8869
+   public void F1<T>() where T : class, struct, I {}   // CS0449
    public void F2<T>() where T : I, struct {}   // CS0449
    public void F3<T>() where T : I, class {}   // CS0449
    // OK
@@ -884,15 +884,15 @@ class C4
 }
 ";
             CreateCompilation(test).VerifyDiagnostics(
-                // (5,41): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
-                //    public void F1<T>() where T : class, struct, I {}   // CS8869
-                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(5, 41),
-                // (6,37): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                // (5,41): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
+                //    public void F1<T>() where T : class, struct, I {}   // CS0449
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "struct").WithLocation(5, 41),
+                // (6,37): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //    public void F2<T>() where T : I, struct {}   // CS0449
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "struct").WithLocation(6, 37),
-                // (7,37): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "struct").WithLocation(6, 37),
+                // (7,37): error CS0449: The 'class', 'struct', 'unmanaged', and 'notnull' constraints cannot be combined or duplicated, and must be specified first in the constraints list.
                 //    public void F3<T>() where T : I, class {}   // CS0449
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "class").WithLocation(7, 37));
+                Diagnostic(ErrorCode.ERR_TypeConstraintsMustBeUniqueAndFirst, "class").WithLocation(7, 37));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -874,7 +874,7 @@ class MyClass
 interface I {}
 class C4 
 {
-   public void F1<T>() where T : class, struct, I {}   // CS0449
+   public void F1<T>() where T : class, struct, I {}   // CS8869
    public void F2<T>() where T : I, struct {}   // CS0449
    public void F3<T>() where T : I, class {}   // CS0449
    // OK
@@ -884,11 +884,14 @@ class C4
 }
 ";
             CreateCompilation(test).VerifyDiagnostics(
-                // (5,41): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
-                Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "struct").WithLocation(5, 41),
+                // (5,41): error CS8869: The 'struct' constraint cannot be combined with the 'class' constraint
+                //    public void F1<T>() where T : class, struct, I {}   // CS8869
+                Diagnostic(ErrorCode.ERR_CannotCombineTypeConstraints, "struct").WithArguments("struct", "class").WithLocation(5, 41),
                 // (6,37): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                //    public void F2<T>() where T : I, struct {}   // CS0449
                 Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "struct").WithLocation(6, 37),
                 // (7,37): error CS0449: The 'class' or 'struct' constraint must come before any other constraints
+                //    public void F3<T>() where T : I, class {}   // CS0449
                 Diagnostic(ErrorCode.ERR_RefValBoundMustBeFirst, "class").WithLocation(7, 37));
         }
 


### PR DESCRIPTION
Instead of reporting that a constraint must come first, if there are multiple constraints that must come first, we now report that these constraints cannot be combined. We also suppress these errors if a previous error about inherited constraints was reported. Fixes https://github.com/dotnet/roslyn/issues/45141.
