### PR TITLE
Origin/bug fix/explicit cast on switch expression

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                    shouldMoveNextStatementToSwitchExpression: shouldRemoveNextStatement,
                    generateDeclaration: declaratorToRemoveLocationOpt is object);
 
-                editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation));
+                editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation));
 
                 if (declaratorToRemoveLocationOpt is object)
                 {

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
@@ -83,28 +84,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
                 var switchStatement = (SwitchStatementSyntax)switchLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
 
-                // If the swith statement expression is being implicitly converted then we need to explicitly cast the expression
-                // before rewriting as a switch expression
-                var expressionISymbolType = semanticModel.GetSymbolInfo(switchStatement.Expression).Symbol.GetSymbolType();
-                var expConversionISymbolType = semanticModel.GetTypeInfo(switchStatement.Expression).ConvertedType;
-
-                var needsCast = false;
-                SwitchStatementSyntax newSwitch = null;
-                if (expConversionISymbolType != expressionISymbolType && expConversionISymbolType != null)
-                {
-                    needsCast = true;
-                    newSwitch = switchStatement.Update(switchStatement.SwitchKeyword, switchStatement.OpenParenToken,
-                        switchStatement.Expression.Cast(expConversionISymbolType).WithAdditionalAnnotations(Formatter.Annotation),
-                        switchStatement.CloseParenToken, switchStatement.OpenBraceToken,
-                        switchStatement.Sections, switchStatement.CloseBraceToken);
-                }
+                var expressionCastType = semanticModel.GetTypeInfo(switchStatement.Expression).ConvertedType;
 
                 var switchExpression = Rewriter.Rewrite(
-                   needsCast ? newSwitch : switchStatement, declaratorToRemoveTypeOpt, nodeToGenerate,
+                   switchStatement, expressionCastType, declaratorToRemoveTypeOpt, nodeToGenerate,
                    shouldMoveNextStatementToSwitchExpression: shouldRemoveNextStatement,
                    generateDeclaration: declaratorToRemoveLocationOpt is object);
 
-                editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation));
+                editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation));
 
                 if (declaratorToRemoveLocationOpt is object)
                 {

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -84,10 +84,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
                 var switchStatement = (SwitchStatementSyntax)switchLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
 
-                var expressionCastType = semanticModel.GetTypeInfo(switchStatement.Expression).ConvertedType;
-
                 var switchExpression = Rewriter.Rewrite(
-                   switchStatement, expressionCastType, declaratorToRemoveTypeOpt, nodeToGenerate,
+                   switchStatement, semanticModel, declaratorToRemoveTypeOpt, nodeToGenerate,
                    shouldMoveNextStatementToSwitchExpression: shouldRemoveNextStatement,
                    generateDeclaration: declaratorToRemoveLocationOpt is object);
 

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionFixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionFixAllTests.cs
@@ -270,5 +270,47 @@ class Program
     }
 }");
         }
+        [WorkItem(44572, "https://github.com/dotnet/roslyn/issues/44572")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        public async Task TestImplicitConversion()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"using System;
+
+class C
+{
+    public C(String s) => _s = s;
+    private readonly String _s;
+    public static implicit operator String(C value) => value._s;
+    public static implicit operator C(String value) => new C(value);
+    
+    public bool method(C c)
+    {
+        [|switch|] (c)
+        {
+            case ""A"": return true;
+            default: return false;
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    public C(String s) => _s = s;
+    private readonly String _s;
+    public static implicit operator String(C value) => value._s;
+    public static implicit operator C(String value) => new C(value);
+    
+    public bool method(C c)
+    {
+        return ((string)c) switch
+        {
+            ""A"" => true,
+            _ => false,
+        };
+    }
+}");
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -1666,10 +1666,10 @@ class Program
         [|switch|] (a)
         {
             case 0:
-                o = default;
+                o = default(object);
                 break;
             default:
-                o = default;
+                o = default(object);
                 break;
         }
     }
@@ -1682,8 +1682,8 @@ class Program
         var a = 0;
         var o = a switch
         {
-            0 => default,
-            _ => default,
+            0 => default(object),
+            _ => default(object),
         };
     }
 }";

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -1666,10 +1666,10 @@ class Program
         [|switch|] (a)
         {
             case 0:
-                o = default(object);
+                o = default;
                 break;
             default:
-                o = default(object);
+                o = default;
                 break;
         }
     }
@@ -1682,8 +1682,8 @@ class Program
         var a = 0;
         var o = a switch
         {
-            0 => default(object),
-            _ => default(object),
+            0 => default,
+            _ => default,
         };
     }
 }";


### PR DESCRIPTION
A switch statement on a type that has a conversion to another type applies that conversion before doing the switch. But it doesn't occur for the switch expression. So if the switch expression's input type is C and the constant pattern is a string "A", then the string "A" is converted to the input type C and results in a value that is not a constant. Since the pattern is required to be a constant, that is an error. Converting a switch statement to a switch expression would require making the conversion on the input value explicit.

This fix simply checks if the switch statements input type is the same as the constant patter and if it is not it explicitly casts the input value to match.  (if possible)

The original bug: https://github.com/dotnet/roslyn/issues/44572 