### PR TITLE
Perf improvement for completion of unimported extension methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
@@ -1537,6 +1537,92 @@ namespace NS1
                 inlineDescription: "NS2");
         }
 
+        [InlineData(ReferenceType.Project, "(int,int)")]
+        [InlineData(ReferenceType.Project, "(int,int,int,int,int,int,int,int,int,int)")]    // more than 8 tuple elements
+        [InlineData(ReferenceType.Metadata, "(int,int)")]
+        [InlineData(ReferenceType.Metadata, "(int,int,int,int,int,int,int,int,int,int)")]   // more than 8 tuple elements
+        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestTupleArray(ReferenceType refType, string tupleType)
+        {
+            var refDoc = $@"
+using System;
+
+namespace NS2
+{{
+    public static class Extensions
+    {{
+        public static bool ExtentionMethod(this {tupleType}[] x) => false;
+    }}
+}}";
+            var srcDoc = $@"
+namespace NS1
+{{
+    public class C
+    {{
+        public void M({tupleType}[] x)
+        {{
+            x.$$
+        }}
+    }}
+}}";
+
+            var markup = refType switch
+            {
+                ReferenceType.Project => CreateMarkupForProjectWithProjectReference(srcDoc, refDoc, LanguageNames.CSharp, LanguageNames.CSharp),
+                ReferenceType.Metadata => CreateMarkupForProjectWithMetadataReference(srcDoc, refDoc, LanguageNames.CSharp, LanguageNames.CSharp),
+                _ => null,
+            };
+
+            await VerifyImportItemExistsAsync(
+                markup,
+                "ExtentionMethod",
+                glyph: (int)Glyph.ExtensionMethodPublic,
+                inlineDescription: "NS2");
+        }
+
+        [InlineData(ReferenceType.Project, "(int[],int[])")]
+        [InlineData(ReferenceType.Project, "(int[],int[],int[],int[],int[],int[],int[],int[],int[],int[])")] // more than 8 tuple elements
+        [InlineData(ReferenceType.Metadata, "(int[],int[])")]
+        [InlineData(ReferenceType.Metadata, "(int[],int[],int[],int[],int[],int[],int[],int[],int[],int[])")] // more than 8 tuple elements
+        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestArrayTuple(ReferenceType refType, string tupleType)
+        {
+            var refDoc = $@"
+using System;
+
+namespace NS2
+{{
+    public static class Extensions
+    {{
+        public static bool ExtentionMethod(this {tupleType} x) => false;
+    }}
+}}";
+            var srcDoc = $@"
+namespace NS1
+{{
+    public class C
+    {{
+        public void M({tupleType} x)
+        {{
+            x.$$
+        }}
+    }}
+}}";
+
+            var markup = refType switch
+            {
+                ReferenceType.Project => CreateMarkupForProjectWithProjectReference(srcDoc, refDoc, LanguageNames.CSharp, LanguageNames.CSharp),
+                ReferenceType.Metadata => CreateMarkupForProjectWithMetadataReference(srcDoc, refDoc, LanguageNames.CSharp, LanguageNames.CSharp),
+                _ => null,
+            };
+
+            await VerifyImportItemExistsAsync(
+                markup,
+                "ExtentionMethod",
+                glyph: (int)Glyph.ExtensionMethodPublic,
+                inlineDescription: "NS2");
+        }
+
         private Task VerifyImportItemExistsAsync(string markup, string expectedItem, int glyph, string inlineDescription, string displayTextSuffix = null, string expectedDescriptionOrNull = null)
             => VerifyItemExistsAsync(markup, expectedItem, displayTextSuffix: displayTextSuffix, glyph: glyph, inlineDescription: inlineDescription, expectedDescriptionOrNull: expectedDescriptionOrNull);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
@@ -1623,6 +1623,50 @@ namespace NS1
                 inlineDescription: "NS2");
         }
 
+
+        [InlineData(ReferenceType.Project)]
+        [InlineData(ReferenceType.Metadata)]
+        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestDescriptionOfGenericReceiverType(ReferenceType refType)
+        {
+            var refDoc = @"
+using System;
+
+namespace NS2
+{
+    public static class Extensions
+    {
+        public static bool ExtentionMethod<T>(this T t) => false;
+    }
+}";
+            var srcDoc = @"
+namespace NS1
+{
+    public class C
+    {
+        public void M(int x)
+        {
+            x.$$
+        }
+    }
+}";
+
+            var markup = refType switch
+            {
+                ReferenceType.Project => CreateMarkupForProjectWithProjectReference(srcDoc, refDoc, LanguageNames.CSharp, LanguageNames.CSharp),
+                ReferenceType.Metadata => CreateMarkupForProjectWithMetadataReference(srcDoc, refDoc, LanguageNames.CSharp, LanguageNames.CSharp),
+                _ => null,
+            };
+
+            await VerifyImportItemExistsAsync(
+                markup,
+                "ExtentionMethod",
+                displayTextSuffix: "<>",
+                glyph: (int)Glyph.ExtensionMethodPublic,
+                inlineDescription: "NS2",
+                expectedDescriptionOrNull: "(extension) bool int.ExtentionMethod<int>()");
+        }
+
         private Task VerifyImportItemExistsAsync(string markup, string expectedItem, int glyph, string inlineDescription, string displayTextSuffix = null, string expectedDescriptionOrNull = null)
             => VerifyItemExistsAsync(markup, expectedItem, displayTextSuffix: displayTextSuffix, glyph: glyph, inlineDescription: inlineDescription, expectedDescriptionOrNull: expectedDescriptionOrNull);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
@@ -1663,7 +1664,7 @@ namespace NS1
                 displayTextSuffix: "<>",
                 glyph: (int)Glyph.ExtensionMethodPublic,
                 inlineDescription: "NS2",
-                expectedDescriptionOrNull: "(extension) bool int.ExtentionMethod<int>()");
+                expectedDescriptionOrNull: $"({CSharpFeaturesResources.extension}) bool int.ExtentionMethod<int>()");
         }
 
         private Task VerifyImportItemExistsAsync(string markup, string expectedItem, int glyph, string inlineDescription, string displayTextSuffix = null, string expectedDescriptionOrNull = null)

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
@@ -1623,7 +1623,6 @@ namespace NS1
                 inlineDescription: "NS2");
         }
 
-
         [InlineData(ReferenceType.Project)]
         [InlineData(ReferenceType.Metadata)]
         [Theory, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.vb
@@ -275,5 +275,58 @@ End Class]]></Text>.Value
             Dim markup = GetMarkup(file2, file1, refType)
             Await VerifyItemIsAbsentAsync(markup, "ExtentionMethod", inlineDescription:="NS")
         End Function
+
+        <InlineData(ReferenceType.Project, "()", "ExtentionMethod2")>
+        <InlineData(ReferenceType.Project, "()()", "ExtentionMethod3")>
+        <InlineData(ReferenceType.Project, "(,)", "ExtentionMethod4")>
+        <InlineData(ReferenceType.Project, "()(,)", "ExtentionMethod5")>
+        <InlineData(ReferenceType.None, "()", "ExtentionMethod2")>
+        <InlineData(ReferenceType.None, "()()", "ExtentionMethod3")>
+        <InlineData(ReferenceType.None, "(,)", "ExtentionMethod4")>
+        <InlineData(ReferenceType.None, "()(,)", "ExtentionMethod5")>
+        <Theory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestExtensionMethodsForArrayType(refType As ReferenceType, rank As String, expectedName As String) As Task
+
+            Dim file1 = <Text><![CDATA[
+Imports System
+Imports System.Runtime.CompilerServices
+
+Namespace NS
+    Public Module Foo
+        <Extension>
+        Public Function ExtentionMethod1(x As Integer) As Boolean
+            Return True
+        End Function
+        <Extension>
+        Public Function ExtentionMethod2(x As Integer()) As Boolean
+            Return True
+        End Function
+        <Extension>
+        Public Function ExtentionMethod3(x As Integer()()) As Boolean
+            Return True
+        End Function
+        <Extension>
+        Public Function ExtentionMethod4(x As Integer(,)) As Boolean
+            Return True
+        End Function
+        <Extension>
+        Public Function ExtentionMethod5(x As Integer()(,)) As Boolean
+            Return True
+        End Function
+    End Module
+End Namespace]]></Text>.Value
+
+            Dim file2 As String = $"
+Imports System
+
+Public Class Baz
+    Sub M(x As Integer{rank})
+        x.$$
+    End Sub
+End Class"
+
+            Dim markup = GetMarkup(file2, file1, refType)
+            Await VerifyItemExistsAsync(markup, expectedName, glyph:=Glyph.ExtensionMethodPublic, inlineDescription:="NS")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                         forceIndexCreation: isExpandedCompletion,
                         cancellationToken).ConfigureAwait(false);
 
