### PR TITLE
AnalyzerDriver performance improvements

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -45,21 +46,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public bool IsTreeAnalysis => FilterTreeOpt != null;
 
-        public AnalysisScope(Compilation compilation, ImmutableArray<DiagnosticAnalyzer> analyzers, bool concurrentAnalysis, bool categorizeDiagnostics)
-            : this(compilation.SyntaxTrees, analyzers, filterTreeOpt: null, filterSpanOpt: null, isSyntaxOnlyTreeAnalysis: false, concurrentAnalysis: concurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics)
+        /// <summary>
+        /// Flag indicating if this is a partial analysis for the corresponding <see cref="CompilationWithAnalyzers"/>,
+        /// i.e. <see cref="IsTreeAnalysis"/> is true and/or <see cref="Analyzers"/> is a subset of <see cref="CompilationWithAnalyzers.Analyzers"/>.
+        /// </summary>
+        public bool IsPartialAnalysis { get; }
+
+        public AnalysisScope(Compilation compilation, ImmutableArray<DiagnosticAnalyzer> analyzers, bool hasAllAnalyzers, bool concurrentAnalysis, bool categorizeDiagnostics)
+            : this(compilation.SyntaxTrees, analyzers, isPartialAnalysis: !hasAllAnalyzers, filterTreeOpt: null, filterSpanOpt: null, isSyntaxOnlyTreeAnalysis: false, concurrentAnalysis: concurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics)
         {
         }
 
         public AnalysisScope(ImmutableArray<DiagnosticAnalyzer> analyzers, SyntaxTree filterTree, TextSpan? filterSpan, bool syntaxAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
-            : this(SpecializedCollections.SingletonEnumerable(filterTree), analyzers, filterTree, filterSpan, syntaxAnalysis, concurrentAnalysis, categorizeDiagnostics)
+            : this(SpecializedCollections.SingletonEnumerable(filterTree), analyzers, isPartialAnalysis: true, filterTree, filterSpan, syntaxAnalysis, concurrentAnalysis, categorizeDiagnostics)
         {
             Debug.Assert(filterTree != null);
         }
 
-        private AnalysisScope(IEnumerable<SyntaxTree> trees, ImmutableArray<DiagnosticAnalyzer> analyzers, SyntaxTree filterTreeOpt, TextSpan? filterSpanOpt, bool isSyntaxOnlyTreeAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
+        private AnalysisScope(IEnumerable<SyntaxTree> trees, ImmutableArray<DiagnosticAnalyzer> analyzers, bool isPartialAnalysis, SyntaxTree filterTreeOpt, TextSpan? filterSpanOpt, bool isSyntaxOnlyTreeAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
         {
+            Debug.Assert(isPartialAnalysis || FilterTreeOpt == null);
+            Debug.Assert(isPartialAnalysis || FilterSpanOpt == null);
+            Debug.Assert(isPartialAnalysis || !isSyntaxOnlyTreeAnalysis);
+
             SyntaxTrees = trees;
             Analyzers = analyzers;
+            IsPartialAnalysis = isPartialAnalysis;
             FilterTreeOpt = filterTreeOpt;
             FilterSpanOpt = filterSpanOpt;
             IsSyntaxOnlyTreeAnalysis = isSyntaxOnlyTreeAnalysis;
@@ -67,9 +79,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             CategorizeDiagnostics = categorizeDiagnostics;
         }
 
-        public AnalysisScope WithAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        private ImmutableHashSet<DiagnosticAnalyzer> _lazyAnalyzersSet;
+        public bool Contains(DiagnosticAnalyzer analyzer)
         {
-            return new AnalysisScope(SyntaxTrees, analyzers, FilterTreeOpt, FilterSpanOpt, IsSyntaxOnlyTreeAnalysis, ConcurrentAnalysis, CategorizeDiagnostics);
+            if (!IsPartialAnalysis)
+            {
+                Debug.Assert(containsCore());
+                return true;
+            }
+
+            return containsCore();
+
+            bool containsCore()
+            {
+                if (_lazyAnalyzersSet == null)
+                {
+                    Interlocked.CompareExchange(ref _lazyAnalyzersSet, Analyzers.ToImmutableHashSet(), null);
+                }
+
+                return _lazyAnalyzersSet.Contains(analyzer);
+            }
+        }
+
+        public AnalysisScope WithAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers, bool hasAllAnalyzers)
+        {
+            var isPartialAnalysis = IsTreeAnalysis || !hasAllAnalyzers;
+            return new AnalysisScope(SyntaxTrees, analyzers, isPartialAnalysis, FilterTreeOpt, FilterSpanOpt, IsSyntaxOnlyTreeAnalysis, ConcurrentAnalysis, CategorizeDiagnostics);
         }
 
         public static bool ShouldSkipSymbolAnalysis(SymbolDeclaredCompilationEvent symbolEvent)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -602,22 +602,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void MarkEventCompleteForUnprocessedAnalyzers(
             CompilationEvent completedEvent,
             AnalysisScope analysisScope,
-            PooledHashSet<DiagnosticAnalyzer> processedAnalyzers)
-        {
-            Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
-            if (analysisScope.Analyzers.Length == processedAnalyzers.Count)
-            {
-                return;
-            }
-
-            foreach (var analyzer in analysisScope.Analyzers)
-            {
-                if (!processedAnalyzers.Contains(analyzer))
-                {
-                    MarkEventComplete(completedEvent, analyzer);
-                }
-            }
-        }
+            HashSet<DiagnosticAnalyzer> processedAnalyzers)
+            => MarkAnalysisCompleteForUnprocessedAnalyzers(analysisScope, processedAnalyzers, MarkEventComplete, completedEvent);
 
         /// <summary>
         /// Checks if the given event has been fully analyzed for the given analyzer.
@@ -665,22 +651,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void MarkSymbolCompleteForUnprocessedAnalyzers(
             ISymbol symbol,
             AnalysisScope analysisScope,
-            PooledHashSet<DiagnosticAnalyzer> processedAnalyzers)
-        {
-            Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
-            if (analysisScope.Analyzers.Length == processedAnalyzers.Count)
-            {
-                return;
-            }
-
-            foreach (var analyzer in analysisScope.Analyzers)
-            {
-                if (!processedAnalyzers.Contains(analyzer))
-                {
-                    MarkSymbolComplete(symbol, analyzer);
-                }
-            }
-        }
+            HashSet<DiagnosticAnalyzer> processedAnalyzers)
+            => MarkAnalysisCompleteForUnprocessedAnalyzers(analysisScope, processedAnalyzers, MarkSymbolComplete, symbol);
 
         /// <summary>
         /// True if the given symbol is fully analyzed for the given analyzer.
@@ -826,7 +798,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void MarkSyntaxAnalysisCompleteForUnprocessedAnalyzers(
             SyntaxTree tree,
             AnalysisScope analysisScope,
-            PooledHashSet<DiagnosticAnalyzer> processedAnalyzers)
+            HashSet<DiagnosticAnalyzer> processedAnalyzers)
+            => MarkAnalysisCompleteForUnprocessedAnalyzers(analysisScope, processedAnalyzers, MarkSyntaxAnalysisComplete, tree);
+
+        private static void MarkAnalysisCompleteForUnprocessedAnalyzers<T>(
+            AnalysisScope analysisScope,
+            HashSet<DiagnosticAnalyzer> processedAnalyzers,
+            Action<T, DiagnosticAnalyzer> markComplete,
+            T arg)
         {
             Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
             if (analysisScope.Analyzers.Length == processedAnalyzers.Count)
@@ -838,7 +817,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (!processedAnalyzers.Contains(analyzer))
                 {
-                    MarkSyntaxAnalysisComplete(tree, analyzer);
+                    markComplete(arg, analyzer);
                 }
             }
         }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -597,6 +597,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
+        /// Marks the given event as fully analyzed for the unprocessed analyzers in the given analysisScope.
+        /// </summary>
+        public void MarkEventCompleteForUnprocessedAnalyzers(
+            CompilationEvent completedEvent,
+            AnalysisScope analysisScope,
+            PooledHashSet<DiagnosticAnalyzer> processedAnalyzers)
+        {
+            Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
+            if (analysisScope.Analyzers.Length == processedAnalyzers.Count)
+            {
+                return;
+            }
+
+            foreach (var analyzer in analysisScope.Analyzers)
+            {
+                if (!processedAnalyzers.Contains(analyzer))
+                {
+                    MarkEventComplete(completedEvent, analyzer);
+                }
+            }
+        }
+
+        /// <summary>
         /// Checks if the given event has been fully analyzed for the given analyzer.
         /// </summary>
         public bool IsEventComplete(CompilationEvent compilationEvent, DiagnosticAnalyzer analyzer)
@@ -634,6 +657,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void MarkSymbolComplete(ISymbol symbol, DiagnosticAnalyzer analyzer)
         {
             GetAnalyzerState(analyzer).MarkSymbolComplete(symbol);
+        }
+
+        /// <summary>
+        /// Marks the given symbol as fully analyzed for the unprocessed analyzers in the given analysisScope.
+        /// </summary>
+        public void MarkSymbolCompleteForUnprocessedAnalyzers(
+            ISymbol symbol,
+            AnalysisScope analysisScope,
+            PooledHashSet<DiagnosticAnalyzer> processedAnalyzers)
+        {
+            Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
+            if (analysisScope.Analyzers.Length == processedAnalyzers.Count)
+            {
+                return;
+            }
+
+            foreach (var analyzer in analysisScope.Analyzers)
+            {
+                if (!processedAnalyzers.Contains(analyzer))
+                {
+                    MarkSymbolComplete(symbol, analyzer);
+                }
+            }
         }
 
         /// <summary>
