### PR TITLE
Refactor VisitType to be fully iterative

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -273,7 +273,7 @@ $@"        if (F({i}))
         }
 
         [WorkItem(42361, "https://github.com/dotnet/roslyn/issues/42361")]
-        [ConditionalFact(typeof(WindowsOnly))]
+        [Fact]
         public void Constraints()
         {
             int n = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
@@ -160,6 +161,18 @@ namespace Microsoft.CodeAnalysis
             var e = builder.Peek();
             builder.RemoveAt(builder.Count - 1);
             return e;
+        }
+
+        public static bool TryPop<T>(this ArrayBuilder<T> builder, [MaybeNullWhen(false)] out T e)
+        {
+            e = default;
+            if (builder.Count == 0)
+            {
+                return false;
+            }
+
+            e = builder.Pop();
+            return true;
         }
 
         public static T Peek<T>(this ArrayBuilder<T> builder)


### PR DESCRIPTION
Previously, `VisitType` attempted to implement half-tail recursion: for cases where there was a single nested type, such as pointer types and array types, we would use an iterative pattern. However, when visiting a type's containing type or when there were nested types that had potentially multiple children, such generic type arguments or function pointer types, we would fall back to standard recursion. These latter cases, particularly generics, can be deeply nested and often present issues in our smoke tests. I've rewritten `VisitType` to be fully iterative in all cases, using a manual stack instead of recursion to handle deeply nested type cases.