### PR TITLE
Fix AD0001 for IDE0076

### DIFF
--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/SuppressMessageAttributeState.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/SuppressMessageAttributeState.cs
@@ -127,6 +127,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Compilation wide suppression with a non-null target is considered invalid.
                 return targetSymbolString == null;
             }
+            else if (targetScope == TargetScope.NamespaceAndDescendants)
+            {
+                // TargetSymbolResolver expects the callers to normalize 'NamespaceAndDescendants' and 'Namespace' scopes to 'Namespace' scope.
+                targetScope = TargetScope.Namespace;
+            }
 
             var resolver = new TargetSymbolResolver(_compilation, targetScope, targetSymbolString);
             resolvedSymbols = resolver.Resolve(out targetHasDocCommentIdFormat);


### PR DESCRIPTION
Fixes #45465
Ensure we normalize the target scope passed to target symbol resolver. It doesn't handle the recently added 'namespaceanddescendants' scope in legacy target string format and expects it to be normalized to 'namespace' scope.