@@ -771,6 +817,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             foreach (var analyzer in analyzers)
             {
                 GetAnalyzerState(analyzer).MarkSyntaxAnalysisComplete(tree);
+            }
+        }
+
+        /// <summary>
+        /// Marks the given tree as fully syntactically analyzed for the unprocessed analyzers in the given analysisScope.
+        /// </summary>
+        public void MarkSyntaxAnalysisCompleteForUnprocessedAnalyzers(
+            SyntaxTree tree,
+            AnalysisScope analysisScope,
+            PooledHashSet<DiagnosticAnalyzer> processedAnalyzers)
+        {
+            Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
+            if (analysisScope.Analyzers.Length == processedAnalyzers.Count)
+            {
+                return;
+            }
+
+            foreach (var analyzer in analysisScope.Analyzers)
+            {
+                if (!processedAnalyzers.Contains(analyzer))
+                {
+                    MarkSyntaxAnalysisComplete(tree, analyzer);
+                }
             }
         }
     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.ExecutableCodeBlockAnalyzerActions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.ExecutableCodeBlockAnalyzerActions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal partial class AnalyzerDriver<TLanguageKindEnum> : AnalyzerDriver where TLanguageKindEnum : struct
     {
         [StructLayout(LayoutKind.Auto)]
-        private struct CodeBlockAnalyzerActions
+        private struct ExecutableCodeBlockAnalyzerActions
         {
             public DiagnosticAnalyzer Analyzer;
             public ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>> CodeBlockStartActions;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return new GroupedAnalyzerActions(builder.ToImmutableAndFree(), in analyzerActions);
             }
 
-            IGroupedAnalyzerActions IGroupedAnalyzerActions.Append(in IGroupedAnalyzerActions igroupedAnalyzerActions)
+            IGroupedAnalyzerActions IGroupedAnalyzerActions.Append(IGroupedAnalyzerActions igroupedAnalyzerActions)
             {
                 var groupedAnalyzerActions = (GroupedAnalyzerActions)igroupedAnalyzerActions;
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActions.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+#nullable enable
+
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
-using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -16,325 +17,65 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// <see cref="AnalyzerActions"/> grouped by <see cref="DiagnosticAnalyzer"/>, and possibly other entities, such as <see cref="OperationKind"/>, <see cref="SymbolKind"/>, etc.
         /// </summary>
-        private sealed class GroupedAnalyzerActions
+        private sealed class GroupedAnalyzerActions : IGroupedAnalyzerActions
         {
-            private static readonly GroupedAnalyzerActions s_Default = new GroupedAnalyzerActions(in AnalyzerActions.Empty);
+            public static GroupedAnalyzerActions Empty = new GroupedAnalyzerActions(ImmutableArray<(DiagnosticAnalyzer, GroupedAnalyzerActionsForAnalyzer)>.Empty, AnalyzerActions.Empty);
 
-            private readonly AnalyzerActions _analyzerActions;
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>> _lazyNodeActionsByKind;
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>> _lazyOperationActionsByKind;
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>>> _lazyCodeBlockStartActionsByAnalyzer;
-            // Code block actions and code block end actions are kept separate so that it is easy to
-            // execute the code block actions before the code block end actions.
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CodeBlockAnalyzerAction>> _lazyCodeBlockEndActionsByAnalyzer;
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CodeBlockAnalyzerAction>> _lazyCodeBlockActionsByAnalyzer;
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<OperationBlockStartAnalyzerAction>> _lazyOperationBlockStartActionsByAnalyzer;
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<OperationBlockAnalyzerAction>> _lazyOperationBlockActionsByAnalyzer;
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<OperationBlockAnalyzerAction>> _lazyOperationBlockEndActionsByAnalyzer;
-
-            private GroupedAnalyzerActions(in AnalyzerActions analyzerActions)
+            private GroupedAnalyzerActions(ImmutableArray<(DiagnosticAnalyzer, GroupedAnalyzerActionsForAnalyzer)> groupedActionsAndAnalyzers, in AnalyzerActions analyzerActions)
             {
-                _analyzerActions = analyzerActions;
+                GroupedActionsByAnalyzer = groupedActionsAndAnalyzers;
+                AnalyzerActions = analyzerActions;
             }
 
-            public static GroupedAnalyzerActions Create(in AnalyzerActions analyzerActions)
-            {
-                if (analyzerActions.IsEmpty)
-                {
-                    return s_Default;
-                }
+            public ImmutableArray<(DiagnosticAnalyzer analyzer, GroupedAnalyzerActionsForAnalyzer groupedActions)> GroupedActionsByAnalyzer { get; }
 
-                return new GroupedAnalyzerActions(in analyzerActions);
-            }
+            public AnalyzerActions AnalyzerActions { get; }
 
-            public ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>> NodeActionsByAnalyzerAndKind
+            public bool IsEmpty
             {
                 get
                 {
-                    if (_lazyNodeActionsByKind == null)
-                    {
-                        var analyzerActionsByKind = CreateNodeActionsByKind(in _analyzerActions);
-                        Interlocked.CompareExchange(ref _lazyNodeActionsByKind, analyzerActionsByKind, null);
-                    }
-
-                    return _lazyNodeActionsByKind;
+                    var isEmpty = ReferenceEquals(this, Empty);
+                    Debug.Assert(isEmpty || !GroupedActionsByAnalyzer.IsEmpty);
+                    return isEmpty;
                 }
             }
 
-            private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>> CreateNodeActionsByKind(
-                in AnalyzerActions analyzerActions)
+            public static GroupedAnalyzerActions Create(DiagnosticAnalyzer analyzer, in AnalyzerActions analyzerActions)
             {
-                var nodeActions = analyzerActions.GetSyntaxNodeActions<TLanguageKindEnum>();
-                ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>> analyzerActionsByKind;
-                if (!nodeActions.IsEmpty)
+                var groupedActions = new GroupedAnalyzerActionsForAnalyzer(analyzer, analyzerActions, analyzerActionsNeedFiltering: false);
+                var groupedActionsAndAnalyzers = ImmutableArray<(DiagnosticAnalyzer, GroupedAnalyzerActionsForAnalyzer)>.Empty.Add((analyzer, groupedActions));
+                return new GroupedAnalyzerActions(groupedActionsAndAnalyzers, in analyzerActions);
+            }
+
+            public static GroupedAnalyzerActions Create(ImmutableArray<DiagnosticAnalyzer> analyzers, in AnalyzerActions analyzerActions)
+            {
+                Debug.Assert(!analyzers.IsDefaultOrEmpty);
+
+                var builder = ArrayBuilder<(DiagnosticAnalyzer, GroupedAnalyzerActionsForAnalyzer)>.GetInstance();
+                foreach (var analyzer in analyzers)
                 {
-                    var nodeActionsByAnalyzers = nodeActions.GroupBy(a => a.Analyzer);
-                    var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>>();
-                    foreach (var analyzerAndActions in nodeActionsByAnalyzers)
-                    {
-                        ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>> actionsByKind;
-                        if (analyzerAndActions.Any())
-                        {
-                            actionsByKind = AnalyzerExecutor.GetNodeActionsByKind(analyzerAndActions);
-                        }
-                        else
-                        {
-                            actionsByKind = ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>.Empty;
-                        }
-
-                        builder.Add(analyzerAndActions.Key, actionsByKind);
-                    }
-
-                    analyzerActionsByKind = builder.ToImmutable();
-                }
-                else
-                {
-                    analyzerActionsByKind = ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>>.Empty;
+                    var groupedActionsForAnalyzer = new GroupedAnalyzerActionsForAnalyzer(analyzer, analyzerActions, analyzerActionsNeedFiltering: true);
+                    builder.Add((analyzer, groupedActionsForAnalyzer));
                 }
 
-                return analyzerActionsByKind;
+                return new GroupedAnalyzerActions(builder.ToImmutableAndFree(), in analyzerActions);
             }
 
-            public ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>> OperationActionsByAnalyzerAndKind
+            IGroupedAnalyzerActions IGroupedAnalyzerActions.Append(in IGroupedAnalyzerActions igroupedAnalyzerActions)
             {
-                get
-                {
-                    if (_lazyOperationActionsByKind == null)
-                    {
-                        var analyzerActionsByKind = CreateOperationActionsByKind(in _analyzerActions);
-                        Interlocked.CompareExchange(ref _lazyOperationActionsByKind, analyzerActionsByKind, null);
-                    }
+                var groupedAnalyzerActions = (GroupedAnalyzerActions)igroupedAnalyzerActions;
 
-                    return _lazyOperationActionsByKind;
-                }
-            }
+#if DEBUG
+                var inputAnalyzers = groupedAnalyzerActions.GroupedActionsByAnalyzer.Select(a => a.analyzer);
+                var myAnalyzers = GroupedActionsByAnalyzer.Select(a => a.analyzer);
+                var intersected = inputAnalyzers.Intersect(myAnalyzers);
+                Debug.Assert(intersected.IsEmpty());
+#endif
 
-            private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>> CreateOperationActionsByKind(
-                in AnalyzerActions analyzerActions)
-            {
-                var operationActions = analyzerActions.OperationActions;
-                ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>> analyzerActionsByKind;
-                if (!operationActions.IsEmpty)
-                {
-                    var operationActionsByAnalyzers = operationActions.GroupBy(a => a.Analyzer);
-                    var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>>();
-                    foreach (var analyzerAndActions in operationActionsByAnalyzers)
-                    {
-                        ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>> actionsByKind;
-                        if (analyzerAndActions.Any())
-                        {
-                            actionsByKind = AnalyzerExecutor.GetOperationActionsByKind(analyzerAndActions);
-                        }
-                        else
-                        {
-                            actionsByKind = ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>.Empty;
-                        }
-
-                        builder.Add(analyzerAndActions.Key, actionsByKind);
-                    }
-
-                    analyzerActionsByKind = builder.ToImmutable();
-                }
-                else
-                {
-                    analyzerActionsByKind = ImmutableDictionary<DiagnosticAnalyzer, ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>>.Empty;
-                }
-
-                return analyzerActionsByKind;
-            }
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>>> CodeBlockStartActionsByAnalyzer
-            {
-                get { return GetBlockActionsByAnalyzer(ref _lazyCodeBlockStartActionsByAnalyzer, analyzerActions => analyzerActions.GetCodeBlockStartActions<TLanguageKindEnum>(), in _analyzerActions); }
-            }
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CodeBlockAnalyzerAction>> CodeBlockEndActionsByAnalyzer
-            {
-                get { return GetBlockActionsByAnalyzer(ref _lazyCodeBlockEndActionsByAnalyzer, analyzerActions => analyzerActions.CodeBlockEndActions, in _analyzerActions); }
-            }
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CodeBlockAnalyzerAction>> CodeBlockActionsByAnalyzer
-            {
-                get { return GetBlockActionsByAnalyzer(ref _lazyCodeBlockActionsByAnalyzer, analyzerActions => analyzerActions.CodeBlockActions, in _analyzerActions); }
-            }
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<OperationBlockStartAnalyzerAction>> OperationBlockStartActionsByAnalyzer
-            {
-                get { return GetBlockActionsByAnalyzer(ref _lazyOperationBlockStartActionsByAnalyzer, analyzerActions => analyzerActions.OperationBlockStartActions, in _analyzerActions); }
-            }
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<OperationBlockAnalyzerAction>> OperationBlockEndActionsByAnalyzer
-            {
-                get { return GetBlockActionsByAnalyzer(ref _lazyOperationBlockEndActionsByAnalyzer, analyzerActions => analyzerActions.OperationBlockEndActions, in _analyzerActions); }
-            }
-
-            private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<OperationBlockAnalyzerAction>> OperationBlockActionsByAnalyzer
-            {
-                get { return GetBlockActionsByAnalyzer(ref _lazyOperationBlockActionsByAnalyzer, analyzerActions => analyzerActions.OperationBlockActions, in _analyzerActions); }
-            }
-
-            private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ActionType>> GetBlockActionsByAnalyzer<ActionType>(
-                ref ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ActionType>> lazyCodeBlockActionsByAnalyzer,
-                Func<AnalyzerActions, ImmutableArray<ActionType>> codeBlockActionsFactory,
-                in AnalyzerActions analyzerActions)
-                where ActionType : AnalyzerAction
-            {
-                if (lazyCodeBlockActionsByAnalyzer == null)
-                {
-                    var codeBlockActionsByAnalyzer = CreateBlockActionsByAnalyzer(codeBlockActionsFactory, in analyzerActions);
-                    Interlocked.CompareExchange(ref lazyCodeBlockActionsByAnalyzer, codeBlockActionsByAnalyzer, null);
-                }
-
-                return lazyCodeBlockActionsByAnalyzer;
-            }
-
-            private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ActionType>> CreateBlockActionsByAnalyzer<ActionType>(
-                Func<AnalyzerActions, ImmutableArray<ActionType>> codeBlockActionsFactory,
-                in AnalyzerActions analyzerActions)
-                where ActionType : AnalyzerAction
-            {
-                ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ActionType>> codeBlockActionsByAnalyzer;
-                var codeBlockActions = codeBlockActionsFactory(analyzerActions);
-                if (!codeBlockActions.IsEmpty)
-                {
-                    var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<ActionType>>();
-                    var actionsByAnalyzer = codeBlockActions.GroupBy(action => action.Analyzer);
-                    foreach (var analyzerAndActions in actionsByAnalyzer)
-                    {
-                        builder.Add(analyzerAndActions.Key, analyzerAndActions.ToImmutableArrayOrEmpty());
-                    }
-
-                    codeBlockActionsByAnalyzer = builder.ToImmutable();
-                }
-                else
-                {
-                    codeBlockActionsByAnalyzer = ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ActionType>>.Empty;
-                }
-
-                return codeBlockActionsByAnalyzer;
-            }
-
-            public bool ShouldExecuteSyntaxNodeActions(AnalysisScope analysisScope)
-            {
-                if (!this.NodeActionsByAnalyzerAndKind.IsEmpty)
-                {
-                    foreach (var analyzer in analysisScope.Analyzers)
-                    {
-                        if (this.NodeActionsByAnalyzerAndKind.ContainsKey(analyzer))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
-
-            public bool ShouldExecuteOperationActions(AnalysisScope analysisScope)
-            {
-                if (!this.OperationActionsByAnalyzerAndKind.IsEmpty)
-                {
-                    foreach (var analyzer in analysisScope.Analyzers)
-                    {
-                        if (this.OperationActionsByAnalyzerAndKind.ContainsKey(analyzer))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
-
-            public bool ShouldExecuteBlockActions<T0, T1>(ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<T0>> blockStartActions, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<T1>> blockActions, AnalysisScope analysisScope, ISymbol symbol)
-            {
-                if ((!blockStartActions.IsEmpty || !blockActions.IsEmpty) &&
-                    AnalyzerExecutor.CanHaveExecutableCodeBlock(symbol))
-                {
-                    foreach (var analyzer in analysisScope.Analyzers)
-                    {
-                        if (blockStartActions.ContainsKey(analyzer) ||
-                            blockActions.ContainsKey(analyzer))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
-
-            public bool ShouldExecuteCodeBlockActions(AnalysisScope analysisScope, ISymbol symbol)
-            {
-                return ShouldExecuteBlockActions(this.CodeBlockStartActionsByAnalyzer, this.CodeBlockActionsByAnalyzer, analysisScope, symbol);
-            }
-
-            public bool ShouldExecuteOperationBlockActions(AnalysisScope analysisScope, ISymbol symbol)
-            {
-                return ShouldExecuteBlockActions(this.OperationBlockStartActionsByAnalyzer, this.OperationBlockActionsByAnalyzer, analysisScope, symbol);
-            }
-
-            public IEnumerable<CodeBlockAnalyzerActions> GetCodeBlockActions(AnalysisScope analysisScope)
-            {
-                if (_analyzerActions.IsEmpty)
-                {
-                    yield break;
-                }
-
-                foreach (var analyzer in analysisScope.Analyzers)
-                {
-                    ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>> codeBlockStartActions;
-                    if (!this.CodeBlockStartActionsByAnalyzer.TryGetValue(analyzer, out codeBlockStartActions))
-                    {
-                        codeBlockStartActions = ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>>.Empty;
-                    }
-
-                    ImmutableArray<CodeBlockAnalyzerAction> codeBlockActions;
-                    if (!this.CodeBlockActionsByAnalyzer.TryGetValue(analyzer, out codeBlockActions))
-                    {
-                        codeBlockActions = ImmutableArray<CodeBlockAnalyzerAction>.Empty;
-                    }
-
-                    ImmutableArray<CodeBlockAnalyzerAction> codeBlockEndActions;
-                    if (!this.CodeBlockEndActionsByAnalyzer.TryGetValue(analyzer, out codeBlockEndActions))
-                    {
-                        codeBlockEndActions = ImmutableArray<CodeBlockAnalyzerAction>.Empty;
-                    }
-
-                    ImmutableArray<OperationBlockStartAnalyzerAction> operationBlockStartActions;
-                    if (!this.OperationBlockStartActionsByAnalyzer.TryGetValue(analyzer, out operationBlockStartActions))
-                    {
-                        operationBlockStartActions = ImmutableArray<OperationBlockStartAnalyzerAction>.Empty;
-                    }
-
-                    ImmutableArray<OperationBlockAnalyzerAction> operationBlockActions;
-                    if (!this.OperationBlockActionsByAnalyzer.TryGetValue(analyzer, out operationBlockActions))
-                    {
-                        operationBlockActions = ImmutableArray<OperationBlockAnalyzerAction>.Empty;
-                    }
-
-                    ImmutableArray<OperationBlockAnalyzerAction> operationBlockEndActions;
-                    if (!this.OperationBlockEndActionsByAnalyzer.TryGetValue(analyzer, out operationBlockEndActions))
-                    {
-                        operationBlockEndActions = ImmutableArray<OperationBlockAnalyzerAction>.Empty;
-                    }
-
-                    if (!codeBlockStartActions.IsEmpty || !codeBlockActions.IsEmpty || !codeBlockEndActions.IsEmpty || !operationBlockStartActions.IsEmpty || !operationBlockActions.IsEmpty || !operationBlockEndActions.IsEmpty)
-                    {
-                        yield return
-                            new CodeBlockAnalyzerActions
-                            {
-                                Analyzer = analyzer,
-                                CodeBlockStartActions = codeBlockStartActions,
-                                CodeBlockActions = codeBlockActions,
-                                CodeBlockEndActions = codeBlockEndActions,
-                                OperationBlockStartActions = operationBlockStartActions,
-                                OperationBlockActions = operationBlockActions,
-                                OperationBlockEndActions = operationBlockEndActions
-                            };
-                    }
-                }
+                var newGroupedActions = GroupedActionsByAnalyzer.AddRange(groupedAnalyzerActions.GroupedActionsByAnalyzer);
+                var newAnalyzerActions = AnalyzerActions.Append(groupedAnalyzerActions.AnalyzerActions);
+                return new GroupedAnalyzerActions(newGroupedActions, newAnalyzerActions);
             }
         }
     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsByAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsByAnalyzer.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal partial class AnalyzerDriver<TLanguageKindEnum> : AnalyzerDriver where TLanguageKindEnum : struct
+    {
+        private sealed class GroupedAnalyzerActionsForAnalyzer
+        {
+            private readonly DiagnosticAnalyzer _analyzer;
+            private readonly bool _analyzerActionsNeedFiltering;
+
+            private ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>? _lazyNodeActionsByKind;
+            private ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>? _lazyOperationActionsByKind;
+            private ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>> _lazyCodeBlockStartActions;
+            private ImmutableArray<CodeBlockAnalyzerAction> _lazyCodeBlockEndActions;
+            private ImmutableArray<CodeBlockAnalyzerAction> _lazyCodeBlockActions;
+            private ImmutableArray<OperationBlockStartAnalyzerAction> _lazyOperationBlockStartActions;
+            private ImmutableArray<OperationBlockAnalyzerAction> _lazyOperationBlockActions;
+            private ImmutableArray<OperationBlockAnalyzerAction> _lazyOperationBlockEndActions;
+
+            public GroupedAnalyzerActionsForAnalyzer(DiagnosticAnalyzer analyzer, in AnalyzerActions analyzerActions, bool analyzerActionsNeedFiltering)
+            {
+                Debug.Assert(!analyzerActions.IsEmpty);
+
+                _analyzer = analyzer;
+                AnalyzerActions = analyzerActions;
+                _analyzerActionsNeedFiltering = analyzerActionsNeedFiltering;
+            }
+
+            public AnalyzerActions AnalyzerActions { get; }
+
+            [Conditional("DEBUG")]
+            private static void VerifyActions<TAnalyzerAction>(in IEnumerable<TAnalyzerAction> actions, DiagnosticAnalyzer analyzer)
+                where TAnalyzerAction : AnalyzerAction
+            {
+                foreach (var action in actions)
+                {
+                    Debug.Assert(action.Analyzer == analyzer);
+                }
+            }
+
+            private ImmutableArray<TAnalyzerAction> GetFilteredActions<TAnalyzerAction>(in ImmutableArray<TAnalyzerAction> actions)
+                where TAnalyzerAction : AnalyzerAction
+                => GetFilteredActions(actions, _analyzer, _analyzerActionsNeedFiltering);
+
+            private static ImmutableArray<TAnalyzerAction> GetFilteredActions<TAnalyzerAction>(
+                in ImmutableArray<TAnalyzerAction> actions,
+                DiagnosticAnalyzer analyzer,
+                bool analyzerActionsNeedFiltering)
+                where TAnalyzerAction : AnalyzerAction
+            {
+                if (!analyzerActionsNeedFiltering)
+                {
+                    return actions;
+                }
+
+                var builder = ArrayBuilder<TAnalyzerAction>.GetInstance();
+                foreach (var action in actions)
+                {
+                    if (action.Analyzer == analyzer)
+                    {
+                        builder.Add(action);
+                    }
+                }
+
+                return builder.ToImmutableAndFree();
+            }
+
+            public ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>> NodeActionsByAnalyzerAndKind
+            {
+                get
+                {
+                    if (_lazyNodeActionsByKind == null)
+                    {
+                        var nodeActions = _analyzerActionsNeedFiltering ?
+                            AnalyzerActions.GetSyntaxNodeActions<TLanguageKindEnum>(_analyzer) :
+                            AnalyzerActions.GetSyntaxNodeActions<TLanguageKindEnum>();
+                        VerifyActions(nodeActions, _analyzer);
+                        var analyzerActionsByKind = !nodeActions.IsEmpty ?
+                            AnalyzerExecutor.GetNodeActionsByKind(nodeActions) :
+                            ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>>.Empty;
+                        Interlocked.CompareExchange(ref _lazyNodeActionsByKind, analyzerActionsByKind, null);
+                    }
+
+                    return _lazyNodeActionsByKind;
+                }
+            }
+
+            public ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>> OperationActionsByAnalyzerAndKind
+            {
+                get
+                {
+                    if (_lazyOperationActionsByKind == null)
+                    {
+                        var operationActions = GetFilteredActions(AnalyzerActions.OperationActions);
+                        VerifyActions(operationActions, _analyzer);
+                        var analyzerActionsByKind = operationActions.Any() ?
+                            AnalyzerExecutor.GetOperationActionsByKind(operationActions) :
+                            ImmutableDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>>.Empty;
+                        Interlocked.CompareExchange(ref _lazyOperationActionsByKind, analyzerActionsByKind, null);
+                    }
+
+                    return _lazyOperationActionsByKind;
+                }
+            }
+
+            private ImmutableArray<CodeBlockStartAnalyzerAction<TLanguageKindEnum>> CodeBlockStartActions
+            {
+                get
+                {
+                    if (_lazyCodeBlockStartActions.IsDefault)
+                    {
+                        var codeBlockActions = GetFilteredActions(AnalyzerActions.GetCodeBlockStartActions<TLanguageKindEnum>());
+                        VerifyActions(codeBlockActions, _analyzer);
+                        ImmutableInterlocked.InterlockedInitialize(ref _lazyCodeBlockStartActions, codeBlockActions);
+                    }
+
+                    return _lazyCodeBlockStartActions;
+                }
+            }
+
+            private ImmutableArray<CodeBlockAnalyzerAction> CodeBlockEndActions
+                => GetExecutableCodeActions(ref _lazyCodeBlockEndActions, AnalyzerActions.CodeBlockEndActions, _analyzer, _analyzerActionsNeedFiltering);
+
+            private ImmutableArray<CodeBlockAnalyzerAction> CodeBlockActions
+                => GetExecutableCodeActions(ref _lazyCodeBlockActions, AnalyzerActions.CodeBlockActions, _analyzer, _analyzerActionsNeedFiltering);
+
+            private ImmutableArray<OperationBlockStartAnalyzerAction> OperationBlockStartActions
+                => GetExecutableCodeActions(ref _lazyOperationBlockStartActions, AnalyzerActions.OperationBlockStartActions, _analyzer, _analyzerActionsNeedFiltering);
+
+            private ImmutableArray<OperationBlockAnalyzerAction> OperationBlockEndActions
+                => GetExecutableCodeActions(ref _lazyOperationBlockEndActions, AnalyzerActions.OperationBlockEndActions, _analyzer, _analyzerActionsNeedFiltering);
+
+            private ImmutableArray<OperationBlockAnalyzerAction> OperationBlockActions
+                => GetExecutableCodeActions(ref _lazyOperationBlockActions, AnalyzerActions.OperationBlockActions, _analyzer, _analyzerActionsNeedFiltering);
+
+            private static ImmutableArray<ActionType> GetExecutableCodeActions<ActionType>(
+                ref ImmutableArray<ActionType> lazyCodeBlockActions,
+                ImmutableArray<ActionType> codeBlockActions,
+                DiagnosticAnalyzer analyzer,
+                bool analyzerActionsNeedFiltering)
+                where ActionType : AnalyzerAction
+            {
+                if (lazyCodeBlockActions.IsDefault)
+                {
+                    codeBlockActions = GetFilteredActions(codeBlockActions, analyzer, analyzerActionsNeedFiltering);
+                    VerifyActions(codeBlockActions, analyzer);
+                    ImmutableInterlocked.InterlockedInitialize(ref lazyCodeBlockActions, codeBlockActions);
+                }
+
+                return lazyCodeBlockActions;
+            }
+
+            public bool TryGetExecutableCodeBlockActions(out ExecutableCodeBlockAnalyzerActions actions)
+            {
+                if (!OperationBlockStartActions.IsEmpty ||
+                    !OperationBlockActions.IsEmpty ||
+                    !OperationBlockEndActions.IsEmpty ||
+                    !CodeBlockStartActions.IsEmpty ||
+                    !CodeBlockActions.IsEmpty ||
+                    !CodeBlockEndActions.IsEmpty)
+                {
+                    actions = new ExecutableCodeBlockAnalyzerActions
+                    {
+                        Analyzer = _analyzer,
+                        CodeBlockStartActions = CodeBlockStartActions,
+                        CodeBlockActions = CodeBlockActions,
+                        CodeBlockEndActions = CodeBlockEndActions,
+                        OperationBlockStartActions = OperationBlockStartActions,
+                        OperationBlockActions = OperationBlockActions,
+                        OperationBlockEndActions = OperationBlockEndActions
+                    };
+
+                    return true;
+                }
+
+                actions = default;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsForAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsForAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             public AnalyzerActions AnalyzerActions { get; }
 
             [Conditional("DEBUG")]
-            private static void VerifyActions<TAnalyzerAction>(in IEnumerable<TAnalyzerAction> actions, DiagnosticAnalyzer analyzer)
+            private static void VerifyActions<TAnalyzerAction>(in ImmutableArray<TAnalyzerAction> actions, DiagnosticAnalyzer analyzer)
                 where TAnalyzerAction : AnalyzerAction
             {
                 foreach (var action in actions)
@@ -65,16 +65,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return actions;
                 }
 
-                var builder = ArrayBuilder<TAnalyzerAction>.GetInstance();
-                foreach (var action in actions)
-                {
-                    if (action.Analyzer == analyzer)
-                    {
-                        builder.Add(action);
-                    }
-                }
-
-                return builder.ToImmutableAndFree();
+                return actions.WhereAsArray((action, analyzer) => action.Analyzer == analyzer, analyzer);
             }
 
             public ImmutableDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>> NodeActionsByAnalyzerAndKind

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.IGroupedAnalyzerActions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.IGroupedAnalyzerActions.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal abstract partial class AnalyzerDriver
+    {
+        protected abstract IGroupedAnalyzerActions EmptyGroupedActions { get; }
+        protected abstract IGroupedAnalyzerActions CreateGroupedActions(DiagnosticAnalyzer analyzer, in AnalyzerActions analyzerActions);
+
+        protected interface IGroupedAnalyzerActions
+        {
+            bool IsEmpty { get; }
+            AnalyzerActions AnalyzerActions { get; }
+            IGroupedAnalyzerActions Append(IGroupedAnalyzerActions groupedAnalyzerActions);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1421,10 +1421,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     processedState = EventProcessedState.NotProcessed;
                 }
 
-                ImmutableArray<DiagnosticAnalyzer> subsetProcessedAnalyzers;
                 if (processedState.Kind == EventProcessedStateKind.Processed &&
                     hasPerSymbolActions &&
-                    !TryExecuteSymbolEndActions(perSymbolActions.AnalyzerActions, symbolEvent, analysisScope, analysisStateOpt, out subsetProcessedAnalyzers))
+                    !TryExecuteSymbolEndActions(perSymbolActions.AnalyzerActions, symbolEvent, analysisScope, analysisStateOpt, out var subsetProcessedAnalyzers))
                 {
                     Debug.Assert(!subsetProcessedAnalyzers.IsDefault);
                     processedState = subsetProcessedAnalyzers.IsEmpty ? EventProcessedState.NotProcessed : EventProcessedState.CreatePartiallyProcessed(subsetProcessedAnalyzers);
@@ -1530,7 +1529,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     completedAnalyzers.Add(analyzer);
                 }
 
-                Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
                 if (processedAnalyzers.Count < analysisScope.Analyzers.Length)
                 {
                     foreach (var analyzer in analysisScope.Analyzers)
@@ -1573,7 +1571,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCodeSymbol,
-            in IGroupedAnalyzerActions additionalPerSymbolActions,
+            IGroupedAnalyzerActions additionalPerSymbolActions,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -2227,7 +2225,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         protected override IGroupedAnalyzerActions EmptyGroupedActions => GroupedAnalyzerActions.Empty;
         protected override IGroupedAnalyzerActions CreateGroupedActions(DiagnosticAnalyzer analyzer, in AnalyzerActions analyzerActions)
-            => !analyzerActions.IsEmpty ? GroupedAnalyzerActions.Create(analyzer, analyzerActions) : null;
+            => GroupedAnalyzerActions.Create(analyzer, analyzerActions);
 
         /// <summary>
         /// Tries to execute syntax node, code block and operation actions for all declarations for the given symbol.
@@ -2241,7 +2239,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCodeSymbol,
-            in IGroupedAnalyzerActions additionalPerSymbolActions,
+            IGroupedAnalyzerActions additionalPerSymbolActions,
             CancellationToken cancellationToken)
         {
             var symbol = symbolEvent.Symbol;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         // Cache delegates for static methods
         private static readonly Func<DiagnosticAnalyzer, bool> s_IsCompilerAnalyzerFunc = IsCompilerAnalyzer;
-        private static readonly Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> s_GetTopmostNodeForAnalysis = GetTopmostNodeForAnalysis;
 
         private readonly Func<SyntaxTree, CancellationToken, bool> _isGeneratedCode;
 
@@ -55,13 +54,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         private readonly SeverityFilter _severityFilter;
 
-        // Lazy fields/properties
-        private CancellationTokenRegistration _queueRegistration;
         protected ImmutableArray<DiagnosticAnalyzer> Analyzers { get; }
         protected AnalyzerManager AnalyzerManager { get; }
+
+        // Lazy fields/properties
+        private Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> _lazyGetTopmostNodeForAnalysis;
+        private CancellationTokenRegistration _queueRegistration;
         protected AnalyzerExecutor AnalyzerExecutor { get; private set; }
         protected CompilationData CurrentCompilationData { get; private set; }
         protected ref readonly AnalyzerActions AnalyzerActions => ref _analyzerActions;
+
+        /// <summary>
+        /// Lazily initialized set of unsuppressed analyzers that need to be executed. 
+        /// </summary>
+        protected ImmutableHashSet<DiagnosticAnalyzer> UnsuppressedAnalyzers { get; private set; }
 
         /// <summary>
         /// Cache of additional analyzer actions to be executed per symbol per analyzer, which are registered in symbol start actions.
@@ -69,15 +75,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         ///   1. myActions: analyzer actions registered in the symbol start actions of containing namespace/type, which are to be executed for this symbol
         ///   2. childActions: analyzer actions registered in this symbol's start actions, which are to be executed for member symbols.
         /// </summary>
-        private ConcurrentDictionary<(INamespaceOrTypeSymbol, DiagnosticAnalyzer), AnalyzerActions> _perSymbolAnalyzerActionsCache;
+        private ConcurrentDictionary<(INamespaceOrTypeSymbol, DiagnosticAnalyzer), IGroupedAnalyzerActions> _perSymbolAnalyzerActionsCache;
 
-        private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ImmutableArray<SymbolAnalyzerAction>>> _symbolActionsByKind;
-        private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<SemanticModelAnalyzerAction>> _semanticModelActionsMap;
-        private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<SyntaxTreeAnalyzerAction>> _syntaxTreeActionsMap;
+        private ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<ImmutableArray<SymbolAnalyzerAction>>)> _symbolActionsByKind;
+        private ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<SemanticModelAnalyzerAction>)> _semanticModelActions;
+        private ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<SyntaxTreeAnalyzerAction>)> _syntaxTreeActions;
         // Compilation actions and compilation end actions have separate maps so that it is easy to
         // execute the compilation actions before the compilation end actions.
-        private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>> _compilationActionsMap;
-        private ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>> _compilationEndActionsMap;
+        private ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)> _compilationActions;
+        private ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)> _compilationEndActions;
+        private ImmutableHashSet<DiagnosticAnalyzer> _compilationEndAnalyzers;
 
         /// <summary>
         /// Default analysis mode for generated code.
@@ -103,11 +110,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <seealso cref="AnalyzerActions"/>
         private AnalyzerActions _analyzerActions;
-
-        /// <summary>
-        /// Set of unsuppressed analyzers that need to be executed. 
-        /// </summary>
-        private ImmutableHashSet<DiagnosticAnalyzer> _unsuppressedAnalyzers;
 
         /// <summary>
         /// Set of unsuppressed analyzers that report non-configurable diagnostics that cannot be suppressed with end user configuration. 
@@ -225,17 +227,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 this.AnalyzerExecutor = analyzerExecutor;
                 this.CurrentCompilationData = compilationData;
                 this.DiagnosticQueue = diagnosticQueue;
+                _lazyGetTopmostNodeForAnalysis = (symbol, syntaxRef, compilation, ct) => GetTopmostNodeForAnalysis(symbol, syntaxRef, compilation, compilationData, ct);
 
                 // Compute the set of effective actions based on suppression, and running the initial analyzers
                 _initializeTask = Task.Run(async () =>
                 {
-                    (_analyzerActions, _unsuppressedAnalyzers) = await GetAnalyzerActionsAsync(Analyzers, AnalyzerManager, analyzerExecutor, _severityFilter).ConfigureAwait(false);
-                    _analyzerGateMap = await CreateAnalyzerGateMapAsync(_unsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, _severityFilter).ConfigureAwait(false);
-                    _nonConfigurableAnalyzers = ComputeNonConfigurableAnalyzers(_unsuppressedAnalyzers);
-                    _symbolStartAnalyzers = ComputeSymbolStartAnalyzers(_unsuppressedAnalyzers);
-                    _generatedCodeAnalysisFlagsMap = await CreateGeneratedCodeAnalysisFlagsMapAsync(_unsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, _severityFilter).ConfigureAwait(false);
-                    _doNotAnalyzeGeneratedCode = ComputeShouldSkipAnalysisOnGeneratedCode(_unsuppressedAnalyzers);
-                    _treatAllCodeAsNonGeneratedCode = ComputeShouldTreatAllCodeAsNonGeneratedCode(_unsuppressedAnalyzers, _generatedCodeAnalysisFlagsMap);
+                    (_analyzerActions, UnsuppressedAnalyzers) = await GetAnalyzerActionsAsync(Analyzers, AnalyzerManager, analyzerExecutor, _severityFilter).ConfigureAwait(false);
+                    _analyzerGateMap = await CreateAnalyzerGateMapAsync(UnsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, _severityFilter).ConfigureAwait(false);
+                    _nonConfigurableAnalyzers = ComputeNonConfigurableAnalyzers(UnsuppressedAnalyzers);
+                    _symbolStartAnalyzers = ComputeSymbolStartAnalyzers(UnsuppressedAnalyzers);
+                    _generatedCodeAnalysisFlagsMap = await CreateGeneratedCodeAnalysisFlagsMapAsync(UnsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, _severityFilter).ConfigureAwait(false);
+                    _doNotAnalyzeGeneratedCode = ComputeShouldSkipAnalysisOnGeneratedCode(UnsuppressedAnalyzers);
+                    _treatAllCodeAsNonGeneratedCode = ComputeShouldTreatAllCodeAsNonGeneratedCode(UnsuppressedAnalyzers, _generatedCodeAnalysisFlagsMap);
                     _lazyGeneratedCodeFilesMap = _treatAllCodeAsNonGeneratedCode ? null : new ConcurrentDictionary<SyntaxTree, bool>();
                     _lazyGeneratedCodeSymbolsForTreeMap = _treatAllCodeAsNonGeneratedCode ? null : new Dictionary<SyntaxTree, ImmutableHashSet<ISymbol>>();
                     _lazyIsGeneratedCodeSymbolMap = _treatAllCodeAsNonGeneratedCode ? null : new ConcurrentDictionary<ISymbol, bool>();
@@ -244,14 +247,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     _generatedCodeAttribute = analyzerExecutor.Compilation?.GetTypeByMetadataName("System.CodeDom.Compiler.GeneratedCodeAttribute");
 
                     _symbolActionsByKind = MakeSymbolActionsByKind(in AnalyzerActions);
-                    _semanticModelActionsMap = MakeSemanticModelActionsByAnalyzer(in AnalyzerActions);
-                    _syntaxTreeActionsMap = MakeSyntaxTreeActionsByAnalyzer(in AnalyzerActions);
-                    _compilationActionsMap = MakeCompilationActionsByAnalyzer(this.AnalyzerActions.CompilationActions);
-                    _compilationEndActionsMap = MakeCompilationActionsByAnalyzer(this.AnalyzerActions.CompilationEndActions);
+                    _semanticModelActions = MakeSemanticModelActionsByAnalyzer(in AnalyzerActions);
+                    _syntaxTreeActions = MakeSyntaxTreeActionsByAnalyzer(in AnalyzerActions);
+                    _compilationActions = MakeCompilationActionsByAnalyzer(this.AnalyzerActions.CompilationActions);
+                    _compilationEndActions = MakeCompilationActionsByAnalyzer(this.AnalyzerActions.CompilationEndActions);
+                    _compilationEndAnalyzers = MakeCompilationEndAnalyzers(_compilationEndActions);
 
                     if (this.AnalyzerActions.SymbolStartActionsCount > 0)
                     {
-                        _perSymbolAnalyzerActionsCache = new ConcurrentDictionary<(INamespaceOrTypeSymbol, DiagnosticAnalyzer), AnalyzerActions>();
+                        _perSymbolAnalyzerActionsCache = new ConcurrentDictionary<(INamespaceOrTypeSymbol, DiagnosticAnalyzer), IGroupedAnalyzerActions>();
                     }
 
                 }, cancellationToken);
@@ -571,20 +575,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     continue;
                 }
 
-                foreach (var analyzer in analysisScope.Analyzers)
+                var processedAnalyzers = analysisStateOpt != null ? PooledHashSet<DiagnosticAnalyzer>.GetInstance() : null;
+                try
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    ImmutableArray<SyntaxTreeAnalyzerAction> syntaxTreeActions;
-                    if (_syntaxTreeActionsMap.TryGetValue(analyzer, out syntaxTreeActions))
+                    foreach (var (analyzer, syntaxTreeActions) in _syntaxTreeActions)
                     {
+                        if (!analysisScope.Contains(analyzer))
+                        {
+                            continue;
+                        }
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         // Execute actions for a given analyzer sequentially.
                         AnalyzerExecutor.TryExecuteSyntaxTreeActions(syntaxTreeActions, analyzer, tree, analysisScope, analysisStateOpt, isGeneratedCode);
+
+                        processedAnalyzers?.Add(analyzer);
                     }
-                    else
-                    {
-                        analysisStateOpt?.MarkSyntaxAnalysisComplete(tree, analyzer);
-                    }
+
+                    analysisStateOpt?.MarkSyntaxAnalysisCompleteForUnprocessedAnalyzers(tree, analysisScope, processedAnalyzers);
+                }
+                finally
+                {
+                    processedAnalyzers?.Free();
                 }
             }
         }
@@ -644,7 +657,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var analysisOptions = new CompilationWithAnalyzersOptions(options, onAnalyzerException, analyzerExceptionFilter: analyzerExceptionFilter, concurrentAnalysis: true, logAnalyzerExecutionTime: reportAnalyzer, reportSuppressedDiagnostics: false);
             analyzerDriver.Initialize(newCompilation, analysisOptions, new CompilationData(newCompilation), categorizeDiagnostics, cancellationToken);
 
-            var analysisScope = new AnalysisScope(newCompilation, analyzers, concurrentAnalysis: newCompilation.Options.ConcurrentBuild, categorizeDiagnostics: categorizeDiagnostics);
+            var analysisScope = new AnalysisScope(newCompilation, analyzers, hasAllAnalyzers: true, concurrentAnalysis: newCompilation.Options.ConcurrentBuild, categorizeDiagnostics: categorizeDiagnostics);
             analyzerDriver.AttachQueueAndStartProcessingEvents(newCompilation.EventQueue, analysisScope, cancellationToken: cancellationToken);
             return analyzerDriver;
         }
@@ -1021,7 +1034,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             ImmutableHashSet<DiagnosticAnalyzer>.Builder suppressedAnalyzersBuilderOpt = null;
-            foreach (var analyzer in _unsuppressedAnalyzers)
+            foreach (var analyzer in UnsuppressedAnalyzers)
             {
                 if (_nonConfigurableAnalyzers.Contains(analyzer))
                 {
@@ -1029,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     continue;
                 }
 
-                if ((_symbolStartAnalyzers.Contains(analyzer) || _compilationEndActionsMap.ContainsKey(analyzer)) &&
+                if ((_symbolStartAnalyzers.Contains(analyzer) || _compilationEndAnalyzers.Contains(analyzer)) &&
                     !ShouldSkipAnalysisOnGeneratedCode(analyzer))
                 {
                     // SymbolStart/End analyzers and CompilationStart/End analyzers that analyze generated code
@@ -1073,13 +1086,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         internal ImmutableDictionary<DiagnosticAnalyzer, TimeSpan> AnalyzerExecutionTimes => AnalyzerExecutor.AnalyzerExecutionTimes;
         internal TimeSpan ResetAnalyzerExecutionTime(DiagnosticAnalyzer analyzer) => AnalyzerExecutor.ResetAnalyzerExecutionTime(analyzer);
 
-        private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<ImmutableArray<SymbolAnalyzerAction>>> MakeSymbolActionsByKind(in AnalyzerActions analyzerActions)
+        private static ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<ImmutableArray<SymbolAnalyzerAction>>)> MakeSymbolActionsByKind(in AnalyzerActions analyzerActions)
         {
-            var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<ImmutableArray<SymbolAnalyzerAction>>>();
+            var builder = ArrayBuilder<(DiagnosticAnalyzer, ImmutableArray<ImmutableArray<SymbolAnalyzerAction>>)>.GetInstance();
             var actionsByAnalyzers = analyzerActions.SymbolActions.GroupBy(action => action.Analyzer);
+            var actionsByKindBuilder = ArrayBuilder<ArrayBuilder<SymbolAnalyzerAction>>.GetInstance();
             foreach (var analyzerAndActions in actionsByAnalyzers)
             {
-                var actionsByKindBuilder = new List<ArrayBuilder<SymbolAnalyzerAction>>();
+                actionsByKindBuilder.Clear();
                 foreach (var symbolAction in analyzerAndActions)
                 {
                     var kinds = symbolAction.Kinds;
@@ -1096,43 +1110,55 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 var actionsByKind = actionsByKindBuilder.Select(a => a.ToImmutableAndFree()).ToImmutableArray();
-                builder.Add(analyzerAndActions.Key, actionsByKind);
+                builder.Add((analyzerAndActions.Key, actionsByKind));
             }
 
-            return builder.ToImmutable();
+            actionsByKindBuilder.Free();
+            return builder.ToImmutableAndFree();
         }
 
-        private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<SyntaxTreeAnalyzerAction>> MakeSyntaxTreeActionsByAnalyzer(in AnalyzerActions analyzerActions)
+        private static ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<SyntaxTreeAnalyzerAction>)> MakeSyntaxTreeActionsByAnalyzer(in AnalyzerActions analyzerActions)
         {
-            var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<SyntaxTreeAnalyzerAction>>();
+            var builder = ArrayBuilder<(DiagnosticAnalyzer, ImmutableArray<SyntaxTreeAnalyzerAction>)>.GetInstance();
             var actionsByAnalyzers = analyzerActions.SyntaxTreeActions.GroupBy(action => action.Analyzer);
             foreach (var analyzerAndActions in actionsByAnalyzers)
             {
-                builder.Add(analyzerAndActions.Key, analyzerAndActions.ToImmutableArray());
+                builder.Add((analyzerAndActions.Key, analyzerAndActions.ToImmutableArray()));
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndFree();
         }
 
-        private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<SemanticModelAnalyzerAction>> MakeSemanticModelActionsByAnalyzer(in AnalyzerActions analyzerActions)
+        private static ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<SemanticModelAnalyzerAction>)> MakeSemanticModelActionsByAnalyzer(in AnalyzerActions analyzerActions)
         {
-            var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<SemanticModelAnalyzerAction>>();
+            var builder = ArrayBuilder<(DiagnosticAnalyzer, ImmutableArray<SemanticModelAnalyzerAction>)>.GetInstance();
             var actionsByAnalyzers = analyzerActions.SemanticModelActions.GroupBy(action => action.Analyzer);
             foreach (var analyzerAndActions in actionsByAnalyzers)
             {
-                builder.Add(analyzerAndActions.Key, analyzerAndActions.ToImmutableArray());
+                builder.Add((analyzerAndActions.Key, analyzerAndActions.ToImmutableArray()));
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndFree();
         }
 
-        private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>> MakeCompilationActionsByAnalyzer(ImmutableArray<CompilationAnalyzerAction> compilationActions)
+        private static ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)> MakeCompilationActionsByAnalyzer(ImmutableArray<CompilationAnalyzerAction> compilationActions)
         {
-            var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>>();
+            var builder = ArrayBuilder<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)>.GetInstance();
             var actionsByAnalyzers = compilationActions.GroupBy(action => action.Analyzer);
             foreach (var analyzerAndActions in actionsByAnalyzers)
             {
-                builder.Add(analyzerAndActions.Key, analyzerAndActions.ToImmutableArray());
+                builder.Add((analyzerAndActions.Key, analyzerAndActions.ToImmutableArray()));
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        private static ImmutableHashSet<DiagnosticAnalyzer> MakeCompilationEndAnalyzers(ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)> compilationEndActionsByAnalyzer)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<DiagnosticAnalyzer>();
+            foreach (var (analyzer, _) in compilationEndActionsByAnalyzer)
+            {
+                builder.Add(analyzer);
             }
 
             return builder.ToImmutable();
@@ -1312,7 +1338,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (containerSymbol != null &&
                     AnalyzerExecutor.TryExecuteSymbolEndActionsForContainer(containerSymbol, processedMemberSymbol,
-                        analyzer, s_GetTopmostNodeForAnalysis, analysisStateOpt, out SymbolDeclaredCompilationEvent processedContainerEvent))
+                        analyzer, _lazyGetTopmostNodeForAnalysis, analysisStateOpt, out SymbolDeclaredCompilationEvent processedContainerEvent))
                 {
                     await OnEventProcessedCoreAsync(processedContainerEvent, ImmutableArray.Create(analyzer), analysisStateOpt, cancellationToken).ConfigureAwait(false);
                 }
@@ -1343,7 +1369,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var endEvent = e as CompilationCompletedEvent;
             if (endEvent != null)
             {
-                return TryProcessCompilationCompleted(endEvent, analysisScope, analysisStateOpt, cancellationToken) ?
+                return TryProcessCompilationCompleted(endEvent, analysisScope, analysisStateOpt) ?
                     EventProcessedState.Processed :
                     EventProcessedState.NotProcessed;
             }
@@ -1351,7 +1377,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var startedEvent = e as CompilationStartedEvent;
             if (startedEvent != null)
             {
-                return TryProcessCompilationStarted(startedEvent, analysisScope, analysisStateOpt, cancellationToken) ?
+                return TryProcessCompilationStarted(startedEvent, analysisScope, analysisStateOpt) ?
                     EventProcessedState.Processed :
                     EventProcessedState.NotProcessed;
             }
@@ -1381,9 +1407,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var skipDeclarationAnalysis = AnalysisScope.ShouldSkipDeclarationAnalysis(symbol);
                 var hasPerSymbolActions = AnalyzerActions.SymbolStartActionsCount > 0 && (!skipSymbolAnalysis || !skipDeclarationAnalysis);
 
-                AnalyzerActions perSymbolActions = hasPerSymbolActions ?
+                var perSymbolActions = hasPerSymbolActions ?
                     await GetPerSymbolAnalyzerActionsAsync(symbol, analysisScope, analysisStateOpt, cancellationToken).ConfigureAwait(false) :
-                    AnalyzerActions.Empty;
+                    EmptyGroupedActions;
 
                 if (!skipSymbolAnalysis &&
                     !TryExecuteSymbolActions(symbolEvent, analysisScope, analysisStateOpt, isGeneratedCodeSymbol, cancellationToken))
@@ -1397,12 +1423,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     processedState = EventProcessedState.NotProcessed;
                 }
 
-                ImmutableArray<DiagnosticAnalyzer> subsetProcessedAnalyzers = default;
+                ImmutableArray<DiagnosticAnalyzer> subsetProcessedAnalyzers;
                 if (processedState.Kind == EventProcessedStateKind.Processed &&
                     hasPerSymbolActions &&
-                    !TryExecuteSymbolEndActions(perSymbolActions, symbolEvent, analysisScope, analysisStateOpt, cancellationToken, out subsetProcessedAnalyzers))
+                    !TryExecuteSymbolEndActions(perSymbolActions.AnalyzerActions, symbolEvent, analysisScope, analysisStateOpt, out subsetProcessedAnalyzers))
                 {
-                    processedState = subsetProcessedAnalyzers.IsDefaultOrEmpty ? EventProcessedState.NotProcessed : EventProcessedState.CreatePartiallyProcessed(subsetProcessedAnalyzers);
+                    Debug.Assert(!subsetProcessedAnalyzers.IsDefault);
+                    processedState = subsetProcessedAnalyzers.IsEmpty ? EventProcessedState.NotProcessed : EventProcessedState.CreatePartiallyProcessed(subsetProcessedAnalyzers);
                 }
 
                 return processedState;
@@ -1428,25 +1455,36 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return true;
             }
 
-            var success = true;
-            foreach (var analyzer in analysisScope.Analyzers)
+            var processedAnalyzers = analysisStateOpt != null ? PooledHashSet<DiagnosticAnalyzer>.GetInstance() : null;
+            try
             {
-                // Invoke symbol analyzers only for source symbols.
-                ImmutableArray<ImmutableArray<SymbolAnalyzerAction>> actionsByKind;
-                if (_symbolActionsByKind.TryGetValue(analyzer, out actionsByKind) && (int)symbol.Kind < actionsByKind.Length)
+                var success = true;
+                foreach (var (analyzer, actionsByKind) in _symbolActionsByKind)
                 {
-                    if (!AnalyzerExecutor.TryExecuteSymbolActions(actionsByKind[(int)symbol.Kind], analyzer, symbolEvent, s_GetTopmostNodeForAnalysis, analysisScope, analysisStateOpt, isGeneratedCodeSymbol))
+                    if (!analysisScope.Contains(analyzer))
                     {
-                        success = false;
+                        continue;
+                    }
+
+                    // Invoke symbol analyzers only for source symbols.
+                    if ((int)symbol.Kind < actionsByKind.Length)
+                    {
+                        if (!AnalyzerExecutor.TryExecuteSymbolActions(actionsByKind[(int)symbol.Kind], analyzer, symbolEvent, _lazyGetTopmostNodeForAnalysis, analysisScope, analysisStateOpt, isGeneratedCodeSymbol))
+                        {
+                            success = false;
+                        }
+
+                        processedAnalyzers?.Add(analyzer);
                     }
                 }
-                else
-                {
-                    analysisStateOpt?.MarkSymbolComplete(symbol, analyzer);
-                }
-            }
 
-            return success;
+                analysisStateOpt?.MarkSymbolCompleteForUnprocessedAnalyzers(symbol, analysisScope, processedAnalyzers);
+                return success;
+            }
+            finally
+            {
+                processedAnalyzers?.Free();
+            }
         }
 
         private bool TryExecuteSymbolEndActions(
@@ -1454,71 +1492,82 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SymbolDeclaredCompilationEvent symbolEvent,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
-            CancellationToken cancellationToken,
             out ImmutableArray<DiagnosticAnalyzer> subsetProcessedAnalyzers)
         {
             Debug.Assert(AnalyzerActions.SymbolStartActionsCount > 0);
-            subsetProcessedAnalyzers = default;
 
             var symbol = symbolEvent.Symbol;
             var symbolEndActions = perSymbolActions.SymbolEndActions;
             if (!analysisScope.ShouldAnalyze(symbol) || symbolEndActions.IsEmpty)
             {
                 analysisStateOpt?.MarkSymbolEndAnalysisComplete(symbol, analysisScope.Analyzers);
+                subsetProcessedAnalyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
                 return true;
             }
 
             var success = true;
-            ArrayBuilder<DiagnosticAnalyzer> subsetProcessedAnalyzersBuilderOpt = null;
-            for (int i = 0; i < analysisScope.Analyzers.Length; i++)
+            var completedAnalyzers = ArrayBuilder<DiagnosticAnalyzer>.GetInstance();
+            var processedAnalyzers = PooledHashSet<DiagnosticAnalyzer>.GetInstance();
+            try
             {
-                var analyzer = analysisScope.Analyzers[i];
-                var analyzerSuccess = true;
-                var symbolEndActionsForAnalyzer = symbolEndActions.Where(a => a.Analyzer == analyzer).ToImmutableArrayOrEmpty();
-                if (!symbolEndActionsForAnalyzer.IsEmpty)
+                foreach (var groupedActions in symbolEndActions.GroupBy(a => a.Analyzer))
                 {
-                    if (!AnalyzerExecutor.TryExecuteSymbolEndActions(symbolEndActionsForAnalyzer, analyzer, symbolEvent, s_GetTopmostNodeForAnalysis, analysisStateOpt))
+                    var analyzer = groupedActions.Key;
+                    if (!analysisScope.Contains(analyzer))
                     {
-                        if (subsetProcessedAnalyzersBuilderOpt == null)
-                        {
-                            subsetProcessedAnalyzersBuilderOpt = ArrayBuilder<DiagnosticAnalyzer>.GetInstance();
-                            subsetProcessedAnalyzersBuilderOpt.AddRange(analysisScope.Analyzers, i);
-                        }
+                        continue;
+                    }
 
-                        analyzerSuccess = false;
+                    processedAnalyzers.Add(analyzer);
+
+                    var symbolEndActionsForAnalyzer = groupedActions.ToImmutableArrayOrEmpty();
+                    if (!symbolEndActionsForAnalyzer.IsEmpty &&
+                        !AnalyzerExecutor.TryExecuteSymbolEndActions(symbolEndActionsForAnalyzer, analyzer, symbolEvent, _lazyGetTopmostNodeForAnalysis, analysisStateOpt))
+                    {
                         success = false;
+                        continue;
+                    }
+
+                    AnalyzerExecutor.MarkSymbolEndAnalysisComplete(symbol, analyzer, analysisStateOpt);
+                    completedAnalyzers.Add(analyzer);
+                }
+
+                Debug.Assert(processedAnalyzers.All(analysisScope.Contains));
+                if (processedAnalyzers.Count < analysisScope.Analyzers.Length)
+                {
+                    foreach (var analyzer in analysisScope.Analyzers)
+                    {
+                        if (!processedAnalyzers.Contains(analyzer))
+                        {
+                            AnalyzerExecutor.MarkSymbolEndAnalysisComplete(symbol, analyzer, analysisStateOpt);
+                            completedAnalyzers.Add(analyzer);
+                        }
                     }
                 }
 
-                if (analyzerSuccess)
+                if (!success)
                 {
-                    AnalyzerExecutor.MarkSymbolEndAnalysisComplete(symbol, analyzer, analysisStateOpt);
-                    subsetProcessedAnalyzersBuilderOpt?.Add(analyzer);
-                }
-            }
-
-            if (subsetProcessedAnalyzersBuilderOpt != null)
-            {
-                Debug.Assert(!success);
-                Debug.Assert(subsetProcessedAnalyzersBuilderOpt.Count < analysisScope.Analyzers.Length);
-
-                if (subsetProcessedAnalyzersBuilderOpt.Count > 0)
-                {
-                    subsetProcessedAnalyzers = subsetProcessedAnalyzersBuilderOpt.ToImmutableAndFree();
+                    Debug.Assert(completedAnalyzers.Count < analysisScope.Analyzers.Length);
+                    subsetProcessedAnalyzers = completedAnalyzers.ToImmutable();
+                    return false;
                 }
                 else
                 {
-                    subsetProcessedAnalyzersBuilderOpt.Free();
+                    subsetProcessedAnalyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
+                    return true;
                 }
             }
-
-            return success;
+            finally
+            {
+                processedAnalyzers.Free();
+                completedAnalyzers.Free();
+            }
         }
 
