### PR TITLE
Soft select the item with longest common prefix

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -307,14 +307,30 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var chosenItems = filterMethod(matchingItems, filterText);
 
-            var selectedItemIndex = 0;
+            int selectedItemIndex;
             VSCompletionItem uniqueItem = null;
             MatchResult bestOrFirstMatchResult;
 
             if (chosenItems.Length == 0)
             {
-                // We do not have matches: pick the first item from the list.
-                bestOrFirstMatchResult = itemsInList.FirstOrDefault();
+                // We do not have matches: pick the one with longest common prefix or the first item from the list.
+                selectedItemIndex = 0;
+                bestOrFirstMatchResult = itemsInList[0];
+
+                var longestCommonPrefixLength = bestOrFirstMatchResult.RoslynCompletionItem.FilterText.GetCaseInsensitivePrefixLength(filterText);
+
+                for (var i = 1; i < itemsInList.Length; ++i)
+                {
+                    var item = itemsInList[i];
+                    var commonPrefixLength = item.RoslynCompletionItem.FilterText.GetCaseInsensitivePrefixLength(filterText);
+
+                    if (commonPrefixLength > longestCommonPrefixLength)
+                    {
+                        selectedItemIndex = i;
+                        bestOrFirstMatchResult = item;
+                        longestCommonPrefixLength = commonPrefixLength;
+                    }
+                }
             }
             else
             {
@@ -328,7 +344,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // without bringing up the completion list.  An item is unique if it was the
                 // only item to match the text typed so far, and there was at least some text
                 // typed.  i.e.  if we have "Console.$$" we don't want to commit something
-                // like "WriteLine" since no filter text has actually been provided.  HOwever,
+                // like "WriteLine" since no filter text has actually been provided.  However,
                 // if "Console.WriteL$$" is typed, then we do want "WriteLine" to be committed.
                 selectedItemIndex = itemsInList.IndexOf(i => Equals(i.RoslynCompletionItem, bestItem));
                 bestOrFirstMatchResult = itemsInList[selectedItemIndex];
@@ -358,12 +374,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var updateSelectionHint = isHardSelection ? UpdateSelectionHint.Selected : UpdateSelectionHint.SoftSelected;
 
-            // If no items found above, select the first item.
-            if (selectedItemIndex == -1)
-            {
-                selectedItemIndex = 0;
-            }
-
             return new FilteredCompletionModel(
                 GetHighlightedList(itemsInList), selectedItemIndex, filters,
                 updateSelectionHint, centerSelection: true, uniqueItem);
@@ -389,7 +399,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
 
             MatchResult? bestMatchResult = null;
-            bool moreThanOneMatchWithSamePriority = false;
+            var moreThanOneMatchWithSamePriority = false;
             foreach (var currentMatchResult in matchingItems)
             {
                 if (bestMatchResult == null)

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -7443,6 +7443,36 @@ class Program
             End Using
         End Function
 
+        <WorkItem(1128749, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1128749")>
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFallingBackToItemWithLongestCommonPrefixWhenNoMatch(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                              <Document>
+class SomePrefixAndName {}
+
+class C
+{
+    void Method()
+    {
+        SomePrefixOrName$$
+    }
+}
+                              </Document>,
+                  showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                Await state.SendCommitUniqueCompletionListItemAsync()
+                Await state.AssertNoCompletionSession()
+
+                state.SendEscape()
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="SomePrefixAndName", isHardSelected:=False)
+
+            End Using
+        End Function
+
         ' Simulates a situation where IntelliCode provides items not included into the Rolsyn original list.
         ' We want to ignore these items in CommitIfUnique.
         ' This situation should not happen. Tests with this provider were added to cover protective scenarios.

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -256,9 +256,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 #Enable Warning BC42358 ' Because this call is not awaited, execution of the current method continues before the call is completed
 
             Dim itemsUpdatedHandler = Sub(sender As Object, e As Data.ComputedCompletionItemsEventArgs)
-                                          ' If there is more than one item left, then it means this was the filter operation that resulted and we're done. Otherwise we know a
-                                          ' Dismiss operation is coming so we should wait for it.
-                                          If e.Items.Items.Select(Function(i) i.FilterText).Skip(1).Any() Then
+                                          ' If there is 0 or more than one item left, then it means this was the filter operation that resulted and we're done. 
+                                          ' Otherwise we know a Dismiss operation is coming so we should wait for it.
+                                          If e.Items.Items.Count() <> 1 Then
                                               Task.Run(Sub()
                                                            Thread.Sleep(5000)
                                                            sessionComplete.TrySetResult(Nothing)


### PR DESCRIPTION
instead of the first item, when there's no item matches filter text. This seems to be the behavior of old C# completion in VS 2013 (prior to Roslyn)
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1128749

@CyrusNajmabadi @dotnet/roslyn-ide 