### PR TITLE
Update vs-threading analyzers to 16.7.53

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
     <MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion>16.0.0</MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion>
-    <MicrosoftVisualStudioThreadingAnalyzersVersion>16.7.40</MicrosoftVisualStudioThreadingAnalyzersVersion>
+    <MicrosoftVisualStudioThreadingAnalyzersVersion>16.7.53</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <MicrosoftVisualStudioThreadingVersion>16.6.13</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioUtilitiesVersion>16.6.29925.50</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.5.31</MicrosoftVisualStudioValidationVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
     <MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion>16.0.0</MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion>
-    <MicrosoftVisualStudioThreadingAnalyzersVersion>16.6.13</MicrosoftVisualStudioThreadingAnalyzersVersion>
+    <MicrosoftVisualStudioThreadingAnalyzersVersion>16.7.40</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <MicrosoftVisualStudioThreadingVersion>16.6.13</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioUtilitiesVersion>16.6.29925.50</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.5.31</MicrosoftVisualStudioValidationVersion>

--- a/src/Analyzers/VisualBasic/CodeFixes/RemoveUnnecessaryCast/VisualBasicRemoveUnnecessaryCastCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/RemoveUnnecessaryCast/VisualBasicRemoveUnnecessaryCastCodeFixProvider.vb
@@ -91,13 +91,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryCast
             Dim expandedRoot = Await ExpandSurroundingStatementsAsync(trackedDocument, originalCastNodes, cancellationToken).ConfigureAwait(False)
             Dim expandedDocument = document.WithSyntaxRoot(expandedRoot)
 
-            Dim removedRoot = Await RemoveCasts(
+            Dim removedRoot = Await RemoveCastsAsync(
                 expandedDocument, originalCastNodes, cancellationToken).ConfigureAwait(False)
 
             editor.ReplaceNode(editor.OriginalRoot, removedRoot)
         End Function
 
-        Private Shared Async Function RemoveCasts(
+        Private Shared Async Function RemoveCastsAsync(
                 document As Document, originalCastNodes As ImmutableArray(Of ExpressionSyntax),
                 cancellationToken As CancellationToken) As Task(Of SyntaxNode)
 

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -186,7 +186,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
                         // the server and we need to fall back to the command line.
                         //
                         // Example: https://github.com/dotnet/roslyn/issues/24124
+#pragma warning disable VSTHRD114 // Avoid returning a null Task (False positive: https://github.com/microsoft/vs-threading/issues/637)
                         return null;
+#pragma warning restore VSTHRD114 // Avoid returning a null Task
                     }
 
                     if (!holdsMutex)
@@ -197,7 +199,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
                             if (!holdsMutex)
                             {
+#pragma warning disable VSTHRD114 // Avoid returning a null Task (False positive: https://github.com/microsoft/vs-threading/issues/637)
                                 return null;
+#pragma warning restore VSTHRD114 // Avoid returning a null Task
                             }
                         }
                         catch (AbandonedMutexException)

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -459,14 +459,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             _cancellationToken.ThrowIfCancellationRequested()
 
             If Me._compilation.Options.ConcurrentBuild Then
-                Dim worker As Task = CompileNamespaceAsTask(symbol)
+                Dim worker As Task = CompileNamespaceAsync(symbol)
                 _compilerTasks.Push(worker)
             Else
                 CompileNamespace(symbol)
             End If
         End Sub
 
-        Private Function CompileNamespaceAsTask(symbol As NamespaceSymbol) As Task
+        Private Function CompileNamespaceAsync(symbol As NamespaceSymbol) As Task
             Return Task.Run(
                 UICultureUtilities.WithCurrentUICulture(
                     Sub()
@@ -491,7 +491,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             _cancellationToken.ThrowIfCancellationRequested()
             If PassesFilter(_filterOpt, symbol) Then
                 If Me._compilation.Options.ConcurrentBuild Then
-                    Dim worker As Task = CompileNamedTypeAsTask(symbol, _filterOpt)
+                    Dim worker As Task = CompileNamedTypeAsync(symbol, _filterOpt)
                     _compilerTasks.Push(worker)
                 Else
                     CompileNamedType(symbol, _filterOpt)
@@ -499,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Function CompileNamedTypeAsTask(symbol As NamedTypeSymbol, filter As Predicate(Of Symbol)) As Task
+        Private Function CompileNamedTypeAsync(symbol As NamedTypeSymbol, filter As Predicate(Of Symbol)) As Task
             Return Task.Run(
                 UICultureUtilities.WithCurrentUICulture(
                     Sub()

--- a/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
+Imports System.Diagnostics.CodeAnalysis
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.PooledObjects
@@ -118,6 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Try
         End Function
 
+        <SuppressMessage("Style", "VSTHRD200:Use ""Async"" suffix for async methods", Justification:="'Async' refers to the language feature here.")>
         Friend Shared Function RewriteIteratorAndAsync(bodyWithoutLambdas As BoundBlock,
                                                        method As MethodSymbol,
                                                        methodOrdinal As Integer,

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.FailureInlineRenameInfo.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken) => null;
 
-            public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => null;
+            public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => Task.FromResult<IInlineRenameLocationSet>(null);
 
             public bool TryOnAfterGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;
 

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -500,7 +500,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
         <WpfFact, WorkItem(937915, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/937915"), Trait(Traits.Feature, Traits.Features.Diagnostics)>
         <WorkItem(759, "https://github.com/dotnet/roslyn/issues/759")>
-        Public Async Sub TestDiagnosticAnalyzerExceptionHandledGracefully2()
+        Public Async Function TestDiagnosticAnalyzerExceptionHandledGracefully2() As Task
             Dim test = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document FilePath="Test.cs">
@@ -534,7 +534,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Assert.True(diagnostic.Id = "AD0001")
                 Assert.Contains("CodeBlockStartedAnalyzer", diagnostic.Message, StringComparison.Ordinal)
             End Using
-        End Sub
+        End Function
 
         <Fact, WorkItem(1167439, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1167439"), Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub TestDiagnosticAnalyzerExceptionHandledNoCrash()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3072,7 +3072,7 @@ class Program
         <WorkItem(785637, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/785637")>
         <WpfTheory, CombinatorialData>
         <Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Sub CommitMovesCaretToWordEnd(showCompletionInArgumentLists As Boolean)
+        Public Async Function CommitMovesCaretToWordEnd(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document><![CDATA[
 using System;
@@ -3089,7 +3089,7 @@ class C
                 Await state.SendCommitUniqueCompletionListItemAsync()
                 Assert.Equal(state.GetLineFromCurrentCaretPosition().End, state.GetCaretPoint().BufferPosition)
             End Using
-        End Sub
+        End Function
 
         <WorkItem(775370, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/775370")>
         <WpfTheory, CombinatorialData>

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33001, "https://github.com/dotnet/roslyn/issues/33001")>
-        Public Async Sub BuildQuickInfoItem()
+        Public Async Function BuildQuickInfoItem() As Task
 
             Dim codeAnalysisQuickInfoItem =
                 QuickInfoItem.Create(
@@ -108,11 +108,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.ClassName, "IOException"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33001, "https://github.com/dotnet/roslyn/issues/33001")>
-        Public Async Sub BuildQuickInfoItemWithoutDocumentation()
+        Public Async Function BuildQuickInfoItemWithoutDocumentation() As Task
 
             Dim codeAnalysisQuickInfoItem =
                 QuickInfoItem.Create(
@@ -194,11 +194,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.ClassName, "IOException"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33001, "https://github.com/dotnet/roslyn/issues/33001")>
-        Public Async Sub BuildQuickInfoItemWithMultiLineDocumentation()
+        Public Async Function BuildQuickInfoItemWithMultiLineDocumentation() As Task
 
             Dim codeAnalysisQuickInfoItem =
                 QuickInfoItem.Create(
@@ -310,11 +310,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.ClassName, "IOException"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33001, "https://github.com/dotnet/roslyn/issues/33001")>
-        Public Async Sub BuildQuickInfoFromSymbol()
+        Public Async Function BuildQuickInfoFromSymbol() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -391,11 +391,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.ClassName, "IOException", navigationAction:=Sub() Return, "IOException"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
-        Public Async Sub QuickInfoShowsMethodRemarks()
+        Public Async Function QuickInfoShowsMethodRemarks() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -439,11 +439,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                     New ClassifiedTextRun(ClassificationTypeNames.Text, "Remarks text.")))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
-        Public Async Sub QuickInfoShowsMethodReturns()
+        Public Async Function QuickInfoShowsMethodReturns() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -497,11 +497,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                 New ClassifiedTextRun(ClassificationTypeNames.Text, "Returns text."))))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
-        Public Async Sub QuickInfoShowsDelegateReturns()
+        Public Async Function QuickInfoShowsDelegateReturns() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -557,11 +557,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                 New ClassifiedTextRun(ClassificationTypeNames.Text, "Returns text."))))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(31618, "https://github.com/dotnet/roslyn/issues/31618")>
-        Public Async Sub QuickInfoShowsPropertyValue()
+        Public Async Function QuickInfoShowsPropertyValue() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -620,7 +620,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                 New ClassifiedTextRun(ClassificationTypeNames.Text, "Value text."))))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfTheory, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <InlineData("<para>text1</para><para>text2</para>")>
@@ -633,7 +633,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <InlineData("<para/><para/>text1<br/><br/>text2<para/><para/>")>
         <InlineData("<para>text1</para><br/><para>text2</para>")>
         <WorkItem(33001, "https://github.com/dotnet/roslyn/issues/33001")>