-        private static SyntaxNode GetTopmostNodeForAnalysis(ISymbol symbol, SyntaxReference syntaxReference, Compilation compilation)
+        private static SyntaxNode GetTopmostNodeForAnalysis(ISymbol symbol, SyntaxReference syntaxReference, Compilation compilation, CompilationData compilationData, CancellationToken cancellationToken)
         {
-            var model = compilation.GetSemanticModel(syntaxReference.SyntaxTree);
-            return model.GetTopmostNodeForDiagnosticAnalysis(symbol, syntaxReference.GetSyntax());
+            var model = compilationData.GetOrCreateCachedSemanticModel(syntaxReference.SyntaxTree, compilation, cancellationToken);
+            return model.GetTopmostNodeForDiagnosticAnalysis(symbol, syntaxReference.GetSyntax(cancellationToken));
         }
 
         protected abstract bool TryExecuteDeclaringReferenceActions(
@@ -1526,8 +1575,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCodeSymbol,
-            in AnalyzerActions additionalPerSymbolActions,
+            in IGroupedAnalyzerActions additionalPerSymbolActions,
             CancellationToken cancellationToken);
+
+        protected abstract IGroupedAnalyzerActions EmptyGroupedActions { get; }
+        protected abstract IGroupedAnalyzerActions CreateGroupedActions(DiagnosticAnalyzer analyzer, in AnalyzerActions analyzerActions);
+
+        protected interface IGroupedAnalyzerActions
+        {
+            bool IsEmpty { get; }
+            AnalyzerActions AnalyzerActions { get; }
+            IGroupedAnalyzerActions Append(in IGroupedAnalyzerActions groupedAnalyzerActions);
+        }
 
         /// <summary>
         /// Tries to execute compilation unit actions.
