### PR TITLE
Fix crash in 'replace property with methods' when updating object initializers

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -1124,3 +1124,4 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
     End Class
 End Namespace
+

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -1843,6 +1843,50 @@ class C : IGoo
 }");
         }
 
+        [WorkItem(45171, "https://github.com/dotnet/roslyn/issues/45171")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestReferenceInObjectInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class Tweet
+{
+    public string [||]Tweet { get; }
+}
+
+class C
+{
+    void Main()
+    {
+        var t = new Tweet();
+        var t1 = new Tweet
+        {
+            Tweet = t.Tweet
+        };
+    }
+}",
+@"public class Tweet
+{
+    private readonly string tweet;
+
+    public string GetTweet()
+    {
+        return tweet;
+    }
+}
+
+class C
+{
+    void Main()
+    {
+        var t = new Tweet();
+        var t1 = new Tweet
+        {
+            {|Conflict:Tweet|} = t.GetTweet()
+        };
+    }
+}");
+        }
+
         private OptionsCollection PreferExpressionBodiedMethods =>
             new OptionsCollection(GetLanguage()) { { CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCodeStyleOptions.WhenPossibleWithSuggestionEnforcement } };
     }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
@@ -664,5 +664,45 @@ Class C
     End Sub
 End Class")
         End Function
+
+        <WorkItem(45171, "https://github.com/dotnet/roslyn/issues/45171")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)>
+        Public Async Function TestReferenceInObjectInitializer() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Class Tweet
+    Public Property [||]Tweet As String
+End Class
+
+Class C 
+    Sub Main()
+        Dim t = New Tweet
+        Dim t1 = New Tweet With {
+            .Tweet = t.Tweet   
+        }
+
+    End Sub
+End Class",
+"Public Class Tweet
+    Private _Tweet As String
+
+    Public Function GetTweet() As String
+        Return _Tweet
+    End Function
+
+    Public Sub SetTweet(AutoPropertyValue As String)
+        _Tweet = AutoPropertyValue
+    End Sub
+End Class
+
+Class C 
+    Sub Main()
+        Dim t = New Tweet
+        Dim t1 = New Tweet With {
+            .{|Conflict:Tweet|} = t.GetTweet()
+        }
+
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
+++ b/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -16,7 +18,9 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.ReplacePropertyWithMethods;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
@@ -31,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
         {
         }
 
-        public override async Task<IList<SyntaxNode>> GetReplacementMembersAsync(
+        public override async Task<ImmutableArray<SyntaxNode>> GetReplacementMembersAsync(
             Document document,
             IPropertySymbol property,
             SyntaxNode propertyDeclarationNode,
@@ -41,12 +45,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             CancellationToken cancellationToken)
         {
             if (!(propertyDeclarationNode is PropertyDeclarationSyntax propertyDeclaration))
-            {
-                return SpecializedCollections.EmptyList<SyntaxNode>();
-            }
+                return ImmutableArray<SyntaxNode>.Empty;
 
             var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var parseOptions = syntaxTree.Options;
 
             return ConvertPropertyToMembers(
@@ -57,18 +59,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
                 cancellationToken);
         }
 
-        private static List<SyntaxNode> ConvertPropertyToMembers(
+        private static ImmutableArray<SyntaxNode> ConvertPropertyToMembers(
             DocumentOptionSet documentOptions,
             ParseOptions parseOptions,
             SyntaxGenerator generator,
             IPropertySymbol property,
             PropertyDeclarationSyntax propertyDeclaration,
-            IFieldSymbol propertyBackingField,
+            IFieldSymbol? propertyBackingField,
             string desiredGetMethodName,
             string desiredSetMethodName,
             CancellationToken cancellationToken)
         {
-            var result = new List<SyntaxNode>();
+            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var result);
 
             if (propertyBackingField != null)
             {
@@ -96,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
                     cancellationToken: cancellationToken));
             }
 
