### PR TITLE
Document and test how CanApplyParse/CompilationOptions works

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1383,9 +1383,29 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// Called during a call to <see cref="TryApplyChanges(Solution)"/> to determine if a specific change to <see cref="Project.CompilationOptions"/> is allowed.
+        /// </summary>
+        /// <remarks>
+        /// This method is only called if <see cref="CanApplyChange" /> returns false for <see cref="ApplyChangesKind.ChangeCompilationOptions"/>.
+        /// If <see cref="CanApplyChange" /> returns true, then that means all changes are allowed and this method does not need to be called.
+        /// </remarks>
+        /// <param name="oldOptions">The old <see cref="CompilationOptions"/> of the project from prior to the change.</param>
+        /// <param name="newOptions">The new <see cref="CompilationOptions"/> of the project that was passed to <see cref="TryApplyChanges(Solution)"/>.</param>
+        /// <param name="project">The project contained in the <see cref="Solution"/> passed to <see cref="TryApplyChanges(Solution)"/>.</param>
         protected virtual bool CanApplyCompilationOptionChange(CompilationOptions oldOptions, CompilationOptions newOptions, Project project)
             => false;
 
+        /// <summary>
+        /// Called during a call to <see cref="TryApplyChanges(Solution)"/> to determine if a specific change to <see cref="Project.ParseOptions"/> is allowed.
+        /// </summary>
+        /// <remarks>
+        /// This method is only called if <see cref="CanApplyChange" /> returns false for <see cref="ApplyChangesKind.ChangeParseOptions"/>.
+        /// If <see cref="CanApplyChange" /> returns true, then that means all changes are allowed and this method does not need to be called.
+        /// </remarks>
+        /// <param name="oldOptions">The old <see cref="ParseOptions"/> of the project from prior to the change.</param>
+        /// <param name="newOptions">The new <see cref="ParseOptions"/> of the project that was passed to <see cref="TryApplyChanges(Solution)"/>.</param>
+        /// <param name="project">The project contained in the <see cref="Solution"/> passed to <see cref="TryApplyChanges(Solution)"/>.</param>
         public virtual bool CanApplyParseOptionChange(ParseOptions oldOptions, ParseOptions newOptions, Project project)
             => false;
 
@@ -1642,7 +1662,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected virtual void ApplyCompilationOptionsChanged(ProjectId projectId, CompilationOptions options)
         {
-            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeCompilationOptions));
+#if DEBUG
+            var oldProject = CurrentSolution.GetRequiredProject(projectId);
+            var newProjectForAssert = oldProject.WithCompilationOptions(options);
+
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeCompilationOptions) ||
+                         CanApplyCompilationOptionChange(oldProject.CompilationOptions!, options, newProjectForAssert));
+#endif
+
             this.OnCompilationOptionsChanged(projectId, options);
         }
 
@@ -1653,7 +1680,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected virtual void ApplyParseOptionsChanged(ProjectId projectId, ParseOptions options)
         {
-            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeParseOptions));
+#if DEBUG
+            var oldProject = CurrentSolution.GetRequiredProject(projectId);
+            var newProjectForAssert = oldProject.WithParseOptions(options);
+
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeParseOptions) ||
+                         CanApplyParseOptionChange(oldProject.ParseOptions!, options, newProjectForAssert));
+#endif
             this.OnParseOptionsChanged(projectId, options);
         }
 