@@ -1558,30 +1617,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return true;
             }
 
+            var processedAnalyzers = analysisStateOpt != null ? PooledHashSet<DiagnosticAnalyzer>.GetInstance() : null;
             try
             {
                 var success = true;
-                foreach (var analyzer in analysisScope.Analyzers)
+                foreach (var (analyzer, semanticModelActions) in _semanticModelActions)
                 {
-                    ImmutableArray<SemanticModelAnalyzerAction> semanticModelActions;
-                    if (_semanticModelActionsMap.TryGetValue(analyzer, out semanticModelActions))
+                    if (!analysisScope.Contains(analyzer))
                     {
-                        // Execute actions for a given analyzer sequentially.
-                        if (!AnalyzerExecutor.TryExecuteSemanticModelActions(semanticModelActions, analyzer, semanticModel, completedEvent, analysisScope, analysisStateOpt, isGeneratedCode))
-                        {
-                            success = false;
-                        }
+                        continue;
                     }
-                    else
+
+                    // Execute actions for a given analyzer sequentially.
+                    if (!AnalyzerExecutor.TryExecuteSemanticModelActions(semanticModelActions, analyzer, semanticModel, completedEvent, analysisScope, analysisStateOpt, isGeneratedCode))
                     {
-                        analysisStateOpt?.MarkEventComplete(completedEvent, analyzer);
+                        success = false;
                     }
+
+                    processedAnalyzers?.Add(analyzer);
                 }
 
+                analysisStateOpt?.MarkEventCompleteForUnprocessedAnalyzers(completedEvent, analysisScope, processedAnalyzers);
                 return success;
             }
             finally
             {
+                processedAnalyzers?.Free();
                 completedEvent.FlushCache();
             }
         }
