### PR TITLE
Do not keep track of compilation symbosl for compilations that we will not pass out to features.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis
                     : base(new WeakValueSource<Compilation>(declarationCompilation),
                            declarationCompilation.Clone().RemoveAllReferences(),
                            generatorDriver,
-                           unrootedSymbolSet: null)
+                           GetUnrootedSymbols(declarationCompilation))
                 {
                 }
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis
                     : base(compilation: new ConstantValueSource<Optional<Compilation>>(inProgressCompilation),
                            declarationOnlyCompilation: null,
                            generatorDriver: inProgressGeneratorDriver,
-                           GetUnrootedSymbols(inProgressCompilation))
+                           unrootedSymbolSet: null)
                 {
                     Contract.ThrowIfTrue(intermediateProjects.IsDefault);
                     Contract.ThrowIfFalse(intermediateProjects.Length > 0);
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis
                     : base(new WeakValueSource<Compilation>(declarationCompilation),
                            declarationCompilation.Clone().RemoveAllReferences(),
                            generatorDriver,
-                           GetUnrootedSymbols(declarationCompilation))
+                           unrootedSymbolSet: null)
                 {
                 }
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -107,7 +107,8 @@ namespace Microsoft.CodeAnalysis
                              symbol.Kind == SymbolKind.DynamicType);
                 var state = this.ReadState();
                 var unrootedSymbolSet = state.UnrootedSymbolSet;
-                return unrootedSymbolSet != null && unrootedSymbolSet.TryGetValue(symbol, out _);
+                Contract.ThrowIfNull(unrootedSymbolSet, $"Should not be checking if a symbol is from this compilation for this {state.GetType()} state");
+                return unrootedSymbolSet.TryGetValue(symbol, out _);
             }
 
             /// <summary>


### PR DESCRIPTION
Running this to get test coverage to see if any code we have violates this assumption.  Note: this is complimentary with https://github.com/dotnet/roslyn/pull/45435.  Both/either could likely be taken.  