### PR TITLE
Don't fetch output paths for Intellisense projects

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService_ICSharpProjectHost.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService_ICSharpProjectHost.cs
@@ -24,9 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 projectName,
                 hierarchy,
                 this.SystemServiceProvider,
-                this.Package.ComponentModel.GetService<IThreadingContext>(),
-                this.HostDiagnosticUpdateSource,
-                this.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService<ICommandLineParserService>());
+                this.Package.ComponentModel.GetService<IThreadingContext>());
 
             projectRoot.SetProjectSite(project);
         }

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -6,13 +6,11 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;
-using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
@@ -51,17 +49,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             string projectSystemName,
             IVsHierarchy hierarchy,
             IServiceProvider serviceProvider,
-            IThreadingContext threadingContext,
-            HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt,
-            ICommandLineParserService commandLineParserServiceOpt)
+            IThreadingContext threadingContext)
             : base(projectSystemName,
                    hierarchy,
                    LanguageNames.CSharp,
                    serviceProvider,
                    threadingContext,
-                   externalErrorReportingPrefix: "CS",
-                   hostDiagnosticUpdateSourceOpt: hostDiagnosticUpdateSourceOpt,
-                   commandLineParserServiceOpt: commandLineParserServiceOpt)
+                   externalErrorReportingPrefix: "CS")
         {
             _projectRoot = projectRoot;
             _serviceProvider = serviceProvider;

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -53,6 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             : base(projectSystemName,
                    hierarchy,
                    LanguageNames.CSharp,
+                   isVsIntellisenseProject: projectRoot is IVsIntellisenseProject,
                    serviceProvider,
                    threadingContext,
                    externalErrorReportingPrefix: "CS")

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.UnitTests;
 using Microsoft.VisualStudio;
@@ -39,9 +38,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 projectSystemName: projectName,
                 hierarchy: hierarchy,
                 serviceProvider: environment.ServiceProvider,
-                threadingContext: environment.ThreadingContext,
-                hostDiagnosticUpdateSourceOpt: null,
-                commandLineParserServiceOpt: new CSharpCommandLineParserService());
+                threadingContext: environment.ThreadingContext);
         }
 
         public static CPSProject CreateCSharpCPSProject(TestEnvironment environment, string projectName, params string[] commandLineArguments)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -267,22 +267,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             return Guid.Empty;
         }
 
-        private static bool GetIsWebsiteProject(IVsHierarchy hierarchy)
-        {
-            try
-            {
-                if (hierarchy.TryGetProject(out var project))
-                {
-                    return project.Kind == VsWebSite.PrjKind.prjKindVenusProject;
-                }
-            }
-            catch (Exception)
-            {
-            }
-
-            return false;
-        }
-
         /// <summary>
         /// Map of folder item IDs in the workspace to the string version of their path.
         /// </summary>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -9,10 +9,8 @@ using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
-using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
@@ -56,9 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             string language,
             IServiceProvider serviceProvider,
             IThreadingContext threadingContext,
-            string externalErrorReportingPrefix,
-            HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt,
-            ICommandLineParserService commandLineParserServiceOpt)
+            string externalErrorReportingPrefix)
             : base(threadingContext, assertIsForeground: true)
         {
             Contract.ThrowIfNull(hierarchy);

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.IO
-Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
@@ -16,8 +15,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Vi
                                           If(compilerHost, MockCompilerHost.FullFrameworkCompilerHost),
                                           environment.CreateHierarchy(projectName, projectBinPath, projectRefPath:=Nothing, "VB"),
                                           environment.ServiceProvider,
-                                          environment.ThreadingContext,
-                                          commandLineParserServiceOpt:=New VisualBasicCommandLineParserService())
+                                          environment.ThreadingContext)
         End Function
 
         Public Function CreateMinimalCompilerOptions(project As VisualBasicProject) As VBCompilerOptions

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
@@ -14,6 +14,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Vi
             Return New VisualBasicProject(projectName,
                                           If(compilerHost, MockCompilerHost.FullFrameworkCompilerHost),
                                           environment.CreateHierarchy(projectName, projectBinPath, projectRefPath:=Nothing, "VB"),
+                                          isIntellisenseProject:=False,
                                           environment.ServiceProvider,
                                           environment.ThreadingContext)
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
@@ -2,9 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
-Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
@@ -28,9 +26,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 pVbCompilerHost,
                 pProjHier,
                 Me,