-        Public Async Sub EquivalentParagraphForms(summary As String)
+        Public Async Function EquivalentParagraphForms(summary As String) As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -678,10 +678,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                     New ClassifiedTextRun(ClassificationTypeNames.Text, "text2")))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub InlineCodeElement()
+        Public Async Function InlineCodeElement() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -727,10 +727,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub BlockLevelCodeElement()
+        Public Async Function BlockLevelCodeElement() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -777,11 +777,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                     New ClassifiedTextRun(ClassificationTypeNames.Text, ".")))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForParameterReference()
+        Public Async Function QuickInfoForParameterReference() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -829,11 +829,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForReadOnlyMethodReference()
+        Public Async Function QuickInfoForReadOnlyMethodReference() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -869,11 +869,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Punctuation, ")"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForReadOnlyPropertyReference()
+        Public Async Function QuickInfoForReadOnlyPropertyReference() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -912,11 +912,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "}"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForReadOnlyEventReference()
+        Public Async Function QuickInfoForReadOnlyEventReference() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -950,11 +950,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.EventName, "MyEvent", navigationAction:=Sub() Return, "readonly event Action MyStruct.MyEvent"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForTypeParameterReference()
+        Public Async Function QuickInfoForTypeParameterReference() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -1002,11 +1002,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForTypeParameterReferenceClosedGeneric()
+        Public Async Function QuickInfoForTypeParameterReferenceClosedGeneric() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -1054,11 +1054,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <WorkItem(33546, "https://github.com/dotnet/roslyn/issues/33546")>
-        Public Async Sub QuickInfoForTypeParameterReferenceBoundGeneric()
+        Public Async Function QuickInfoForTypeParameterReferenceBoundGeneric() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -1109,6 +1109,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Inheritdoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Inheritdoc.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Inherits AbstractIntellisenseQuickInfoBuilderTests
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub NoImplicitInheritedQuickInfoForType()
+        Public Async Function NoImplicitInheritedQuickInfoForType() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -49,10 +49,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.ClassName, "MyClass", navigationAction:=Sub() Return, "MyClass"))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub ExplicitInheritedQuickInfoForType()
+        Public Async Function ExplicitInheritedQuickInfoForType() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -93,10 +93,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "This is the base class."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub ExplicitInheritedQuickInfoForSummary1()
+        Public Async Function ExplicitInheritedQuickInfoForSummary1() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -139,10 +139,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "This is the base class."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub ExplicitInheritedQuickInfoForSummary2()
+        Public Async Function ExplicitInheritedQuickInfoForSummary2() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -193,10 +193,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "This is the base class. This is not the base class."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub InheritedQuickInfoForParameterButNotSummary1()
+        Public Async Function InheritedQuickInfoForParameterButNotSummary1() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -251,10 +251,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "Override summary."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub InheritedQuickInfoForParameterButNotSummary2()
+        Public Async Function InheritedQuickInfoForParameterButNotSummary2() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -306,6 +306,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "A parameter."))))
 
             ToolTipAssert.EqualContent(expected, container)
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Links.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Links.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <WpfTheory, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <InlineData("see")>
         <InlineData("a")>
-        Public Async Sub QuickInfoForPlainHyperlink(tag As String)
+        Public Async Function QuickInfoForPlainHyperlink(tag As String) As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -58,12 +58,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
 
         <WpfTheory, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <InlineData("see")>
         <InlineData("a")>
-        Public Async Sub QuickInfoForHyperlinkWithText(tag As String)
+        Public Async Function QuickInfoForHyperlinkWithText(tag As String) As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -105,6 +105,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Lists.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Lists.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <WpfTheory, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <InlineData(New Object() {New String() {"item", "description"}})>
         <InlineData(New Object() {New String() {"item"}})>