-            return result;
+            return result.ToImmutable();
         }
 
         private static SyntaxNode GetSetMethod(
@@ -104,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             ParseOptions parseOptions,
             SyntaxGenerator generator,
             PropertyDeclarationSyntax propertyDeclaration,
-            IFieldSymbol propertyBackingField,
+            IFieldSymbol? propertyBackingField,
             IMethodSymbol setMethod,
             string desiredSetMethodName,
             CancellationToken cancellationToken)
@@ -125,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
         private static MethodDeclarationSyntax GetSetMethodWorker(
             SyntaxGenerator generator,
             PropertyDeclarationSyntax propertyDeclaration,
-            IFieldSymbol propertyBackingField,
+            IFieldSymbol? propertyBackingField,
             IMethodSymbol setMethod,
             string desiredSetMethodName,
             CancellationToken cancellationToken)
@@ -168,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             ParseOptions parseOptions,
             SyntaxGenerator generator,
             PropertyDeclarationSyntax propertyDeclaration,
-            IFieldSymbol propertyBackingField,
+            IFieldSymbol? propertyBackingField,
             IMethodSymbol getMethod,
             string desiredGetMethodName,
             CancellationToken cancellationToken)
@@ -207,8 +209,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
         private static SyntaxTrivia ConvertDocumentationComment(SyntaxTrivia trivia, CSharpSyntaxRewriter rewriter)
         {
             var structure = trivia.GetStructure();
-            var updatedStructure = (StructuredTriviaSyntax)rewriter.Visit(structure);
-            return SyntaxFactory.Trivia(updatedStructure);
+            var rewritten = rewriter.Visit(structure);
+            Contract.ThrowIfNull(rewritten);
+            return SyntaxFactory.Trivia((StructuredTriviaSyntax)rewritten);
         }
 
         private static SyntaxNode UseExpressionOrBlockBodyIfDesired(
@@ -216,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             MethodDeclarationSyntax methodDeclaration, bool createReturnStatementForExpression)
         {
             var expressionBodyPreference = documentOptions.GetOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods).Value;
