### PR TITLE
Use ImmutableArray<string> instead of string for arguments

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -9,8 +10,6 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
 using Roslyn.Test.Utilities;
 using Xunit;
-
-#pragma warning disable CS0618 // Testing obsolete overload
 
 namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 {
@@ -34,7 +33,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 
             Assert.Equal(expected: ReportDiagnostic.Default, actual: options.GeneralDiagnosticOption);
 
-            project.SetOptions($"/ruleset:{ruleSetFile.Path}");
+            project.SetOptions(ImmutableArray.Create($"/ruleset:{ruleSetFile.Path}"));
 
             workspaceProject = environment.Workspace.CurrentSolution.Projects.Single();
             options = (CSharpCompilationOptions)workspaceProject.CompilationOptions;
@@ -59,10 +58,10 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             using var environment = new TestEnvironment();
             using var project = CSharpHelpers.CreateCSharpCPSProject(environment, "Test");
             // Verify SetRuleSetFile updates the ruleset.
-            project.SetOptions($"/ruleset:{ruleSetFile.Path}");
+            project.SetOptions(ImmutableArray.Create($"/ruleset:{ruleSetFile.Path}"));
 
             // We need to explicitly update the command line arguments so the new ruleset is used to update options.
-            project.SetOptions($"/ruleset:{ruleSetFile.Path}");
+            project.SetOptions(ImmutableArray.Create($"/ruleset:{ruleSetFile.Path}"));
             var ca1012DiagnosticOption = environment.Workspace.CurrentSolution.Projects.Single().CompilationOptions.SpecificDiagnosticOptions["CA1012"];
             Assert.Equal(expected: ReportDiagnostic.Error, actual: ca1012DiagnosticOption);
         }
