### PR TITLE
Function pointer bug fixes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1671,6 +1671,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!overloadResolutionResult.Succeeded)
             {
+                ImmutableArray<FunctionPointerMethodSymbol> methods = methodsBuilder.ToImmutableAndFree();
                 overloadResolutionResult.ReportDiagnostics(
                     binder: this,
                     node.Location,
@@ -1680,7 +1681,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     boundExpression,
                     boundExpression.Syntax,
                     analyzedArguments,
-                    methodsBuilder.ToImmutableAndFree(),
+                    methods,
                     typeContainingConstructor: null,
                     delegateTypeBeingInvoked: null,
                     returnRefKind: funcPtr.Signature.RefKind);
@@ -1688,7 +1689,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundFunctionPointerInvocation(
                     node,
                     boundExpression,
-                    analyzedArguments.Arguments.SelectAsArray((expr, args) => args.binder.BindToNaturalType(expr, args.diagnostics), (binder: this, diagnostics)),
+                    BuildArgumentsForErrorRecovery(analyzedArguments, StaticCast<MethodSymbol>.From(methods)),
                     analyzedArguments.RefKinds.ToImmutableOrNull(),
                     LookupResultKind.OverloadResolutionFailure,
                     funcPtr.Signature.ReturnType,

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     break;
 
                 case BoundKind.FunctionPointerLoad:
-                    EmitLoadFunction((BoundFunctionPointerLoad)expression);
+                    EmitLoadFunction((BoundFunctionPointerLoad)expression, used);
                     break;
 
                 default:
@@ -3466,11 +3466,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        private void EmitLoadFunction(BoundFunctionPointerLoad load)
+        private void EmitLoadFunction(BoundFunctionPointerLoad load, bool used)
         {
             Debug.Assert(load.Type is { TypeKind: TypeKind.FunctionPointer });
-            _builder.EmitOpCode(ILOpCode.Ldftn);
-            EmitSymbolToken(load.TargetMethod, load.Syntax, optArgList: null);
+
+            if (used)
+            {
+                _builder.EmitOpCode(ILOpCode.Ldftn);
+                EmitSymbolToken(load.TargetMethod, load.Syntax, optArgList: null);
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -1303,6 +1303,30 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitDelegateCreationExpression(node);
         }
 
+        public override BoundNode VisitFunctionPointerLoad(BoundFunctionPointerLoad node)
+        {
+            if (node.TargetMethod.MethodKind == MethodKind.LocalFunction)
+            {
+                Debug.Assert(node.TargetMethod is { RequiresInstanceReceiver: false, IsStatic: true });
+                ImmutableArray<BoundExpression> arguments = default;
+                ImmutableArray<RefKind> argRefKinds = default;
+
+                RemapLocalFunction(
+                    node.Syntax,
+                    node.TargetMethod,
+                    out var receiver,
+                    out var remappedMethod,
+                    ref arguments,
+                    ref argRefKinds);
+
+                Debug.Assert(arguments.IsDefault && argRefKinds.IsDefault && receiver.Kind == BoundKind.TypeExpression);
+
+                return node.Update(remappedMethod, node.Type);
+            }
+
+            return base.VisitFunctionPointerLoad(node);
+        }
+
         public override BoundNode VisitConversion(BoundConversion conversion)
         {
             // a conversion with a method should have been rewritten, e.g. to an invocation

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -1314,12 +1314,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 RemapLocalFunction(
                     node.Syntax,
                     node.TargetMethod,
-                    out var receiver,
-                    out var remappedMethod,
+                    out BoundExpression receiver,
+                    out MethodSymbol remappedMethod,
                     ref arguments,
                     ref argRefKinds);
 
-                Debug.Assert(arguments.IsDefault && argRefKinds.IsDefault && receiver.Kind == BoundKind.TypeExpression);
+                Debug.Assert(arguments.IsDefault &&
+                             argRefKinds.IsDefault &&
+                             receiver.Kind == BoundKind.TypeExpression &&
+                             remappedMethod is { RequiresInstanceReceiver: false, IsStatic: true });
 
                 return node.Update(remappedMethod, node.Type);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override BoundNode VisitFunctionPointerLoad(BoundFunctionPointerLoad node)
         {
-            return node.Update(VisitMethodSymbol(node.TargetMethod), node.Type);
+            return node.Update(VisitMethodSymbol(node.TargetMethod), VisitType(node.Type));
         }
 
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -506,6 +506,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(rewrittenArgument, method, node.IsExtensionMethod, type);
         }
 
+        public override BoundNode VisitFunctionPointerLoad(BoundFunctionPointerLoad node)
+        {
+            return node.Update(VisitMethodSymbol(node.TargetMethod), node.Type);
+        }
+
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -7197,39 +7197,39 @@ unsafe class Test
 }");
 
             comp.VerifyDiagnostics(
-                // (5,20): error CS1620: Argument 1 must be passed with the 'ref' keyword
+                // (6,20): error CS1620: Argument 1 must be passed with the 'ref' keyword
                 //         param1(out var l);
-                Diagnostic(ErrorCode.ERR_BadArgRef, "var l").WithArguments("1", "ref").WithLocation(5, 20),
-                // (7,16): error CS1620: Argument 1 must be passed with the 'ref' keyword
+                Diagnostic(ErrorCode.ERR_BadArgRef, "var l").WithArguments("1", "ref").WithLocation(6, 20),
+                // (8,16): error CS1620: Argument 1 must be passed with the 'ref' keyword
                 //         param1(s);
-                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "ref").WithLocation(7, 16),
-                // (8,19): error CS1620: Argument 1 must be passed with the 'ref' keyword
+                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "ref").WithLocation(8, 16),
+                // (9,19): error CS1620: Argument 1 must be passed with the 'ref' keyword
                 //         param1(in s);
-                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "ref").WithLocation(8, 19),
-                // (12,20): error CS1615: Argument 1 may not be passed with the 'out' keyword
+                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "ref").WithLocation(9, 19),
+                // (14,20): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //         param2(out var l);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var l").WithArguments("1", "out").WithLocation(12, 20),
-                // (15,20): error CS1615: Argument 1 may not be passed with the 'ref' keyword
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var l").WithArguments("1", "out").WithLocation(14, 20),
+                // (17,20): error CS1615: Argument 1 may not be passed with the 'ref' keyword
                 //         param2(ref s);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "s").WithArguments("1", "ref").WithLocation(15, 20),