-            if (methodDeclaration?.Body != null && expressionBodyPreference != ExpressionBodyPreference.Never)
+            if (methodDeclaration.Body != null && expressionBodyPreference != ExpressionBodyPreference.Never)
             {
                 if (methodDeclaration.Body.TryConvertToArrowExpressionBody(
                         methodDeclaration.Kind(), parseOptions, expressionBodyPreference,
@@ -228,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
                                             .WithAdditionalAnnotations(Formatter.Annotation);
                 }
             }
-            else if (methodDeclaration?.ExpressionBody != null && expressionBodyPreference == ExpressionBodyPreference.Never)
+            else if (methodDeclaration.ExpressionBody != null && expressionBodyPreference == ExpressionBodyPreference.Never)
             {
                 if (methodDeclaration.ExpressionBody.TryConvertToBlock(
                         methodDeclaration.SemicolonToken, createReturnStatementForExpression, out var block))
@@ -246,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
         private static MethodDeclarationSyntax GetGetMethodWorker(
             SyntaxGenerator generator,
             PropertyDeclarationSyntax propertyDeclaration,
-            IFieldSymbol propertyBackingField,
+            IFieldSymbol? propertyBackingField,
             IMethodSymbol getMethod,
             string desiredGetMethodName,
             CancellationToken cancellationToken)
@@ -305,10 +308,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             return propertyDeclaration;
         }
 
-        protected override NameMemberCrefSyntax TryGetCrefSyntax(IdentifierNameSyntax identifierName)
+        protected override NameMemberCrefSyntax? TryGetCrefSyntax(IdentifierNameSyntax identifierName)
             => identifierName.Parent as NameMemberCrefSyntax;
 
-        protected override NameMemberCrefSyntax CreateCrefSyntax(NameMemberCrefSyntax originalCref, SyntaxToken identifierToken, SyntaxNode parameterType)
+        protected override NameMemberCrefSyntax CreateCrefSyntax(NameMemberCrefSyntax originalCref, SyntaxToken identifierToken, SyntaxNode? parameterType)
         {
             CrefParameterListSyntax parameterList;
             if (parameterType is TypeSyntax typeSyntax)

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2777,4 +2777,7 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Generate_constructor_in_0_with_properties" xml:space="preserve">
     <value>Generate constructor in '{0}' (with properties)</value>
   </data>
+  <data name="Property_reference_cannot_be_updated" xml:space="preserve">
+    <value>Property reference cannot be updated</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -27,9 +28,9 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
         where TPropertySyntax : SyntaxNode
     {
         public abstract SyntaxNode GetPropertyNodeToReplace(SyntaxNode propertyDeclaration);
-        public abstract Task<IList<SyntaxNode>> GetReplacementMembersAsync(Document document, IPropertySymbol property, SyntaxNode propertyDeclaration, IFieldSymbol propertyBackingField, string desiredGetMethodName, string desiredSetMethodName, CancellationToken cancellationToken);
+        public abstract Task<ImmutableArray<SyntaxNode>> GetReplacementMembersAsync(Document document, IPropertySymbol property, SyntaxNode propertyDeclaration, IFieldSymbol propertyBackingField, string desiredGetMethodName, string desiredSetMethodName, CancellationToken cancellationToken);
 
-        protected abstract TCrefSyntax TryGetCrefSyntax(TIdentifierNameSyntax identifierName);
+        protected abstract TCrefSyntax? TryGetCrefSyntax(TIdentifierNameSyntax identifierName);
         protected abstract TCrefSyntax CreateCrefSyntax(TCrefSyntax originalCref, SyntaxToken identifierToken, SyntaxNode? parameterType);
 
         protected abstract TExpressionSyntax UnwrapCompoundAssignment(SyntaxNode compoundAssignment, TExpressionSyntax readExpression);
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
 
             private readonly TIdentifierNameSyntax _identifierName;
             private readonly TExpressionSyntax _expression;
-            private readonly TCrefSyntax _cref;
+            private readonly TCrefSyntax? _cref;
             private readonly CancellationToken _cancellationToken;
 
             public ReferenceReplacer(
@@ -95,7 +96,8 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                 ISemanticFactsService semanticFacts,
                 SyntaxEditor editor,
                 TIdentifierNameSyntax identifierName,
-                IPropertySymbol property, IFieldSymbol propertyBackingField,
+                IPropertySymbol property,
+                IFieldSymbol propertyBackingField,
                 string desiredGetMethodName,
                 string desiredSetMethodName,
                 CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/IReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/IReplacePropertyWithMethodsService.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             string desiredGetMethodName, string desiredSetMethodName,
             CancellationToken cancellationToken);
 
-        Task<IList<SyntaxNode>> GetReplacementMembersAsync(
+        Task<ImmutableArray<SyntaxNode>> GetReplacementMembersAsync(
             Document document,
             IPropertySymbol property, SyntaxNode propertyDeclaration,
             IFieldSymbol propertyBackingField,

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -17,6 +19,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
@@ -41,18 +44,16 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             var (document, _, cancellationToken) = context;
             var service = document.GetLanguageService<IReplacePropertyWithMethodsService>();
             if (service == null)
-            {
                 return;
-            }
 
             var propertyDeclaration = await service.GetPropertyDeclarationAsync(context).ConfigureAwait(false);
             if (propertyDeclaration == null)
-            {
                 return;
-            }
 
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration) as IPropertySymbol;
+
+            Contract.ThrowIfNull(propertySymbol);
             var propertyName = propertySymbol.Name;
 
             var accessorCount =
@@ -115,9 +116,9 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             return updatedSolution;
         }
 
-        private static Dictionary<IPropertySymbol, IFieldSymbol> CreateDefinitionToBackingFieldMap(IEnumerable<ReferencedSymbol> propertyReferences)
+        private static ImmutableDictionary<IPropertySymbol, IFieldSymbol?> CreateDefinitionToBackingFieldMap(IEnumerable<ReferencedSymbol> propertyReferences)
         {
-            var definitionToBackingField = new Dictionary<IPropertySymbol, IFieldSymbol>(SymbolEquivalenceComparer.Instance);
+            var definitionToBackingField = ImmutableDictionary.CreateBuilder<IPropertySymbol, IFieldSymbol?>(SymbolEquivalenceComparer.Instance);
 
             foreach (var reference in propertyReferences)
             {
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                 }
             }
 
-            return definitionToBackingField;
+            return definitionToBackingField.ToImmutable();
         }
 
         private static bool HasAnyMatchingGetOrSetMethods(IPropertySymbol property, string name)
@@ -156,21 +157,17 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                                     comparer.Equals(m.Parameters[0].Type, property.Type));
         }
 
