### PR TITLE
Undo incorrect name change

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -112,7 +112,7 @@
 
       <!-- Record that we'll write a file, and add it to the analyzerconfig inputs -->
       <FileWrites Include="$(GeneratedMSBuildEditorConfigFile)" />
-      <AnalyzerConfigFiles Include="$(GeneratedMSBuildEditorConfigFile)" />
+      <EditorConfigFiles Include="$(GeneratedMSBuildEditorConfigFile)" />
     </ItemGroup>
 
     <!-- Transform the collected properties and items into an editor config file -->

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             bool runSuccess = instance.Build(target: "GenerateMSBuildEditorConfigFile", GetTestLoggers());
             Assert.True(runSuccess);
 
-            var items = instance.GetItems("AnalyzerConfigFiles");
+            var items = instance.GetItems("EditorConfigFiles");
             Assert.Single(items);
         }
 


### PR DESCRIPTION
I am an idiot, and this (https://github.com/dotnet/roslyn/pull/45357#discussion_r444514499) shouldn't have been changed. 

This PR fixes the name change.