-                // (20,16): error CS1620: Argument 1 must be passed with the 'out' keyword
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "s").WithArguments("1", "ref").WithLocation(17, 20),
+                // (23,16): error CS1620: Argument 1 must be passed with the 'out' keyword
                 //         param3(s);
-                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "out").WithLocation(20, 16),
-                // (21,20): error CS1620: Argument 1 must be passed with the 'out' keyword
+                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "out").WithLocation(23, 16),
+                // (24,20): error CS1620: Argument 1 must be passed with the 'out' keyword
                 //         param3(ref s);
-                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "out").WithLocation(21, 20),
-                // (22,19): error CS1620: Argument 1 must be passed with the 'out' keyword
+                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "out").WithLocation(24, 20),
+                // (25,19): error CS1620: Argument 1 must be passed with the 'out' keyword
                 //         param3(in s);
-                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "out").WithLocation(22, 19),
-                // (26,20): error CS1615: Argument 1 may not be passed with the 'out' keyword
+                Diagnostic(ErrorCode.ERR_BadArgRef, "s").WithArguments("1", "out").WithLocation(25, 19),
+                // (30,20): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //         param4(out var l);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var l").WithArguments("1", "out").WithLocation(26, 20),
-                // (28,20): error CS1615: Argument 1 may not be passed with the 'ref' keyword
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var l").WithArguments("1", "out").WithLocation(30, 20),
+                // (32,20): error CS1615: Argument 1 may not be passed with the 'ref' keyword
                 //         param4(ref s);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "s").WithArguments("1", "ref").WithLocation(28, 20),
-                // (29,19): error CS1615: Argument 1 may not be passed with the 'in' keyword
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "s").WithArguments("1", "ref").WithLocation(32, 20),
+                // (33,19): error CS1615: Argument 1 may not be passed with the 'in' keyword
                 //         param4(in s);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "s").WithArguments("1", "in").WithLocation(29, 19)
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "s").WithArguments("1", "in").WithLocation(33, 19)
             );
         }
 


### PR DESCRIPTION
Fixes a couple of function pointer bugs:

* Commit 1 ensures that we use translated local function symbols, not the original symbol, when emitting the `ldftn` instruction, and corrects handling of non-static local functions. This fixes https://github.com/dotnet/roslyn/issues/45447.
* Commit 2 ensures that we correctly bind arguments for error recovery in all cases. Fixes https://github.com/dotnet/roslyn/issues/45418.
* Commit 5 ensures that we don't emit an ldftn the result is not used.

@dotnet/roslyn-compiler @AlekseyTs for review.