### PR TITLE
[LSP] Remove snippets from completion list until they are supported

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -43,6 +43,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
 
+            // Filter out snippets as they are not supported in the LSP client
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1139740
             // Filter out unimported types for now as there are two issues with providing them:
             // 1.  LSP client does not currently provide a way to provide detail text on the completion item to show the namespace.
             //     https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1076759
@@ -51,6 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // 3.  LSP client should support completion filters / expanders
             var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var completionOptions = documentOptions
+                .WithChangedOption(CompletionOptions.SnippetsBehavior, SnippetsRule.NeverInclude)
                 .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, false)
                 .WithChangedOption(CompletionServiceOptions.IsExpandedCompletion, false);
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -60,6 +60,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             Assert.False(results.Any(item => "Console" == item.Label));
         }
 
+        [Fact]
+        public async Task TestGetCompletionsDoesNotIncludeSnippetsAsync()
+        {
+            var markup =
+@"class A
+{
+    {|caret:|}
+}";
+            using var workspace = CreateTestWorkspace(markup, out var locations);
+            var solution = workspace.CurrentSolution;
+            solution = solution.WithOptions(solution.Options
+                .WithChangedOption(CompletionOptions.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.AlwaysInclude));
+
+            var expected = CreateCompletionItem("A", LSP.CompletionItemKind.Class, new string[] { "Class", "Internal" }, CreateCompletionParams(locations["caret"].Single()));
+            var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
+
+            var results = await RunGetCompletionsAsync(solution, locations["caret"].Single(), clientCapabilities);
+
+            Assert.False(results.Any(item => "ctor" == item.Label));
+        }
+
         private static async Task<LSP.CompletionItem[]> RunGetCompletionsAsync(Solution solution, LSP.Location caret, LSP.ClientCapabilities clientCapabilities = null)
             => await GetLanguageServer(solution).ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionItem[]>(LSP.Methods.TextDocumentCompletionName,
                 CreateCompletionParams(caret), clientCapabilities, null, CancellationToken.None);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -73,7 +73,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             solution = solution.WithOptions(solution.Options
                 .WithChangedOption(CompletionOptions.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.AlwaysInclude));
 
-            var expected = CreateCompletionItem("A", LSP.CompletionItemKind.Class, new string[] { "Class", "Internal" }, CreateCompletionParams(locations["caret"].Single()));
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
 
             var results = await RunGetCompletionsAsync(solution, locations["caret"].Single(), clientCapabilities);


### PR DESCRIPTION
Fixes - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1145547/

Long term support for snippets is coming in late 16.8 timeframe.  Until then since committing these items does nothing, we should remove them from the LSP completion results.