### PR TITLE
Fix MakeMethodAsynchronous on ValueTask without generics.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -960,6 +960,47 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task AwaitInValueTaskWithoutGenericMethod()
+        {
+            var initial =
+@"using System;
+using System.Threading.Tasks;
+
+namespace System.Threading.Tasks {
+    struct ValueTask
+    {
+    }
+}
+
+class Program 
+{
+    ValueTask Test() 
+    {
+        [|await Task.Delay(1);|]
+    }
+}";
+
+            var expected =
+@"using System;
+using System.Threading.Tasks;
+
+namespace System.Threading.Tasks {
+    struct ValueTask
+    {
+    }
+}
+
+class Program 
+{
+    async ValueTask Test() 
+    {
+        await Task.Delay(1);
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         [WorkItem(14133, "https://github.com/dotnet/roslyn/issues/14133")]
         public async Task AddAsyncInLocalFunction()
         {

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
         {
             public readonly INamedTypeSymbol _taskType;
             public readonly INamedTypeSymbol _taskOfTType;
+            public readonly INamedTypeSymbol _valueTaskType;
             public readonly INamedTypeSymbol _valueTaskOfTTypeOpt;
 
             public readonly INamedTypeSymbol _iEnumerableOfTType;
@@ -24,6 +25,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             {
                 _taskType = compilation.TaskType();
                 _taskOfTType = compilation.TaskOfTType();
+                _valueTaskType = compilation.ValueTaskType();
                 _valueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
 
                 _iEnumerableOfTType = compilation.IEnumerableOfTType();

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -204,6 +204,11 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
                 return true;
             }
 
+            if (returnType.Equals(knownTypes._valueTaskType))
+            {
+                return true;
+            }
+
             if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
             {
                 return true;


### PR DESCRIPTION
Hello ~
The MakeMethodAsynchronous code fix does not recognize method return type ValueTask, resulting in a Task<ValueTask>.
The fix is straightforward and I added a test for it.