### PR TITLE
Fix up nondeterminism in serializing naming style preferences

### DIFF
--- a/src/Workspaces/CoreTest/CodeStyle/NamingStylePreferencesUpgradeTests.cs
+++ b/src/Workspaces/CoreTest/CodeStyle/NamingStylePreferencesUpgradeTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Linq;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -20,7 +22,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
         private static void AssertTrimmedEqual(string expected, string actual)
             => Assert.Equal(expected.Trim(), actual.Trim());
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44714"), Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public void TestPreserveDefaultPreferences()
         {
             AssertTrimmedEqual(
@@ -28,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
                 ReserializePreferences(NamingStylePreferences.DefaultNamingPreferencesString));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44714"), Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public void TestCannotUpgrade3To5()
         {
             var serializedPreferences = @"
@@ -138,7 +140,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
                 ReserializePreferences(serializedPreferences));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44714"), Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public void TestCannotDowngradeHigherThanLatestVersion5()
         {
             var serializedPreferences = @"
@@ -172,6 +174,30 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
             AssertTrimmedEqual(
                 NamingStylePreferences.DefaultNamingPreferencesString,
                 ReserializePreferences(serializedPreferences));
+        }
+
+        /// <summary>
+        /// Having duplicates in enums like this means that calling Enum.ToString() will potentially be unstable.
+        /// See https://github.com/dotnet/roslyn/issues/44714 for an example where were previously bitten by this;
+        /// we should avoid doing this in the future. If this test fails, update <see cref="SymbolSpecification.ModifierKind"/>
+        /// to ensure the existing naming styles continue to serialize as they originally did.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(SymbolKind))]
+        [InlineData(typeof(TypeKind), nameof(TypeKind.Struct), nameof(TypeKind.Structure))]
+        [InlineData(typeof(MethodKind), nameof(MethodKind.AnonymousFunction), nameof(MethodKind.LambdaMethod), nameof(MethodKind.SharedConstructor), nameof(MethodKind.StaticConstructor))]
+        public void NoDuplicateEntriesInKindEnumerations(Type type, params string[] expectedDuplicates)
+        {
+            Assert.True(type.IsEnum);
+
+            var enumNamesAndValues = type.GetEnumNames().Zip(type.GetEnumValues().Cast<object>(), (name, value) => (name, value));
+            var duplicates = enumNamesAndValues.GroupBy(e => e.value)
+                                               .Where(group => group.Count() > 1)
+                                               .SelectMany(group => group)
+                                               .Select(e => e.name)
+                                               .OrderBy(name => name);
+
+            Assert.Equal(expectedDuplicates, duplicates);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
@@ -365,9 +365,35 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
             internal XElement CreateXElement()
                 => SymbolKind.HasValue ? new XElement(nameof(SymbolKind), SymbolKind) :
-                   TypeKind.HasValue ? new XElement(nameof(TypeKind), TypeKind) :
-                   MethodKind.HasValue ? new XElement(nameof(MethodKind), MethodKind) :
+                   TypeKind.HasValue ? new XElement(nameof(TypeKind), GetTypeKindString(TypeKind.Value)) :
+                   MethodKind.HasValue ? new XElement(nameof(MethodKind), GetMethodKindString(MethodKind.Value)) :
                    throw ExceptionUtilities.Unreachable;
+
+            private static string GetTypeKindString(TypeKind typeKind)
+            {
+                // We have two members in TypeKind that point to the same value, Struct and Structure. Because of this,
+                // Enum.ToString(), which under the covers uses a binary search, isn't stable which one it will pick and it can
+                // change if other TypeKinds are added. This ensures we keep using the same string consistently.
+                return typeKind switch
+                {
+                    CodeAnalysis.TypeKind.Structure => nameof(CodeAnalysis.TypeKind.Struct),
+                    _ => typeKind.ToString()
+                };
+            }
+
+            private static string GetMethodKindString(MethodKind methodKind)
+            {
+                // We ehave some members in TypeKind that point to the same value. Because of this,
+                // Enum.ToString(), which under the covers uses a binary search, isn't stable which one it will pick and it can
+                // change if other MethodKinds are added. This ensures we keep using the same string consistently.
+                return methodKind switch
+                {
+
+                    CodeAnalysis.MethodKind.SharedConstructor => nameof(CodeAnalysis.MethodKind.StaticConstructor),
+                    CodeAnalysis.MethodKind.AnonymousFunction => nameof(CodeAnalysis.MethodKind.LambdaMethod),
+                    _ => methodKind.ToString()
+                };
+            }
 
             public bool ShouldReuseInSerialization => false;
 


### PR DESCRIPTION
We have two members in TypeKind that point to the same value, Struct and Structure. Because of this, Enum.ToString(), which under the covers uses a binary search, isn't stable which one it will pick and it can change if other TypeKinds are added. This ensures we keep using the same string consistently.

Fixes https://github.com/dotnet/roslyn/issues/44714