### PR TITLE
Defer creation of the unrooted symbol set until the point that someone actually asks for a compilation

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -198,8 +198,7 @@ namespace Microsoft.CodeAnalysis
                         new ConstantValueSource<Optional<Compilation>>(inProgressCompilation),
                         inProgressCompilation,
                         generatorDriver: new TrackedGeneratorDriver(null),
-                        hasSuccessfullyLoaded: false,
-                        State.GetUnrootedSymbols(inProgressCompilation)));
+                        hasSuccessfullyLoaded: false));
             }
 
             /// <summary>
@@ -722,8 +721,7 @@ namespace Microsoft.CodeAnalysis
                             State.CreateValueSource(compilationWithoutGeneratedFiles, solution.Services),
                             compilationWithoutGeneratedFiles,
                             generatorDriver,
-                            hasSuccessfullyLoaded,
-                            State.GetUnrootedSymbols(compilation)),
+                            hasSuccessfullyLoaded),
                         solution.Services);
 
                     return new CompilationInfo(compilation, hasSuccessfullyLoaded);


### PR DESCRIPTION
WIP.  Doing this to get CI coverage.