-        private static IFieldSymbol GetBackingField(IPropertySymbol property)
+        private static IFieldSymbol? GetBackingField(IPropertySymbol property)
         {
             var field = property.GetBackingFieldIfAny();
             if (field == null)
-            {
                 return null;
-            }
 
             // If the field is something can be referenced with the name it has, then just use
             // it as the backing field we'll generate.  This is the case in VB where the backing
             // field can be referenced as is.
             if (field.CanBeReferencedByName)
-            {
                 return field;
-            }
 
             // Otherwise, generate a good name for the backing field we're generating.  This is
             // the case for C# where we have mangled names for the backing field and need something
@@ -188,7 +185,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
         }
 
 #pragma warning disable IDE0060 // Remove unused parameter - Method not completely implemented.
-        private static string GetDefinitionIssues(IEnumerable<ReferencedSymbol> getMethodReferences)
+        private static string? GetDefinitionIssues(IEnumerable<ReferencedSymbol> getMethodReferences)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
             // TODO: add things to be concerned about here.  For example:
@@ -201,7 +198,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
         private static async Task<Solution> UpdateReferencesAsync(
             Solution updatedSolution,
             ILookup<Document, (IPropertySymbol property, ReferenceLocation location)> referencesByDocument,
-            Dictionary<IPropertySymbol, IFieldSymbol> propertyToBackingField,
+            ImmutableDictionary<IPropertySymbol, IFieldSymbol?> propertyToBackingField,
             string desiredGetMethodName, string desiredSetMethodName,
             CancellationToken cancellationToken)
         {
@@ -220,14 +217,14 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             Solution updatedSolution,
             Document originalDocument,
             IEnumerable<(IPropertySymbol property, ReferenceLocation location)> references,
-            Dictionary<IPropertySymbol, IFieldSymbol> propertyToBackingField,
+            ImmutableDictionary<IPropertySymbol, IFieldSymbol?> propertyToBackingField,
             string desiredGetMethodName, string desiredSetMethodName,
             CancellationToken cancellationToken)
         {
-            var root = await originalDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var root = await originalDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var editor = new SyntaxEditor(root, originalDocument.Project.Solution.Workspace);
-            var service = originalDocument.GetLanguageService<IReplacePropertyWithMethodsService>();
+            var service = originalDocument.GetRequiredLanguageService<IReplacePropertyWithMethodsService>();
 
             await ReplaceReferencesAsync(
                 originalDocument, references, propertyToBackingField, root, editor, service,
@@ -241,7 +238,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
         private static async Task ReplaceReferencesAsync(
             Document originalDocument,
             IEnumerable<(IPropertySymbol property, ReferenceLocation location)> references,
-            IDictionary<IPropertySymbol, IFieldSymbol> propertyToBackingField,
+            IDictionary<IPropertySymbol, IFieldSymbol?> propertyToBackingField,
             SyntaxNode root, SyntaxEditor editor,
             IReplacePropertyWithMethodsService service,
             string desiredGetMethodName, string desiredSetMethodName,
@@ -249,33 +246,32 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
         {
             if (references != null)
             {
-                var syntaxFacts = originalDocument.GetLanguageService<ISyntaxFactsService>();
+                var syntaxFacts = originalDocument.GetRequiredLanguageService<ISyntaxFactsService>();
 
-                foreach (var tuple in references)
+                foreach (var (property, referenceLocation) in references)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var property = tuple.property;
-                    var referenceLocation = tuple.location;
                     var location = referenceLocation.Location;
                     var nameToken = root.FindToken(location.SourceSpan.Start, findInsideTrivia: true);
 
                     var parent = nameToken.Parent;
+                    Contract.ThrowIfNull(parent);
 
                     if (referenceLocation.IsImplicit || !syntaxFacts.IsIdentifierName(parent))
                     {
                         // Warn the user that we can't properly replace this property with a method.
-                        editor.ReplaceNode(parent, nameToken.Parent.WithAdditionalAnnotations(
+                        editor.ReplaceNode(parent, parent.WithAdditionalAnnotations(
                             ConflictAnnotation.Create(FeaturesResources.Property_referenced_implicitly)));
                     }
                     else if (syntaxFacts.IsObjectInitializerNamedAssignmentIdentifier(parent))
                     {
-                        editor.ReplaceNode(parent, nameToken.Parent.WithAdditionalAnnotations(
+                        editor.ReplaceNode(parent, parent.WithAdditionalAnnotations(
                             ConflictAnnotation.Create(FeaturesResources.Property_reference_cannot_be_updated)));
                     }
                     else
                     {
-                        var fieldSymbol = propertyToBackingField.GetValueOrDefault(tuple.property);
+                        var fieldSymbol = propertyToBackingField.GetValueOrDefault(property);
                         await service.ReplaceReferenceAsync(
                             originalDocument, editor, parent,
                             property, fieldSymbol,
@@ -289,7 +285,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             Solution originalSolution,
             Solution updatedSolution,
             IEnumerable<ReferencedSymbol> references,
-            IDictionary<IPropertySymbol, IFieldSymbol> definitionToBackingField,
+            ImmutableDictionary<IPropertySymbol, IFieldSymbol?> definitionToBackingField,
             string desiredGetMethodName, string desiredSetMethodName,
             CancellationToken cancellationToken)
         {
@@ -339,21 +335,20 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             Solution updatedSolution,
             DocumentId documentId,
             MultiDictionary<DocumentId, IPropertySymbol>.ValueSet originalDefinitions,
-            IDictionary<IPropertySymbol, IFieldSymbol> definitionToBackingField,
+            IDictionary<IPropertySymbol, IFieldSymbol?> definitionToBackingField,
             string desiredGetMethodName, string desiredSetMethodName,
             CancellationToken cancellationToken)
         {
-            var updatedDocument = updatedSolution.GetDocument(documentId);
-            var compilation = await updatedDocument.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var updatedDocument = updatedSolution.GetRequiredDocument(documentId);
+            var semanticModel = await updatedDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             // We've already gone and updated all references.  So now re-resolve all the definitions
             // in the current compilation to find their updated location.
             var currentDefinitions = await GetCurrentPropertiesAsync(
-                updatedSolution, compilation, documentId, originalDefinitions, cancellationToken).ConfigureAwait(false);
+                updatedSolution, semanticModel.Compilation, documentId, originalDefinitions, cancellationToken).ConfigureAwait(false);
 
-            var service = updatedDocument.GetLanguageService<IReplacePropertyWithMethodsService>();
+            var service = updatedDocument.GetRequiredLanguageService<IReplacePropertyWithMethodsService>();
 
-            var semanticModel = await updatedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var editor = new SyntaxEditor(root, updatedSolution.Workspace);
@@ -376,7 +371,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                 {
                     members = members.Select(editor.Generator.AsInterfaceMember)
                                      .WhereNotNull()
-                                     .ToList();
+                                     .ToImmutableArray();
                 }
 
                 var nodeToReplace = service.GetPropertyNodeToReplace(declaration);
@@ -387,14 +382,14 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
             return updatedSolution.WithDocumentSyntaxRoot(documentId, editor.GetChangedRoot());
         }
 
-        private static async Task<List<(IPropertySymbol property, SyntaxNode declaration)>> GetCurrentPropertiesAsync(
+        private static async Task<ImmutableArray<(IPropertySymbol property, SyntaxNode declaration)>> GetCurrentPropertiesAsync(
             Solution updatedSolution,
             Compilation compilation,
             DocumentId documentId,
             MultiDictionary<DocumentId, IPropertySymbol>.ValueSet originalDefinitions,
             CancellationToken cancellationToken)
         {
-            var result = new List<(IPropertySymbol property, SyntaxNode declaration)>();
+            using var _ = ArrayBuilder<(IPropertySymbol property, SyntaxNode declaration)>.GetInstance(out var result);
             foreach (var originalDefinition in originalDefinitions)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -402,29 +397,25 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                 var property = GetSymbolInCurrentCompilation(compilation, originalDefinition, cancellationToken);
                 var declaration = await GetPropertyDeclarationAsync(property, cancellationToken).ConfigureAwait(false);
 
-                if (declaration != null && updatedSolution.GetDocument(declaration.SyntaxTree)?.Id == documentId)
-                {
+                if (property != null && declaration != null && updatedSolution.GetDocument(declaration.SyntaxTree)?.Id == documentId)
                     result.Add((property, declaration));
-                }
             }
 
-            return result;
+            return result.ToImmutable();
         }
 
-        private static async Task<SyntaxNode> GetPropertyDeclarationAsync(
-            IPropertySymbol property, CancellationToken cancellationToken)
+        private static async Task<SyntaxNode?> GetPropertyDeclarationAsync(
+            IPropertySymbol? property, CancellationToken cancellationToken)
         {
             if (property == null)
-            {
                 return null;
-            }
 
             Debug.Assert(property.DeclaringSyntaxReferences.Length == 1);
             var reference = property.DeclaringSyntaxReferences[0];
             return await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private static TSymbol GetSymbolInCurrentCompilation<TSymbol>(Compilation compilation, TSymbol originalDefinition, CancellationToken cancellationToken)
+        private static TSymbol? GetSymbolInCurrentCompilation<TSymbol>(Compilation compilation, TSymbol originalDefinition, CancellationToken cancellationToken)
             where TSymbol : class, ISymbol
         {
             return originalDefinition.GetSymbolKey(cancellationToken).Resolve(compilation, cancellationToken: cancellationToken).GetAnySymbol() as TSymbol;

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
@@ -268,6 +268,11 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                         editor.ReplaceNode(parent, nameToken.Parent.WithAdditionalAnnotations(
                             ConflictAnnotation.Create(FeaturesResources.Property_referenced_implicitly)));
                     }
+                    else if (syntaxFacts.IsObjectInitializerNamedAssignmentIdentifier(parent))
+                    {
+                        editor.ReplaceNode(parent, nameToken.Parent.WithAdditionalAnnotations(
+                            ConflictAnnotation.Create(FeaturesResources.Property_reference_cannot_be_updated)));
+                    }
                     else
                     {
                         var fieldSymbol = propertyToBackingField.GetValueOrDefault(tuple.property);

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
@@ -295,12 +295,9 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
         {
             var definitionsByDocumentId = await GetDefinitionsByDocumentIdAsync(originalSolution, references, cancellationToken).ConfigureAwait(false);
 
-            foreach (var kvp in definitionsByDocumentId)
+            foreach (var (documentId, definitions) in definitionsByDocumentId)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-
-                var documentId = kvp.Key;
-                var definitions = kvp.Value;
 
                 updatedSolution = await ReplaceDefinitionsWithMethodsAsync(
                     updatedSolution, documentId, definitions, definitionToBackingField,

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Povýšit {0}</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">"{0}" nach oben ziehen</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Extraer "{0}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Tirer '{0}' vers le haut</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Esegui pull '{0}' al livello superiore</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">最大 '{0}' 個をプル</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">'{0}' 끌어오기</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Ściągnij element „{0}” w górę</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Efetuar pull de '{0}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">Извлечь "{0}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">'{0}' öğesini yukarı çek</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">向上拉 "{0}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -620,6 +620,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="new">Not enough )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (a</note>
       </trans-unit>
+      <trans-unit id="Property_reference_cannot_be_updated">
+        <source>Property reference cannot be updated</source>
+        <target state="new">Property reference cannot be updated</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pull_0_up">
         <source>Pull '{0}' up</source>
         <target state="translated">向上提取 ‘{0}’</target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/45171