-                ComponentModel.GetService(Of IThreadingContext),
-                hostDiagnosticUpdateSource,
-                commandLineParserServiceOpt:=Workspace.Services.GetLanguageServices(LanguageNames.VisualBasic).GetService(Of ICommandLineParserService))
+                ComponentModel.GetService(Of IThreadingContext))
         End Function
 
         Public Function IsValidIdentifier(wszIdentifier As String) As Boolean Implements IVbCompiler.IsValidIdentifier

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
@@ -25,6 +25,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 wszName,
                 pVbCompilerHost,
                 pProjHier,
+                TypeOf punkProject Is IVsIntellisenseProject,
                 Me,
                 ComponentModel.GetService(Of IThreadingContext))
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -40,11 +40,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                        compilerHost As IVbCompilerHost,
                        hierarchy As IVsHierarchy,
                        serviceProvider As IServiceProvider,
-                       threadingContext As IThreadingContext,
-                       Optional hostDiagnosticUpdateSourceOpt As HostDiagnosticUpdateSource = Nothing,
-                       Optional commandLineParserServiceOpt As ICommandLineParserService = Nothing)
-            MyBase.New(projectSystemName, hierarchy, LanguageNames.VisualBasic,
-                       serviceProvider, threadingContext, "VB", hostDiagnosticUpdateSourceOpt, commandLineParserServiceOpt)
+                       threadingContext As IThreadingContext)
+            MyBase.New(projectSystemName, hierarchy, LanguageNames.VisualBasic, serviceProvider, threadingContext, "VB")
 
             _compilerHost = compilerHost
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -39,9 +39,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         Friend Sub New(projectSystemName As String,
                        compilerHost As IVbCompilerHost,
                        hierarchy As IVsHierarchy,
+                       isIntellisenseProject As Boolean,
                        serviceProvider As IServiceProvider,
                        threadingContext As IThreadingContext)
-            MyBase.New(projectSystemName, hierarchy, LanguageNames.VisualBasic, serviceProvider, threadingContext, "VB")
+            MyBase.New(projectSystemName, hierarchy, LanguageNames.VisualBasic, isIntellisenseProject, serviceProvider, threadingContext, "VB")
 
             _compilerHost = compilerHost
 


### PR DESCRIPTION
Web projects based on the legacy project system use special projects called "intellisense projects" which are fake projects that are used to act as a container for some contained languages. These are usually created with the same IVsHierarchy as a regular project, which has an unfortunate side effect. We get our build output paths from the IVsHierarchy, so it would mean both the "real" project and the Intellisense project would get the same output path.

In VS 2017, we would use that build output path to potentially convert metadata references on disk back to project references. The ambiguous path was problematic, but there was a bug: if the metadata reference was converted to a project reference when there was only one project (i.e. before you opened the file with a contained document), we converted it but then left that project converted; if a later project came along and outputted to the same output path the connection would be left around. If the reference got added after the duplicate project, it'd potentially stay a metadata reference.

In VS 2019, we rewrote the whole system that did metadata-reference-to-project-reference conversion, and this time wrote it "correctly" in that the end state didn't depend on the order of events you took to get there; if you have two projects outputting the same path, then we just don't convert a metadata reference to a project reference.

The fix being taken here is to recognize when the projects we are being handed are IVsIntellisenseProjects which means we can distinguish the projects that don't need an output path from ones that do. This ensures we don't end up with these projects having output paths at all, which probably wouldn't end well since they don't correspond to the actual code ultimately emitted to disk. We'll only ignore the project if it also has a duplicate IVsHierarchy, to avoid breaking project types (like database projects) that do create an IVsIntellisenseProject for some files, but it's not a secondary project but rather the only project.
