### PR TITLE
Stop attempting to include InteractiveComponents VSIX

### DIFF
--- a/src/Deployment/RoslynDeployment.csproj
+++ b/src/Deployment/RoslynDeployment.csproj
@@ -38,12 +38,6 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>VSIXContainerProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
     </ProjectReference>
-    <ProjectReference Include="..\VisualStudio\VisualStudioInteractiveComponents\Roslyn.VisualStudio.InteractiveComponents.csproj">
-      <Name>VisualStudioInteractiveComponents</Name>
-      <VSIXSubPath>Vsixes</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>VSIXContainerProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="$(MicrosoftVisualStudioSDKAnalyzersVersion)" PrivateAssets="all" />

--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -29,15 +29,6 @@
                 Location="|VisualStudioSetup;VSIXContainerProjectOutputGroup|"
                 Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
     
-    <Dependency d:ProjectName="VisualStudioInteractiveComponents" 
-                DisplayName="Roslyn Interactive Components" 
-                Version="[|%CurrentProject%;GetVsixVersion|,)"
-                d:Source="Project"  
-                d:InstallSource="Embed" 
-                d:VsixSubPath="Vsixes" 
-                Location="|VisualStudioInteractiveComponents;VSIXContainerProjectOutputGroup|" 
-                Id="500fff63-afcf-4195-8db4-3fa8a5180e79" />
-    
     <Dependency  d:ProjectName="ExpressionEvaluatorPackage" 
                  DisplayName="Roslyn Expression Evaluators" 
                  Version="[|%CurrentProject%;GetVsixVersion|,)"


### PR DESCRIPTION
Given we stopped generating the InteractiveComponents VSIX
since #43208, we should not try to include it in the deployment
VSIX either, since this then fails to install because of the
missing payload.

Fixes #45327