@@ -1593,9 +1654,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// True, if successfully executed the actions for the given analysis scope OR no actions were required to be executed for the given analysis scope.
         /// False, otherwise.
         /// </returns>
-        private bool TryProcessCompilationStarted(CompilationStartedEvent startedEvent, AnalysisScope analysisScope, AnalysisState analysisStateOpt, CancellationToken cancellationToken)
+        private bool TryProcessCompilationStarted(CompilationStartedEvent startedEvent, AnalysisScope analysisScope, AnalysisState analysisStateOpt)
         {
-            return TryExecuteCompilationActions(_compilationActionsMap, startedEvent, analysisScope, analysisStateOpt, cancellationToken);
+            return TryExecuteCompilationActions(_compilationActions, startedEvent, analysisScope, analysisStateOpt);
         }
 
         /// <summary>
@@ -1605,9 +1666,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// True, if successfully executed the actions for the given analysis scope OR no actions were required to be executed for the given analysis scope.
         /// False, otherwise.
         /// </returns>
-        private bool TryProcessCompilationCompleted(CompilationCompletedEvent endEvent, AnalysisScope analysisScope, AnalysisState analysisStateOpt, CancellationToken cancellationToken)
+        private bool TryProcessCompilationCompleted(CompilationCompletedEvent endEvent, AnalysisScope analysisScope, AnalysisState analysisStateOpt)
         {
-            return TryExecuteCompilationActions(_compilationEndActionsMap, endEvent, analysisScope, analysisStateOpt, cancellationToken);
+            return TryExecuteCompilationActions(_compilationEndActions, endEvent, analysisScope, analysisStateOpt);
         }
 
         /// <summary>
