### PR TITLE
Reserve feature branch error codes

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal enum ErrorCode
@@ -1771,7 +1773,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NoOutputDirectory = 8771,
         ERR_StdInOptionProvidedButConsoleInputIsNotRedirected = 8772,
 
-        // available 8773
+        ERR_FeatureNotAvailableInVersion9 = 8773,
 
         WRN_MemberNotNull = 8774,
         WRN_MemberNotNullWhen = 8775,
@@ -1818,15 +1820,29 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AddressOfMethodGroupInExpressionTree = 8810,
         ERR_CannotConvertAddressOfToDelegate = 8811,
         ERR_AddressOfToNonFunctionPointer = 8812,
-        ERR_FeatureNotAvailableInVersion9 = 8813,
 
-        // Codes 8813, 8814, 8815, 8816 used by features/module-initializers
+        [Obsolete("used by features/module-initializers")]
+        ERR_8813 = 8813,
+
+        [Obsolete("used by features/module-initializers")]
+        ERR_8814 = 8814,
+
+        [Obsolete("used by features/module-initializers")]
+        ERR_8815 = 8815,
+
+        [Obsolete("used by features/module-initializers")]
+        ERR_8816 = 8816,
 
         ERR_PartialMethodReturnTypeDifference = 8817,
         ERR_PartialMethodRefReturnDifference = 8818,
         WRN_NullabilityMismatchInReturnTypeOnPartial = 8819,
 
-        // Codes 8820, 8821 used by features/static-lambdas
+
+        [Obsolete("used by features/static-lambdas")]
+        ERR_8820 = 8820,
+
+        [Obsolete("used by features/static-lambdas")]
+        ERR_8821 = 8821,
 
         ERR_ExpressionTreeContainsWithExpression = 8849,
         ERR_BadRecordDeclaration = 8850,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal enum ErrorCode
@@ -1821,28 +1819,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CannotConvertAddressOfToDelegate = 8811,
         ERR_AddressOfToNonFunctionPointer = 8812,
 
-        [Obsolete("used by features/module-initializers")]
-        ERR_8813 = 8813,
+        ERR_8813 = 8813, // used by features/module-initializers
 
-        [Obsolete("used by features/module-initializers")]
-        ERR_8814 = 8814,
+        ERR_8814 = 8814, // used by features/module-initializers
 
-        [Obsolete("used by features/module-initializers")]
-        ERR_8815 = 8815,
+        ERR_8815 = 8815, // used by features/module-initializers
 
-        [Obsolete("used by features/module-initializers")]
-        ERR_8816 = 8816,
+        ERR_8816 = 8816, // used by features/module-initializers
 
         ERR_PartialMethodReturnTypeDifference = 8817,
         ERR_PartialMethodRefReturnDifference = 8818,
         WRN_NullabilityMismatchInReturnTypeOnPartial = 8819,
 
 
-        [Obsolete("used by features/static-lambdas")]
-        ERR_8820 = 8820,
+        ERR_8820 = 8820, // used by features/static-lambdas
 
-        [Obsolete("used by features/static-lambdas")]
-        ERR_8821 = 8821,
+        ERR_8821 = 8821, // used by features/static-lambdas
 
         ERR_ExpressionTreeContainsWithExpression = 8849,
         ERR_BadRecordDeclaration = 8850,

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ErrorCode.Unknown,
                 ErrorCode.WRN_ALinkWarn, // Not reported, but retained to allow configuring class of related warnings. See CSharpDiagnosticFilter.Filter.
 
-#pragma warning disable 618
                 ErrorCode.ERR_8813,
                 ErrorCode.ERR_8814,
                 ErrorCode.ERR_8815,
@@ -40,7 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
                 ErrorCode.ERR_8820,
                 ErrorCode.ERR_8821,
-#pragma warning restore 618
             };
             foreach (ErrorCode code in Enum.GetValues(typeof(ErrorCode)))
             {

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ErrorCode.Unknown,
                 ErrorCode.WRN_ALinkWarn, // Not reported, but retained to allow configuring class of related warnings. See CSharpDiagnosticFilter.Filter.
 
+                // The following error codes are reserved by feature branches
                 ErrorCode.ERR_8813,
                 ErrorCode.ERR_8814,
                 ErrorCode.ERR_8815,

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -31,6 +31,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ErrorCode.Void,
                 ErrorCode.Unknown,
                 ErrorCode.WRN_ALinkWarn, // Not reported, but retained to allow configuring class of related warnings. See CSharpDiagnosticFilter.Filter.
+
+#pragma warning disable 618
+                ErrorCode.ERR_8813,
+                ErrorCode.ERR_8814,
+                ErrorCode.ERR_8815,
+                ErrorCode.ERR_8816,
+
+                ErrorCode.ERR_8820,
+                ErrorCode.ERR_8821,
+#pragma warning restore 618
             };
             foreach (ErrorCode code in Enum.GetValues(typeof(ErrorCode)))
             {


### PR DESCRIPTION
#44911 ended up using error codes which are in use in a feature branch. Since it's tricky to pack these error codes together I'd like to just move the LangVersion 9 error code over to a single unoccupied space in the C# 9 range, if that's acceptable. Also using a more obvious method to indicate that the error codes are in use in feature branches. Hopefully this will all be moot in a few weeks after we've finished feature review and ensured test coverage, etc. on par with our standards.