### PR TITLE
(16.7) Reduce release/x64 baseline in DeeplyNestedGeneric

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 460, // 270
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1310, // 1290
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 260, // 170
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 750, // 730
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 730, // 730
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 


### PR DESCRIPTION
Porting #45554 to 16.7 branch per @jaredpar's request.