-        Public Async Sub QuickInfoForBulletedList(itemTags As String())
+        Public Async Function QuickInfoForBulletedList(itemTags As String()) As Task
             Dim openItemTag = String.Join("", itemTags.Select(Function(tag) $"<{tag}>"))
             Dim closeItemTag = String.Join("", itemTags.Reverse().Select(Function(tag) $"</{tag}>"))
             Dim workspace =
@@ -73,12 +73,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                             New ClassifiedTextRun(ClassificationTypeNames.Text, "Item 2")))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
 
         <WpfTheory, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <InlineData(New Object() {New String() {"item", "description"}})>
         <InlineData(New Object() {New String() {"item"}})>
-        Public Async Sub QuickInfoForNumberedList(itemTags As String())
+        Public Async Function QuickInfoForNumberedList(itemTags As String()) As Task
             Dim openItemTag = String.Join("", itemTags.Select(Function(tag) $"<{tag}>"))
             Dim closeItemTag = String.Join("", itemTags.Reverse().Select(Function(tag) $"</{tag}>"))
             Dim workspace =
@@ -136,10 +136,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                             New ClassifiedTextRun(ClassificationTypeNames.Text, "Item 2")))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub QuickInfoForBulletedTermList()
+        Public Async Function QuickInfoForBulletedTermList() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -201,10 +201,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                             New ClassifiedTextRun(ClassificationTypeNames.Text, "Item 2")))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        Public Async Sub QuickInfoForNumberedTermList()
+        Public Async Function QuickInfoForNumberedTermList() As Task
             Dim workspace =
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -266,12 +266,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                             New ClassifiedTextRun(ClassificationTypeNames.Text, "Item 2")))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
 
         <WpfTheory, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         <InlineData(New Object() {New String() {"item", "description"}})>
         <InlineData(New Object() {New String() {"item"}})>
-        Public Async Sub QuickInfoForNestedLists(itemTags As String())
+        Public Async Function QuickInfoForNestedLists(itemTags As String()) As Task
             Dim openItemTag = String.Join("", itemTags.Select(Function(tag) $"<{tag}>"))
             Dim closeItemTag = String.Join("", itemTags.Reverse().Select(Function(tag) $"</{tag}>"))
             Dim workspace =
@@ -379,6 +379,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                             New ClassifiedTextRun(ClassificationTypeNames.Text, "Line2")))))))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Styles.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Styles.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <InlineData({"em", "strong"}, ClassifiedTextRunStyle.Italic Or ClassifiedTextRunStyle.Bold)>
         <InlineData({"b", "i"}, ClassifiedTextRunStyle.Italic Or ClassifiedTextRunStyle.Bold)>
         <InlineData({"i", "strong", "c", "u"}, ClassifiedTextRunStyle.Bold Or ClassifiedTextRunStyle.Italic Or ClassifiedTextRunStyle.Underline Or ClassifiedTextRunStyle.UseClassificationFont)>
-        Public Async Sub QuickInfoForStylizedText(styleTags As String(), style As ClassifiedTextRunStyle)
+        Public Async Function QuickInfoForStylizedText(styleTags As String(), style As ClassifiedTextRunStyle) As Task
             Dim openStyleTag = String.Join("", styleTags.Select(Function(tag) $"<{tag}>"))
             Dim closeStyleTag = String.Join("", styleTags.Reverse().Select(Function(tag) $"</{tag}>"))
             Dim workspace =
@@ -67,6 +67,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                         New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))
 
             ToolTipAssert.EqualContent(expected, intellisenseQuickInfo.Item)
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -4,7 +4,6 @@
 
 Imports System.Runtime.CompilerServices
 Imports System.Threading
-Imports System.Windows.Threading
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
@@ -150,7 +149,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <WpfFact>
         <WorkItem(179726, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=179726&_a=edit")>
         Public Async Function UpKeyShouldBlockOnRecomputationAfterPresentation() As Task
-            Dim dispatcher = System.Windows.Threading.Dispatcher.CurrentDispatcher
+            Dim exportProvider = TestExportProvider.ExportProviderFactoryWithCSharpAndVisualBasic.CreateExportProvider()
+            Dim threadingContext = exportProvider.GetExportedValue(Of IThreadingContext)()
+
             Dim worker = Async Function()
                              Dim slowProvider = New Mock(Of ISignatureHelpProvider)(MockBehavior.Strict)
                              slowProvider.Setup(Function(p) p.IsTriggerCharacter(" "c)).Returns(True)
@@ -158,7 +159,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                              slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), It.IsAny(Of CancellationToken))) _
                                  .Returns(Task.FromResult(New SignatureHelpItems(CreateItems(2), TextSpan.FromBounds(0, 0), selectedItem:=0, argumentIndex:=0, argumentCount:=0, argumentName:=Nothing)))
 
-                             Dim controller = dispatcher.Invoke(Function() CreateController(provider:=slowProvider.Object, waitForPresentation:=True))
+                             Await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync()
+                             Dim controller = CreateController(provider:=slowProvider.Object, waitForPresentation:=True)
 
                              ' Update session so that providers are requeried.
                              ' SlowProvider now blocks on the checkpoint's task.
@@ -169,18 +171,23 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                               Return Task.FromResult(New SignatureHelpItems(CreateItems(2), TextSpan.FromBounds(0, 2), selectedItem:=0, argumentIndex:=0, argumentCount:=0, argumentName:=Nothing))
                                           End Function)
 
-                             dispatcher.Invoke(Sub() DirectCast(controller, IChainedCommandHandler(Of TypeCharCommandArgs)).ExecuteCommand(
+                             Await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync()
+                             DirectCast(controller, IChainedCommandHandler(Of TypeCharCommandArgs)).ExecuteCommand(
                                  New TypeCharCommandArgs(CreateMock(Of ITextView), CreateMock(Of ITextBuffer), " "c),
-                                 Sub() GetMocks(controller).Buffer.Insert(0, " "), TestCommandExecutionContext.Create()))
+                                 Sub() GetMocks(controller).Buffer.Insert(0, " "), TestCommandExecutionContext.Create())
 
                              GetMocks(controller).PresenterSession.Setup(Sub(p) p.SelectPreviousItem())
 
-                             Dim handled = dispatcher.InvokeAsync(Function() controller.TryHandleUpKey()) ' Send the controller an up key, which should block on the computation
+                             Dim handled = threadingContext.JoinableTaskFactory.RunAsync(Async Function()
+                                                                                             Await Task.Yield()
+                                                                                             ' Send the controller an up key, which should block on the computation
+                                                                                             Return controller.TryHandleUpKey()
+                                                                                         End Function)
                              checkpoint.Release() ' Allow slowprovider to finish
