### PR TITLE
Inline Rename Color Change

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameFieldBackgroundAndBorderTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameFieldBackgroundAndBorderTagDefinition.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename.HighlightTag
             // The Border color should match the BackgroundColor from the
             // InlineRenameFieldFormatDefinition.
             this.Border = new Pen(new SolidColorBrush(Color.FromRgb(0xFF, 0xFF, 0xFF)), thickness: 2.0);
-            this.BackgroundColor = Color.FromRgb(0xA6, 0xF1, 0xA6);
+            this.BackgroundColor = Color.FromRgb(0xd3, 0xf8, 0xd3);
             this.DisplayName = EditorFeaturesResources.Inline_Rename_Field_Background_and_Border;
 
             // Needs to show above highlight references, but below the resolved/unresolved rename 


### PR DESCRIPTION
Inline rename highlight color in Dark Theme only has a contrast ratio of 1.238:1, and the target is 1.5:1 

Original Color: #A6F1A6 
New Color: #D3F8D3

Contrast ratio is 1.485:1 with new color 

Resolves: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1139737