-                    completionContext.AddItems(items.Select(i => Convert(i)));
+                    completionContext.AddItems(items.Select(i => Convert(i, SymbolKey.CreateString(receiverTypeSymbol))));
                 }
                 else
                 {
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 _ => symbol as ITypeSymbol,
             };
 
-        private CompletionItem Convert(SerializableImportCompletionItem serializableItem)
+        private CompletionItem Convert(SerializableImportCompletionItem serializableItem, string receiverTypeSymbolKey)
             => ImportCompletionItem.Create(
                 serializableItem.Name,
                 serializableItem.Arity,
@@ -112,6 +112,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 serializableItem.Glyph,
                 GenericSuffix,
                 CompletionItemFlags.Expanded,
-                serializableItem.SymbolKeyData);
+                (serializableItem.SymbolKeyData, receiverTypeSymbolKey));
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -47,7 +47,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                         forceIndexCreation: isExpandedCompletion,
                         cancellationToken).ConfigureAwait(false);
 
-                    completionContext.AddItems(items.Select(i => Convert(i, SymbolKey.CreateString(receiverTypeSymbol))));
+                    var receiverTypeKey = SymbolKey.CreateString(receiverTypeSymbol);
+                    completionContext.AddItems(items.Select(i => Convert(i, receiverTypeKey)));
                 }
                 else
                 {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.CacheEntry.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.CacheEntry.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +13,6 @@ using Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -28,39 +26,33 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             public string Language { get; }
 
             /// <summary>
-            /// Mapping from the name of target type to extension method symbol infos.
+            /// Mapping from the name of receiver type to extension method symbol infos.
             /// </summary>
-            public readonly MultiDictionary<string, DeclaredSymbolInfo> SimpleExtensionMethodInfo { get; }
-
-            public readonly ImmutableArray<DeclaredSymbolInfo> ComplexExtensionMethodInfo { get; }
+            public readonly MultiDictionary<string, DeclaredSymbolInfo> ReceiverTypeNameToExtensionMethodMap { get; }
 
             private CacheEntry(
                 Checksum checksum,
                 string language,
-                MultiDictionary<string, DeclaredSymbolInfo> simpleExtensionMethodInfo,
-                ImmutableArray<DeclaredSymbolInfo> complexExtensionMethodInfo)
+                MultiDictionary<string, DeclaredSymbolInfo> receiverTypeNameToExtensionMethodMap)
             {
                 Checksum = checksum;
                 Language = language;
-                SimpleExtensionMethodInfo = simpleExtensionMethodInfo;
-                ComplexExtensionMethodInfo = complexExtensionMethodInfo;
+                ReceiverTypeNameToExtensionMethodMap = receiverTypeNameToExtensionMethodMap;
             }
 
-            public class Builder : IDisposable
+            public class Builder
             {
                 private readonly Checksum _checksum;
                 private readonly string _language;
 
-                private readonly MultiDictionary<string, DeclaredSymbolInfo> _simpleItemBuilder;
-                private readonly ArrayBuilder<DeclaredSymbolInfo> _complexItemBuilder;
+                private readonly MultiDictionary<string, DeclaredSymbolInfo> _mapBuilder;
 
                 public Builder(Checksum checksum, string langauge, IEqualityComparer<string> comparer)
                 {
                     _checksum = checksum;
                     _language = langauge;
 
-                    _simpleItemBuilder = new MultiDictionary<string, DeclaredSymbolInfo>(comparer);
-                    _complexItemBuilder = ArrayBuilder<DeclaredSymbolInfo>.GetInstance();
+                    _mapBuilder = new MultiDictionary<string, DeclaredSymbolInfo>(comparer);
                 }
 
                 public CacheEntry ToCacheEntry()
@@ -68,28 +60,19 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     return new CacheEntry(
                         _checksum,
                         _language,
-                        _simpleItemBuilder,
-                        _complexItemBuilder.ToImmutable());
+                        _mapBuilder);
                 }
 
                 public void AddItem(SyntaxTreeIndex syntaxIndex)
                 {
-                    foreach (var (targetType, symbolInfoIndices) in syntaxIndex.SimpleExtensionMethodInfo)
+                    foreach (var (receiverType, symbolInfoIndices) in syntaxIndex.ReceiverTypeNameToExtensionMethodMap)
                     {
                         foreach (var index in symbolInfoIndices)
                         {
-                            _simpleItemBuilder.Add(targetType, syntaxIndex.DeclaredSymbolInfos[index]);
+                            _mapBuilder.Add(receiverType, syntaxIndex.DeclaredSymbolInfos[index]);
                         }
                     }
-
-                    foreach (var index in syntaxIndex.ComplexExtensionMethodInfo)
-                    {
-                        _complexItemBuilder.Add(syntaxIndex.DeclaredSymbolInfos[index]);
-                    }
                 }
-
-                public void Dispose()
-                    => _complexItemBuilder.Free();
             }
         }
 
