### PR TITLE
Show format string completion options when the initial quote is typed

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DateAndTime.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DateAndTime.vb
@@ -8,6 +8,47 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     <[UseExportProvider]>
     Public Class CSharpCompletionCommandHandlerTests_DateAndTime
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionListIsShownWithDefaultFormatStringAfterTypingFirstQuote(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class c
+{
+    void goo(DateTime d)
+    {
+        d.ToString($$);
+    }
+}
+]]></Document>, showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("""")
+                Await state.AssertSelectedCompletionItem("G", inlineDescription:=FeaturesResources.general_long_date_time)
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("d.ToString(""G)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionListIsNotShownAfterTypingEndingQuote(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class c
+{
+    void goo(DateTime d)
+    {
+        d.ToString(" $$);
+    }
+}
+]]></Document>, showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("""")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function ExplicitInvoke(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document><![CDATA[

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DateAndTime.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DateAndTime.vb
@@ -63,10 +63,10 @@ class c
 ]]></Document>, showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.SendInvokeCompletionList()
-                Await state.AssertSelectedCompletionItem("d", inlineDescription:=FeaturesResources.short_date)
+                Await state.AssertSelectedCompletionItem("G", inlineDescription:=FeaturesResources.general_long_date_time)
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("d.ToString(""d"")", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("d.ToString(""G"")", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -44,7 +44,12 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 
             if (trigger.Kind == CompletionTriggerKind.Insertion)
             {
-                // We only trigger on typing if it's the first character in a sequence.
+                if (trigger.Character == '"')
+                {
+                    return true;
+                }
+
+                // Only trigger if it's the first character of a sequence
                 return char.IsLetter(trigger.Character) &&
                        caretPosition >= 2 &&
                        !char.IsLetter(text[caretPosition - 2]);

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -116,7 +116,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
                     inlineDescription: embeddedItem.InlineDescription,
                     sortText: sortText,
                     properties: properties.ToImmutable(),
-                    rules: s_rules));
+                    rules: embeddedItem.IsDefault
+                        ? s_rules.WithMatchPriority(MatchPriority.Preselect)
+                        : s_rules));
             }
 
             context.IsExclusive = true;
@@ -129,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
             context.AddStandard("f", FeaturesResources.full_short_date_time, FeaturesResources.full_short_date_time_description);
             context.AddStandard("F", FeaturesResources.full_long_date_time, FeaturesResources.full_long_date_time_description);
             context.AddStandard("g", FeaturesResources.general_short_date_time, FeaturesResources.general_short_date_time_description);
-            context.AddStandard("G", FeaturesResources.general_long_date_time, FeaturesResources.general_long_date_time_description);
+            context.AddStandard("G", FeaturesResources.general_long_date_time, FeaturesResources.general_long_date_time_description, isDefault: true); // This is what DateTime.ToString() uses
             context.AddStandard("M", FeaturesResources.month_day, FeaturesResources.month_day_description);
             context.AddStandard("O", FeaturesResources.round_trip_date_time, FeaturesResources.round_trip_date_time_description);
             context.AddStandard("R", FeaturesResources.rfc1123_date_time, FeaturesResources.rfc1123_date_time_description);

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeItem.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeItem.cs
@@ -16,14 +16,16 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
             public readonly string InlineDescription;
             public readonly string FullDescription;
             public readonly CompletionChange Change;
+            public readonly bool IsDefault;
 
             public DateAndTimeItem(
-                string displayText, string inlineDescription, string fullDescription, CompletionChange change)
+                string displayText, string inlineDescription, string fullDescription, CompletionChange change, bool isDefault)
             {
                 DisplayText = displayText;
                 InlineDescription = inlineDescription;
                 FullDescription = fullDescription;
                 Change = change;
+                IsDefault = isDefault;
             }
         }
     }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/EmbeddedCompletionContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/EmbeddedCompletionContext.cs
@@ -120,13 +120,13 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
                     examples.Add(example);
             }
 
-            public void AddStandard(string displayText, string suffix, string description)
-                => Add(displayText, suffix, description, standard: true);
+            public void AddStandard(string displayText, string suffix, string description, bool isDefault = false)
+                => Add(displayText, suffix, description, standard: true, isDefault);
 
             public void AddCustom(string displayText, string suffix, string description)
-                => Add(displayText, suffix, description, standard: false);
+                => Add(displayText, suffix, description, standard: false, isDefault: false);
 
-            private void Add(string displayText, string suffix, string description, bool standard)
+            private void Add(string displayText, string suffix, string description, bool standard, bool isDefault)
             {
                 using var _1 = PooledStringBuilder.GetInstance(out var descriptionBuilder);
                 using var _2 = ArrayBuilder<string>.GetInstance(out var examples);
@@ -144,7 +144,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
                 _items.Add(new DateAndTimeItem(
                     displayText, suffix, descriptionBuilder.ToString(),
                     CompletionChange.Create(
-                        new TextChange(_replacementSpan, displayText))));
+                        new TextChange(_replacementSpan, displayText)),
+                    isDefault));
             }
         }
     }


### PR DESCRIPTION
This reminds me that the feature exists and that I don't need to search my way over to the docs to remember what I want.

fyi @CyrusNajmabadi


![list_after_initial_quote](https://user-images.githubusercontent.com/8040367/85090123-55ccc680-b1b2-11ea-8e64-e51a83c8ef37.gif)