--- a/src/Workspaces/CoreTest/SolutionTests/TryApplyChangesTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/TryApplyChangesTests.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    [UseExportProvider]
+    public class TryApplyChangesTests
+    {
+        private class CustomizedCanApplyWorkspace : Workspace
+        {
+            private readonly ImmutableArray<ApplyChangesKind> _allowedKinds;
+            private readonly Func<ParseOptions, ParseOptions, bool>? _canApplyParseOptions;
+            private readonly Func<CompilationOptions, CompilationOptions, bool>? _canApplyCompilationOptions;
+
+            public CustomizedCanApplyWorkspace(params ApplyChangesKind[] allowedKinds)
+                : this(allowedKinds, canApplyParseOptions: null)
+            {
+            }
+
+            public CustomizedCanApplyWorkspace(ApplyChangesKind[] allowedKinds,
+                Func<ParseOptions, ParseOptions, bool>? canApplyParseOptions = null,
+                Func<CompilationOptions, CompilationOptions, bool>? canApplyCompilationOptions = null)
+                : base(Host.Mef.MefHostServices.DefaultHost, workspaceKind: nameof(CustomizedCanApplyWorkspace))
+            {
+                _allowedKinds = allowedKinds.ToImmutableArray();
+                _canApplyParseOptions = canApplyParseOptions;
+                _canApplyCompilationOptions = canApplyCompilationOptions;
+
+                // Add a C# project automatically so each test has something to try mutating
+                OnProjectAdded(ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Default, "TestProject", "TestProject", LanguageNames.CSharp));
+            }
+
+            public override bool CanApplyChange(ApplyChangesKind feature)
+            {
+                return _allowedKinds.Contains(feature);
+            }
+
+            public override bool CanApplyParseOptionChange(ParseOptions oldOptions, ParseOptions newOptions, Project project)
+            {
+                if (_canApplyParseOptions != null)
+                {
+                    return _canApplyParseOptions(oldOptions, newOptions);
+                }
+
+                return base.CanApplyParseOptionChange(oldOptions, newOptions, project);
+            }
+
+            protected override bool CanApplyCompilationOptionChange(CompilationOptions oldOptions, CompilationOptions newOptions, Project project)
+            {
+                if (_canApplyCompilationOptions != null)
+                {
+                    return _canApplyCompilationOptions(oldOptions, newOptions);
+                }
+
+                return base.CanApplyCompilationOptionChange(oldOptions, newOptions, project);
+            }
+        }
+
+        [Fact]
+        public void TryApplyWorksIfAllowingAnyCompilationOption()
+        {
+            // If we simply support the main change kind, then any type of change should be supported and we should not get called
+            // to the other method
+            using var workspace = new CustomizedCanApplyWorkspace(
+                allowedKinds: new[] { ApplyChangesKind.ChangeCompilationOptions },
+                canApplyCompilationOptions: (_, __) => throw new Exception("This should not have been called."));
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            Assert.True(workspace.TryApplyChanges(project.WithCompilationOptions(project.CompilationOptions!.WithMainTypeName("Test")).Solution));
+        }
+
+        [Fact]
+        public void TryApplyWorksSpecificChangeIsAllowedForCompilationOption()
+        {
+            // If we don't support the main change kind, then the other method should be called
+            using var workspace = new CustomizedCanApplyWorkspace(
+                allowedKinds: new ApplyChangesKind[] { },
+                canApplyCompilationOptions: (_, newCompilationOptions) => newCompilationOptions.MainTypeName == "Test");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            Assert.True(workspace.TryApplyChanges(project.WithCompilationOptions(project.CompilationOptions!.WithMainTypeName("Test")).Solution));
+        }
+
+        [Fact]
+        public void TryApplyWorksThrowsIfChangeIsDisallowedForCompilationOption()
+        {
+            // If we don't support the main change kind, then the other method should be called
+            using var workspace = new CustomizedCanApplyWorkspace(
+                allowedKinds: new ApplyChangesKind[] { },
+                canApplyCompilationOptions: (_, newCompilationOptions) => newCompilationOptions.MainTypeName == "Expected");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            var exception = Assert.Throws<NotSupportedException>(
+                () => workspace.TryApplyChanges(project.WithCompilationOptions(project.CompilationOptions!.WithMainTypeName("WrongThing")).Solution));
+
+            Assert.Equal(WorkspacesResources.Changing_compilation_options_is_not_supported, exception.Message);
+        }
+
+        [Fact]
+        public void TryApplyWorksIfAllowingAnyParseOption()
+        {
+            // If we simply support the main change kind, then any type of change should be supported and we should not get called
+            // to the other method
+            using var workspace = new CustomizedCanApplyWorkspace(
+                allowedKinds: new[] { ApplyChangesKind.ChangeParseOptions },
+                canApplyParseOptions: (_, __) => throw new Exception("This should not have been called."));
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            Assert.True(workspace.TryApplyChanges(
+                project.WithParseOptions(
+                    project.ParseOptions!.WithFeatures(new[] { KeyValuePairUtil.Create("Feature", "") })).Solution));
+        }
+
+        [Fact]
+        public void TryApplyWorksSpecificChangeIsAllowedForParseOption()
+        {
+            // If we don't support the main change kind, then the other method should be called
+            using var workspace = new CustomizedCanApplyWorkspace(
+                allowedKinds: new ApplyChangesKind[] { },
+                canApplyParseOptions: (_, newParseOptions) => newParseOptions.Features["Feature"] == "ExpectedValue");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            Assert.True(
+                workspace.TryApplyChanges(
+                    project.WithParseOptions(project.ParseOptions!.WithFeatures(new[] { KeyValuePairUtil.Create("Feature", "ExpectedValue") })).Solution));
+        }
+
+        [Fact]
+        public void TryApplyWorksThrowsIfChangeIsDisallowedForParseOption()
+        {
+            // If we don't support the main change kind, then the other method should be called
+            using var workspace = new CustomizedCanApplyWorkspace(
+                allowedKinds: new ApplyChangesKind[] { },
+                canApplyParseOptions: (_, newParseOptions) => newParseOptions.Features["Feature"] == "ExpectedValue");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            var exception = Assert.Throws<NotSupportedException>(
+                () => workspace.TryApplyChanges(
+                    project.WithParseOptions(project.ParseOptions!.WithFeatures(new[] { KeyValuePairUtil.Create("Feature", "WrongThing") })).Solution));
+
+            Assert.Equal(WorkspacesResources.Changing_parse_options_is_not_supported, exception.Message);
+        }
+
+        [Fact]
+        public void TryApplyWorksWhenAddingEditorConfigWithoutSupportingCompilationOptionsChanging()
+        {
+            using var workspace = new CustomizedCanApplyWorkspace(allowedKinds: ApplyChangesKind.AddAnalyzerConfigDocument);
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            Assert.True(workspace.TryApplyChanges(project.AddAnalyzerConfigDocument(".editorconfig", SourceText.From("")).Project.Solution));
+        }
+    }
+}


### PR DESCRIPTION
A workspace can customize which changes are allowed to be applied through TryApplyChanges. There's a CanApplyChanges that generally is called with each type of change which you can opt in for. There is also a specific overloads for filtering specific changes to CompilationOptions or ParseOptions, since a host may support changing some of those but not all of them.

This documents our existing behavior and adds tests to confirm the behavior. There were some Debug.Asserts() that are incorrect and are now fixed.