@@ -125,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 cacheEntry.Language != project.Language)
             {
                 var syntaxFacts = project.LanguageServices.GetRequiredService<ISyntaxFactsService>();
-                using var builder = new CacheEntry.Builder(checksum, project.Language, syntaxFacts.StringComparer);
+                var builder = new CacheEntry.Builder(checksum, project.Language, syntaxFacts.StringComparer);
 
                 foreach (var document in project.Documents)
                 {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             switch (typeSymbol)
             {
                 case INamedTypeSymbol namedType:
-                    return namedType.IsTupleType ? string.Empty : namedType.MetadataName;
+                    return namedType.MetadataName;
 
                 case IArrayTypeSymbol arrayType:
                     var elementType = arrayType.ElementType;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             return completionItemsbuilder.ToImmutable();
 
-            // Add string represent complex types (i.e. "" and "[]") to the receiver type, so we would include in the filter
+            // Add strings represent complex types (i.e. "" and "[]") to the receiver type, so we would include in the filter
             // info about extension methods with complex receiver type.
             static ImmutableArray<string> AttachComplexTypes(ImmutableArray<string> receiverTypeNames)
             {
@@ -268,8 +268,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 // Need to find the matching one in current compilation
                 // before any further checks is done.
                 var methodSymbolInCurrentCompilation = isSymbolFromCurrentCompilation
-                                                        ? methodSymbol
-                                                        : SymbolFinder.FindSimilarSymbols(methodSymbol, semanticModel.Compilation).FirstOrDefault();
+                    ? methodSymbol
+                    : SymbolFinder.FindSimilarSymbols(methodSymbol, semanticModel.Compilation).FirstOrDefault();
 
                 if (methodSymbolInCurrentCompilation == null
                     || !semanticModel.IsAccessible(position, methodSymbolInCurrentCompilation))
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         private static ImmutableArray<IMethodSymbol> GetPotentialMatchingSymbolsFromAssembly(
             IAssemblySymbol assembly,
-            MultiDictionary<string, (string, string)> extensionMethodFilter,
+            MultiDictionary<string, (string methodName, string receiverTypeName)> extensionMethodFilter,
             ISet<string> namespaceFilter,
             bool internalsVisible,
             StatisticCounter counter,
@@ -445,7 +445,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         // Create filter for extension methods from source.
-        private static MultiDictionary<string, (string, string)> CreateAggregatedFilter(ImmutableArray<string> receiverTypeNames, CacheEntry syntaxIndex)
+        private static MultiDictionary<string, (string methodName, string receiverTypeName)> CreateAggregatedFilter(ImmutableArray<string> receiverTypeNames, CacheEntry syntaxIndex)
         {
             var results = new MultiDictionary<string, (string, string)>();
 
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         // Create filter for extension methods from metadata
-        private static MultiDictionary<string, (string, string)> CreateAggregatedFilter(ImmutableArray<string> receiverTypeNames, SymbolTreeInfo symbolInfo)
+        private static MultiDictionary<string, (string methodName, string receiverTypeName)> CreateAggregatedFilter(ImmutableArray<string> receiverTypeNames, SymbolTreeInfo symbolInfo)
         {
             var results = new MultiDictionary<string, (string, string)>();
 

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -120,11 +120,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
                     // We do not differentiate array of different kinds sicne they are all represented in the indices as "NonArrayElementTypeName[]"
                     // e.g. int[], int[][], int[,], etc. are all represented as "int[]", whereas array of complex type such as T[] is "[]".
-                    return elementTypeName + "[]";
+                    return elementTypeName + FindSymbols.Extensions.ArrayReceiverTypeNameSuffix;
 
                 default:
                     // Complex types are represented by "";
-                    return string.Empty;
+                    return FindSymbols.Extensions.ComplexReceiverTypeName;
             }
         }
 
@@ -237,14 +237,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             return completionItemsbuilder.ToImmutable();
 
-            // Add strings represent complex types (i.e. "" and "[]") to the receiver type, so we would include in the filter
-            // info about extension methods with complex receiver type.
+            // Add strings represent complex types (i.e. "" for non-array types and "[]" for array types) to the receiver type, 
+            // so we would include in the filter info about extension methods with complex receiver type.
             static ImmutableArray<string> AttachComplexTypes(ImmutableArray<string> receiverTypeNames)
             {
                 using var _ = ArrayBuilder<string>.GetInstance(receiverTypeNames.Length + 2, out var receiverTypeNamesBuilder);
                 receiverTypeNamesBuilder.AddRange(receiverTypeNames);
-                receiverTypeNamesBuilder.Add(string.Empty);
-                receiverTypeNamesBuilder.Add("[]");
+                receiverTypeNamesBuilder.Add(FindSymbols.Extensions.ComplexReceiverTypeName);
+                receiverTypeNamesBuilder.Add(FindSymbols.Extensions.ComplexArrayReceiverTypeName);
 
                 return receiverTypeNamesBuilder.ToImmutable();
             }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     // Here's SymbolKey for System.String from those two framework as an example:
                     //
                     //  {1 (D "String" (N "System" 0 (N "" 0 (U (S "netstandard" 4) 3) 2) 1) 0 0 (% 0) 0)}
-                    //  {1 (D "String"(N "System" 0(N "" 0(U(S "mscorlib" 4) 3) 2) 1) 0 0(% 0) 0)}
+                    //  {1 (D "String"(N "System" 0 (N "" 0 (U (S "mscorlib" 4) 3) 2) 1) 0 0 (% 0) 0)}
                     //
                     // Also we don't use the "ignoreAssemblyKey" option for SymbolKey resolution because its perfermance doesn't meet our requirement.
                     continue;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     // Here's SymbolKey for System.String from those two framework as an example:
                     //
                     //  {1 (D "String" (N "System" 0 (N "" 0 (U (S "netstandard" 4) 3) 2) 1) 0 0 (% 0) 0)}
-                    //  {1 (D "String"(N "System" 0 (N "" 0 (U (S "mscorlib" 4) 3) 2) 1) 0 0 (% 0) 0)}
+                    //  {1 (D "String" (N "System" 0 (N "" 0 (U (S "mscorlib" 4) 3) 2) 1) 0 0 (% 0) 0)}
                     //
                     // Also we don't use the "ignoreAssemblyKey" option for SymbolKey resolution because its perfermance doesn't meet our requirement.
                     continue;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
                     GetExtensionMethodItemsWorker(
                         position, semanticModel, receiverTypeSymbol, matchingMethodSymbols,
-                        isSymbolFromCurrentCompilation: false, builder, namespaceNameCache, cancellationToken);
+                        isSymbolFromCurrentCompilation: true, builder, namespaceNameCache, cancellationToken);
                 }
             }
 
@@ -237,13 +237,12 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // Symbols could be from a different compilation,
-                // because we retrieved them on a per-assembly basis.
+                // Symbols could be from a different compilation.
                 // Need to find the matching one in current compilation
                 // before any further checks is done.
                 var methodSymbolInCurrentCompilation = isSymbolFromCurrentCompilation
-                    ? methodSymbol
-                    : SymbolFinder.FindSimilarSymbols(methodSymbol, semanticModel.Compilation).FirstOrDefault();
+                                                        ? methodSymbol
+                                                        : SymbolFinder.FindSimilarSymbols(methodSymbol, semanticModel.Compilation).FirstOrDefault();
 
                 if (methodSymbolInCurrentCompilation == null
                     || !semanticModel.IsAccessible(position, methodSymbolInCurrentCompilation))

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -20,22 +20,24 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         private const string TypeAritySuffixName = nameof(TypeAritySuffixName);
         private const string AttributeFullName = nameof(AttributeFullName);
-        private const string SymbolKeyData = nameof(SymbolKeyData);
+        private const string MethodKey = nameof(MethodKey);
+        private const string ReceiverKey = nameof(ReceiverKey);
 
         public static CompletionItem Create(INamedTypeSymbol typeSymbol, string containingNamespace, string genericTypeSuffix)
-            => Create(typeSymbol.Name, typeSymbol.Arity, containingNamespace, typeSymbol.GetGlyph(), genericTypeSuffix, CompletionItemFlags.CachedAndExpanded, symbolKeyData: null);
+            => Create(typeSymbol.Name, typeSymbol.Arity, containingNamespace, typeSymbol.GetGlyph(), genericTypeSuffix, CompletionItemFlags.CachedAndExpanded, extensionMethodData: null);
 
-        public static CompletionItem Create(string name, int arity, string containingNamespace, Glyph glyph, string genericTypeSuffix, CompletionItemFlags flags, string? symbolKeyData)
+        public static CompletionItem Create(string name, int arity, string containingNamespace, Glyph glyph, string genericTypeSuffix, CompletionItemFlags flags, (string methodSymbolKey, string receiverTypeSymbolKey)? extensionMethodData)
         {
             ImmutableDictionary<string, string>? properties = null;
 
-            if (symbolKeyData != null || arity > 0)
+            if (extensionMethodData != null || arity > 0)
             {
                 var builder = PooledDictionary<string, string>.GetInstance();
 
-                if (symbolKeyData != null)
+                if (extensionMethodData.HasValue)
                 {
-                    builder.Add(SymbolKeyData, symbolKeyData);
+                    builder.Add(MethodKey, extensionMethodData.Value.methodSymbolKey);
+                    builder.Add(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey);
                 }
                 else
                 {
@@ -128,9 +130,21 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private static ISymbol? GetSymbol(CompletionItem item, Compilation compilation)
         {
             // If we have SymbolKey data (i.e. this is an extension method item), use it to recover symbol
-            if (item.Properties.TryGetValue(SymbolKeyData, out var symbolId))
+            if (item.Properties.TryGetValue(MethodKey, out var methodSymbolKey))
             {
-                return SymbolKey.ResolveString(symbolId, compilation).GetAnySymbol();
+                var methodSymbol = SymbolKey.ResolveString(methodSymbolKey, compilation).GetAnySymbol() as IMethodSymbol;
+
+                // Get reduced extension method symbol for the given receiver type.
+                if (item.Properties.TryGetValue(ReceiverKey, out var receiverTypeKey))
+                {
+                    var receiverTypeSymbol = SymbolKey.ResolveString(receiverTypeKey, compilation).GetAnySymbol() as ITypeSymbol;
+                    if (receiverTypeSymbol != null)
+                    {
+                        return methodSymbol?.ReduceExtensionMethod(receiverTypeSymbol) ?? methodSymbol;
+                    }
+                }
+
+                return methodSymbol;
             }
 
             // Otherwise, this is a type item, so we don't have SymbolKey data. But we should still have all

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -134,13 +134,15 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             {
                 var methodSymbol = SymbolKey.ResolveString(methodSymbolKey, compilation).GetAnySymbol() as IMethodSymbol;
 
-                // Get reduced extension method symbol for the given receiver type.
-                if (item.Properties.TryGetValue(ReceiverKey, out var receiverTypeKey))
+                if (methodSymbol != null)
                 {
-                    var receiverTypeSymbol = SymbolKey.ResolveString(receiverTypeKey, compilation).GetAnySymbol() as ITypeSymbol;
-                    if (receiverTypeSymbol != null)
+                    // Get reduced extension method symbol for the given receiver type.
+                    if (item.Properties.TryGetValue(ReceiverKey, out var receiverTypeKey))
                     {
-                        return methodSymbol?.ReduceExtensionMethod(receiverTypeSymbol) ?? methodSymbol;
+                        if (SymbolKey.ResolveString(receiverTypeKey, compilation).GetAnySymbol() is ITypeSymbol receiverTypeSymbol)
+                        {
+                            return methodSymbol.ReduceExtensionMethod(receiverTypeSymbol) ?? methodSymbol;
+                        }
                     }
                 }
 

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -568,6 +568,10 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         // Ignore nullability, becase nullable reference type might not be enabled universally.
                         // In the worst case we just include more methods to check in out filter.
                         return TryGetSimpleTypeName(nullableNode.ElementType, typeParameterNames, out simpleTypeName, out isArray);
+
+                    case TupleTypeSyntax tupleType:
+                        simpleTypeName = CreateValueTupleTypeString(tupleType.Elements.Count);
+                        return true;
                 }
             }
 

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -540,6 +540,14 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         simpleTypeName = typeParameterNames?.Contains(text) == true ? null : text;
                         return simpleTypeName != null;
 
+                    case ArrayTypeSyntax arrayTypeNode:
+                        // We do not differentiate array of different kinds for simplicity.
+                        // e.g. int[], int[][], int[,], etc. are all represented as int[] in the index.
+                        simpleTypeName = TryGetSimpleTypeName(arrayTypeNode.ElementType, typeParameterNames, out var elementTypeName)
+                            ? CreateTargetTypeStringForArray(elementTypeName)
+                            : null;
+                        return simpleTypeName != null;
+
                     case GenericNameSyntax genericNameNode:
                         var name = genericNameNode.Identifier.Text;
                         var arity = genericNameNode.Arity;

--- a/src/Workspaces/Core/Portable/FindSymbols/Extensions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Extensions.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal static partial class Extensions
     {
         public const string ComplexReceiverTypeName = "";
+        // Although they have same value, one constant here is used for the entire name
+        // and the other is just a suffix. Defining separate constants for clarity.
         public const string ComplexArrayReceiverTypeName = "[]";
         public const string ArrayReceiverTypeNameSuffix = "[]";
 

--- a/src/Workspaces/Core/Portable/FindSymbols/Extensions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Extensions.cs
@@ -13,6 +13,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 {
     internal static partial class Extensions
     {
+        public const string ComplexReceiverTypeName = "";
+        public const string ComplexArrayReceiverTypeName = "[]";
+        public const string ArrayReceiverTypeNameSuffix = "[]";
+
         public static async Task<IEnumerable<SyntaxToken>> GetConstructorInitializerTokensAsync(this Document document, SemanticModel model, CancellationToken cancellationToken)
         {
             var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -198,6 +198,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <returns></returns>
         public static IEnumerable<TSymbol> FindSimilarSymbols<TSymbol>(TSymbol symbol, Compilation compilation, CancellationToken cancellationToken = default)
             where TSymbol : ISymbol
+            => FindSimilarSymbols(symbol, compilation, ignoreAssemblyKey: false, cancellationToken);
+
+        internal static IEnumerable<TSymbol> FindSimilarSymbols<TSymbol>(TSymbol symbol, Compilation compilation, bool ignoreAssemblyKey, CancellationToken cancellationToken = default)
+            where TSymbol : ISymbol
         {
             if (symbol == null)
             {
@@ -213,7 +217,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             // We may be talking about different compilations.  So do not try to resolve locations.
             var result = new HashSet<TSymbol>();
-            var resolution = key.Resolve(compilation, cancellationToken: cancellationToken);
+            var resolution = key.Resolve(compilation, ignoreAssemblyKey, cancellationToken);
             foreach (var current in resolution.OfType<TSymbol>())
             {
                 result.Add(current);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -198,10 +198,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <returns></returns>
         public static IEnumerable<TSymbol> FindSimilarSymbols<TSymbol>(TSymbol symbol, Compilation compilation, CancellationToken cancellationToken = default)
             where TSymbol : ISymbol
-            => FindSimilarSymbols(symbol, compilation, ignoreAssemblyKey: false, cancellationToken);
-
-        internal static IEnumerable<TSymbol> FindSimilarSymbols<TSymbol>(TSymbol symbol, Compilation compilation, bool ignoreAssemblyKey, CancellationToken cancellationToken = default)
-            where TSymbol : ISymbol
         {
             if (symbol == null)
             {
@@ -217,7 +213,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             // We may be talking about different compilations.  So do not try to resolve locations.
             var result = new HashSet<TSymbol>();
-            var resolution = key.Resolve(compilation, ignoreAssemblyKey, cancellationToken);
+            var resolution = key.Resolve(compilation, cancellationToken: cancellationToken);
             foreach (var current in resolution.OfType<TSymbol>())
             {
                 result.Add(current);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// <summary>
             /// Similar to <see cref="SyntaxTreeIndex.ExtensionMethodInfo"/>, we divide extension methods into simple 
             /// and complex categories for filtering purpose. Whether a method is simple is determined based on if we 
-            /// can determine it's target type easily with a pure text matching. For complex methods, we will need to
+            /// can determine it's receiver type easily with a pure text matching. For complex methods, we will need to
             /// rely on symbol to decide if it's feasible.
             /// 
             /// Simple types include:

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -82,11 +82,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// <summary>
             /// This is the type name of the parameter when <see cref="IsComplexType"/> is false. 
             /// For array types, this is just the elemtent type name.
+            /// e.g. `int` for `int[][,]` 
             /// </summary>
             public readonly string Name;
 
             /// <summary>
-            /// Indicate if the type of parameter is any kind of array.
+            /// Indicate if the type of parameter is any kind of array (used for both simple and complex types)
             /// </summary>
 
             public readonly bool IsArray;
@@ -101,6 +102,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// - Primitive types
             /// - Types which is not a generic method parameter
             /// - By reference type of any types above
+            /// - Array types of with element of any types above
             /// </summary>
             public readonly bool IsComplexType;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// - Primitive types
             /// - Types which is not a generic method parameter
             /// - By reference type of any types above
-            /// - Array types of with element of any types above
+            /// - Array types with element of any types above
             /// </summary>
             public readonly bool IsComplexType;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             private static ParameterTypeInfo GetArrayTypeInfo(ParameterTypeInfo elementType)
                 => elementType.IsComplexType
-                    ? ComplexInfo
+                    ? new ParameterTypeInfo(string.Empty, isComplex: true, isArray: true)
                     : new ParameterTypeInfo(elementType.Name, isComplex: false, isArray: true);
 
             public ParameterTypeInfo GetFunctionPointerType(MethodSignature<ParameterTypeInfo> signature) => ComplexInfo;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -89,7 +89,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// <summary>
             /// Indicate if the type of parameter is any kind of array (used for both simple and complex types)
             /// </summary>
-
             public readonly bool IsArray;
 
             /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -87,7 +87,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public readonly string Name;
 
             /// <summary>
-            /// Indicate if the type of parameter is any kind of array (used for both simple and complex types)
+            /// Indicate if the type of parameter is any kind of array.
+            /// This is relevant for both simple and complex types. For example:
+            /// - array of simple type like int[], int[][], int[][,], etc. are all ultimately represented as "int[]" in index.
+            /// - array of complex type like T[], T[][], etc are all represented as "[]" in index, 
+            ///   in contrast to just "" for non-array types.
             /// </summary>
             public readonly bool IsArray;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -54,8 +54,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private readonly OrderPreservingMultiDictionary<int, int> _inheritanceMap;
 
         /// <summary>
-        /// Maps the name of target type name to its <see cref="ExtensionMethodInfo" />.
+        /// Maps the name of receiver type name to its <see cref="ExtensionMethodInfo" />.
         /// <see cref="ParameterTypeInfo"/> for the definition of simple/complex methods.
+        /// For non-array simple types, the receiver type name would be its metadata name, e.g. "Int32".
+        /// For any array types with simple type as element, the receiver type name would be just "ElementTypeName[]", e.g. "Int32[]" for int[][,]
+        /// For non-array complex types, the receiver type name is "".
+        /// For any array types with complex type as element, the receier type name is "[]"
         /// </summary>
         private readonly MultiDictionary<string, ExtensionMethodInfo>? _receiverTypeNameToExtensionMethodMap;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -57,34 +57,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Maps the name of target type name of simple extension methods to its <see cref="ExtensionMethodInfo" />.
         /// <see cref="ParameterTypeInfo"/> for the definition of simple/complex methods.
         /// </summary>
-        private readonly MultiDictionary<string, ExtensionMethodInfo>? _simpleTypeNameToExtensionMethodMap;
+        public MultiDictionary<string, ExtensionMethodInfo>? SimpleTypeNameToExtensionMethodMap { get; }
 
         /// <summary>
         /// A list of <see cref="ExtensionMethodInfo" /> for complex extension methods.
         /// <see cref="ParameterTypeInfo"/> for the definition of simple/complex methods.
         /// </summary>
-        private readonly ImmutableArray<ExtensionMethodInfo> _extensionMethodOfComplexType;
+        public ImmutableArray<ExtensionMethodInfo> ExtensionMethodOfComplexType { get; }
 
-        public bool ContainsExtensionMethod => _simpleTypeNameToExtensionMethodMap?.Count > 0 || _extensionMethodOfComplexType.Length > 0;
-
-        public ImmutableArray<ExtensionMethodInfo> GetMatchingExtensionMethodInfo(ImmutableArray<string> parameterTypeNames)
-        {
-            if (_simpleTypeNameToExtensionMethodMap == null)
-            {
-                return _extensionMethodOfComplexType;
-            }
-
-            var builder = ArrayBuilder<ExtensionMethodInfo>.GetInstance();
-            builder.AddRange(_extensionMethodOfComplexType);
-
-            foreach (var parameterTypeName in parameterTypeNames)
-            {
-                var simpleMethods = _simpleTypeNameToExtensionMethodMap[parameterTypeName];
-                builder.AddRange(simpleMethods);
-            }
-
-            return builder.ToImmutableAndFree();
-        }
+        public bool ContainsExtensionMethod => SimpleTypeNameToExtensionMethodMap?.Count > 0 || ExtensionMethodOfComplexType.Length > 0;
 
         /// <summary>
         /// The task that produces the spell checker we use for fuzzy match queries.
@@ -145,8 +126,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             _nodes = sortedNodes;
             _spellCheckerTask = spellCheckerTask;
             _inheritanceMap = inheritanceMap;
-            _extensionMethodOfComplexType = extensionMethodOfComplexType;
-            _simpleTypeNameToExtensionMethodMap = simpleTypeNameToExtensionMethodMap;
+            ExtensionMethodOfComplexType = extensionMethodOfComplexType;
+            SimpleTypeNameToExtensionMethodMap = simpleTypeNameToExtensionMethodMap;
         }
 
         public static SymbolTreeInfo CreateEmpty(Checksum checksum)
@@ -164,7 +145,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public SymbolTreeInfo WithChecksum(Checksum checksum)
         {
             return new SymbolTreeInfo(
-                checksum, _concatenatedNames, _nodes, _spellCheckerTask, _inheritanceMap, _extensionMethodOfComplexType, _simpleTypeNameToExtensionMethodMap);
+                checksum, _concatenatedNames, _nodes, _spellCheckerTask, _inheritanceMap, ExtensionMethodOfComplexType, SimpleTypeNameToExtensionMethodMap);
         }
 
         public Task<ImmutableArray<ISymbol>> FindAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         {
                             // We do not differentiate array of different kinds for simplicity.
                             // e.g. int[], int[][], int[,], etc. are all represented as int[] in the index.
-                            // similar for complex receiver types, "[]" means it's an array type.
+                            // similar for complex receiver types, "[]" means it's an array type, "" otherwise.
                             var parameterTypeName = (parameterTypeInfo.IsComplexType, parameterTypeInfo.IsArray) switch
                             {
                                 (true, true) => "[]",

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -730,10 +730,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             // similar for complex receiver types, "[]" means it's an array type, "" otherwise.
                             var parameterTypeName = (parameterTypeInfo.IsComplexType, parameterTypeInfo.IsArray) switch
                             {
-                                (true, true) => "[]",
-                                (true, false) => string.Empty,
-                                (false, true) => parameterTypeInfo.Name + "[]",
-                                (false, false) => parameterTypeInfo.Name
+                                (true, true) => Extensions.ComplexArrayReceiverTypeName,                          // complex array type, e.g. "T[,]"
+                                (true, false) => Extensions.ComplexReceiverTypeName,                              // complex non-array type, e.g. "T"
+                                (false, true) => parameterTypeInfo.Name + Extensions.ArrayReceiverTypeNameSuffix, // simple array type, e.g. "int[][,]"
+                                (false, false) => parameterTypeInfo.Name                                          // simple non-array type, e.g. "int"
                             };
 
                             receiverTypeNameToMethodMap.Add(parameterTypeName, new ExtensionMethodInfo(fullyQualifiedContainerName, child.Name));

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private readonly List<MetadataDefinition> _allTypeDefinitions;
 
             // Map from node represents extension method to list of possible parameter type info.
-            // We can have more than one if there's multiple methods with same name but different target type.
+            // We can have more than one if there's multiple methods with same name but different receiver type.
             // e.g.
             //
             //      public static bool AnotherExtensionMethod1(this int x);
@@ -371,8 +371,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     {
                         if (definition.Kind == MetadataDefinitionKind.Member)
                         {
-                            // We need to support having multiple methods with same name but different target type.
-                            _extensionMethodToParameterTypeInfo.Add(childNode, definition.TargetTypeInfo);
+                            // We need to support having multiple methods with same name but different receiver type.
+                            _extensionMethodToParameterTypeInfo.Add(childNode, definition.ReceiverTypeInfo);
                         }
 
                         LookupMetadataDefinitions(definition, definitionMap);
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             method.GetParameters().Count > 0 &&
                             method.GetCustomAttributes().Count > 0)
                         {
-                            // Decode method signature to get the target type name (i.e. type name for the first parameter)
+                            // Decode method signature to get the receiver type name (i.e. type name for the first parameter)
                             var blob = _metadataReader.GetBlobReader(method.Signature);
                             var decoder = new SignatureDecoder<ParameterTypeInfo, object>(ParameterTypeInfoProvider.Instance, _metadataReader, genericContext: null);
                             var signature = decoder.DecodeMethodSignature(ref blob);
@@ -797,17 +797,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// <summary>
             /// Only applies to member kind. Represents the type info of the first parameter.
             /// </summary>
-            public ParameterTypeInfo TargetTypeInfo { get; }
+            public ParameterTypeInfo ReceiverTypeInfo { get; }
 
             public NamespaceDefinition Namespace { get; private set; }
             public TypeDefinition Type { get; private set; }
 
-            public MetadataDefinition(MetadataDefinitionKind kind, string name, ParameterTypeInfo targetTypeInfo = default)
+            public MetadataDefinition(MetadataDefinitionKind kind, string name, ParameterTypeInfo receiverTypeInfo = default)
                 : this()
             {
                 Kind = kind;
                 Name = name;
-                TargetTypeInfo = targetTypeInfo;
+                ReceiverTypeInfo = receiverTypeInfo;
             }
 
             public static MetadataDefinition Create(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class SymbolTreeInfo : IObjectWritable
     {
         private const string PrefixMetadataSymbolTreeInfo = "<SymbolTreeInfo>";
-        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("19");
+        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("20");
 
         /// <summary>
         /// Loads the SpellChecker for a given assembly symbol (metadata or project).  If the

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -158,18 +158,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 }
             }
 
-            if (_simpleTypeNameToExtensionMethodMap == null)
+            if (SimpleTypeNameToExtensionMethodMap == null)
             {
                 writer.WriteInt32(0);
             }
             else
             {
-                writer.WriteInt32(_simpleTypeNameToExtensionMethodMap.Count);
-                foreach (var key in _simpleTypeNameToExtensionMethodMap.Keys)
+                writer.WriteInt32(SimpleTypeNameToExtensionMethodMap.Count);
+                foreach (var key in SimpleTypeNameToExtensionMethodMap.Keys)
                 {
                     writer.WriteString(key);
 
-                    var values = _simpleTypeNameToExtensionMethodMap[key];
+                    var values = SimpleTypeNameToExtensionMethodMap[key];
                     writer.WriteInt32(values.Count);
 
                     foreach (var value in values)
@@ -180,8 +180,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 }
             }
 
-            writer.WriteInt32(_extensionMethodOfComplexType.Length);
-            foreach (var methodInfo in _extensionMethodOfComplexType)
+            writer.WriteInt32(ExtensionMethodOfComplexType.Length);
+            foreach (var methodInfo in ExtensionMethodOfComplexType)
             {
                 writer.WriteString(methodInfo.FullyQualifiedContainerName);
                 writer.WriteString(methodInfo.Name);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -158,18 +158,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 }
             }
 
-            if (SimpleTypeNameToExtensionMethodMap == null)
+            if (_receiverTypeNameToExtensionMethodMap == null)
             {
                 writer.WriteInt32(0);
             }
             else
             {
-                writer.WriteInt32(SimpleTypeNameToExtensionMethodMap.Count);
-                foreach (var key in SimpleTypeNameToExtensionMethodMap.Keys)
+                writer.WriteInt32(_receiverTypeNameToExtensionMethodMap.Count);
+                foreach (var key in _receiverTypeNameToExtensionMethodMap.Keys)
                 {
                     writer.WriteString(key);
 
-                    var values = SimpleTypeNameToExtensionMethodMap[key];
+                    var values = _receiverTypeNameToExtensionMethodMap[key];
                     writer.WriteInt32(values.Count);
 
                     foreach (var value in values)
@@ -178,13 +178,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         writer.WriteString(value.Name);
                     }
                 }
-            }
-
-            writer.WriteInt32(ExtensionMethodOfComplexType.Length);
-            foreach (var methodInfo in ExtensionMethodOfComplexType)
-            {
-                writer.WriteString(methodInfo.FullyQualifiedContainerName);
-                writer.WriteString(methodInfo.Name);
             }
         }
 
@@ -230,17 +223,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     }
                 }
 
-                MultiDictionary<string, ExtensionMethodInfo> simpleTypeNameToExtensionMethodMap;
-                ImmutableArray<ExtensionMethodInfo> extensionMethodOfComplexType;
+                MultiDictionary<string, ExtensionMethodInfo> receiverTypeNameToExtensionMethodMap;
 
                 var keyCount = reader.ReadInt32();
                 if (keyCount == 0)
                 {
-                    simpleTypeNameToExtensionMethodMap = null;
+                    receiverTypeNameToExtensionMethodMap = null;
                 }
                 else
                 {
-                    simpleTypeNameToExtensionMethodMap = new MultiDictionary<string, ExtensionMethodInfo>();
+                    receiverTypeNameToExtensionMethodMap = new MultiDictionary<string, ExtensionMethodInfo>();
 
                     for (var i = 0; i < keyCount; i++)
                     {
@@ -252,34 +244,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             var containerName = reader.ReadString();
                             var name = reader.ReadString();
 
-                            simpleTypeNameToExtensionMethodMap.Add(typeName, new ExtensionMethodInfo(containerName, name));
+                            receiverTypeNameToExtensionMethodMap.Add(typeName, new ExtensionMethodInfo(containerName, name));
                         }
                     }
-                }
-
-                var arrayLength = reader.ReadInt32();
-                if (arrayLength == 0)
-                {
-                    extensionMethodOfComplexType = ImmutableArray<ExtensionMethodInfo>.Empty;
-                }
-                else
-                {
-                    var builder = ArrayBuilder<ExtensionMethodInfo>.GetInstance(arrayLength);
-                    for (var i = 0; i < arrayLength; ++i)
-                    {
-                        var containerName = reader.ReadString();
-                        var name = reader.ReadString();
-                        builder.Add(new ExtensionMethodInfo(containerName, name));
-                    }
-
-                    extensionMethodOfComplexType = builder.ToImmutableAndFree();
                 }
 
                 var nodeArray = nodes.ToImmutableAndFree();
                 var spellCheckerTask = createSpellCheckerTask(concatenatedNames, nodeArray);
                 return new SymbolTreeInfo(
                     checksum, concatenatedNames, nodeArray, spellCheckerTask, inheritanceMap,
-                    extensionMethodOfComplexType, simpleTypeNameToExtensionMethodMap);
+                    receiverTypeNameToExtensionMethodMap);
             }
             catch
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -114,8 +114,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return CreateSymbolTreeInfo(
                 project.Solution, checksum, project.FilePath, unsortedNodes.ToImmutableAndFree(),
                 inheritanceMap: new OrderPreservingMultiDictionary<string, string>(),
-                simpleMethods: null,
-                complexMethods: ImmutableArray<ExtensionMethodInfo>.Empty);
+                simpleMethods: null);
         }
 
         // generate nodes for the global namespace an all descendants

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </summary>
             public readonly ImmutableDictionary<string, ImmutableArray<int>> ReceiverTypeNameToExtensionMethodMap { get; }
 
-            public bool ContainsExtensionMethod => ReceiverTypeNameToExtensionMethodMap.Count > 0;
+            public bool ContainsExtensionMethod => !ReceiverTypeNameToExtensionMethodMap.IsEmpty;
 
             public ExtensionMethodInfo(ImmutableDictionary<string, ImmutableArray<int>> receiverTypeNameToExtensionMethodMap)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
@@ -16,45 +16,47 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private readonly struct ExtensionMethodInfo
         {
             // We divide extension methods into two categories, simple and complex, for filtering purpose.
-            // Whether a method is simple is determined based on if we can determine it's target type easily
+            // Whether a method is simple is determined based on if we can determine it's receiver type easily
             // with a pure text matching. For complex methods, we will need to rely on symbol to decide if it's 
             // feasible.
             //
             // Complex methods include:
             // - Method declared in the document which includes using alias directive
-            // - Generic method where the target type is a type-paramter (e.g. List<T> would be considered simple, not complex)
-            // - If the target type name is one of the following (i.e. name of the type for the first parameter) 
+            // - Generic method where the receiver type is a type-paramter (e.g. List<T> would be considered simple, not complex)
+            // - If the receiver type name is one of the following (i.e. name of the type for the first parameter) 
             //      1. ValueTuple type
             //      2. Pointer type
             //
             // The rest of methods are considered simple.
 
             /// <summary>
-            /// Name of the simple method's target type name to the index of its DeclaredSymbolInfo in `_declarationInfo`.
-            /// All predefined types are converted to its metadata form. e.g. int => Int32. For generic types, type parameters are ignored.
+            /// Name of the extension method's receiver type to the index of its DeclaredSymbolInfo in `_declarationInfo`.
+            /// 
+            /// For simple types, the receiver type name is it's metadata name. All predefined types are converted to its metadata form.
+            /// e.g. int => Int32. For generic types, type parameters are ignored.
+            /// 
+            /// For complex types, the receiver type name is "".
+            /// 
+            /// For any kind of array types, it's "{element's receiver type name}[]".
+            /// e.g. 
+            /// int[][,] => "Int32[]"
+            /// T (where T is a type parameter) => ""
+            /// T[,] (where T is a type parameter) => "T[]"
             /// </summary>
-            public readonly ImmutableDictionary<string, ImmutableArray<int>> SimpleExtensionMethodInfo { get; }
+            public readonly ImmutableDictionary<string, ImmutableArray<int>> ReceiverTypeNameToExtensionMethodMap { get; }
 
-            /// <summary>
-            /// Indices of to all complex methods' DeclaredSymbolInfo in `_declarationInfo`.
-            /// </summary>
-            public readonly ImmutableArray<int> ComplexExtensionMethodInfo { get; }
+            public bool ContainsExtensionMethod => ReceiverTypeNameToExtensionMethodMap.Count > 0;
 
-            public bool ContainsExtensionMethod => SimpleExtensionMethodInfo.Count > 0 || ComplexExtensionMethodInfo.Length > 0;
-
-            public ExtensionMethodInfo(
-                ImmutableDictionary<string, ImmutableArray<int>> simpleExtensionMethodInfo,
-                ImmutableArray<int> complexExtensionMethodInfo)
+            public ExtensionMethodInfo(ImmutableDictionary<string, ImmutableArray<int>> receiverTypeNameToExtensionMethodMap)
             {
-                SimpleExtensionMethodInfo = simpleExtensionMethodInfo;
-                ComplexExtensionMethodInfo = complexExtensionMethodInfo;
+                ReceiverTypeNameToExtensionMethodMap = receiverTypeNameToExtensionMethodMap;
             }
 
             public void WriteTo(ObjectWriter writer)
             {
-                writer.WriteInt32(SimpleExtensionMethodInfo.Count);
+                writer.WriteInt32(ReceiverTypeNameToExtensionMethodMap.Count);
 
-                foreach (var kvp in SimpleExtensionMethodInfo)
+                foreach (var kvp in ReceiverTypeNameToExtensionMethodMap)
                 {
                     writer.WriteString(kvp.Key);
                     writer.WriteInt32(kvp.Value.Length);
@@ -64,19 +66,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         writer.WriteInt32(declaredSymbolInfoIndex);
                     }
                 }
-
-                writer.WriteInt32(ComplexExtensionMethodInfo.Length);
-                foreach (var declaredSymbolInfoIndex in ComplexExtensionMethodInfo)
-                {
-                    writer.WriteInt32(declaredSymbolInfoIndex);
-                }
             }
 
             public static ExtensionMethodInfo? TryReadFrom(ObjectReader reader)
             {
                 try
                 {
-                    var simpleExtensionMethodInfo = ImmutableDictionary.CreateBuilder<string, ImmutableArray<int>>();
+                    var receiverTypeNameToExtensionMethodMapBuilder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<int>>();
                     var count = reader.ReadInt32();
 
                     for (var i = 0; i < count; ++i)
@@ -91,18 +87,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             arrayBuilder.Add(declaredSymbolInfoIndex);
                         }
 
-                        simpleExtensionMethodInfo[typeName] = arrayBuilder.ToImmutableAndFree();
+                        receiverTypeNameToExtensionMethodMapBuilder[typeName] = arrayBuilder.ToImmutableAndFree();
                     }
 
-                    count = reader.ReadInt32();
-                    var complexExtensionMethodInfo = ArrayBuilder<int>.GetInstance(count);
-                    for (var i = 0; i < count; ++i)
-                    {
-                        var declaredSymbolInfoIndex = reader.ReadInt32();
-                        complexExtensionMethodInfo.Add(declaredSymbolInfoIndex);
-                    }
-
-                    return new ExtensionMethodInfo(simpleExtensionMethodInfo.ToImmutable(), complexExtensionMethodInfo.ToImmutableAndFree());
+                    return new ExtensionMethodInfo(receiverTypeNameToExtensionMethodMapBuilder.ToImmutable());
                 }
                 catch (Exception)
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // Complex methods include:
             // - Method declared in the document which includes using alias directive
             // - Generic method where the receiver type is a type-paramter (e.g. List<T> would be considered simple, not complex)
-            // - If the receiver type name is one of the following (i.e. name of the type for the first parameter) 
-            //      1. ValueTuple type
-            //      2. Pointer type
+            // - If the receiver type name is Pointer type (i.e. name of the type for the first parameter) 
             //
             // The rest of methods are considered simple.
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
@@ -24,9 +24,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // - Method declared in the document which includes using alias directive
             // - Generic method where the target type is a type-paramter (e.g. List<T> would be considered simple, not complex)
             // - If the target type name is one of the following (i.e. name of the type for the first parameter) 
-            //      1. Array type
-            //      2. ValueTuple type
-            //      3. Pointer type
+            //      1. ValueTuple type
+            //      2. Pointer type
             //
             // The rest of methods are considered simple.
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -314,7 +314,7 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                 // simply treat it as a complex method.
                 if (originalName == null)
                 {
-                    receiverTypeName = string.Empty;
+                    receiverTypeName = Extensions.ComplexReceiverTypeName;
                 }
                 else
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -323,7 +323,7 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                 }
             }
 
-            if (!extensionMethodsInfoBuilder.TryGetValue(string.Empty, out var arrayBuilder))
+            if (!extensionMethodsInfoBuilder.TryGetValue(receiverTypeName, out var arrayBuilder))
             {
                 arrayBuilder = ArrayBuilder<int>.GetInstance();
                 extensionMethodsInfoBuilder[receiverTypeName] = arrayBuilder;

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         // otherwise we would not be able to get correct data from syntax.
         bool TryGetDeclaredSymbolInfo(StringTable stringTable, SyntaxNode node, string rootNamespace, out DeclaredSymbolInfo declaredSymbolInfo);
 
-        // Get the name of the target type of specified extension method declaration node.
-        // The returned value would be null for complex type.
-        string GetTargetTypeName(SyntaxNode node);
+        // Get the name of the receiver type of specified extension method declaration node.
+        // The returned value would be "" or "[]" for complex types.
+        string GetReceiverTypeName(SyntaxNode node);
 
         bool TryGetAliasesFromUsingDirective(SyntaxNode node, out ImmutableArray<(string aliasName, string name)> aliases);
 
@@ -71,8 +71,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var longLiterals = LongLiteralHashSetPool.Allocate();
 
             var declaredSymbolInfos = ArrayBuilder<DeclaredSymbolInfo>.GetInstance();
-            var complexExtensionMethodInfoBuilder = ArrayBuilder<int>.GetInstance();
-            var simpleExtensionMethodInfoBuilder = PooledDictionary<string, ArrayBuilder<int>>.GetInstance();
+            var extensionMethodInfoBuilder = PooledDictionary<string, ArrayBuilder<int>>.GetInstance();
             using var _ = PooledDictionary<string, string>.GetInstance(out var usingAliases);
 
             try
@@ -171,8 +170,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                                         usingAliases,
                                         declaredSymbolInfoIndex,
                                         declaredSymbolInfo,
-                                        simpleExtensionMethodInfoBuilder,
-                                        complexExtensionMethodInfoBuilder);
+                                        extensionMethodInfoBuilder);
                                 }
                                 else
                                 {
@@ -273,8 +271,7 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                     new DeclarationInfo(
                             declaredSymbolInfos.ToImmutable()),
                     new ExtensionMethodInfo(
-                        simpleExtensionMethodInfoBuilder.ToImmutableDictionary(s_getKey, s_getValuesAsImmutableArray),
-                        complexExtensionMethodInfoBuilder.ToImmutable()));
+                        extensionMethodInfoBuilder.ToImmutableDictionary(s_getKey, s_getValuesAsImmutableArray)));
             }
             finally
             {
@@ -282,13 +279,12 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                 StringLiteralHashSetPool.ClearAndFree(stringLiterals);
                 LongLiteralHashSetPool.ClearAndFree(longLiterals);
 
-                foreach (var (_, builder) in simpleExtensionMethodInfoBuilder)
+                foreach (var (_, builder) in extensionMethodInfoBuilder)
                 {
                     builder.Free();
                 }
 
-                simpleExtensionMethodInfoBuilder.Free();
-                complexExtensionMethodInfoBuilder.Free();
+                extensionMethodInfoBuilder.Free();
                 declaredSymbolInfos.Free();
             }
         }
