### PR TITLE
Enable AdditionalFiles to respect CopyToOutputDirectory option

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -231,8 +231,8 @@
     CopyAdditionalFiles
     =======
 
-    If a user requests that any @(AdditionalFile) items are copied to the output directory
-    We add them to the @(None) group to ensure they will be copied.
+    If a user requests that any @(AdditionalFiles) items are copied to the output directory
+    we add them to the @(None) group to ensure they will be copied.
  -->
  
    <Target Name="CopyAdditionalFiles" 

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -226,4 +226,20 @@
     </PropertyGroup>
   </Target>
 
+  <!--
+    =======
+    CopyAdditionalFiles
+    =======
+
+    If a user requests that any @(AdditionalFile) items are copied to the output directory
+    We add them to the @(None) group to ensure they will be copied.
+ -->
+ 
+   <Target Name="CopyAdditionalFiles" 
+           BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <None Include="@(AdditionalFiles)" Condition="'%(AdditionalFiles.CopyToOutputDirectory)' != ''" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -412,6 +412,38 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Single(items);
         }
 
+        [Fact]
+        public void AdditionalFilesAreAddedToNoneWhenCopied()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+    <ItemGroup>
+        <AdditionalFiles Include=""file1.cs"" CopyToOutputDirectory=""Always"" />
+        <AdditionalFiles Include=""file2.cs"" CopyToOutputDirectory=""PreserveNewest"" />
+        <AdditionalFiles Include=""file3.cs"" CopyToOutputDirectory=""Never"" />
+        <AdditionalFiles Include=""file4.cs"" CopyToOutputDirectory="""" />
+        <AdditionalFiles Include=""file5.cs"" />
+    </ItemGroup>
+</Project>
+"));
+            var instance = CreateProjectInstance(xmlReader);
+            bool runSuccess = instance.Build(target: "CopyAdditionalFiles", GetTestLoggers());
+            Assert.True(runSuccess);
+
+            var noneItems = instance.GetItems("None").ToArray();
+            Assert.Equal(3, noneItems.Length);
+
+            Assert.Equal("file1.cs", noneItems[0].EvaluatedInclude);
+            Assert.Equal("Always", noneItems[0].GetMetadataValue("CopyToOutputDirectory"));
+
+            Assert.Equal("file2.cs", noneItems[1].EvaluatedInclude);
+            Assert.Equal("PreserveNewest", noneItems[1].GetMetadataValue("CopyToOutputDirectory"));
+
+            Assert.Equal("file3.cs", noneItems[2].EvaluatedInclude);
+            Assert.Equal("Never", noneItems[2].GetMetadataValue("CopyToOutputDirectory"));
+        }
+
         private ProjectInstance CreateProjectInstance(XmlReader reader)
         {
             Project proj = new Project(reader);


### PR DESCRIPTION
- Add a target that appends any AdditionalFiles with CopyToOutputDirectory set to the None itemgroup
- Add test