### PR TITLE
Sg latebreak fixes

### DIFF
--- a/docs/features/source-generators.cookbook.md
+++ b/docs/features/source-generators.cookbook.md
@@ -509,7 +509,7 @@ MyGenerator.props:
 <Project>
     <ItemGroup>
         <CompilerVisibleProperty Include="MyGenerator_EnableLogging" />
-        <CompilerVisibleMetadata Include="AdditionalFiles" MetadataName="MyGenerator_EnableLogging" />
+        <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="MyGenerator_EnableLogging" />
     </ItemGroup>
 </Project>
 ```

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -110,9 +110,9 @@
         <MetadataName>%(CompilerVisibleItemMetadata.MetadataName)</MetadataName>
       </_GeneratedEditorConfigMetadata>
 
-      <!-- Record that we'll write a file, and add it to the editorconfig inputs -->
+      <!-- Record that we'll write a file, and add it to the analyzerconfig inputs -->
       <FileWrites Include="$(GeneratedMSBuildEditorConfigFile)" />
-      <EditorConfigFiles Include="$(GeneratedMSBuildEditorConfigFile)" />
+      <AnalyzerConfigFiles Include="$(GeneratedMSBuildEditorConfigFile)" />
     </ItemGroup>
 
     <!-- Transform the collected properties and items into an editor config file -->

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -390,6 +390,28 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("", metaName.EvaluatedValue);
         }
 
+        [Fact]
+        public void GenerateEditorConfigIsPassedToTheCompiler()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+
+    <ItemGroup>
+        <CompilerVisibleProperty Include=""prop"" />
+    </ItemGroup>
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+
+            bool runSuccess = instance.Build(target: "GenerateMSBuildEditorConfigFile", GetTestLoggers());
+            Assert.True(runSuccess);
+
+            var items = instance.GetItems("AnalyzerConfigFiles");
+            Assert.Single(items);
+        }
+
         private ProjectInstance CreateProjectInstance(XmlReader reader)
         {
             Project proj = new Project(reader);

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -175,6 +175,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
             }
+            int globalConfigOptionsCount = sectionKey.Count;
 
             // The editorconfig paths are sorted from shortest to longest, so matches
             // are resolved from most nested to least nested, where last setting wins
@@ -188,7 +189,7 @@ namespace Microsoft.CodeAnalysis
                     // to this source file.
                     if (config.IsRoot)
                     {
-                        sectionKey.Clear();
+                        sectionKey.RemoveRange(globalConfigOptionsCount, sectionKey.Count - globalConfigOptionsCount);
                     }
 
                     int dirLength = config.NormalizedDirectory.Length;


### PR DESCRIPTION
Fixes two global analyzer issues:

**Commit1**: When we renamed the targets files, we also accidentally renamed the `AnalyzerConfigFiles` item to `EditorConfigFiles` meaning it was no longer passed to the compiler. We didn't have tests for this before, but we've since added target tests and I've added a test to cover this specific case.

**Commit2:** Global analyzer config options where getting incorrectly cleared when there was a root config lower in the hierarchy. This is a somewhat niche case but we are hitting it in the source generator samples in roslyn-sdk. Fixed and added a test to verify a combination of root config cases.