@@ -1618,37 +1679,38 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// False, otherwise.
         /// </returns>
         private bool TryExecuteCompilationActions(
-            ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>> compilationActionsMap,
+            ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)> compilationActionsMap,
             CompilationEvent compilationEvent,
             AnalysisScope analysisScope,
-            AnalysisState analysisStateOpt,
-            CancellationToken cancellationToken)
+            AnalysisState analysisStateOpt)
         {
             Debug.Assert(compilationEvent is CompilationStartedEvent || compilationEvent is CompilationCompletedEvent);
 
+            var processedAnalyzers = analysisStateOpt != null ? PooledHashSet<DiagnosticAnalyzer>.GetInstance() : null;
             try
             {
                 var success = true;
-                foreach (var analyzer in analysisScope.Analyzers)
+                foreach (var (analyzer, compilationActions) in compilationActionsMap)
                 {
-                    ImmutableArray<CompilationAnalyzerAction> compilationActions;
-                    if (compilationActionsMap.TryGetValue(analyzer, out compilationActions))
+                    if (!analysisScope.Contains(analyzer))
                     {
-                        if (!AnalyzerExecutor.TryExecuteCompilationActions(compilationActions, analyzer, compilationEvent, analysisScope, analysisStateOpt))
-                        {
-                            success = false;
-                        }
+                        continue;
                     }
-                    else
+
+                    if (!AnalyzerExecutor.TryExecuteCompilationActions(compilationActions, analyzer, compilationEvent, analysisScope, analysisStateOpt))
                     {
-                        analysisStateOpt?.MarkEventComplete(compilationEvent, analyzer);
+                        success = false;
                     }
+
+                    processedAnalyzers?.Add(analyzer);
                 }
 
+                analysisStateOpt?.MarkEventCompleteForUnprocessedAnalyzers(compilationEvent, analysisScope, processedAnalyzers);
                 return success;
             }
             finally
             {
+                processedAnalyzers?.Free();
                 compilationEvent.FlushCache();
             }
         }
@@ -1791,7 +1853,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [PerformanceSensitive(
             "https://developercommunity.visualstudio.com/content/problem/805524/ctrl-suggestions-are-very-slow-and-produce-gatheri.html",
             OftenCompletesSynchronously = true)]