-                             Await handled.Task.ConfigureAwait(False)
+                             Await handled.JoinAsync().ConfigureAwait(False)
 
                              ' We expect 2 calls to the presenter (because we had an existing presentation session when we started the second computation).
-                             Assert.True(handled.Result)
+                             Assert.True(handled.Task.Result)
                              GetMocks(controller).PresenterSession.Verify(Sub(p) p.PresentItems(It.IsAny(Of ITrackingSpan), It.IsAny(Of IList(Of SignatureHelpItem)),
                                                                                                 It.IsAny(Of SignatureHelpItem), It.IsAny(Of Integer?)), Times.Exactly(2))
                          End Function

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Dim comp = VisualBasicCompilation.Create("Text", syntaxTrees:={tree}, references:={TestReferences.NetFx.v4_0_30319.mscorlib})
             Dim semanticModel = comp.GetSemanticModel(tree)
 
-            Dim context = Await VisualBasicSyntaxContext.CreateContextAsync_Test(semanticModel, position, CancellationToken.None)
+            Dim context = Await VisualBasicSyntaxContext.TestAccessor.CreateContextAsync(semanticModel, position, CancellationToken.None)
             Return s_parts.SelectMany(Function(part) part.RecommendKeywords_Test(context))
         End Function
 

--- a/src/Features/Lsif/GeneratorTest/CompilerInvocationTests.vb
+++ b/src/Features/Lsif/GeneratorTest/CompilerInvocationTests.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     <UseExportProvider>
     Public Class CompilerInvocationTests
         <Fact>
-        Public Async Sub TestCSharpProject()
+        Public Async Function TestCSharpProject() As Task
             ' PortableExecutableReference.CreateFromFile implicitly reads the file so the file must exist.
             Dim referencePath = GetType(Object).Assembly.Location
 
@@ -31,10 +31,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim metadataReference = Assert.Single(compilerInvocation.Compilation.References)
 
             Assert.Equal(referencePath, DirectCast(metadataReference, PortableExecutableReference).FilePath)
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub TestVisualBasicProject()
+        Public Async Function TestVisualBasicProject() As Task
             ' PortableExecutableReference.CreateFromFile implicitly reads the file so the file must exist.
             Dim referencePath = GetType(Object).Assembly.Location
 
@@ -57,11 +57,11 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim metadataReference = Assert.Single(compilerInvocation.Compilation.References)
 
             Assert.Equal(referencePath, DirectCast(metadataReference, PortableExecutableReference).FilePath)
-        End Sub
+        End Function
 
         <Theory>
         <CombinatorialData>
