### PR TITLE
Feature/convert name of

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertNameOf/CSharpConvertNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNameOf/CSharpConvertNameOfDiagnosticAnalyzer.cs
@@ -44,8 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNameOf
             //var cancellationToken = syntaxContext.CancellationToken;
             var node = syntaxContext.Node;
 
-            // TODO: Any relevant style options?
-
             // nameof was added in CSharp 6.0, so don't offer it for any languages before that time
             if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp6)
             {
@@ -53,21 +51,22 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNameOf
             }
 
             // TODO: Check for compiler errors on the declaration
-            //var siblings = node.Parent.ChildNodes();
+
             var parent = node.Parent;
-            //var name = siblings.ElementAt(1).SyntaxTo;
 
             // We know that it is a typeof() instance, but we only want to offer the fix if it is a .Name access
-            if (!(node.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression) && parent.IsDotNameAccess()))
+            if (!(node.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression) && parent.IsNameMemberAccess()))
             {
                 return;
             }
 
-            // TODO: Filter cases that don't work
+            // TODO: if argument is primitive cases
+
+            //TODO: if argument is generic
 
 
-            // TODO: Create and report the right diagnostic
-            var location = Location.Create(syntaxTree, node.Span);
+            // Current case can be effectively changed to a nameof instance so report a diagnostic
+            var location = Location.Create(syntaxTree, parent.Span);
             var additionalLocations = ImmutableArray.Create(node.GetLocation());
 
             syntaxContext.ReportDiagnostic(DiagnosticHelper.Create(
@@ -81,6 +80,5 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNameOf
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        // HELPERS GO HERE
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/ConvertNameOf/CSharpConvertNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNameOf/CSharpConvertNameOfDiagnosticAnalyzer.cs
@@ -46,21 +46,25 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNameOf
 
             // TODO: Any relevant style options?
 
-            // nameof was added in CSharp 6.0, so don't offer it for any languages after that time
+            // nameof was added in CSharp 6.0, so don't offer it for any languages before that time
             if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp6)
             {
                 return;
             }
 
             // TODO: Check for compiler errors on the declaration
+            //var siblings = node.Parent.ChildNodes();
+            var parent = node.Parent;
+            //var name = siblings.ElementAt(1).SyntaxTo;
 
             // We know that it is a typeof() instance, but we only want to offer the fix if it is a .Name access
-            if (!node.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            if (!(node.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression) && parent.IsDotNameAccess()))
             {
                 return;
             }
 
             // TODO: Filter cases that don't work
+
 
             // TODO: Create and report the right diagnostic
             var location = Location.Create(syntaxTree, node.Span);

--- a/src/Analyzers/CSharp/Analyzers/ConvertNameOf/CSharpConvertNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNameOf/CSharpConvertNameOfDiagnosticAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNameOf
     {
         public CSharpConvertNameOfDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.ConvertNameOfDiagnosticId,
-                   CSharpCodeStyleOptions.PreferBraces,
+                   CSharpCodeStyleOptions.PreferBraces, //TODO: Update code style options
                    LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Convert_type_name_to_nameof), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
@@ -52,9 +52,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNameOf
                 return;
             }
 
-            // TODO: Check for compiler errors on the typeof(someType).Name declaration
+            // TODO: Check for compiler errors on the declaration
 
-            // TODO: Check that the current span is the case we're looking for
+            // We know that it is a typeof() instance, but we only want to offer the fix if it is a .Name access
+            if (!node.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            {
+                return;
+            }
 
             // TODO: Filter cases that don't work
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -373,9 +373,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         /// <summary>
-        /// Returns if <paramref name="node"/> is an access to the .Name attribute of a type.
+        /// Returns if <paramref name="node"/> is a member access to the .Name attribute of a type.
         /// </summary>
-        public static bool IsDotNameAccess(this SyntaxNode node)
+        public static bool IsNameMemberAccess(this SyntaxNode node)
         {
             var access = node.IsKind(SyntaxKind.SimpleMemberAccessExpression);
             if (node != null && access)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -373,6 +373,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         /// <summary>
+        /// Returns if <paramref name="node"/> is an access to the .Name attribute of a type.
+        /// </summary>
+        public static bool IsDotNameAccess(this SyntaxNode node)
+        {
+            var access = node.IsKind(SyntaxKind.SimpleMemberAccessExpression);
+            if (node != null && access)
+            {
+                var name = ((MemberAccessExpressionSyntax)node).Name;
+
+                if (name.Identifier.ValueText == "Name")
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Returns the list of using directives that affect <paramref name="node"/>. The list will be returned in
         /// top down order.  
         /// </summary>


### PR DESCRIPTION
Previously, the analyzer worked for all typeof(someType) instances, now it only works for typeof(someType).Name instances.