-        private async ValueTask<AnalyzerActions> GetPerSymbolAnalyzerActionsAsync(
+        private async ValueTask<IGroupedAnalyzerActions> GetPerSymbolAnalyzerActionsAsync(
             ISymbol symbol,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
@@ -1799,10 +1861,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (AnalyzerActions.SymbolStartActionsCount == 0 || symbol.IsImplicitlyDeclared)
             {
-                return AnalyzerActions.Empty;
+                return EmptyGroupedActions;
             }
 
-            var allActions = AnalyzerActions.Empty;
+            var allActions = EmptyGroupedActions;
             foreach (var analyzer in analysisScope.Analyzers)
             {
                 if (!_symbolStartAnalyzers.Contains(analyzer))
@@ -1823,7 +1885,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [PerformanceSensitive(
             "https://developercommunity.visualstudio.com/content/problem/805524/ctrl-suggestions-are-very-slow-and-produce-gatheri.html",
             OftenCompletesSynchronously = true)]
-        private async ValueTask<AnalyzerActions> GetPerSymbolAnalyzerActionsAsync(
+        private async ValueTask<IGroupedAnalyzerActions> GetPerSymbolAnalyzerActionsAsync(
             ISymbol symbol,
             DiagnosticAnalyzer analyzer,
             AnalysisState analysisStateOpt,
@@ -1834,7 +1896,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             if (symbol.IsImplicitlyDeclared)
             {
-                return AnalyzerActions.Empty;
+                return EmptyGroupedActions;
             }
 
             // PERF: For containing symbols, we want to cache the computed actions.
@@ -1852,17 +1914,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var allActions = await getAllActionsAsync(this, symbol, analyzer, analysisStateOpt, cancellationToken).ConfigureAwait(false);
             return _perSymbolAnalyzerActionsCache.GetOrAdd((namespaceOrType, analyzer), allActions);
 
-            static async ValueTask<AnalyzerActions> getAllActionsAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer, AnalysisState analysisStateOpt, CancellationToken cancellationToken)
+            async ValueTask<IGroupedAnalyzerActions> getAllActionsAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer, AnalysisState analysisStateOpt, CancellationToken cancellationToken)
             {
                 // Compute additional inherited actions for this symbol by running the containing symbol's start actions.
-                AnalyzerActions inheritedActions = await getInheritedActionsAsync(driver, symbol, analyzer, analysisStateOpt, cancellationToken).ConfigureAwait(false);
+                var inheritedActions = await getInheritedActionsAsync(driver, symbol, analyzer, analysisStateOpt, cancellationToken).ConfigureAwait(false);
 
                 // Execute the symbol start actions for this symbol to compute additional actions for its members.
                 AnalyzerActions myActions = await getSymbolActionsCoreAsync(driver, symbol, analyzer).ConfigureAwait(false);
-                return !myActions.IsEmpty ? inheritedActions.Append(in myActions) : inheritedActions;
+                if (myActions.IsEmpty)
+                {
+                    return inheritedActions;
+                }
+
+                var allActions = inheritedActions.AnalyzerActions.Append(in myActions);
+                return CreateGroupedActions(analyzer, allActions);
             }
 
-            static async ValueTask<AnalyzerActions> getInheritedActionsAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer, AnalysisState analysisStateOpt, CancellationToken cancellationToken)
+            async ValueTask<IGroupedAnalyzerActions> getInheritedActionsAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer, AnalysisState analysisStateOpt, CancellationToken cancellationToken)
             {
                 if (symbol.ContainingSymbol != null)
                 {
@@ -1876,17 +1944,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         if (symbol.ContainingSymbol.Kind != symbol.Kind)
                         {
                             // Don't inherit the symbol start and symbol end actions.
-                            return AnalyzerActions.Empty.Append(in containerActions, appendSymbolStartAndSymbolEndActions: false);
+                            var containerAnalyzerActions = containerActions.AnalyzerActions;
+                            var actions = AnalyzerActions.Empty.Append(in containerAnalyzerActions, appendSymbolStartAndSymbolEndActions: false);
+                            return CreateGroupedActions(analyzer, actions);
                         }
                     }
                 }
 
-                return AnalyzerActions.Empty;
+                return EmptyGroupedActions;
             }
 
             static async ValueTask<AnalyzerActions> getSymbolActionsCoreAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer)
             {
-                if (!driver._unsuppressedAnalyzers.Contains(analyzer) ||
+                if (!driver.UnsuppressedAnalyzers.Contains(analyzer) ||
                     driver.IsGeneratedCodeSymbol(symbol) && driver.ShouldSkipAnalysisOnGeneratedCode(analyzer))
                 {
                     return AnalyzerActions.Empty;
@@ -2102,38 +2172,74 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _getKind = getKind;
         }
 
-        private GroupedAnalyzerActions CoreActions
+        private GroupedAnalyzerActions GetOrCreateCoreActions()
         {
-            get
+            if (_lazyCoreActions == null)
             {
-                if (_lazyCoreActions == null)
+                Interlocked.CompareExchange(ref _lazyCoreActions, createCoreActions(), null);
+            }
+
+            return _lazyCoreActions;
+
+            GroupedAnalyzerActions createCoreActions()
+            {
+                if (AnalyzerActions.IsEmpty)
                 {
-                    Interlocked.CompareExchange(ref _lazyCoreActions, GroupedAnalyzerActions.Create(in AnalyzerActions), null);
+                    return GroupedAnalyzerActions.Empty;
                 }
 
-                return _lazyCoreActions;
+                // Keep analyzers in original order.
+                var analyzers = Analyzers.WhereAsArray(UnsuppressedAnalyzers.Contains);
+                return GroupedAnalyzerActions.Create(analyzers, AnalyzerActions);
             }
         }
 
-        private static bool ShouldExecuteSyntaxNodeActions(GroupedAnalyzerActions coreActions, GroupedAnalyzerActions additionalActions, AnalysisScope analysisScope)
+        private static void ComputeShouldExecuteActions(
+            in AnalyzerActions coreActions,
+            in AnalyzerActions additionalActions,
+            ISymbol symbol,
+            out bool executeSyntaxNodeActions,
+            out bool executeCodeBlockActions,
+            out bool executeOperationActions,
+            out bool executeOperationBlockActions)
         {
-            return coreActions.ShouldExecuteSyntaxNodeActions(analysisScope) || additionalActions.ShouldExecuteSyntaxNodeActions(analysisScope);
+            executeSyntaxNodeActions = false;
+            executeCodeBlockActions = false;
+            executeOperationActions = false;
+            executeOperationBlockActions = false;
+
+            var canHaveExecutableCodeBlock = AnalyzerExecutor.CanHaveExecutableCodeBlock(symbol);
+            computeShouldExecuteActions(coreActions, canHaveExecutableCodeBlock, ref executeSyntaxNodeActions, ref executeCodeBlockActions, ref executeOperationActions, ref executeOperationBlockActions);
+            computeShouldExecuteActions(additionalActions, canHaveExecutableCodeBlock, ref executeSyntaxNodeActions, ref executeCodeBlockActions, ref executeOperationActions, ref executeOperationBlockActions);
+            return;
+
+            static void computeShouldExecuteActions(
+                AnalyzerActions analyzerActions,
+                bool canHaveExecutableCodeBlock,
+                ref bool executeSyntaxNodeActions,
+                ref bool executeCodeBlockActions,
+                ref bool executeOperationActions,
+                ref bool executeOperationBlockActions)
+            {
+                if (analyzerActions.IsEmpty)
+                {
+                    return;
+                }
+
+                executeSyntaxNodeActions |= analyzerActions.SyntaxNodeActionsCount > 0;
+                executeOperationActions |= analyzerActions.OperationActionsCount > 0;
+
+                if (canHaveExecutableCodeBlock)
+                {
+                    executeCodeBlockActions |= analyzerActions.CodeBlockStartActionsCount > 0 || analyzerActions.CodeBlockActionsCount > 0;
+                    executeOperationBlockActions |= analyzerActions.OperationBlockStartActionsCount > 0 || analyzerActions.OperationBlockActionsCount > 0;
+                }
+            }
         }
 
-        private static bool ShouldExecuteCodeBlockActions(GroupedAnalyzerActions coreActions, GroupedAnalyzerActions additionalActions, AnalysisScope analysisScope, ISymbol symbol)
-        {
-            return coreActions.ShouldExecuteCodeBlockActions(analysisScope, symbol) || additionalActions.ShouldExecuteCodeBlockActions(analysisScope, symbol);
-        }
-
-        private static bool ShouldExecuteOperationActions(GroupedAnalyzerActions coreActions, GroupedAnalyzerActions additionalActions, AnalysisScope analysisScope)
-        {
-            return coreActions.ShouldExecuteOperationActions(analysisScope) || additionalActions.ShouldExecuteOperationActions(analysisScope);
-        }
-
-        private static bool ShouldExecuteOperationBlockActions(GroupedAnalyzerActions coreActions, GroupedAnalyzerActions additionalActions, AnalysisScope analysisScope, ISymbol symbol)
-        {
-            return coreActions.ShouldExecuteOperationBlockActions(analysisScope, symbol) || additionalActions.ShouldExecuteOperationBlockActions(analysisScope, symbol);
-        }
+        protected override IGroupedAnalyzerActions EmptyGroupedActions => GroupedAnalyzerActions.Empty;
+        protected override IGroupedAnalyzerActions CreateGroupedActions(DiagnosticAnalyzer analyzer, in AnalyzerActions analyzerActions)
+            => !analyzerActions.IsEmpty ? GroupedAnalyzerActions.Create(analyzer, analyzerActions) : null;
 
         /// <summary>
         /// Tries to execute syntax node, code block and operation actions for all declarations for the given symbol.
@@ -2147,21 +2253,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCodeSymbol,
-            in AnalyzerActions additionalPerSymbolActions,
+            in IGroupedAnalyzerActions additionalPerSymbolActions,
             CancellationToken cancellationToken)
         {
             var symbol = symbolEvent.Symbol;
-            var additionalGroupedPerSymbolActions = GroupedAnalyzerActions.Create(in additionalPerSymbolActions);
 
-            var executeSyntaxNodeActions = ShouldExecuteSyntaxNodeActions(CoreActions, additionalGroupedPerSymbolActions, analysisScope);
-            var executeCodeBlockActions = ShouldExecuteCodeBlockActions(CoreActions, additionalGroupedPerSymbolActions, analysisScope, symbol);
-            var executeOperationActions = ShouldExecuteOperationActions(CoreActions, additionalGroupedPerSymbolActions, analysisScope);
-            var executeOperationBlockActions = ShouldExecuteOperationBlockActions(CoreActions, additionalGroupedPerSymbolActions, analysisScope, symbol);
+            ComputeShouldExecuteActions(
+                AnalyzerActions, additionalPerSymbolActions.AnalyzerActions, symbol,
+                executeSyntaxNodeActions: out var executeSyntaxNodeActions,
+                executeCodeBlockActions: out var executeCodeBlockActions,
+                executeOperationActions: out var executeOperationActions,
+                executeOperationBlockActions: out var executeOperationBlockActions);
 
             var success = true;
             if (executeSyntaxNodeActions || executeOperationActions || executeCodeBlockActions || executeOperationBlockActions)
             {
                 var declaringReferences = symbolEvent.DeclaringSyntaxReferences;
+                var coreActions = GetOrCreateCoreActions();
                 for (var i = 0; i < declaringReferences.Length; i++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -2179,7 +2287,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
-                    if (!TryExecuteDeclaringReferenceActions(decl, i, symbolEvent, analysisScope, analysisStateOpt, additionalGroupedPerSymbolActions,
+                    if (!TryExecuteDeclaringReferenceActions(decl, i, symbolEvent, analysisScope, analysisStateOpt, coreActions, (GroupedAnalyzerActions)additionalPerSymbolActions,
                         executeSyntaxNodeActions, executeOperationActions, executeCodeBlockActions, executeOperationBlockActions, isInGeneratedCode, cancellationToken))
                     {
                         success = false;
@@ -2255,6 +2363,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SymbolDeclaredCompilationEvent symbolEvent,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
+            GroupedAnalyzerActions coreActions,
             GroupedAnalyzerActions additionalPerSymbolActions,
             bool shouldExecuteSyntaxNodeActions,
             bool shouldExecuteOperationActions,
@@ -2319,22 +2428,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (shouldExecuteSyntaxNodeActions)
                 {
                     var nodesToAnalyze = declarationAnalysisData.DescendantNodesToAnalyze;
-                    foreach (var analyzer in analysisScope.Analyzers)
-                    {
-                        executeNodeActionsByKind(analyzer, nodesToAnalyze, CoreActions);
-                        executeNodeActionsByKind(analyzer, nodesToAnalyze, additionalPerSymbolActions);
-                    }
+                    executeNodeActionsByKind(analysisScope, nodesToAnalyze, coreActions);
+                    executeNodeActionsByKind(analysisScope, nodesToAnalyze, additionalPerSymbolActions);
                 }
             }
 
-            void executeNodeActionsByKind(DiagnosticAnalyzer analyzer, ImmutableArray<SyntaxNode> nodesToAnalyze, GroupedAnalyzerActions groupedActions)
+            void executeNodeActionsByKind(AnalysisScope analysisScope, ImmutableArray<SyntaxNode> nodesToAnalyze, GroupedAnalyzerActions groupedActions)
             {
-                if (groupedActions.NodeActionsByAnalyzerAndKind.TryGetValue(analyzer, out var nodeActionsByKind) &&
-                    !nodeActionsByKind.IsEmpty)
+                foreach (var (analyzer, groupedActionsForAnalyzer) in groupedActions.GroupedActionsByAnalyzer)
                 {
+                    var nodeActionsByKind = groupedActionsForAnalyzer.NodeActionsByAnalyzerAndKind;
+                    if (nodeActionsByKind.IsEmpty || !analysisScope.Contains(analyzer))
+                    {
+                        continue;
+                    }
+
                     if (!AnalyzerExecutor.TryExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind,
-                        analyzer, semanticModel, _getKind, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
-                        decl, declarationIndex, symbol, analysisScope, analysisStateOpt, isInGeneratedCode))
+                            analyzer, semanticModel, _getKind, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
+                            decl, declarationIndex, symbol, analysisScope, analysisStateOpt, isInGeneratedCode))
                     {
                         success = false;
                     }
@@ -2350,7 +2461,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 // Compute the executable code blocks of interest.
                 var executableCodeBlocks = ImmutableArray<SyntaxNode>.Empty;
-                IEnumerable<CodeBlockAnalyzerActions> codeBlockActions = null;
+                IEnumerable<ExecutableCodeBlockAnalyzerActions> executableCodeBlockActions = null;
                 foreach (var declInNode in declarationAnalysisData.DeclarationsInNode)
                 {
                     if (declInNode.DeclaredNode == declarationAnalysisData.TopmostNodeForAnalysis || declInNode.DeclaredNode == declarationAnalysisData.DeclaringReferenceSyntax)
@@ -2360,8 +2471,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         {
                             if (shouldExecuteCodeBlockActions || shouldExecuteOperationBlockActions)
                             {
-                                codeBlockActions = CoreActions.GetCodeBlockActions(analysisScope)
-                                    .Concat(additionalPerSymbolActions.GetCodeBlockActions(analysisScope));
+                                executableCodeBlockActions = getExecutableCodeBlockAnalyzerActions(analysisScope, coreActions, additionalPerSymbolActions);
                             }
 
                             // Execute operation actions.
@@ -2375,7 +2485,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                     try
                                     {
                                         executeOperationsActions(operationsToAnalyze);
-                                        executeOperationsBlockActions(operationBlocksToAnalyze, operationsToAnalyze, codeBlockActions);
+                                        executeOperationsBlockActions(operationBlocksToAnalyze, operationsToAnalyze, executableCodeBlockActions);
                                     }
                                     finally
                                     {
@@ -2389,7 +2499,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
                 }
 
-                executeCodeBlockActions(executableCodeBlocks, codeBlockActions);
+                executeCodeBlockActions(executableCodeBlocks, executableCodeBlockActions);
             }
 
             ImmutableArray<IOperation> getOperationsToAnalyzeWithStackGuard(ImmutableArray<IOperation> operationBlocksToAnalyze)
@@ -2414,29 +2524,31 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (shouldExecuteOperationActions)
                 {
-                    foreach (var analyzer in analysisScope.Analyzers)
-                    {
-                        executeOperationsActionsByKind(analyzer, operationsToAnalyze, CoreActions);
-                        executeOperationsActionsByKind(analyzer, operationsToAnalyze, additionalPerSymbolActions);
-                    }
+                    executeOperationsActionsByKind(analysisScope, operationsToAnalyze, coreActions);
+                    executeOperationsActionsByKind(analysisScope, operationsToAnalyze, additionalPerSymbolActions);
                 }
             }
 
-            void executeOperationsActionsByKind(DiagnosticAnalyzer analyzer, ImmutableArray<IOperation> operationsToAnalyze, GroupedAnalyzerActions groupedActions)
+            void executeOperationsActionsByKind(AnalysisScope analysisScope, ImmutableArray<IOperation> operationsToAnalyze, GroupedAnalyzerActions groupedActions)
             {
-                if (groupedActions.OperationActionsByAnalyzerAndKind.TryGetValue(analyzer, out var operationActionsByKind) &&
-                    !operationActionsByKind.IsEmpty)
+                foreach (var (analyzer, groupedActionsForAnalyzer) in groupedActions.GroupedActionsByAnalyzer)
                 {
+                    var operationActionsByKind = groupedActionsForAnalyzer.OperationActionsByAnalyzerAndKind;
+                    if (operationActionsByKind.IsEmpty || !analysisScope.Contains(analyzer))
+                    {
+                        continue;
+                    }
+
                     if (!AnalyzerExecutor.TryExecuteOperationActions(operationsToAnalyze, operationActionsByKind,
-                        analyzer, semanticModel, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
-                        decl, declarationIndex, symbol, analysisScope, analysisStateOpt, isInGeneratedCode))
+                            analyzer, semanticModel, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
+                            decl, declarationIndex, symbol, analysisScope, analysisStateOpt, isInGeneratedCode))
                     {
                         success = false;
                     }
                 }
             }
 
-            void executeOperationsBlockActions(ImmutableArray<IOperation> operationBlocksToAnalyze, ImmutableArray<IOperation> operationsToAnalyze, IEnumerable<CodeBlockAnalyzerActions> codeBlockActions)
+            void executeOperationsBlockActions(ImmutableArray<IOperation> operationBlocksToAnalyze, ImmutableArray<IOperation> operationsToAnalyze, IEnumerable<ExecutableCodeBlockAnalyzerActions> codeBlockActions)
             {
                 if (!shouldExecuteOperationBlockActions)
                 {
@@ -2452,6 +2564,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
+                    if (!analysisScope.Contains(analyzerActions.Analyzer))
+                    {
+                        continue;
+                    }
+
                     if (!AnalyzerExecutor.TryExecuteOperationBlockActions(
                         analyzerActions.OperationBlockStartActions, analyzerActions.OperationBlockActions,
                         analyzerActions.OperationBlockEndActions, analyzerActions.Analyzer, declarationAnalysisData.TopmostNodeForAnalysis, symbol,
@@ -2462,7 +2579,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            void executeCodeBlockActions(ImmutableArray<SyntaxNode> executableCodeBlocks, IEnumerable<CodeBlockAnalyzerActions> codeBlockActions)
+            void executeCodeBlockActions(ImmutableArray<SyntaxNode> executableCodeBlocks, IEnumerable<ExecutableCodeBlockAnalyzerActions> codeBlockActions)
             {
                 if (executableCodeBlocks.IsEmpty || !shouldExecuteCodeBlockActions)
                 {
@@ -2478,12 +2595,38 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
+                    if (!analysisScope.Contains(analyzerActions.Analyzer))
+                    {
+                        continue;
+                    }
+
                     if (!AnalyzerExecutor.TryExecuteCodeBlockActions(
                         analyzerActions.CodeBlockStartActions, analyzerActions.CodeBlockActions,
                         analyzerActions.CodeBlockEndActions, analyzerActions.Analyzer, declarationAnalysisData.TopmostNodeForAnalysis, symbol,
                         executableCodeBlocks, semanticModel, _getKind, decl, declarationIndex, analysisScope, analysisStateOpt, isInGeneratedCode))
                     {
                         success = false;
+                    }
+                }
+            }
+
+            static IEnumerable<ExecutableCodeBlockAnalyzerActions> getExecutableCodeBlockAnalyzerActions(
+                AnalysisScope analysisScope,
+                GroupedAnalyzerActions coreActions,
+                GroupedAnalyzerActions additionalActions)
+            {
+                return getExecutableCodeBlockAnalyzerActions(analysisScope, coreActions)
+                    .Concat(getExecutableCodeBlockAnalyzerActions(analysisScope, additionalActions));
+
+                static IEnumerable<ExecutableCodeBlockAnalyzerActions> getExecutableCodeBlockAnalyzerActions(AnalysisScope analysisScope, GroupedAnalyzerActions groupedActions)
+                {
+                    foreach (var (analyzer, groupedActionsForAnalyzer) in groupedActions.GroupedActionsByAnalyzer)
+                    {
+                        if (analysisScope.Contains(analyzer) &&
+                            groupedActionsForAnalyzer.TryGetExecutableCodeBlockActions(out var executableCodeBlockActions))
+                        {
+                            yield return executableCodeBlockActions;
+                        }
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SymbolAnalyzerAction> symbolActions,
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCodeSymbol)
@@ -443,7 +443,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SymbolAnalyzerAction> symbolActions,
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             AnalyzerStateData analyzerStateOpt,
             bool isGeneratedCodeSymbol)
         {
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             INamespaceOrTypeSymbol containingSymbol,
             ISymbol processedMemberSymbol,
             DiagnosticAnalyzer analyzer,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             AnalysisState analysisStateOpt,
             out SymbolDeclaredCompilationEvent containingSymbolDeclaredEvent)
         {
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SymbolEndAnalyzerAction> symbolEndActions,
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             AnalysisState analysisStateOpt)
         {
             return _analyzerManager.TryStartExecuteSymbolEndActions(symbolEndActions, analyzer, symbolDeclaredEvent) &&
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SymbolEndAnalyzerAction> symbolEndActions,
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             AnalysisState analysisStateOpt)
         {
             var symbol = symbolDeclaredEvent.Symbol;
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SymbolEndAnalyzerAction> symbolEndActions,
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             AnalyzerStateData analyzerStateOpt)
         {
             Debug.Assert(getTopMostNodeForAnalysis != null);
@@ -1642,7 +1642,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _analyzerManager.IsSupportedDiagnostic(analyzer, diagnostic, _isCompilerAnalyzer, this);
         }
 
-        private Action<Diagnostic> GetAddDiagnostic(ISymbol contextSymbol, ImmutableArray<SyntaxReference> cachedDeclaringReferences, DiagnosticAnalyzer analyzer, Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis)
+        private Action<Diagnostic> GetAddDiagnostic(ISymbol contextSymbol, ImmutableArray<SyntaxReference> cachedDeclaringReferences, DiagnosticAnalyzer analyzer, Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis)
         {
             return GetAddDiagnostic(contextSymbol, cachedDeclaringReferences, _compilation, analyzer, _addNonCategorizedDiagnosticOpt,
                  _addCategorizedLocalDiagnosticOpt, _addCategorizedNonLocalDiagnosticOpt, getTopMostNodeForAnalysis, _shouldSuppressGeneratedCodeDiagnostic, _cancellationToken);
@@ -1656,7 +1656,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Diagnostic> addNonCategorizedDiagnosticOpt,
             Action<Diagnostic, DiagnosticAnalyzer, bool> addCategorizedLocalDiagnosticOpt,
             Action<Diagnostic, DiagnosticAnalyzer> addCategorizedNonLocalDiagnosticOpt,
-            Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
+            Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> shouldSuppressGeneratedCodeDiagnostic,
             CancellationToken cancellationToken)
         {
@@ -1683,7 +1683,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         if (syntaxRef.SyntaxTree == diagnostic.Location.SourceTree)
                         {
-                            var syntax = getTopMostNodeForAnalysis(contextSymbol, syntaxRef, compilation);
+                            var syntax = getTopMostNodeForAnalysis(contextSymbol, syntaxRef, compilation, cancellationToken);
                             if (diagnostic.Location.SourceSpan.IntersectsWith(syntax.FullSpan))
                             {
                                 addCategorizedLocalDiagnosticOpt(diagnostic, analyzer, false);
@@ -1835,7 +1835,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static bool TryStartProcessingEvent(CompilationEvent nonSymbolCompilationEvent, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out AnalyzerStateData analyzerStateOpt)
         {
             Debug.Assert(!(nonSymbolCompilationEvent is SymbolDeclaredCompilationEvent));
-            Debug.Assert(analysisScope.Analyzers.Contains(analyzer));
+            Debug.Assert(analysisScope.Contains(analyzer));
 
             analyzerStateOpt = null;
             return analysisStateOpt == null || analysisStateOpt.TryStartProcessingEvent(nonSymbolCompilationEvent, analyzer, out analyzerStateOpt);
@@ -1843,7 +1843,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static bool TryStartSyntaxAnalysis(SyntaxTree tree, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out AnalyzerStateData analyzerStateOpt)
         {
-            Debug.Assert(analysisScope.Analyzers.Contains(analyzer));
+            Debug.Assert(analysisScope.Contains(analyzer));
 
             analyzerStateOpt = null;
             return analysisStateOpt == null || analysisStateOpt.TryStartSyntaxAnalysis(tree, analyzer, out analyzerStateOpt);
@@ -1851,7 +1851,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static bool TryStartAnalyzingSymbol(ISymbol symbol, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out AnalyzerStateData analyzerStateOpt)
         {
-            Debug.Assert(analysisScope.Analyzers.Contains(analyzer));
+            Debug.Assert(analysisScope.Contains(analyzer));
 
             analyzerStateOpt = null;
             return analysisStateOpt == null || analysisStateOpt.TryStartAnalyzingSymbol(symbol, analyzer, out analyzerStateOpt);
@@ -1865,7 +1865,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static bool TryStartAnalyzingDeclaration(ISymbol symbol, int declarationIndex, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out DeclarationAnalyzerStateData analyzerStateOpt)
         {
-            Debug.Assert(analysisScope.Analyzers.Contains(analyzer));
+            Debug.Assert(analysisScope.Contains(analyzer));
 
             analyzerStateOpt = null;
             return analysisStateOpt == null || analysisStateOpt.TryStartAnalyzingDeclaration(symbol, declarationIndex, analyzer, out analyzerStateOpt);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -340,7 +340,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             await WaitForActiveAnalysisTasksAsync(waitForTreeTasks: true, waitForCompilationOrNonConcurrentTask: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             var diagnostics = ImmutableArray<Diagnostic>.Empty;
-            var analysisScope = new AnalysisScope(_compilation, analyzers, _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: true);
+            var hasAllAnalyzers = analyzers.Length == Analyzers.Length;
+            var analysisScope = new AnalysisScope(_compilation, analyzers, hasAllAnalyzers, _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: true);
             Func<ImmutableArray<CompilationEvent>> getPendingEvents = () =>
                 _analysisState.GetPendingEvents(analyzers, includeSourceEvents: true, includeNonSourceEvents: true, cancellationToken);
 
@@ -365,7 +366,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             await ComputeAnalyzerDiagnosticsWithoutStateTrackingAsync(cancellationToken).ConfigureAwait(false);
 
             // Get analyzer diagnostics for the given analysis scope.
-            var analysisScope = new AnalysisScope(_compilation, analyzers, concurrentAnalysis: _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: true);
+            var hasAllAnalyzers = analyzers.Length == Analyzers.Length;
+            var analysisScope = new AnalysisScope(_compilation, analyzers, hasAllAnalyzers, concurrentAnalysis: _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: true);
             return _analysisResultBuilder.GetDiagnostics(analysisScope, getLocalDiagnostics: true, getNonLocalDiagnostics: true);
         }
 
@@ -391,7 +393,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var categorizeDiagnostics = true;
                 driver = compilation.CreateAnalyzerDriver(analyzers, _analyzerManager, severityFilter: SeverityFilter.None);
                 driver.Initialize(compilation, _analysisOptions, compilationData, categorizeDiagnostics, cancellationToken);
-                var analysisScope = new AnalysisScope(compilation, analyzers, concurrentAnalysis: _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics);
+                var hasAllAnalyzers = analyzers.Length == Analyzers.Length;
+                var analysisScope = new AnalysisScope(compilation, analyzers, hasAllAnalyzers, concurrentAnalysis: _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics);
                 driver.AttachQueueAndStartProcessingEvents(compilation.EventQueue, analysisScope, cancellationToken);
 
                 // Force compilation diagnostics and wait for analyzer execution to complete.
@@ -431,7 +434,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var categorizeDiagnostics = false;
                 driver = compilation.CreateAnalyzerDriver(analyzers, _analyzerManager, severityFilter: SeverityFilter.None);
                 driver.Initialize(compilation, _analysisOptions, compilationData, categorizeDiagnostics, cancellationToken);
-                var analysisScope = new AnalysisScope(compilation, analyzers, concurrentAnalysis: _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics);
+                var hasAllAnalyzers = analyzers.Length == Analyzers.Length;
+                var analysisScope = new AnalysisScope(compilation, analyzers, hasAllAnalyzers, concurrentAnalysis: _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics);
                 driver.AttachQueueAndStartProcessingEvents(compilation.EventQueue, analysisScope, cancellationToken);
 
                 // Force compilation diagnostics and wait for analyzer execution to complete.
@@ -530,7 +534,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var pendingAnalyzers = _analysisResultBuilder.GetPendingAnalyzers(analysisScope.Analyzers);
                 if (pendingAnalyzers.Length > 0)
                 {
-                    var pendingAnalysisScope = pendingAnalyzers.Length < analysisScope.Analyzers.Length ? analysisScope.WithAnalyzers(pendingAnalyzers) : analysisScope;
+                    var pendingAnalysisScope = pendingAnalyzers.Length < analysisScope.Analyzers.Length ? analysisScope.WithAnalyzers(pendingAnalyzers, hasAllAnalyzers: false) : analysisScope;
 
                     // Compute the analyzer diagnostics for the pending analysis scope.
                     await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEventsOpt: null, taskToken, cancellationToken).ConfigureAwait(false);
@@ -625,7 +629,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var pendingAnalyzers = _analysisResultBuilder.GetPendingAnalyzers(analysisScope.Analyzers);
                 if (pendingAnalyzers.Length > 0)
                 {
-                    var pendingAnalysisScope = pendingAnalyzers.Length < analysisScope.Analyzers.Length ? analysisScope.WithAnalyzers(pendingAnalyzers) : analysisScope;
+                    var pendingAnalysisScope = pendingAnalyzers.Length < analysisScope.Analyzers.Length ? analysisScope.WithAnalyzers(pendingAnalyzers, hasAllAnalyzers: false) : analysisScope;
 
                     Func<ImmutableArray<CompilationEvent>> getPendingEvents = () => _analysisState.GetPendingEvents(analysisScope.Analyzers, model.SyntaxTree, cancellationToken);
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -799,6 +800,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         internal readonly ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>> GetSyntaxNodeActions<TLanguageKindEnum>() where TLanguageKindEnum : struct
         {
             return _syntaxNodeActions.OfType<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>().ToImmutableArray();
+        }
+
+        internal readonly ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>> GetSyntaxNodeActions<TLanguageKindEnum>(DiagnosticAnalyzer analyzer) where TLanguageKindEnum : struct
+        {
+            var builder = ArrayBuilder<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>.GetInstance();
+            foreach (var action in _syntaxNodeActions)
+            {
+                if (action.Analyzer == analyzer &&
+                    action is SyntaxNodeAnalyzerAction<TLanguageKindEnum> syntaxNodeAction)
+                {
+                    builder.Add(syntaxNodeAction);
+                }
+            }
+
+            return builder.ToImmutableAndFree();
         }
 
         internal readonly ImmutableArray<OperationBlockAnalyzerAction> OperationBlockActions


### PR DESCRIPTION
1. Avoid creating and querying dictionaries from analyzers to actions. Instead maintain a tuple of (analyzer, actions) and special case IDE partial analysis (open files only and/or subset of analyzers) to skip analyzers not in analysis scope.
2. Cache grouped analyzer actions for per-symbol actions registered within SymbolStart actions instead of re-computing them for every member symbol.

## Performance numbers

Around **10-15%** improvement in analyzer execution time on following test sets:

### 1. Compiler benchmark
Benchmark: https://github.com/dotnet/roslyn/blob/master/docs/wiki/Measuring-Compiler-Performance.md

#### Using compiler built from current master branch
1. Default benchmark:

|                      Method |    Mean   |   Error |  StdDev |  Median |     Min |     Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------:|--------:|--------:|--------:|--------:|--------:|------------:|-----------:|----------:|----------:|
| GetDiagnosticsWithAnalyzers | **14.79 s** | 0.147 s | 0.304 s | 14.87 s | 14.17 s | 15.45 s | 218000.0000 | 64000.0000 | 3000.0000 |   1.28 GB |

2. Default benchmark + one SymbolStart analyzer:

|                      Method |    Mean   |   Error |  StdDev |  Median |     Min |     Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------:|--------:|--------:|--------:|--------:|--------:|------------:|-----------:|----------:|----------:|
| GetDiagnosticsWithAnalyzers | **16.96 s** | 0.079 s | 0.088 s | 16.95 s | 16.85 s | 17.14 s | 225000.0000 | 66000.0000 | 2000.0000 |   1.32 GB |

#### Using compiler built with this PR branch
1. Default benchmark:

|                      Method |    Mean   |   Error |  StdDev |  Median |     Min |     Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------:|--------:|--------:|--------:|--------:|--------:|------------:|-----------:|----------:|----------:|
| GetDiagnosticsWithAnalyzers | **12.76 s** | 0.077 s | 0.085 s | 12.75 s | 12.62 s | 12.92 s | 218000.0000 | 60000.0000 | 2000.0000 |   1.28 GB |

2. Default benchmark + one SymbolStart analyzer:

|                      Method |    Mean   |   Error |  StdDev |  Median |     Min |     Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------:|--------:|--------:|--------:|--------:|--------:|------------:|-----------:|----------:|----------:|
| GetDiagnosticsWithAnalyzers | **14.87 s** | 0.121 s | 0.101 s | 14.90 s | 14.72 s | 15.08 s | 220000.0000 | 65000.0000 | 2000.0000 |   1.29 GB |

### 2. Building real world projects

1. **Microsoft.CodeAnalysis.CSharp.csproj**: `msbuild /v:m /m /t:rebuild /p:UseRoslynAnalyzers=true`: Improvement from _~60 seconds_ to _~51 seconds_
2. **RoslynAnalyzers.sln**:  Improvement from _~55 seconds_ to _~48 seconds_