@@ -302,43 +298,35 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
             PooledDictionary<string, string> aliases,
             int declaredSymbolInfoIndex,
             DeclaredSymbolInfo declaredSymbolInfo,
-            PooledDictionary<string, ArrayBuilder<int>> simpleInfoBuilder,
-            ArrayBuilder<int> complexInfoBuilder)
+            PooledDictionary<string, ArrayBuilder<int>> extensionMethodsInfoBuilder)
         {
             if (declaredSymbolInfo.Kind != DeclaredSymbolInfoKind.ExtensionMethod)
             {
                 return;
             }
 
-            var targetTypeName = infoFactory.GetTargetTypeName(node);
-
-            // complex method
-            if (targetTypeName == null)
-            {
-                complexInfoBuilder.Add(declaredSymbolInfoIndex);
-                return;
-            }
+            var receiverTypeName = infoFactory.GetReceiverTypeName(node);
 
             // Target type is an alias
-            if (aliases.TryGetValue(targetTypeName, out var originalName))
+            if (aliases.TryGetValue(receiverTypeName, out var originalName))
             {
                 // it is an alias of multiple with identical name,
                 // simply treat it as a complex method.
                 if (originalName == null)
                 {
-                    complexInfoBuilder.Add(declaredSymbolInfoIndex);
-                    return;
+                    receiverTypeName = string.Empty;
                 }
-
-                // replace the alias with its original name.
-                targetTypeName = originalName;
+                else
+                {
+                    // replace the alias with its original name.
+                    receiverTypeName = originalName;
+                }
             }
 
-            // So we've got a simple method.
-            if (!simpleInfoBuilder.TryGetValue(targetTypeName, out var arrayBuilder))
+            if (!extensionMethodsInfoBuilder.TryGetValue(string.Empty, out var arrayBuilder))
             {
                 arrayBuilder = ArrayBuilder<int>.GetInstance();
-                simpleInfoBuilder[targetTypeName] = arrayBuilder;
+                extensionMethodsInfoBuilder[receiverTypeName] = arrayBuilder;
             }
 
             arrayBuilder.Add(declaredSymbolInfoIndex);

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -11,11 +11,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         public ImmutableArray<DeclaredSymbolInfo> DeclaredSymbolInfos => _declarationInfo.DeclaredSymbolInfos;
 
-        public ImmutableDictionary<string, ImmutableArray<int>> SimpleExtensionMethodInfo
-            => _extensionMethodInfo.SimpleExtensionMethodInfo;
-
-        public ImmutableArray<int> ComplexExtensionMethodInfo
-            => _extensionMethodInfo.ComplexExtensionMethodInfo;
+        public ImmutableDictionary<string, ImmutableArray<int>> ReceiverTypeNameToExtensionMethodMap
+            => _extensionMethodInfo.ReceiverTypeNameToExtensionMethodMap;
 
         public bool ContainsExtensionMethod => _extensionMethodInfo.ContainsExtensionMethod;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class SyntaxTreeIndex : IObjectWritable
     {
         private const string PersistenceName = "<SyntaxTreeIndex>";
-        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("19");
+        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("20");
 
         public readonly Checksum Checksum;
 

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -32,6 +32,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         protected static List<Dictionary<string, string>> AllocateAliasMapList()
             => s_aliasMapListPool.Allocate();
 
+        protected static string CreateTargetTypeStringForArray(string elementTypeName)
+            => elementTypeName + "[]";
+
         protected static void FreeAliasMapList(List<Dictionary<string, string>> list)
         {
             if (list != null)

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -46,6 +46,17 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
         }
 
+        protected static string CreateValueTupleTypeString(int elementCount)
+        {
+            const string ValueTupleName = "ValueTuple";
+            if (elementCount == 0)
+            {
+                return ValueTupleName;
+            }
+            // A ValueTuple can have up to 8 type parameters.
+            return ValueTupleName + GetMetadataAritySuffix(elementCount > 8 ? 8 : elementCount);
+        }
+
         protected static void FreeAliasMapList(List<Dictionary<string, string>> list)
         {
             if (list != null)

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -32,8 +32,19 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         protected static List<Dictionary<string, string>> AllocateAliasMapList()
             => s_aliasMapListPool.Allocate();
 
-        protected static string CreateTargetTypeStringForArray(string elementTypeName)
-            => elementTypeName + "[]";
+        // We do not differentiate arrays of different kinds for simplicity.
+        // e.g. int[], int[][], int[,], etc. are all represented as int[] in the index.
+        protected static string CreateReceiverTypeString(string typeName, bool isArray)
+        {
+            if (typeName == null)
+            {
+                return isArray ? "[]" : string.Empty;
+            }
+            else
+            {
+                return isArray ? typeName + "[]" : typeName;
+            }
+        }
 
         protected static void FreeAliasMapList(List<Dictionary<string, string>> list)
         {
@@ -98,7 +109,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// on `node` should return a `DeclaredSymbolInfo` of kind `ExtensionMethod`. 
         /// If the return value is null, then it means this is a "complex" method (as described at <see cref="SyntaxTreeIndex.ExtensionMethodInfo"/>).
         /// </summary>
-        public abstract string GetTargetTypeName(SyntaxNode node);
+        public abstract string GetReceiverTypeName(SyntaxNode node);
 
         public abstract bool TryGetAliasesFromUsingDirective(SyntaxNode node, out ImmutableArray<(string aliasName, string name)> aliases);
 

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -36,13 +36,17 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         // e.g. int[], int[][], int[,], etc. are all represented as int[] in the index.
         protected static string CreateReceiverTypeString(string typeName, bool isArray)
         {
-            if (typeName == null)
+            if (string.IsNullOrEmpty(typeName))
             {
-                return isArray ? "[]" : string.Empty;
+                return isArray
+                    ? FindSymbols.Extensions.ComplexArrayReceiverTypeName
+                    : FindSymbols.Extensions.ComplexReceiverTypeName;
             }
             else
             {
-                return isArray ? typeName + "[]" : typeName;
+                return isArray
+                    ? typeName + FindSymbols.Extensions.ArrayReceiverTypeNameSuffix
+                    : typeName;
             }
         }
 

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -463,15 +463,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Next
         End Sub
 
-        Public Overrides Function GetTargetTypeName(node As SyntaxNode) As String
+        Public Overrides Function GetReceiverTypeName(node As SyntaxNode) As String
             Dim funcDecl = CType(node, MethodBlockSyntax)
             Debug.Assert(IsExtensionMethod(funcDecl))
 
             Dim typeParameterNames = funcDecl.SubOrFunctionStatement.TypeParameterList?.Parameters.SelectAsArray(Function(p) p.Identifier.Text)
             Dim targetTypeName As String = Nothing
-            TryGetSimpleTypeNameWorker(funcDecl.BlockStatement.ParameterList.Parameters(0).AsClause?.Type, typeParameterNames, targetTypeName)
+            Dim isArray As Boolean = False
 
-            Return targetTypeName
+            TryGetSimpleTypeNameWorker(funcDecl.BlockStatement.ParameterList.Parameters(0).AsClause?.Type, typeParameterNames, targetTypeName, isArray)
+            Return CreateReceiverTypeString(targetTypeName, isArray)
         End Function
 
         Public Overrides Function TryGetAliasesFromUsingDirective(node As SyntaxNode, ByRef aliases As ImmutableArray(Of (aliasName As String, name As String))) As Boolean
@@ -488,8 +489,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
 
 #Disable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
                         If simpleImportsClause.Alias IsNot Nothing AndAlso
-                            TryGetSimpleTypeNameWorker(simpleImportsClause.Alias, Nothing, aliasName) AndAlso
-                            TryGetSimpleTypeNameWorker(simpleImportsClause, Nothing, name) Then
+                            TryGetSimpleTypeNameWorker(simpleImportsClause.Alias, Nothing, aliasName, False) AndAlso
+                            TryGetSimpleTypeNameWorker(simpleImportsClause, Nothing, name, False) Then
 #Enable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
 
                             builder.Add((aliasName, name))
@@ -505,7 +506,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Return False
         End Function
 
-        Private Shared Function TryGetSimpleTypeNameWorker(node As SyntaxNode, typeParameterNames As ImmutableArray(Of String)?, ByRef simpleTypeName As String) As Boolean
+        Private Shared Function TryGetSimpleTypeNameWorker(node As SyntaxNode, typeParameterNames As ImmutableArray(Of String)?, ByRef simpleTypeName As String, ByRef isArray As Boolean) As Boolean
+
+            isArray = False
+
             If TypeOf node Is IdentifierNameSyntax Then
                 Dim identifierName = DirectCast(node, IdentifierNameSyntax)
                 Dim text = identifierName.Identifier.Text
@@ -513,14 +517,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                 Return simpleTypeName IsNot Nothing
 
             ElseIf TypeOf node Is ArrayTypeSyntax Then
-                ' We do Not differentiate array of different kinds for simplicity.
-                ' e.g. int(), int()(), int(,), etc. are all represented as int[] in the index.
+                isArray = True
                 Dim arrayType = DirectCast(node, ArrayTypeSyntax)
-                Dim elementTypeName As String
-#Disable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
-                simpleTypeName = If(TryGetSimpleTypeNameWorker(arrayType.ElementType, typeParameterNames, elementTypeName), CreateTargetTypeStringForArray(elementTypeName), Nothing)
-#Enable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
-                Return simpleTypeName IsNot Nothing
+                Return TryGetSimpleTypeNameWorker(arrayType.ElementType, typeParameterNames, simpleTypeName, False)
 
             ElseIf TypeOf node Is GenericNameSyntax Then
                 Dim genericName = DirectCast(node, GenericNameSyntax)
@@ -533,10 +532,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                 ' For an identifier to the right of a '.', it can't be a type parameter,
                 ' so we don't need to check for it further.
                 Dim qualifiedName = DirectCast(node, QualifiedNameSyntax)
-                Return TryGetSimpleTypeNameWorker(qualifiedName.Right, Nothing, simpleTypeName)
+                Return TryGetSimpleTypeNameWorker(qualifiedName.Right, Nothing, simpleTypeName, False)
 
             ElseIf TypeOf node Is NullableTypeSyntax Then
-                Return TryGetSimpleTypeNameWorker(DirectCast(node, NullableTypeSyntax).ElementType, typeParameterNames, simpleTypeName)
+                Return TryGetSimpleTypeNameWorker(DirectCast(node, NullableTypeSyntax).ElementType, typeParameterNames, simpleTypeName, isArray)
 
             ElseIf TypeOf node Is PredefinedTypeSyntax Then
                 simpleTypeName = GetSpecialTypeName(DirectCast(node, PredefinedTypeSyntax))

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -489,8 +489,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
 
 #Disable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
                         If simpleImportsClause.Alias IsNot Nothing AndAlso
-                            TryGetSimpleTypeNameWorker(simpleImportsClause.Alias, Nothing, aliasName, False) AndAlso
-                            TryGetSimpleTypeNameWorker(simpleImportsClause, Nothing, name, False) Then
+                            TryGetSimpleTypeNameWorker(simpleImportsClause.Alias, Nothing, aliasName, Nothing) AndAlso
+                            TryGetSimpleTypeNameWorker(simpleImportsClause, Nothing, name, Nothing) Then
 #Enable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
 
                             builder.Add((aliasName, name))
@@ -519,7 +519,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             ElseIf TypeOf node Is ArrayTypeSyntax Then
                 isArray = True
                 Dim arrayType = DirectCast(node, ArrayTypeSyntax)
-                Return TryGetSimpleTypeNameWorker(arrayType.ElementType, typeParameterNames, simpleTypeName, False)
+                Return TryGetSimpleTypeNameWorker(arrayType.ElementType, typeParameterNames, simpleTypeName, Nothing)
 
             ElseIf TypeOf node Is GenericNameSyntax Then
                 Dim genericName = DirectCast(node, GenericNameSyntax)
@@ -532,7 +532,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                 ' For an identifier to the right of a '.', it can't be a type parameter,
                 ' so we don't need to check for it further.
                 Dim qualifiedName = DirectCast(node, QualifiedNameSyntax)
-                Return TryGetSimpleTypeNameWorker(qualifiedName.Right, Nothing, simpleTypeName, False)
+                Return TryGetSimpleTypeNameWorker(qualifiedName.Right, Nothing, simpleTypeName, Nothing)
 
             ElseIf TypeOf node Is NullableTypeSyntax Then
                 Return TryGetSimpleTypeNameWorker(DirectCast(node, NullableTypeSyntax).ElementType, typeParameterNames, simpleTypeName, isArray)
@@ -540,6 +540,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             ElseIf TypeOf node Is PredefinedTypeSyntax Then
                 simpleTypeName = GetSpecialTypeName(DirectCast(node, PredefinedTypeSyntax))
                 Return simpleTypeName IsNot Nothing
+
+            ElseIf TypeOf node Is TupleTypeSyntax Then
+                Dim tupleArity = DirectCast(node, TupleTypeSyntax).Elements.Count
+                simpleTypeName = CreateValueTupleTypeString(tupleArity)
+                Return True
             End If
 
             simpleTypeName = Nothing

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -512,6 +512,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                 simpleTypeName = If(typeParameterNames?.Contains(text), Nothing, text)
                 Return simpleTypeName IsNot Nothing
 
+            ElseIf TypeOf node Is ArrayTypeSyntax Then
+                ' We do Not differentiate array of different kinds for simplicity.
+                ' e.g. int(), int()(), int(,), etc. are all represented as int[] in the index.
+                Dim arrayType = DirectCast(node, ArrayTypeSyntax)
+                Dim elementTypeName As String
+#Disable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
+                simpleTypeName = If(TryGetSimpleTypeNameWorker(arrayType.ElementType, typeParameterNames, elementTypeName), CreateTargetTypeStringForArray(elementTypeName), Nothing)
+#Enable Warning BC42030 ' Variable is passed by reference before it has been assigned a value
+                Return simpleTypeName IsNot Nothing
+
             ElseIf TypeOf node Is GenericNameSyntax Then
                 Dim genericName = DirectCast(node, GenericNameSyntax)
                 Dim name = genericName.Identifier.Text


### PR DESCRIPTION
Fix #45042. 

I only did some quick measurement with stopwatch, the completion perf using repro project (ConsoleApp with reference to Accord.Math package) improved from ~65s to ms.

@CyrusNajmabadi could you please take a look?

FYI @AmadeusW
