### PR TITLE
Make VisitType tail recursive in more cases

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -656,17 +656,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Struct:
                     case TypeKind.Interface:
                     case TypeKind.Delegate:
-                        var namedType = (NamedTypeSymbol)current;
-                        if (namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.IsEmpty)
+                        var typeArguments = ((NamedTypeSymbol)current).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+                        if (typeArguments.IsEmpty)
                         {
                             return null;
                         }
 
                         int i;
-                        for (i = 0; i < namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.Length - 1; i++)
+                        for (i = 0; i < typeArguments.Length - 1; i++)
                         {
                             // Let's try to avoid early resolution of nullable types
-                            (TypeWithAnnotations nextTypeWithAnnotations, TypeSymbol? nextType) = getNextIterationElements(namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i], canDigThroughNullable);
+                            (TypeWithAnnotations nextTypeWithAnnotations, TypeSymbol? nextType) = getNextIterationElements(typeArguments[i], canDigThroughNullable);
                             var result = VisitType(
                                 typeWithAnnotationsOpt: nextTypeWithAnnotations,
                                 type: nextType,
@@ -681,7 +681,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                         }
 
-                        next = namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i];
+                        next = typeArguments[i];
                         break;
 
                     case TypeKind.Array:

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -656,12 +656,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Struct:
                     case TypeKind.Interface:
                     case TypeKind.Delegate:
-                        foreach (var typeArg in ((NamedTypeSymbol)current).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics)
+                        var namedType = (NamedTypeSymbol)current;
+                        if (namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.IsEmpty)
+                        {
+                            return null;
+                        }
+
+                        int i;
+                        for (i = 0; i < namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.Length - 1; i++)
                         {
                             // Let's try to avoid early resolution of nullable types
+                            (TypeWithAnnotations nextTypeWithAnnotations, TypeSymbol? nextType) = getNextIterationElements(namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i], canDigThroughNullable);
                             var result = VisitType(
-                                typeWithAnnotationsOpt: canDigThroughNullable ? default : typeArg,
-                                type: canDigThroughNullable ? typeArg.NullableUnderlyingTypeOrSelf : null,
+                                typeWithAnnotationsOpt: nextTypeWithAnnotations,
+                                type: nextType,
                                 typeWithAnnotationsPredicate,
                                 typePredicate,
                                 arg,
@@ -672,7 +680,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 return result;
                             }
                         }
-                        return null;
+
+                        next = namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[i];
+                        break;
 
                     case TypeKind.Array:
                         next = ((ArrayTypeSymbol)current).ElementTypeWithAnnotations;
@@ -683,7 +693,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case TypeKind.FunctionPointer:
-                        return visitFunctionPointerType((FunctionPointerTypeSymbol)current, typeWithAnnotationsPredicate, typePredicate, arg, useDefaultType, canDigThroughNullable);
+                        {
+                            var result = visitFunctionPointerType((FunctionPointerTypeSymbol)current, typeWithAnnotationsPredicate, typePredicate, arg, useDefaultType, canDigThroughNullable, out next);
+                            if (result is object)
+                            {
+                                return result;
+                            }
+
+                            break;
+                        }
 
                     default:
                         throw ExceptionUtilities.UnexpectedValue(current.TypeKind);
@@ -694,9 +712,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 type = canDigThroughNullable ? next.NullableUnderlyingTypeOrSelf : null;
             }
 
-            static TypeSymbol? visitFunctionPointerType(FunctionPointerTypeSymbol type, Func<TypeWithAnnotations, T, bool, bool>? typeWithAnnotationsPredicate, Func<TypeSymbol, T, bool, bool>? typePredicate, T arg, bool useDefaultType, bool canDigThroughNullable)
+            static (TypeWithAnnotations, TypeSymbol?) getNextIterationElements(TypeWithAnnotations type, bool canDigThroughNullable)
+                => canDigThroughNullable ? (default(TypeWithAnnotations), type.NullableUnderlyingTypeOrSelf) : (type, null);
+
+            static TypeSymbol? visitFunctionPointerType(FunctionPointerTypeSymbol type, Func<TypeWithAnnotations, T, bool, bool>? typeWithAnnotationsPredicate, Func<TypeSymbol, T, bool, bool>? typePredicate, T arg, bool useDefaultType, bool canDigThroughNullable, out TypeWithAnnotations next)
             {
                 MethodSymbol currentPointer = type.Signature;
+                if (currentPointer.ParameterCount == 0)
+                {
+                    next = currentPointer.ReturnTypeWithAnnotations;
+                    return null;
+                }
+
                 var result = VisitType(
                     typeWithAnnotationsOpt: canDigThroughNullable ? default : currentPointer.ReturnTypeWithAnnotations,
                     type: canDigThroughNullable ? currentPointer.ReturnTypeWithAnnotations.NullableUnderlyingTypeOrSelf : null,
@@ -707,14 +734,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     useDefaultType);
                 if (result is object)
                 {
+                    next = default;
                     return result;
                 }
 
-                foreach (var parameter in currentPointer.Parameters)
+                int i;
+                for (i = 0; i < currentPointer.ParameterCount - 1; i++)
                 {
+                    (TypeWithAnnotations nextTypeWithAnnotations, TypeSymbol? nextType) = getNextIterationElements(currentPointer.Parameters[i].TypeWithAnnotations, canDigThroughNullable);
                     result = VisitType(
-                        typeWithAnnotationsOpt: canDigThroughNullable ? default : parameter.TypeWithAnnotations,
-                        type: canDigThroughNullable ? parameter.TypeWithAnnotations.NullableUnderlyingTypeOrSelf : null,
+                        typeWithAnnotationsOpt: nextTypeWithAnnotations,
+                        type: nextType,
                         typeWithAnnotationsPredicate,
                         typePredicate,
                         arg,
@@ -722,10 +752,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         useDefaultType);
                     if (result is object)
                     {
+                        next = default;
                         return result;
                     }
                 }
 
+                next = currentPointer.Parameters[i].TypeWithAnnotations;
                 return null;
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -227,7 +227,7 @@ public class Test
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly))]
+        [ConditionalFact(typeof(WindowsOrLinuxOnly))]
         public void NestedIfStatements()
         {
             int nestingLevel = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
@@ -273,7 +273,7 @@ $@"        if (F({i}))
         }
 
         [WorkItem(42361, "https://github.com/dotnet/roslyn/issues/42361")]
-        [ConditionalFact(typeof(WindowsOnly))]
+        [ConditionalFact(typeof(WindowsOrLinuxOnly))]
         public void Constraints()
         {
             int n = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch


### PR DESCRIPTION
Currently, when we encounter a INamedTypeSymbol or a function pointer in `VisitType`, we abandon any attempt to be tail recursive and instead go for a fully recursive solution. This makes the code simple, but it does mean that we are recursive even for the simple case of a named type with one type argument, which is completely possible to handle without any recursion whatsoever. This changes our implementation to always be tail recursive for the last type argument or function pointer type.