@@ -77,7 +76,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 
             using (var project = CSharpHelpers.CreateCSharpCPSProject(environment, "Test"))
             {
-                project.SetOptions($"/ruleset:{ruleSetFile.Path}");
+                project.SetOptions(ImmutableArray.Create($"/ruleset:{ruleSetFile.Path}"));
 
                 projectId = project.Id;
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
@@ -10,6 +10,8 @@ using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framew
 using Roslyn.Test.Utilities;
 using Xunit;
 
+#pragma warning disable CS0618 // Testing obsolete overload
+
 namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 {
     [UseExportProvider]

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -12,8 +13,6 @@ using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framew
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-
-#pragma warning disable CS0618 // Testing obsolete overload
 
 namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 {
@@ -49,7 +48,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             var options = environment.GetUpdatedCompilationOptionOfSingleProject();
             Assert.Equal(expected: ReportDiagnostic.Error, actual: options.SpecificDiagnosticOptions["CS1111"]);
 
-            project.SetOptions(@"/warnaserror");
+            project.SetOptions(ImmutableArray.Create(@"/warnaserror"));
             options = environment.GetUpdatedCompilationOptionOfSingleProject();
             Assert.False(options.SpecificDiagnosticOptions.ContainsKey("CS1111"));
         }
@@ -68,19 +67,19 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 
             // Change obj output folder from command line arguments - verify that objOutputPath changes, but binOutputPath is the same.
             var newObjPath = @"C:\NewFolder\test.dll";
-            project.SetOptions($"/out:{newObjPath}");
+            project.SetOptions(ImmutableArray.Create($"/out:{newObjPath}"));
             Assert.Equal(newObjPath, project.CompilationOutputAssemblyFilePath);
             Assert.Equal(initialBinPath, project.BinOutputPath);
 
             // Change output file name - verify that objOutputPath changes, but binOutputPath is the same.
             newObjPath = @"C:\NewFolder\test2.dll";
-            project.SetOptions($"/out:{newObjPath}");
+            project.SetOptions(ImmutableArray.Create($"/out:{newObjPath}"));
             Assert.Equal(newObjPath, project.CompilationOutputAssemblyFilePath);
             Assert.Equal(initialBinPath, project.BinOutputPath);
 
             // Change output file name and folder - verify that objOutputPath changes, but binOutputPath is the same.
             newObjPath = @"C:\NewFolder3\test3.dll";
-            project.SetOptions($"/out:{newObjPath}");
+            project.SetOptions(ImmutableArray.Create($"/out:{newObjPath}"));
             Assert.Equal(newObjPath, project.CompilationOutputAssemblyFilePath);
             Assert.Equal(initialBinPath, project.BinOutputPath);
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -13,6 +13,8 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 
+#pragma warning disable CS0618 // Testing obsolete overload
+
 namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 {
     [UseExportProvider]

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
@@ -85,8 +86,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 hierarchy,
                 binOutputPath);
 
-            var commandLineForOptions = string.Join(" ", commandLineArguments);
-            cpsProject.SetOptions(commandLineForOptions);
+            cpsProject.SetOptions(ImmutableArray.Create(commandLineArguments));
 
             return cpsProject;
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
@@ -31,7 +32,10 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         ProjectId Id { get; }
 
         // Options.
+
+        [Obsolete("To avoid contributing to the large object heap, use SetOptions(ImmutableArray<string>). This API will be removed in the future.")]
         void SetOptions(string commandLineForOptions);
+        void SetOptions(ImmutableArray<string> arguments);
 
         // Other project properties.
         void SetProperty(string name, string value);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_ICompilerOptionsHostObject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_ICompilerOptionsHostObject.cs
@@ -10,7 +10,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     {
         int ICompilerOptionsHostObject.SetCompilerOptions(string compilerOptions, out bool supported)
         {
+#pragma warning disable CS0618 // Type or member is obsolete (Legacy API that cannot be changed)
             VisualStudioProjectOptionsProcessor.SetCommandLine(compilerOptions);
+#pragma warning restore CS0618
             supported = true;
             return VSConstants.S_OK;
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -237,7 +237,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // effective values was potentially done by the act of parsing the command line. Even though the command line didn't change textually,
                 // the effective result did. Then we call UpdateProjectOptions_NoLock to reapply any values; that will also re-acquire the new ruleset
                 // includes in the IDE so we can be watching for changes again.
-                var commandLine = _commandLineStorage.ReadLines();
+                var commandLine = _commandLineStorage == null ? ImmutableArray<string>.Empty : _commandLineStorage.ReadLines();
 
                 DisposeOfRuleSetFile_NoLock();
                 ReparseCommandLine_NoLock(commandLine);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis;
@@ -38,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// temp-storage-service. This is helpful as compiler command-lines can grow extremely large
         /// (especially in cases with many references).
         /// </summary>
-        /// <remarks>Note: this will be null in the case that the command line is an empty string.</remarks>
+        /// <remarks>Note: this will be null in the case that the command line is an empty array.</remarks>
         private ITemporaryStreamStorage? _commandLineStorage;
 
         private CommandLineArguments _commandLineArgumentsForCommandLine;
@@ -59,13 +60,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             // Silence NRT warning.  This will be initialized by the call below to ReparseCommandLineIfChanged_NoLock.
             _commandLineArgumentsForCommandLine = null!;
-            ReparseCommandLineIfChanged_NoLock(commandLine: "");
+            ReparseCommandLineIfChanged_NoLock(arguments: ImmutableArray<string>.Empty);
         }
 
         /// <returns><see langword="true"/> if the command line was updated.</returns>
-        private bool ReparseCommandLineIfChanged_NoLock(string commandLine)
+        private bool ReparseCommandLineIfChanged_NoLock(ImmutableArray<string> arguments)
         {
-            var checksum = Checksum.Create(commandLine);
+            var checksum = Checksum.Create(arguments);
             if (_commandLineChecksum == checksum)
                 return false;
 
@@ -76,26 +77,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             _commandLineStorage?.Dispose();
             _commandLineStorage = null;
-            if (commandLine.Length > 0)
+            if (!arguments.IsEmpty)
             {
                 _commandLineStorage = _temporaryStorageService.CreateTemporaryStreamStorage();
-                _commandLineStorage.WriteString(commandLine);
+                _commandLineStorage.WriteAllLines(arguments);
             }
 
-            ReparseCommandLine_NoLock(commandLine);
+            ReparseCommandLine_NoLock(arguments);
             return true;
         }
 
+        [Obsolete("To avoid contributing to the large object heap, use SetOptions(ImmutableArray<string>). This API will be removed in the future.")]
         public void SetCommandLine(string commandLine)
         {
             if (commandLine == null)
                 throw new ArgumentNullException(nameof(commandLine));
 
+            var arguments = CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments: false);
+
+            SetCommandLine(arguments.ToImmutableArray());
+        }
+
+        public void SetCommandLine(ImmutableArray<string> arguments)
+        {
             lock (_gate)
             {
                 // If we actually got a new command line, then update the project options, otherwise
                 // we don't need to do anything.
-                if (ReparseCommandLineIfChanged_NoLock(commandLine))
+                if (ReparseCommandLineIfChanged_NoLock(arguments))
                 {
                     UpdateProjectOptions_NoLock();
                 }
@@ -148,9 +157,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        private void ReparseCommandLine_NoLock(string commandLine)
+        private void ReparseCommandLine_NoLock(ImmutableArray<string> arguments)
         {
-            var arguments = CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments: false);
             _commandLineArgumentsForCommandLine = _commandLineParserService.Parse(arguments, Path.GetDirectoryName(_project.FilePath), isInteractive: false, sdkDirectory: null);
         }
 
@@ -229,7 +237,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // effective values was potentially done by the act of parsing the command line. Even though the command line didn't change textually,
                 // the effective result did. Then we call UpdateProjectOptions_NoLock to reapply any values; that will also re-acquire the new ruleset
                 // includes in the IDE so we can be watching for changes again.
-                var commandLine = _commandLineStorage?.ReadString() ?? "";
+                var commandLine = _commandLineStorage.ReadLines();
 
                 DisposeOfRuleSetFile_NoLock();
                 ReparseCommandLine_NoLock(commandLine);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -140,8 +141,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
         public ProjectId Id => _visualStudioProject.Id;
 
+        [Obsolete("To avoid contributing to the large object heap, use SetOptions(ImmutableArray<string>). This API will be removed in the future.")]
         public void SetOptions(string commandLineForOptions)
             => _visualStudioProjectOptionsProcessor?.SetCommandLine(commandLineForOptions);
+
+        public void SetOptions(ImmutableArray<string> arguments)
+            => _visualStudioProjectOptionsProcessor?.SetCommandLine(arguments);
 
         public string? DefaultNamespace
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
             foreach (var value in values)
             {
                 AppendData(hash, pooledBuffer.Object, value);
-                AppendData(hash, pooledBuffer.Object, ";");
+                AppendData(hash, pooledBuffer.Object, "\0");
             }
 
             return From(hash.GetHashAndReset());

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -22,27 +22,28 @@ namespace Microsoft.CodeAnalysis
         private static readonly ObjectPool<IncrementalHash> s_incrementalHashPool =
             new ObjectPool<IncrementalHash>(() => IncrementalHash.CreateHash(HashAlgorithmName.SHA256), size: 20);
 
-        public static Checksum Create(string val)
+        public static Checksum Create(IEnumerable<string> values)
         {
             using var pooledHash = s_incrementalHashPool.GetPooledObject();
             using var pooledBuffer = SharedPools.ByteArray.GetPooledObject();
             var hash = pooledHash.Object;
 
-            var stringBytes = MemoryMarshal.AsBytes(val.AsSpan());
-            Debug.Assert(stringBytes.Length == val.Length * 2);
-            var buffer = pooledBuffer.Object;
-
-            var index = 0;
-            while (index < stringBytes.Length)
+            foreach (var value in values)
             {
-                var remaining = stringBytes.Length - index;
-                var toCopy = Math.Min(remaining, buffer.Length);
-
-                stringBytes.Slice(index, toCopy).CopyTo(buffer);
-                hash.AppendData(buffer, 0, toCopy);
-
-                index += toCopy;
+                AppendData(hash, pooledBuffer.Object, value);
+                AppendData(hash, pooledBuffer.Object, ";");
             }
+
+            return From(hash.GetHashAndReset());
+        }
+
+        public static Checksum Create(string value)
+        {
+            using var pooledHash = s_incrementalHashPool.GetPooledObject();
+            using var pooledBuffer = SharedPools.ByteArray.GetPooledObject();
+            var hash = pooledHash.Object;
+
+            AppendData(hash, pooledBuffer.Object, value);
 
             return From(hash.GetHashAndReset());
         }
@@ -144,6 +145,24 @@ namespace Microsoft.CodeAnalysis
 
             stream.Position = 0;
             return Create(stream);
+        }
+
+        private static void AppendData(IncrementalHash hash, byte[] buffer, string value)
+        {
+            var stringBytes = MemoryMarshal.AsBytes(value.AsSpan());
+            Debug.Assert(stringBytes.Length == value.Length * 2);
+
+            var index = 0;
+            while (index < stringBytes.Length)
+            {
+                var remaining = stringBytes.Length - index;
+                var toCopy = Math.Min(remaining, buffer.Length);
+
+                stringBytes.Slice(index, toCopy).CopyTo(buffer);
+                hash.AppendData(buffer, 0, toCopy);
+
+                index += toCopy;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: #32594.

This converts from a flat string to represent the command-line to an ImmutableArray<string> to avoid the string ending up on the LOH.