### PR TITLE
Replace CodeGenCapturing test with better implementation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,6 +46,7 @@
     <EnvDTEVersion>8.0.2</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
     <FakeSignVersion>0.9.2</FakeSignVersion>
+    <FsCheckVersion>2.14.3</FsCheckVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>5.0.2.5153</ICSharpCodeDecompilerVersion>
     <MicrosoftBuildVersion>15.3.409</MicrosoftBuildVersion>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -192,7 +192,7 @@
     <!-- C# specific settings -->
     <When Condition="'$(Language)' == 'C#'">
       <PropertyGroup>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>preview</LangVersion>
         <WarningLevel>4</WarningLevel>
         <ErrorReport>prompt</ErrorReport>
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -2,465 +2,196 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
+using FsCheck;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Roslyn.Test.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Xunit;
-using System.Collections;
-using System.Collections.Immutable;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
+using static System.Environment;
+
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
+    /// <summary>
+    /// This class contains fuzzing code to generate random combinations of capturing of local
+    /// functions and lambdas.
+    /// </summary>
     public class CodeGenCapturing : CSharpTestBase
     {
-        private class CaptureContext
+        [Fact]
+        public void CompileSamples()
         {
-            // Stores a mapping from scope index (0-based count of scopes
-            // from `this` to most nested scope)
-            public readonly List<IList<string>> VariablesByScope = new List<IList<string>>();
-
-            private CaptureContext() { }
-
-            public CaptureContext(int MaxVariables)
-            {
-                // Fields are shared among methods, so we also share them in the
-                // capture context when cloning
-                var fieldsBuilder = ImmutableArray.CreateBuilder<string>(MaxVariables);
-                for (int i = 0; i < MaxVariables; i++)
-                {
-                    fieldsBuilder.Add($"field_{i}");
-                }
-                VariablesByScope.Add(fieldsBuilder.MoveToImmutable());
-            }
-
-            public void Add(int depth, string varName)
-            {
-                if (VariablesByScope.Count <= depth ||
-                    VariablesByScope[depth] == null)
-                {
-                    VariablesByScope.Insert(depth, new List<string>() { varName });
-                }
-                else
-                {
-                    VariablesByScope[depth].Add(varName);
-                }
-            }
-
-            public CaptureContext Clone()
-            {
-                var fields = VariablesByScope[0];
-                var newCtx = new CaptureContext();
-                newCtx.VariablesByScope.Add(fields);
-                newCtx.VariablesByScope.AddRange(
-                    this.VariablesByScope
-                    .Skip(1)
-                    .Select(list => list == null ? null : new List<string>(list)));
-                newCtx.CaptureNameIndex = this.CaptureNameIndex;
-                return newCtx;
-            }
-
-            public int CaptureNameIndex = 0;
-        }
-
-        private static string MakeLocalFunc(int nameIndex, string captureExpression)
-            => $@"int Local_{nameIndex}() => {captureExpression};";
-
-        private static string MakeCaptureExpression(IList<int> varsToCapture, CaptureContext ctx)
-        {
-            var varNames = new List<string>();
-            for (int varDepth = 0; varDepth < varsToCapture.Count; varDepth++)
-            {
-                var variablesByScope = ctx.VariablesByScope;
-                // Do we have any variables in this scope depth?
-                // If not, initialize an empty list
-                if (variablesByScope.Count <= varDepth)
-                {
-                    variablesByScope.Add(new List<string>());
-                }
-
-                var varsAtCurrentDepth = variablesByScope[varDepth];
-
-                int numToCapture = varsToCapture[varDepth];
-                int numVarsAvailable = variablesByScope[varDepth].Count;
-                // If we have enough variables to capture in the context
-                // just add them
-                if (numVarsAvailable >= numToCapture)
-                {
-                    // Capture the last variables added since if there are more
-                    // vars in the context than the max vars to capture we'll never
-                    // have code coverage of the newest vars added to the context.
-                    varNames.AddRange(varsAtCurrentDepth
-                        .Skip(numVarsAvailable - numToCapture)
-                        .Take(numToCapture));
-                }
-                else
-                {
-                    // Not enough variables in the context -- add more
-                    for (int i = 0; i < numToCapture - numVarsAvailable; i++)
-                    {
-                        varsAtCurrentDepth.Add($"captureVar_{ctx.CaptureNameIndex++}");
-                    }
-
-                    varNames.AddRange(varsAtCurrentDepth);
-                }
-            }
-
-            return varNames.Count == 0 ? "0" : string.Join(" + ", varNames);
-        }
-
-        /// <summary>
-        /// Generates all combinations of distributing a sum to a list of subsets.
-        /// This is equivalent to the "stars and bars" combinatorics construction.
-        /// </summary>
-        private static IEnumerable<IList<int>> GenerateAllSetCombinations(int sum, int numSubsets)
-        {
-            Assert.True(numSubsets > 0);
-            return GenerateAll(sum, 0, ImmutableList<int>.Empty);
-
-            IEnumerable<ImmutableList<int>> GenerateAll(
-                int remainingSum,
-                int setIndex, // 0-based index of subset we're generating
-                ImmutableList<int> setsSoFar)
-            {
-                for (int i = 0; i <= remainingSum; i++)
-                {
-                    var newSets = setsSoFar.Add(i);
-                    if (setIndex == numSubsets - 1)
-                    {
-                        yield return newSets;
-                    }
-                    else
-                    {
-                        foreach (var captures in GenerateAll(remainingSum - i,
-                                                             setIndex + 1,
-                                                             newSets))
-                        {
-                            yield return captures;
-                        }
-                    }
-                }
-            }
-        }
-
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30212")]
-        public void GenerateAllTest()
-        {
-            Assert.Equal(new[]
-            {
-                ImmutableList<int>.Empty.Add(0),
-                ImmutableList<int>.Empty.Add(1),
-                ImmutableList<int>.Empty.Add(2),
-                ImmutableList<int>.Empty.Add(3)
-            }, GenerateAllSetCombinations(3, 1));
-            Assert.Equal(new[]
-            {
-                ImmutableList<int>.Empty.Add(0).Add(0),
-                ImmutableList<int>.Empty.Add(0).Add(1),
-                ImmutableList<int>.Empty.Add(0).Add(2),
-                ImmutableList<int>.Empty.Add(0).Add(3),
-                ImmutableList<int>.Empty.Add(1).Add(0),
-                ImmutableList<int>.Empty.Add(1).Add(1),
-                ImmutableList<int>.Empty.Add(1).Add(2),
-                ImmutableList<int>.Empty.Add(2).Add(0),
-                ImmutableList<int>.Empty.Add(2).Add(1),
-                ImmutableList<int>.Empty.Add(3).Add(0)
-            }, GenerateAllSetCombinations(3, 2));
-        }
-
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30212")]
-        public void ExpressionGeneratorTest01()
-        {
-            var ctx = new CaptureContext(1);
-            int[] captures = { 1 }; // Capture 1 var at the 0 depth
-            var expr = MakeCaptureExpression(captures, ctx);
-            Assert.Equal("field_0", expr);
-            VerifyContext(new[]
-            {
-                new[] { "field_0"}
-            }, ctx.VariablesByScope);
-
-            ctx = new CaptureContext(3);
-            captures = new[] { 3 }; // Capture 3 vars at 0 depth
-            expr = MakeCaptureExpression(captures, ctx);
-            Assert.Equal("field_0 + field_1 + field_2", expr);
-            VerifyContext(new[]
-            {
-                new[] { "field_0", "field_1", "field_2" }
-            }, ctx.VariablesByScope);
-
-            ctx = new CaptureContext(3);
-            captures = new[] { 1, 1, 1 }; // Capture 1 var at each of 3 depths
-            expr = MakeCaptureExpression(captures, ctx);
-            Assert.Equal("field_2 + captureVar_0 + captureVar_1", expr);
-            VerifyContext(new[]
-            {
-                new[] { "field_0", "field_1", "field_2"},
-                new[] { "captureVar_0"},
-                new[] { "captureVar_1"}
-            }, ctx.VariablesByScope);
-
-            void VerifyContext(IList<IEnumerable<string>> expectedCtx, List<IList<string>> actualCtx)
-            {
-                Assert.Equal(expectedCtx.Count, ctx.VariablesByScope.Count);
-                for (int depth = 0; depth < expectedCtx.Count; depth++)
-                {
-                    AssertEx.Equal(expectedCtx[depth], ctx.VariablesByScope[depth]);
-                }
-            }
-        }
-        private struct LayoutEnumerator : IEnumerator<(int depth, int localFuncIndex)>
-        {
-            private readonly IList<int> _layout;
-            private (int depth, int localFuncIndex) _current;
-
-            public LayoutEnumerator(IList<int> layout)
-            {
-                _layout = layout;
-                _current = (-1, -1);
-            }
-
-            public (int depth, int localFuncIndex) Current => _current;
-
-            object IEnumerator.Current => throw new NotImplementedException();
-
-            public void Dispose() => throw new NotImplementedException();
-
-            public bool MoveNext()
-            {
-                if (_current.depth < 0)
-                {
-                    return FindNonEmptyDepth(0, _layout, out _current);
-                }
-                else
-                {
-                    int newIndex = _current.localFuncIndex + 1;
-                    if (newIndex == _layout[_current.depth])
-                    {
-                        return FindNonEmptyDepth(_current.depth + 1, _layout, out _current);
-                    }
-
-                    _current = (_current.depth, newIndex);
-                    return true;
-                }
-
-                bool FindNonEmptyDepth(int startingDepth, IList<int> layout, out (int depth, int localFuncIndex) newCurrent)
-                {
-                    for (int depth = startingDepth; depth < layout.Count; depth++)
-                    {
-                        if (layout[depth] > 0)
-                        {
-                            newCurrent = (depth, 0);
-                            return true;
-                        }
-                    }
-                    newCurrent = (layout.Count, 0);
-                    return false;
-                }
-            }
-
-            public void Reset() => throw new NotImplementedException();
-        }
-
-        private class MethodInfo
-        {
-            public MethodInfo(int MaxCaptures)
-            {
-                LocalFuncs = new List<IList<string>>();
-                CaptureContext = new CaptureContext(MaxCaptures);
-            }
-
-            private MethodInfo() { }
-
-            public List<IList<string>> LocalFuncs { get; private set; }
-
-            public CaptureContext CaptureContext { get; private set; }
-
-            public int TotalLocalFuncs { get; set; }
-
-            public MethodInfo Clone()
-            {
-                return new MethodInfo
-                {
-                    LocalFuncs = this.LocalFuncs
-                        .Select(x => x == null
-                                     ? null
-                                     : (IList<string>)new List<string>(x)).ToList(),
-                    CaptureContext = this.CaptureContext.Clone()
-                };
-            }
-        }
-
-        private static IEnumerable<MethodInfo> MakeMethodsWithLayout(IList<int> localFuncLayout)
-        {
-            const int MaxCaptures = 3;
-
-            var enumerator = new LayoutEnumerator(localFuncLayout);
-            if (!enumerator.MoveNext())
-            {
-                return Array.Empty<MethodInfo>();
-            }
-
-            var methods = new List<MethodInfo>();
-            DfsLayout(enumerator, new MethodInfo(MaxCaptures), 0);
-            return methods;
-
-            // Note that the enumerator is a struct, so every new var
-            // is a copy
-            void DfsLayout(LayoutEnumerator e, MethodInfo methodSoFar, int localFuncNameIndex)
-            {
-                var (depth, localFuncIndex) = e.Current;
-
-                bool isLastFunc = !e.MoveNext();
-
-                foreach (var captureCombo in GenerateAllSetCombinations(MaxCaptures, depth + 2))
-                {
-                    var copy = methodSoFar.Clone();
-                    var expr = MakeCaptureExpression(captureCombo, copy.CaptureContext);
-                    if (depth >= copy.LocalFuncs.Count)
-                    {
-                        copy.LocalFuncs.AddRange(Enumerable.Repeat<List<string>>(null, depth - copy.LocalFuncs.Count));
-                        copy.LocalFuncs.Insert(depth, new List<string>());
-                    }
-                    string localFuncName = $"Local_{localFuncNameIndex}";
-                    copy.LocalFuncs[depth].Add($"int {localFuncName}() => {expr};");
-                    copy.CaptureContext.Add(depth + 1, $"{localFuncName}()");
-
-                    if (!isLastFunc)
-                    {
-                        DfsLayout(e, copy, localFuncNameIndex + 1);
-                    }
-                    else
-                    {
-                        copy.TotalLocalFuncs = localFuncNameIndex + 1;
-                        methods.Add(copy);
-                    }
-                }
-            }
-        }
-
-        private static IEnumerable<MethodInfo> MakeAllMethods()
-        {
-            const int MaxDepth = 3;
-            const int MaxLocalFuncs = 3;
-
-            // Set combinations indicate what depth we will place local functions
-            // at. For instance, { 0, 1 } indicates 0 local functions at method
-            // depth and 1 local function at one nested scope below method level.
-            foreach (var localFuncLayout in GenerateAllSetCombinations(MaxLocalFuncs, MaxDepth))
-            {
-                // Given a local function map, we need to generate capture
-                // expressions for each local func at each depth
-                foreach (var method in MakeMethodsWithLayout(localFuncLayout))
-                    yield return method;
-            }
-        }
-
-        private void SerializeMethod(MethodInfo methodInfo, StringBuilder builder, int methodIndex)
-        {
-            int totalLocalFuncs = methodInfo.TotalLocalFuncs;
-
-            var methodText = new StringBuilder();
-            var localFuncs = methodInfo.LocalFuncs;
-            for (int depth = 0; depth < localFuncs.Count; depth++)
-            {
-                if (depth > 0)
-                {
-                    methodText.Append(' ', 4 * (depth + 1));
-                    methodText.AppendLine("{");
-                }
-
-                var captureVars = methodInfo.CaptureContext.VariablesByScope;
-                if (captureVars.Count > (depth + 1) &&
-                    captureVars[depth + 1] != null)
-                {
-                    foreach (var captureVar in captureVars[depth + 1])
-                    {
-                        if (captureVar.EndsWith("()"))
-                        {
-                            continue;
-                        }
-
-                        methodText.Append(' ', 4 * (depth + 2));
-                        methodText.AppendLine($"int {captureVar} = 0;");
-                    }
-                }
-
-                if (localFuncs[depth] != null)
-                {
-                    foreach (var localFunc in localFuncs[depth])
-                    {
-                        methodText.Append(' ', 4 * (depth + 2));
-                        methodText.AppendLine(localFunc);
-                    }
-                }
-            }
-
-            var localFuncCalls = string.Join(" + ",
-                Enumerable.Range(0, totalLocalFuncs).Select(f => $"Local_{f}()"));
-            methodText.AppendLine($"Console.WriteLine({localFuncCalls});");
-
-            for (int depth = localFuncs.Count - 1; depth > 0; depth--)
-            {
-                methodText.Append(' ', 4 * (depth + 1));
-                methodText.AppendLine("}");
-            }
-
-            builder.Append($@"
-    public void M_{methodIndex}()
-    {{
-{methodText.ToString()}
-    }}");
-
-        }
-
-        /// <summary>
-        /// This test exercises the C# local function capturing analysis by generating
-        /// all possible combinations of capturing within a certain complexity. The
-        /// generating functions use a maximum number of variables captured per local function,
-        /// a maximum number of local functions, and a maximum scope depth to decide the
-        /// limits of the combinations.
-        /// </summary>
-        [ConditionalFact(typeof(WindowsOnly), typeof(NoIOperationValidation), Reason = "https://github.com/dotnet/roslyn/issues/30212")]
-        public void AllCaptureTests()
-        {
-            var methods = MakeAllMethods().ToList();
-
-            var fields = methods.First().CaptureContext.VariablesByScope[0];
-
-            const int PartitionSize = 500;
-            const string ClassFmt = @"
+            const string template = @"
 using System;
-public class C
+using static System.Console;
+class C
 {{
-    {0}";
-            StringBuilder GetClassStart()
-                => new StringBuilder(string.Format(ClassFmt,
-                    string.Join("\r\n", fields.Select(f => $"public int {f} = 0;"))));
-
-            Parallel.ForEach(Partitioner.Create(0, methods.Count, PartitionSize), (range, state) =>
+    static void Main()
+    {{
+        {0}
+    }}
+}}";
+            // We can customize the size of the input program, and
+            // the number of programs we generate below
+            foreach (StmtList p in Gen.Sample(4, 100, GenerateStmtList()))
             {
-                var methodsText = GetClassStart();
+                var sb = new StringBuilder();
+                p.Print(sb, indent: 0);
 
-                for (int methodIndex = range.Item1; methodIndex < range.Item2; methodIndex++)
-                {
-                    var methodInfo = methods[methodIndex];
-
-                    if (methodInfo.TotalLocalFuncs == 0)
-                    {
-                        continue;
-                    }
-
-                    SerializeMethod(methodInfo, methodsText, methodIndex);
-                }
-
-                methodsText.AppendLine("\r\n}");
-                CreateCompilation(methodsText.ToString()).VerifyEmitDiagnostics();
-            });
+                var src = string.Format(template, sb.ToString());
+                CompileAndVerify(src, options: TestOptions.ReleaseExe);
+            }
         }
+
+        /// Data model: the following type heirarchy represents a simple
+        /// statement list, where a statement is either a variable
+        /// declaration, variable use, or a function, which is either a
+        /// lambda or local function which is immediately declared and
+        /// executed.
+        #region types
+
+        abstract record Stmt
+        {
+            public abstract void Print(StringBuilder b, int indent);
+        }
+        partial record VariableDecl(string Name) : Stmt;
+        partial record Inc(VariableDecl Var) : Stmt;
+        partial record LocalFunc(string Name, StmtList Stmts) : Stmt;
+        partial record Lambda(StmtList Stmts) : Stmt;
+
+        partial record StmtList(Stmt[] Stmts)
+        {
+            public readonly static StmtList Empty = new StmtList(Array.Empty<Stmt>());
+        }
+
+        #endregion
+
+        private static Gen<StmtList> GenerateStmtList()
+        {
+            return Gen.Sized(size => helper(
+                size,
+                ImmutableList<VariableDecl>.Empty,
+                funcCounter: 0));
+
+            static Gen<StmtList> helper(
+                int size,
+                ImmutableList<VariableDecl> varsInScope,
+                int funcCounter)
+            {
+                // Each nested statement list contains:
+                // - newly declared vars
+                // - uses of existing vars
+                // - new nested functions
+                var genNewVars = Gen.Choose(0, 2).Select(count =>
+                {
+                    var builder = ImmutableList.CreateBuilder<VariableDecl>();
+                    for (int i = 0; i < count; i++)
+                    {
+                        builder.Add(new VariableDecl($"i{i + varsInScope.Count}"));
+                    }
+                    return builder.ToImmutableList();
+                });
+                var genIncs = Gen.Resize(2, Gen.SubListOf(varsInScope.AsEnumerable())
+                    .Select(vars => vars.Select(v => (Stmt)new Inc(v))));
+                return from newVars in genNewVars
+                       from incs in genIncs
+                       from func in genFunc(size, varsInScope.AddRange(newVars), funcCounter)
+                       let stmtsWithoutFunc = newVars.Concat(incs)
+                       let stmts = func is object ? stmtsWithoutFunc.Append(func) : stmtsWithoutFunc
+                       select new StmtList(stmts.ToArray());
+            }
+
+            static Gen<Stmt?> genFunc(int size, ImmutableList<VariableDecl> varsInScope, int funcCounter)
+            {
+                if (size == 0)
+                    return Gen.Constant<Stmt?>(null);
+
+                return Arb.Generate<bool>().SelectMany(isLambda =>
+                {
+                    var newCounter = isLambda ? funcCounter : funcCounter + 1;
+                    return helper(size / 2, varsInScope, newCounter).Select(nestedStmts =>
+                        isLambda
+                            ? (Stmt?)new Lambda(nestedStmts)
+                            : (Stmt?)new LocalFunc($"f{funcCounter}", nestedStmts)
+                    );
+                });
+            }
+        }
+
+        #region printing
+
+        internal static void Append(StringBuilder b, int indent, string val)
+        {
+            b.Append(' ', indent * 4);
+            b.Append(val);
+        }
+
+        internal static void AppendLine(StringBuilder b, int indent, string val)
+        {
+            Append(b, indent, val);
+            b.AppendLine();
+        }
+
+        partial record StmtList
+        {
+            public void Print(StringBuilder b, int indent)
+            {
+                foreach (var stmt in Stmts)
+                {
+                    stmt.Print(b, indent);
+                }
+                // Now print values of variables declared in this scope
+                foreach (var stmt in Stmts)
+                {
+                    if (stmt is VariableDecl v)
+                    {
+                        AppendLine(b, indent, $"WriteLine({v.Name});");
+                    }
+                }
+            }
+        }
+        partial record VariableDecl
+        {
+            public override void Print(StringBuilder b, int indent)
+            {
+                AppendLine(b, indent, $"int {Name} = 0;");
+            }
+        }
+        partial record Inc
+        {
+            public override void Print(StringBuilder b, int indent)
+            {
+                AppendLine(b, indent, $"{Var.Name}++;");
+            }
+        }
+        partial record LocalFunc
+        {
+            public override void Print(StringBuilder b, int indent)
+            {
+                AppendLine(b, indent, $"void {Name}()");
+                AppendLine(b, indent, "{");
+                Stmts.Print(b, indent + 1);
+                AppendLine(b, indent, "}");
+                AppendLine(b, indent, $"{Name}();");
+            }
+        }
+
+        partial record Lambda
+        {
+            public override void Print(StringBuilder b, int indent)
+            {
+                AppendLine(b, indent, $"((Action)(() =>");
+                AppendLine(b, indent, "{");
+                Stmts.Print(b, indent + 1);
+                AppendLine(b, indent, "}))();");
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/Emit/Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.UnitTests</RootNamespace>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\Roslyn.Test.PdbUtilities.csproj" />
@@ -24,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
+    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/src/Compilers/Core/Portable/InternalUtilities/IsExternalInit.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/IsExternalInit.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}


### PR DESCRIPTION
This change replaces the old CodeGenCapturing test, which tried to
brute-force test a number of closure capturing combinations, with
an implementation that tries to generate more interesting scenarios.

The replacement uses FsCheck to randomly generate a variety of
test cases. Due to the significantly more interesting cases that are generated
the tests run for much less time, since we don't need to search such a wide space
to find interesting results.

Note: this implementation uses C# 9 records, so it also enables 'preview'
LangVersion