### PR TITLE
Reduce memory required for document change processing queues

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/RecoverableTextAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/RecoverableTextAndVersion.cs
@@ -67,6 +67,10 @@ namespace Microsoft.CodeAnalysis
                 {
                     version = textAndVersion.Version;
                 }
+                else if (_initialSource is ITextVersionable textVersionable)
+                {
+                    return textVersionable.TryGetTextVersion(out version);
+                }
             }
 
             return version != default;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -100,7 +100,12 @@ namespace Microsoft.CodeAnalysis
         {
             var result = new RecoverableTextAndVersion(CreateStrongText(text), services.TemporaryStorage);
 
-            // Ensure the recoverable text is saved in temporary storage
+            // This RecoverableTextAndVersion is created directly from a TextAndVersion instance. In its initial state,
+            // the RecoverableTextAndVersion keeps a strong reference to the initial TextAndVersion, and only
+            // transitions to a weak reference backed by temporary storage after the first time GetValue (or
+            // GetValueAsync) is called. Since we know we are creating a RecoverableTextAndVersion for the purpose of
+            // avoiding problematic address space overhead, we call GetValue immediately to force the object to weakly
+            // hold its data from the start.
             result.GetValue();
 
             return result;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -97,7 +97,14 @@ namespace Microsoft.CodeAnalysis
         }
 
         protected static ValueSource<TextAndVersion> CreateRecoverableText(TextAndVersion text, SolutionServices services)
-            => new RecoverableTextAndVersion(CreateStrongText(text), services.TemporaryStorage);
+        {
+            var result = new RecoverableTextAndVersion(CreateStrongText(text), services.TemporaryStorage);
+
+            // Ensure the recoverable text is saved in temporary storage
+            result.GetValue();
+
+            return result;
+        }
 
         protected static ValueSource<TextAndVersion> CreateRecoverableText(TextLoader loader, DocumentId documentId, SolutionServices services)
         {


### PR DESCRIPTION
Substantially improves the "robustness" of the IDE in handling branch switches in large solutions (e.g. Roslyn.sln).

Fixes #45452