-        Public Async Sub TestSourceFilePathMappingWithDriveLetters(<CombinatorialValues("F:", "F:\")> from As String, <CombinatorialValues("T:", "T:\")> [to] As String)
+        Public Async Function TestSourceFilePathMappingWithDriveLetters(<CombinatorialValues("F:", "F:\")> from As String, <CombinatorialValues("T:", "T:\")> [to] As String) As Task
             Dim compilerInvocation = Await Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.CompilerInvocation.CreateFromJsonAsync("
                 {
                     ""tool"": ""csc"",
@@ -78,10 +78,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim syntaxTree = Assert.Single(compilerInvocation.Compilation.SyntaxTrees)
 
             Assert.Equal("T:\SourceFile.cs", syntaxTree.FilePath)
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub TestSourceFilePathMappingWithSubdirectoriesWithoutTrailingSlashes()
+        Public Async Function TestSourceFilePathMappingWithSubdirectoriesWithoutTrailingSlashes() As Task
             Dim compilerInvocation = Await Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.CompilerInvocation.CreateFromJsonAsync("
                 {
                     ""tool"": ""csc"",
@@ -98,10 +98,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim syntaxTree = Assert.Single(compilerInvocation.Compilation.SyntaxTrees)
 
             Assert.Equal("T:\Directory\SourceFile.cs", syntaxTree.FilePath)
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub TestSourceFilePathMappingWithSubdirectoriesWithDoubleSlashesInFilePath()
+        Public Async Function TestSourceFilePathMappingWithSubdirectoriesWithDoubleSlashesInFilePath() As Task
             Dim compilerInvocation = Await Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.CompilerInvocation.CreateFromJsonAsync("
                 {
                     ""tool"": ""csc"",
@@ -118,10 +118,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim syntaxTree = Assert.Single(compilerInvocation.Compilation.SyntaxTrees)
 
             Assert.Equal("T:\Directory\SourceFile.cs", syntaxTree.FilePath)
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub TestRuleSetPathMapping()
+        Public Async Function TestRuleSetPathMapping() As Task
             Const RuleSetContents = "<?xml version=""1.0""?>
 <RuleSet Name=""Name"" ToolsVersion=""10.0"">
   <Rules AnalyzerId=""Microsoft.Analyzers.ManagedCodeAnalysis"" RuleNamespace=""Microsoft.Rules.Managed"">
@@ -148,6 +148,6 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
                 Assert.Equal(ReportDiagnostic.Warn, compilerInvocation.Compilation.Options.SpecificDiagnosticOptions("CA1001"))
             End Using
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
+++ b/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     <UseExportProvider>
     Public NotInheritable Class OutputFormatTests
         <Fact>
-        Public Async Sub TestLineModeOutput()
+        Public Async Function TestLineModeOutput() As Task
             Dim stringWriter = New StringWriter()
             Dim jsonWriter = New LineModeLsifJsonWriter(stringWriter)
 
@@ -34,10 +34,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 {""outV"":1,""inVs"":[3],""id"":7,""type"":""edge"",""label"":""contains""}
 {""kind"":""end"",""scope"":""project"",""data"":1,""id"":8,""type"":""vertex"",""label"":""$event""}
 ", stringWriter.ToString())
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub TestJsonModeOutput()
+        Public Async Function TestJsonModeOutput() As Task
             Dim stringWriter = New StringWriter()
             Using jsonWriter = New JsonModeLsifJsonWriter(stringWriter)
 
@@ -115,6 +115,6 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     ""label"": ""$event""
   }
 ]", stringWriter.ToString())
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
+++ b/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     <UseExportProvider>
     Public NotInheritable Class ProjectStructureTests
         <Fact>
-        Public Async Sub ProjectContainsDocuments()
+        Public Async Function ProjectContainsDocuments() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -24,6 +24,6 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
             Assert.Single(documentVertices, Function(d) d.Uri.LocalPath = "Z:\A.cs")
             Assert.Single(documentVertices, Function(d) d.Uri.LocalPath = "Z:\B.cs")
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
+++ b/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <InlineData("class C { void M(string s) { string local = """"; M([|local|]); } }", Nothing, Nothing)>
         <InlineData("using [|S|] = System.String;", Nothing, Nothing)>
         <InlineData("class C { [|global|]::System.String s; }", "<global namespace>", WellKnownSymbolMonikerSchemes.DotnetNamespace)>
-        Public Async Sub ReferenceMoniker(code As String, expectedMoniker As String, expectedMonikerScheme As String)
+        Public Async Function ReferenceMoniker(code As String, expectedMoniker As String, expectedMonikerScheme As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -35,12 +35,12 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
             Assert.Equal(expectedMoniker, monikerVertex?.Identifier)
             Assert.Equal(expectedMonikerScheme, monikerVertex?.Scheme)
-        End Sub
+        End Function
 
         <Theory>
         <InlineData("// Comment")>
         <InlineData("extern alias A;")>
-        Public Async Sub NoRangesAtAll(code As String)
+        Public Async Function NoRangesAtAll(code As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -54,10 +54,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                     </Workspace>))
 
             Assert.Empty(lsif.Vertices.OfType(Of Range))
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub DefinitionIncludedInDefinitionResult()
+        Public Async Function DefinitionIncludedInDefinitionResult() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -75,10 +75,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             ' The definition vertex should point back to our range
             Dim referencedRange = Assert.Single(lsif.GetLinkedVertices(Of Graph.Range)(definitionsVertex, "item"))
             Assert.Same(rangeVertex, referencedRange)
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub ReferenceIncludedInReferenceResult()
+        Public Async Function ReferenceIncludedInReferenceResult() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -96,10 +96,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             ' The references vertex should point back to our range
             Dim referencedRange = Assert.Single(lsif.GetLinkedVertices(Of Graph.Range)(referencesVertex, "item"))
             Assert.Same(rangeVertex, referencedRange)
-        End Sub
+        End Function
 
         <Fact>
-        Public Async Sub ReferenceIncludedInSameReferenceResultForMultipleFiles()
+        Public Async Function ReferenceIncludedInSameReferenceResultForMultipleFiles() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                 Dim referencedRanges = lsif.GetLinkedVertices(Of Graph.Range)(referencesVertex, "item")
                 Assert.Contains(rangeVertex, referencedRanges)
             Next
-        End Sub
+        End Function
 
         <Theory>
         <InlineData("class A { public const int C = 42 + 42; }", "class B { public const int C = 42 + 42; }")> ' case for built-in operators
@@ -140,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                         /// <see cref=""A.M()"" />
                         public void M2() { }
                     }")> ' case for crefs
-        Public Async Sub NoCrossDocumentReferencesWithoutAMoniker(file1 As String, file2 As String)
+        Public Async Function NoCrossDocumentReferencesWithoutAMoniker(file1 As String, file2 As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
@@ -178,6 +178,6 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                     Assert.Single(documents)
                 End If
             Next
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
@@ -33,12 +33,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Async
         End Property
 
         Protected Overrides Async Function GetDescriptionAsync(diagnostic As Diagnostic, node As SyntaxNode, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Task(Of String)
-            Dim methodNode = Await GetMethodFromExpression(node, semanticModel, cancellationToken).ConfigureAwait(False)
+            Dim methodNode = Await GetMethodFromExpressionAsync(node, semanticModel, cancellationToken).ConfigureAwait(False)
             Return String.Format(VBFeaturesResources.Make_0_an_Async_Function, methodNode.Item2.BlockStatement)
         End Function
 
         Protected Overrides Async Function GetRootInOtherSyntaxTreeAsync(node As SyntaxNode, semanticModel As SemanticModel, diagnostic As Diagnostic, cancellationToken As CancellationToken) As Task(Of Tuple(Of SyntaxTree, SyntaxNode))
-            Dim tuple = Await GetMethodFromExpression(node, semanticModel, cancellationToken).ConfigureAwait(False)
+            Dim tuple = Await GetMethodFromExpressionAsync(node, semanticModel, cancellationToken).ConfigureAwait(False)
             If tuple Is Nothing Then
                 Return Nothing
             End If
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Async
             Return System.Tuple.Create(oldRoot.SyntaxTree, newRoot)
         End Function
 
-        Private Shared Async Function GetMethodFromExpression(oldNode As SyntaxNode, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Task(Of Tuple(Of SyntaxNode, MethodBlockSyntax))
+        Private Shared Async Function GetMethodFromExpressionAsync(oldNode As SyntaxNode, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Task(Of Tuple(Of SyntaxNode, MethodBlockSyntax))
             If oldNode Is Nothing Then
                 Return Nothing
             End If

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
@@ -113,10 +113,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                 Return Nothing
             End If
 
-            Return Await GenerateCodeAction(document, semanticModel, delegateSymbol, actualEventName, targetType, cancellationToken).ConfigureAwait(False)
+            Return Await GenerateCodeActionAsync(document, semanticModel, delegateSymbol, actualEventName, targetType, cancellationToken).ConfigureAwait(False)
         End Function
 
-        Private Shared Async Function GenerateCodeAction(document As Document, semanticModel As SemanticModel, delegateSymbol As IMethodSymbol, actualEventName As String, targetType As INamedTypeSymbol, cancellationToken As CancellationToken) As Task(Of CodeAction)
+        Private Shared Async Function GenerateCodeActionAsync(document As Document, semanticModel As SemanticModel, delegateSymbol As IMethodSymbol, actualEventName As String, targetType As INamedTypeSymbol, cancellationToken As CancellationToken) As Task(Of CodeAction)
             Dim codeGenService = document.Project.Solution.Workspace.Services.GetLanguageServices(targetType.Language).GetService(Of ICodeGenerationService)
             Dim syntaxFactService = document.Project.Solution.Workspace.Services.GetLanguageServices(targetType.Language).GetService(Of ISyntaxFactsService)
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/IncorrectFunctionReturnType/IncorrectFunctionReturnTypeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/IncorrectFunctionReturnType/IncorrectFunctionReturnTypeCodeFixProvider.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectFunctionReturnTy
             If lambdaHeader IsNot Nothing Then
                 Dim rewrittenLambdaHeader = AsyncOrIteratorFunctionReturnTypeFixer.RewriteLambdaHeader(lambdaHeader, semanticModel, cancellationToken)
                 context.RegisterFixes(
-                    Await GetCodeActions(document, lambdaHeader, rewrittenLambdaHeader, cancellationToken).ConfigureAwait(False),
+                    Await GetCodeActionsAsync(document, lambdaHeader, rewrittenLambdaHeader, cancellationToken).ConfigureAwait(False),
                     context.Diagnostics)
                 Return
             End If
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectFunctionReturnTy
             If methodStatement IsNot Nothing Then
                 Dim rewrittenMethodStatement = AsyncOrIteratorFunctionReturnTypeFixer.RewriteMethodStatement(methodStatement, semanticModel, cancellationToken)
                 context.RegisterFixes(
-                    Await GetCodeActions(document, methodStatement, rewrittenMethodStatement, cancellationToken).ConfigureAwait(False),
+                    Await GetCodeActionsAsync(document, methodStatement, rewrittenMethodStatement, cancellationToken).ConfigureAwait(False),
                     context.Diagnostics)
                 Return
             End If
@@ -75,7 +75,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectFunctionReturnTy
                 .FirstOrDefault(Function(c) c.Span.IntersectsWith(span))
         End Function
 
-        Private Shared Async Function GetCodeActions(document As Document, node As SyntaxNode, rewrittenNode As SyntaxNode, cancellationToken As CancellationToken) As Task(Of IEnumerable(Of CodeAction))
+        Private Shared Async Function GetCodeActionsAsync(document As Document, node As SyntaxNode, rewrittenNode As SyntaxNode, cancellationToken As CancellationToken) As Task(Of IEnumerable(Of CodeAction))
             If rewrittenNode IsNot node Then
                 Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
                 Dim newRoot = root.ReplaceNode(node, rewrittenNode)

--- a/src/Features/VisualBasic/Portable/CodeFixes/Iterator/VisualBasicChangeToYieldCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Iterator/VisualBasicChangeToYieldCodeFixProvider.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Iterator
 
         Protected Overrides Function GetCodeFixAsync(root As SyntaxNode, node As SyntaxNode, document As Document, diagnostics As Diagnostic, cancellationToken As CancellationToken) As Task(Of CodeAction)
             If Not node.IsKind(SyntaxKind.ReturnStatement) Then
-                Return Nothing
+                Return Task.FromResult(Of CodeAction)(Nothing)
             End If
 
             Dim returnStatement = TryCast(node, ReturnStatementSyntax)

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
@@ -225,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
             ' unless those conflicts are inside the local declaration.
             If conflicts.Count() = declaratorConflicts.Count() Then
                 ' Certain semantic conflicts can be detected only after the reference rewriter has inlined the expression
-                Dim newDocument = Await DetectSemanticConflicts(updatedDocument,
+                Dim newDocument = Await DetectSemanticConflictsAsync(updatedDocument,
                                                                 semanticModel,
                                                                 semanticModelBeforeInline,
                                                                 originalInitializerSymbolInfo,
@@ -425,7 +425,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
             Return expression.AncestorsAndSelf().OfType(Of ExpressionSyntax).Last().FirstAncestorOrSelf(Of StatementSyntax)()
         End Function
 
-        Private Shared Async Function DetectSemanticConflicts(
+        Private Shared Async Function DetectSemanticConflictsAsync(
             inlinedDocument As Document,
             newSemanticModelForInlinedDocument As SemanticModel,
             semanticModelBeforeInline As SemanticModel,

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/HandlesClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/HandlesClauseCompletionProvider.vb
@@ -41,12 +41,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             ' Handles or a comma
             If context.TargetToken.IsChildToken(Of HandlesClauseSyntax)(Function(hc) hc.HandlesKeyword) OrElse
                 context.TargetToken.IsChildSeparatorToken(Function(hc As HandlesClauseSyntax) hc.Events) Then
-                Return Task.FromResult(GetTopLevelIdentifiersAsync(vbContext, cancellationToken))
+                Return Task.FromResult(GetTopLevelIdentifiers(vbContext, cancellationToken))
             End If
 
             ' Handles x. or , x.
             If context.TargetToken.IsChildToken(Of HandlesClauseItemSyntax)(Function(hc) hc.DotToken) Then
-                Return Task.FromResult(LookUpEventsAsync(vbContext, context.TargetToken, cancellationToken))
+                Return Task.FromResult(LookUpEvents(vbContext, context.TargetToken, cancellationToken))
             End If
 
             Return SpecializedTasks.EmptyImmutableArray(Of ISymbol)()
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
         Friend Overrides ReadOnly Property TriggerCharacters As ImmutableHashSet(Of Char) = CompletionUtilities.CommonTriggerChars
 
-        Private Shared Function GetTopLevelIdentifiersAsync(
+        Private Shared Function GetTopLevelIdentifiers(
             context As VisualBasicSyntaxContext,
             cancellationToken As CancellationToken
         ) As ImmutableArray(Of ISymbol)
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return symbols.WhereAsArray(Function(s) IsWithEvents(s))
         End Function
 
-        Private Shared Function LookUpEventsAsync(
+        Private Shared Function LookUpEvents(
             context As VisualBasicSyntaxContext,
             token As SyntaxToken,
             cancellationToken As CancellationToken

--- a/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
 
             statement = DirectCast(generator.WithModifiers(statement, generator.GetModifiers(propertyDeclaration).WithIsReadOnly(canBeReadOnly)), PropertyStatementSyntax)
 
-            Dim initializer = Await GetFieldInitializer(fieldSymbol, cancellationToken).ConfigureAwait(False)
+            Dim initializer = Await GetFieldInitializerAsync(fieldSymbol, cancellationToken).ConfigureAwait(False)
             If initializer.equalsValue IsNot Nothing Then
                 statement = statement.WithTrailingTrivia(SyntaxFactory.Space) _
                     .WithInitializer(initializer.equalsValue) _
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             Return statement
         End Function
 
-        Private Shared Async Function GetFieldInitializer(fieldSymbol As IFieldSymbol, cancellationToken As CancellationToken) As Task(Of (equalsValue As EqualsValueSyntax, asNewClause As AsNewClauseSyntax))
+        Private Shared Async Function GetFieldInitializerAsync(fieldSymbol As IFieldSymbol, cancellationToken As CancellationToken) As Task(Of (equalsValue As EqualsValueSyntax, asNewClause As AsNewClauseSyntax))
             Dim identifier = TryCast(Await fieldSymbol.DeclaringSyntaxReferences(0).GetSyntaxAsync(cancellationToken).ConfigureAwait(False), ModifiedIdentifierSyntax)
             Dim declarator = TryCast(identifier?.Parent, VariableDeclaratorSyntax)
             Dim initializer = declarator?.Initializer

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     {
         private const _VSFILECHANGEFLAGS DefaultFileChangeFlags = _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del | _VSFILECHANGEFLAGS.VSFILECHG_Size;
 
-        private static readonly AsyncLazy<uint?> s_none = new AsyncLazy<uint?>(ct => null, cacheResult: true);
+        private static readonly AsyncLazy<uint?> s_none = new AsyncLazy<uint?>(value: null);
 
         private readonly IVsFileChangeEx _fileChangeService;
         private readonly string _filePath;

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -69,7 +69,7 @@ class C
 
         <WorkItem(726497, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/726497")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Sub SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSubstringOfInsertedText()
+        Public Async Function SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSubstringOfInsertedText() As Task
             Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "interfac")
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
@@ -77,28 +77,28 @@ class C
                     "description" & vbCrLf &
                     String.Format(FeaturesResources.Note_colon_Tab_twice_to_insert_the_0_snippet, "interfac"))
             End Using
-        End Sub
+        End Function
 
         <WorkItem(726497, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/726497")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Sub SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSuperstringOfInsertedText()
+        Public Async Function SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSuperstringOfInsertedText() As Task
             Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "interfaces")
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources._0_Keyword, "interface"))
             End Using
-        End Sub
+        End Function
 
         <WorkItem(726497, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/726497")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Sub SnippetExpansionNoteAddedToDescription_DisplayTextDoesNotMatchShortcutButInsertionTextDoes()
+        Public Async Function SnippetExpansionNoteAddedToDescription_DisplayTextDoesNotMatchShortcutButInsertionTextDoes() As Task
             Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "InsertionText")
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Note_colon_Tab_twice_to_insert_the_0_snippet, "InsertionText"))
             End Using
-        End Sub
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion), Trait(Traits.Feature, Traits.Features.Interactive)>
         Public Async Function SnippetExpansionNoteNotAddedToDescription_Interactive() As Task

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -158,7 +158,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub Locals1()
+        Public Async Function Locals1() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -180,10 +180,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertCompletionItemsContainAll("variable1", "variable2")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub Locals2()
+        Public Async Function Locals2() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -205,10 +205,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertCompletionItemsContainAll("variable1", "variable2")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub Locals3()
+        Public Async Function Locals3() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -231,10 +231,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.AssertCompletionItemsDoNotContainAny("variable1")
                 Await state.AssertCompletionItemsContainAll("variable2")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub Locals4()
+        Public Async Function Locals4() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -257,10 +257,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.AssertCompletionItemsDoNotContainAny("variable1")
                 Await state.AssertCompletionItemsContainAll("variable2")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub Locals5()
+        Public Async Function Locals5() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -283,10 +283,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.AssertCompletionItemsDoNotContainAny("variable1")
                 Await state.AssertCompletionItemsContainAll("variable2")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub Locals6()
+        Public Async Function Locals6() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -309,10 +309,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.AssertCompletionItemsDoNotContainAny("variable1")
                 Await state.AssertCompletionItemsDoNotContainAny("variable2")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub SignatureHelpInParameterizedConstructor()
+        Public Async Function SignatureHelpInParameterizedConstructor() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -332,10 +332,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSignatureHelpSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub SignatureHelpInMethodCall()
+        Public Async Function SignatureHelpInMethodCall() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -359,10 +359,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSignatureHelpSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub SignatureHelpInGenericMethodCall()
+        Public Async Function SignatureHelpInGenericMethodCall() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -387,7 +387,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSignatureHelpSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
         Public Async Function InstructionPointerInForeach() As Task
@@ -415,7 +415,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 
         <WorkItem(531165, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531165")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub ClassDesigner1()
+        Public Async Function ClassDesigner1() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -439,11 +439,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertCompletionItemsDoNotContainAny("STATICINT")
             End Using
-        End Sub
+        End Function
 
         <WorkItem(531167, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531167")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub ClassDesigner2()
+        Public Async Function ClassDesigner2() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>class Program
@@ -464,11 +464,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertNoCompletionSession()
             End Using
-        End Sub
+        End Function
 
         <WorkItem(1124544, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1124544")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub CompletionUsesContextBufferPositions()
+        Public Async Function CompletionUsesContextBufferPositions() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>
@@ -621,10 +621,10 @@ $$</Document>
                 state.SendTab()
                 Assert.Equal("args", state.GetCurrentViewLineText())
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub CompletionOnTypeCharacterInLinkedFileContext()
+        Public Async Function CompletionOnTypeCharacterInLinkedFileContext() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document IsLinkFile="true" LinkAssemblyName="CSProj" LinkFilePath="C.cs"/>
@@ -649,7 +649,7 @@ $$</Document>
                 state.SendTab()
                 Assert.Contains("args", state.GetCurrentViewLineText())
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
         Public Async Function TypeNumberAtStartOfViewDoesNotCrash() As Task

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/VisualBasicDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/VisualBasicDebuggerIntellisenseTests.vb
@@ -140,7 +140,7 @@ End Module</Document>
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub TypeALineTenTimes()
+        Public Async Function TypeALineTenTimes() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -167,10 +167,10 @@ End Module</Document>
                     Assert.DoesNotContain("z", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 Next
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub SignatureHelpInParameterizedConstructor()
+        Public Async Function SignatureHelpInParameterizedConstructor() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -187,10 +187,10 @@ End Module</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSignatureHelpSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub SignatureHelpInMethodCall()
+        Public Async Function SignatureHelpInMethodCall() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -207,10 +207,10 @@ End Module</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSignatureHelpSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub SignatureHelpInGenericMethod()
+        Public Async Function SignatureHelpInGenericMethod() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -231,10 +231,10 @@ End Module</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSignatureHelpSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub CompletionInExpression()
+        Public Async Function CompletionInExpression() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -255,10 +255,10 @@ End Module</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertCompletionSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub CompletionShowTypesFromProjectReference()
+        Public Async Function CompletionShowTypesFromProjectReference() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <ProjectReference>ReferencedProject</ProjectReference>
@@ -285,10 +285,10 @@ End Class
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem("AClass")
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub CompletionForGenericType()
+        Public Async Function CompletionForGenericType() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -309,10 +309,10 @@ End Module</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertCompletionSession()
             End Using
-        End Sub
+        End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub LocalsInForBlock()
+        Public Async Function LocalsInForBlock() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -333,11 +333,11 @@ End Module</Document>
                 Await state.VerifyCompletionAndDotAfter("xx")
                 Await state.VerifyCompletionAndDotAfter("z")
             End Using
-        End Sub
+        End Function
 
         <WorkItem(1044441, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1044441")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub StoppedOnEndSub()
+        Public Async Function StoppedOnEndSub() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Module Program
@@ -349,11 +349,11 @@ End Module</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 Await state.VerifyCompletionAndDotAfter("o")
             End Using
-        End Sub
+        End Function
 
         <WorkItem(1044441, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1044441")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Sub StoppedOnEndProperty()
+        Public Async Function StoppedOnEndProperty() As Task
             Dim text = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>Class C
@@ -370,6 +370,6 @@ End Class</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 Await state.VerifyCompletionAndDotAfter("value")
             End Using
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/WorkspaceChangedEventTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/WorkspaceChangedEventTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class WorkspaceChangedEventTests
         <WpfTheory>
         <CombinatorialData>
-        Public Async Sub AddingASingleSourceFileRaisesDocumentAdded(addInBatch As Boolean)
+        Public Async Function AddingASingleSourceFileRaisesDocumentAdded(addInBatch As Boolean) As Task
             Using environment = New TestEnvironment()
                 Dim project = environment.ProjectFactory.CreateAndAddToWorkspace("Project", LanguageNames.CSharp)
                 Dim workspaceChangeEvents = New WorkspaceChangeWatcher(environment)
@@ -27,10 +27,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Equal(project.Id, change.ProjectId)
                 Assert.Equal(environment.Workspace.CurrentSolution.Projects.Single().DocumentIds.Single(), change.DocumentId)
             End Using
-        End Sub
+        End Function
 
         <WpfFact>
-        Public Async Sub AddingTwoDocumentsInBatchRaisesProjectChanged()
+        Public Async Function AddingTwoDocumentsInBatchRaisesProjectChanged() As Task
             Using environment = New TestEnvironment()
                 Dim project = environment.ProjectFactory.CreateAndAddToWorkspace("Project", LanguageNames.CSharp)
                 Dim workspaceChangeEvents = New WorkspaceChangeWatcher(environment)
@@ -46,11 +46,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Equal(project.Id, change.ProjectId)
                 Assert.Null(change.DocumentId)
             End Using
-        End Sub
+        End Function
 
         <WpfTheory>
         <CombinatorialData>
-        Public Async Sub AddingASingleAdditionalFileInABatchRaisesDocumentAdded(addInBatch As Boolean)
+        Public Async Function AddingASingleAdditionalFileInABatchRaisesDocumentAdded(addInBatch As Boolean) As Task
             Using environment = New TestEnvironment()
                 Dim project = environment.ProjectFactory.CreateAndAddToWorkspace("Project", LanguageNames.CSharp)
                 Dim workspaceChangeEvents = New WorkspaceChangeWatcher(environment)
@@ -65,11 +65,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Equal(project.Id, change.ProjectId)
                 Assert.Equal(environment.Workspace.CurrentSolution.Projects.Single().AdditionalDocumentIds.Single(), change.DocumentId)
             End Using
-        End Sub
+        End Function
 
         <WpfTheory>
         <CombinatorialData>
-        Public Async Sub AddingASingleMetadataReferenceRaisesProjectChanged(addInBatch As Boolean)
+        Public Async Function AddingASingleMetadataReferenceRaisesProjectChanged(addInBatch As Boolean) As Task
             Using environment = New TestEnvironment()
                 Dim project = environment.ProjectFactory.CreateAndAddToWorkspace("Project", LanguageNames.CSharp)
                 Dim workspaceChangeEvents = New WorkspaceChangeWatcher(environment)
@@ -84,11 +84,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Equal(project.Id, change.ProjectId)
                 Assert.Null(change.DocumentId)
             End Using
-        End Sub
+        End Function
 
         <WpfFact>
         <WorkItem(34309, "https://github.com/dotnet/roslyn/issues/34309")>
-        Public Async Sub StartingAndEndingBatchWithNoChangesDoesNothing()
+        Public Async Function StartingAndEndingBatchWithNoChangesDoesNothing() As Task
             Using environment = New TestEnvironment()
                 Dim project = environment.ProjectFactory.CreateAndAddToWorkspace("Project", LanguageNames.CSharp)
                 Dim workspaceChangeEvents = New WorkspaceChangeWatcher(environment)
@@ -99,6 +99,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Empty(Await workspaceChangeEvents.GetNewChangeEventsAsync())
                 Assert.Same(startingSolution, environment.Workspace.CurrentSolution)
             End Using
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Rename/RoslynRenameService.FailureRenameInfo.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Rename
             public string GetFinalSymbolName(string replacementText) => null;
             public TextSpan GetReferenceEditSpan(InlineRenameLocation location, string triggerText, CancellationToken cancellationToken) => default;
             public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string triggerText, string replacementText, CancellationToken cancellationToken) => null;
-            public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => null;
+            public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken) => Task.FromResult<IInlineRenameLocationSet>(null);
             public bool TryOnAfterGlobalSymbolRenamed(CodeAnalysis.Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;
             public bool TryOnBeforeGlobalSymbolRenamed(CodeAnalysis.Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText) => false;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ValuesSources/WeaklyCachedRecoverableValueSource.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ValuesSources/WeaklyCachedRecoverableValueSource.cs
@@ -161,7 +161,9 @@ namespace Microsoft.CodeAnalysis.Host
                 }
             }
 
+#pragma warning disable VSTHRD114 // Avoid returning a null Task (False positive: https://github.com/microsoft/vs-threading/issues/637)
             return null;
+#pragma warning restore VSTHRD114 // Avoid returning a null Task
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
@@ -170,10 +170,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 cancellationToken:=cancellationToken)
         End Function
 
-        Public Shared Function CreateContextAsync_Test(semanticModel As SemanticModel, position As Integer, cancellationToken As CancellationToken) As Tasks.Task(Of VisualBasicSyntaxContext)
-            Return CreateContextAsync(Nothing, semanticModel, position, cancellationToken)
-        End Function
-
         Private Function ComputeEnclosingNamedType(cancellationToken As CancellationToken) As INamedTypeSymbol
             Dim enclosingSymbol = Me.SemanticModel.GetEnclosingSymbol(Me.TargetToken.SpanStart, cancellationToken)
             Dim container = TryCast(enclosingSymbol, INamedTypeSymbol)
@@ -285,6 +281,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
         Friend Overrides Function GetTypeInferenceServiceWithoutWorkspace() As ITypeInferenceService
             Return New VisualBasicTypeInferenceService()
         End Function
+
+        Friend Structure TestAccessor
+            Public Shared Function CreateContextAsync(semanticModel As SemanticModel, position As Integer, cancellationToken As CancellationToken) As Tasks.Task(Of VisualBasicSyntaxContext)
+                Return VisualBasicSyntaxContext.CreateContextAsync(Nothing, semanticModel, position, cancellationToken)
+            End Function
+        End Structure
     End Class
 End Namespace
 


### PR DESCRIPTION
This update brings the IOperation version of these analyzers, with two primary benefits:

1. For many rules, analysis now includes Visual Basic code
2. The IOperation analysis is much faster