### PR TITLE
Fixing VS Crash on invalid "MemberNotNull"

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -113,6 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _emptyStructTypeCache.IsEmptyStructType(type);
         }
 
+#nullable enable
         /// <summary>
         /// Force a variable to have a slot.  Returns -1 if the variable has an empty struct type.
         /// </summary>
@@ -120,6 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(containingSlot >= 0);
 
+            if (symbol is null) return -1;
             if (symbol.Kind == SymbolKind.RangeVariable) return -1;
 
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: true);
@@ -169,6 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return slot;
         }
+#nullable restore
 
         private int GetSlotDepth(int slot)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -120,8 +120,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected virtual int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
         {
             Debug.Assert(containingSlot >= 0);
+            Debug.Assert(symbol != null);
 
-            if (symbol is null) return -1;
             if (symbol.Kind == SymbolKind.RangeVariable) return -1;
 
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: true);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -120,7 +120,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(containingSlot >= 0);
 
-            if (symbol is null) return -1;
             if (symbol.Kind == SymbolKind.RangeVariable) return -1;
 
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: true);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -120,6 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(containingSlot >= 0);
 
+            if (symbol is null) return -1;
             if (symbol.Kind == SymbolKind.RangeVariable) return -1;
 
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: true);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -715,6 +715,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!isStatic)
                 {
+                    if (MethodThisParameter is null)
+                    {
+                        return -1;
+                    }
                     thisSlot = GetOrCreateSlot(MethodThisParameter);
                     if (thisSlot < 0)
                     {
@@ -1272,7 +1276,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
         {
 
-            if ((containingSlot > 0 && !IsSlotMember(containingSlot, symbol)) || symbol is null)
+            if (containingSlot > 0 && !IsSlotMember(containingSlot, symbol))
                 return -1;
 
             return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1268,6 +1268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#nullable enable
         protected override int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
         {
 
@@ -1276,6 +1277,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty);
         }
+#nullable restore
 
         private void VisitAndUnsplitAll<T>(ImmutableArray<T> nodes) where T : BoundNode
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1271,7 +1271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
         {
 
-            if (containingSlot > 0 && !IsSlotMember(containingSlot, symbol))
+            if ((containingSlot > 0 && !IsSlotMember(containingSlot, symbol)) || symbol is null)
                 return -1;
 
             return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty);

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -9089,6 +9089,50 @@ public class C2
                 Diagnostic(ErrorCode.ERR_BadAttributeArgument, "C.M(null)").WithLocation(20, 6));
         }
 
+        [Fact, WorkItem(44049, "https://github.com/dotnet/roslyn/issues/44049")]
+        public void AttributeCrashRepro_44049()
+        {
+            string source = @"
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+  public string? field;
+  
+  [MemberNotNull('field')]
+  public static void M()
+            {
+            }
+
+            public void Test()
+            {
+                M();
+                field.ToString();
+            }
+        }
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System.Diagnostics.CodeAnalysis;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Diagnostics.CodeAnalysis;").WithLocation(2, 1),
+                // (6,16): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //   public string? field;
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(6, 16),
+                // (6,18): warning CS0649: Field 'C.field' is never assigned to, and will always have its default value null
+                //   public string? field;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "field").WithArguments("C.field", "null").WithLocation(6, 18),
+                // (8,4): error CS0246: The type or namespace name 'MemberNotNullAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                //   [MemberNotNull('field')]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "MemberNotNull").WithArguments("MemberNotNullAttribute").WithLocation(8, 4),
+                // (8,4): error CS0246: The type or namespace name 'MemberNotNull' could not be found (are you missing a using directive or an assembly reference?)
+                //   [MemberNotNull('field')]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "MemberNotNull").WithArguments("MemberNotNull").WithLocation(8, 4),
+                // (8,18): error CS1012: Too many characters in character literal
+                //   [MemberNotNull('field')]
+                Diagnostic(ErrorCode.ERR_TooManyCharsInConst, "").WithLocation(8, 18));
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -9089,45 +9089,6 @@ public class C2
                 Diagnostic(ErrorCode.ERR_BadAttributeArgument, "C.M(null)").WithLocation(20, 6));
         }
 
-        [Fact]
-        [WorkItem(44049, "https://github.com/dotnet/roslyn/issues/44049")]
-        public void MemberNotNullAnnotationCrashes()
-        {
-            var source =
-@"using System.Diagnostics.CodeAnalysis;
-
-class C
-{
-    public string? field;
-  
-    [MemberNotNull(""field"")]
-    public static void M()
-    {
-    }
-
-    public void Test()
-    {
-        M();
-        field.ToString();
-    }
-}";
-            var comp = CreateCompilation(
-                new[]
-                {
-                    source, MemberNotNullAttributeDefinition
-                },
-                options: WithNonNullTypesTrue(),
-                targetFramework: TargetFramework.NetCoreApp30,
-                parseOptions: TestOptions.RegularPreview);
-            comp.VerifyDiagnostics(
-                // (5,20): warning CS0649: Field 'C.field' is never assigned to, and will always have its default value null
-                //     public string? field;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "field").WithArguments("C.field", "null").WithLocation(5, 20),
-                // (15,9): warning CS8602: Dereference of a possibly null reference.
-                //         field.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "field").WithLocation(15, 9));
-        }
-
         #endregion
     }
 }


### PR DESCRIPTION
Fixes issue #44049.

Changelog:
- Adds null check for `NullPointerException` situation
- Adds corresponding test