### PR TITLE
Remove unnecessary Clone()

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2122,7 +2122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // The starting state is the top state, but with captured
             // variables set according to Joining the state at all the
             // local function use sites
-            State = TopState().Clone();
+            State = TopState();
             for (int slot = 1; slot < localFunctionState.StartingState.Capacity; slot++)
             {
                 var symbol = variableBySlot[RootSlot(slot)].Symbol;


### PR DESCRIPTION
Looking at the implementation of [NullableWalker.TopState()](https://github.com/dotnet/roslyn/blob/312c549f58862cbaf20a4cff55d28d729c4f9a1e/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs#L1836) I do not believe Clone is necessary here.

Making this change independently to simplify review of later PRs.