### PR TITLE
Remove async modifier code fixer

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveAsyncModifier/RemoveAsyncModifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveAsyncModifier/RemoveAsyncModifierTests.cs
@@ -1,0 +1,282 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+using VerifyCS = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.CSharpCodeFixVerifier<
+    Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer,
+    Microsoft.CodeAnalysis.CSharp.RemoveAsyncModifier.CSharpRemoveAsyncModifierCodeFixProvider>;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveAsyncModifier
+{
+    public class RemoveAsyncModifierTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestTaskReturnType()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task {|CS1998:Goo|}()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return;
+        }
+
+        return;
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    Task Goo()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        return Task.CompletedTask;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestTaskOfTReturnType()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task<int> {|CS1998:Goo|}()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return 2;
+        }
+
+        return 3;
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    Task<int> Goo()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return Task.FromResult(2);
+        }
+
+        return Task.FromResult(3);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestExpressionBodiedMethod()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task<int> {|CS1998:Goo|}() => 2;
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    Task<int> Goo() => Task.FromResult(2);
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestLocalFunction()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        async Task {|CS1998:Goo|}()
+        {
+            return;
+        }
+    }
+}",
+@"using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        Task Goo()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestExpressionBodiedLocalFunction()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        async Task<int> {|CS1998:Goo|}() => 1;
+    }
+}",
+@"using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        Task<int> Goo() => Task.FromResult(1);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestExpressionBodiedLambda()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"using System;
+using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        Func<Task<int>> foo = async () {|CS1998:=>|} 1;
+    }
+}",
+@"using System;
+using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        Func<Task<int>> foo = () => Task.FromResult(1);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestLambda()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"using System;
+using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        Func<Task<int>> foo = async () {|CS1998:=>|} {
+            return 1;
+        };
+    }
+}",
+@"using System;
+using System.Threading.Tasks;
+
+class C
+{
+    public void M1()
+    {
+        Func<Task<int>> foo = () => {
+            return Task.FromResult(1);
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestFullyQualifiedTaskReturnType()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+class C
+{
+    async System.Threading.Tasks.Task {|CS1998:Goo|}()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return;
+        }
+
+        return;
+    }
+}",
+@"
+class C
+{
+    System.Threading.Tasks.Task Goo()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveAsyncModifier)]
+        public async Task TestFullyQualifiedTaskOfTReturnType()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+class C
+{
+    async System.Threading.Tasks.Task<int> {|CS1998:Goo|}()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return 1;
+        }
+
+        return 2;
+    }
+}",
+    @"
+class C
+{
+    System.Threading.Tasks.Task<int> Goo()
+    {
+        if (System.DateTime.Now.Ticks > 0)
+        {
+            return System.Threading.Tasks.Task.FromResult(1);
+        }
+
+        return System.Threading.Tasks.Task.FromResult(2);
+    }
+}");
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
             return newReturnType;
         }
 
-        private static SyntaxTokenList FixMethodModifiers(SyntaxTokenList modifiers, ref TypeSyntax newReturnType)
+        internal static SyntaxTokenList FixMethodModifiers(SyntaxTokenList modifiers, ref TypeSyntax newReturnType)
         {
             var asyncTokenIndex = modifiers.IndexOf(SyntaxKind.AsyncKeyword);
             SyntaxTokenList newModifiers;
@@ -119,13 +119,13 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
             return newModifiers;
         }
 
-        private static SyntaxNode FixParenthesizedLambda(ParenthesizedLambdaExpressionSyntax lambda)
+        internal static SyntaxNode FixParenthesizedLambda(ParenthesizedLambdaExpressionSyntax lambda)
             => lambda.WithAsyncKeyword(default).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
 
-        private static SyntaxNode FixSimpleLambda(SimpleLambdaExpressionSyntax lambda)
+        internal static SyntaxNode FixSimpleLambda(SimpleLambdaExpressionSyntax lambda)
             => lambda.WithAsyncKeyword(default).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
 
-        private static SyntaxNode FixAnonymousMethod(AnonymousMethodExpressionSyntax method)
+        internal static SyntaxNode FixAnonymousMethod(AnonymousMethodExpressionSyntax method)
             => method.WithAsyncKeyword(default).WithPrependedLeadingTrivia(method.AsyncKeyword.LeadingTrivia);
     }
 }

--- a/src/Features/CSharp/Portable/RemoveAsyncModifier/CSharpRemoveAsyncModifierCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveAsyncModifier/CSharpRemoveAsyncModifierCodeFixProvider.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.RemoveAsyncModifier;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using static Microsoft.CodeAnalysis.MakeMethodAsynchronous.AbstractMakeMethodAsynchronousCodeFixProvider;
+
+namespace Microsoft.CodeAnalysis.CSharp.RemoveAsyncModifier
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MakeMethodSynchronous), Shared]
+    [ExtensionOrder(After = PredefinedCodeFixProviderNames.AddImport)]
+    internal partial class CSharpRemoveAsyncModifierCodeFixProvider : AbstractRemoveAsyncModifierCodeFixProvider
+    {
+        private const string CS1998 = nameof(CS1998); // This async method lacks 'await' operators and will run synchronously.
+
+        [ImportingConstructor]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        public CSharpRemoveAsyncModifierCodeFixProvider()
+        {
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(CS1998);
+
+        protected override bool IsAsyncSupportingFunctionSyntax(SyntaxNode node)
+            => node.IsAsyncSupportingFunctionSyntax();
+
+        protected override bool CanFix(KnownTypes knownTypes, IMethodSymbol methodSymbolOpt)
+        => !methodSymbolOpt.ReturnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTTypeOpt) &&
+           !methodSymbolOpt.ReturnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTTypeOpt);
+
+        protected override SyntaxNode ChangeReturnStatements(SyntaxNode node, SyntaxGenerator generator, KnownTypes knownTypes)
+        {
+            var converter = new ConvertReturnsToTaskRewriter(generator, knownTypes._taskType);
+
+            return node switch
+            {
+                MethodDeclarationSyntax method => FixMethodReturns(method, converter),
+                LocalFunctionStatementSyntax localFunction => FixLocalFunctionReturns(localFunction, converter),
+                AnonymousMethodExpressionSyntax method => method.WithBody((CSharpSyntaxNode)converter.Visit(method.Body)),
+                ParenthesizedLambdaExpressionSyntax lambda => FixParenthesizedLamdaExpressionReturn(lambda, converter),
+                SimpleLambdaExpressionSyntax lambda => lambda.WithBody((CSharpSyntaxNode)converter.Visit(lambda.Body)),
+                _ => node,
+            };
+        }
+
+        private static ParenthesizedLambdaExpressionSyntax FixParenthesizedLamdaExpressionReturn(ParenthesizedLambdaExpressionSyntax lambda, ConvertReturnsToTaskRewriter converter)
+        {
+            if (lambda.Block != null)
+            {
+                return lambda.WithBlock((BlockSyntax)converter.Visit(lambda.Block));
+            }
+            else
+            {
+                return lambda.WithExpressionBody(converter.WrapWithTaskFromResult(lambda.ExpressionBody));
+            }
+        }
+
+        private static MethodDeclarationSyntax FixMethodReturns(MethodDeclarationSyntax method, ConvertReturnsToTaskRewriter converter)
+        {
+            if (method.Body != null)
+            {
+                return method.WithBody((BlockSyntax)converter.Visit(method.Body));
+            }
+            else
+            {
+                return method.WithExpressionBody((ArrowExpressionClauseSyntax)converter.Visit(method.ExpressionBody));
+            }
+        }
+
+        private static LocalFunctionStatementSyntax FixLocalFunctionReturns(LocalFunctionStatementSyntax localFunction, ConvertReturnsToTaskRewriter converter)
+        {
+            if (localFunction.Body != null)
+            {
+                return localFunction.WithBody((BlockSyntax)converter.Visit(localFunction.Body));
+            }
+            else
+            {
+                return localFunction.WithExpressionBody((ArrowExpressionClauseSyntax)converter.Visit(localFunction.ExpressionBody));
+            }
+        }
+
+        protected override SyntaxNode RemoveAsyncModifier(IMethodSymbol methodSymbolOpt, SyntaxNode node, KnownTypes knownTypes) => node switch
+        {
+            MethodDeclarationSyntax method => FixMethod(method),
+            LocalFunctionStatementSyntax localFunction => FixLocalFunction(localFunction),
+            AnonymousMethodExpressionSyntax method => CSharpMakeMethodSynchronousCodeFixProvider.FixAnonymousMethod(method),
+            ParenthesizedLambdaExpressionSyntax lambda => CSharpMakeMethodSynchronousCodeFixProvider.FixParenthesizedLambda(lambda),
+            SimpleLambdaExpressionSyntax lambda => CSharpMakeMethodSynchronousCodeFixProvider.FixSimpleLambda(lambda),
+            _ => node,
+        };
+
+        private static SyntaxNode FixMethod(MethodDeclarationSyntax method)
+        {
+            var returnType = method.ReturnType;
+            var newModifiers = CSharpMakeMethodSynchronousCodeFixProvider.FixMethodModifiers(method.Modifiers, ref returnType);
+            return method.WithReturnType(returnType).WithModifiers(newModifiers);
+        }
+
+        private static SyntaxNode FixLocalFunction(LocalFunctionStatementSyntax localFunction)
+        {
+            var returnType = localFunction.ReturnType;
+            var newModifiers = CSharpMakeMethodSynchronousCodeFixProvider.FixMethodModifiers(localFunction.Modifiers, ref returnType);
+            return localFunction.WithReturnType(returnType).WithModifiers(newModifiers);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/RemoveAsyncModifier/CSharpRemoveAsyncModifierCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveAsyncModifier/CSharpRemoveAsyncModifierCodeFixProvider.cs
@@ -50,14 +50,12 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveAsyncModifier
             {
                 MethodDeclarationSyntax method => FixMethodReturns(method, converter),
                 LocalFunctionStatementSyntax localFunction => FixLocalFunctionReturns(localFunction, converter),
-                AnonymousMethodExpressionSyntax method => method.WithBody((CSharpSyntaxNode)converter.Visit(method.Body)),
-                ParenthesizedLambdaExpressionSyntax lambda => FixParenthesizedLamdaExpressionReturn(lambda, converter),
-                SimpleLambdaExpressionSyntax lambda => lambda.WithBody((CSharpSyntaxNode)converter.Visit(lambda.Body)),
+                AnonymousFunctionExpressionSyntax method => FixAnonymousFunctionReturns(method, converter),
                 _ => node,
             };
         }
 
-        private static ParenthesizedLambdaExpressionSyntax FixParenthesizedLamdaExpressionReturn(ParenthesizedLambdaExpressionSyntax lambda, ConvertReturnsToTaskRewriter converter)
+        private static AnonymousFunctionExpressionSyntax FixAnonymousFunctionReturns(AnonymousFunctionExpressionSyntax lambda, ConvertReturnsToTaskRewriter converter)
         {
             if (lambda.Block != null)
             {

--- a/src/Features/CSharp/Portable/RemoveAsyncModifier/ConvertReturnsToTaskRewriter.cs
+++ b/src/Features/CSharp/Portable/RemoveAsyncModifier/ConvertReturnsToTaskRewriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -25,23 +26,51 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveAsyncModifier
             {
                 if (node.Expression is null)
                 {
-                    return node.WithExpression((ExpressionSyntax)_generator.MemberAccessExpression(_generator.TypeExpression(_taskType), nameof(Task.CompletedTask)));
+                    // return; ==> return Task.CompletedTask;
+                    return node.WithExpression((ExpressionSyntax)_generator.MemberAccessExpression(TypeExpressionForStaticMemberAccess(_generator, _taskType), nameof(Task.CompletedTask)));
                 }
+                // return <expr>; ==> return Task.FromResult(<expr>);
                 return node.WithExpression(WrapWithTaskFromResult(node.Expression));
             }
 
             public override SyntaxNode VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
             {
+                // For expression bodied methods and local functions just wrap the whole thing in Task.FromResult
                 return node.WithExpression(WrapWithTaskFromResult(node.Expression));
             }
 
             public ExpressionSyntax WrapWithTaskFromResult(ExpressionSyntax expression)
             {
+                // <expr>; ==> Task.FromResult(<expr>);
                 return (ExpressionSyntax)
                     _generator.InvocationExpression(
                         _generator.MemberAccessExpression(
-                            _generator.TypeExpression(_taskType), nameof(Task.FromResult)),
+                            TypeExpressionForStaticMemberAccess(_generator, _taskType), nameof(Task.FromResult)),
                             expression);
+            }
+
+            // Workaround for https://github.com/dotnet/roslyn/issues/43950
+            // Copied from https://github.com/dotnet/roslyn-analyzers/blob/f24a5b42c85be6ee572f3a93bef223767fbefd75/src/Utilities/Workspaces/SyntaxGeneratorExtensions.cs#L68-L74
+            private static SyntaxNode TypeExpressionForStaticMemberAccess(SyntaxGenerator generator, INamedTypeSymbol typeSymbol)
+            {
+                var qualifiedNameSyntaxKind = generator.QualifiedName(generator.IdentifierName("ignored"), generator.IdentifierName("ignored")).RawKind;
+                var memberAccessExpressionSyntaxKind = generator.MemberAccessExpression(generator.IdentifierName("ignored"), "ignored").RawKind;
+
+                var typeExpression = generator.TypeExpression(typeSymbol);
+                return QualifiedNameToMemberAccess(qualifiedNameSyntaxKind, memberAccessExpressionSyntaxKind, typeExpression, generator);
+
+                // Local function
+                static SyntaxNode QualifiedNameToMemberAccess(int qualifiedNameSyntaxKind, int memberAccessExpressionSyntaxKind, SyntaxNode expression, SyntaxGenerator generator)
+                {
+                    if (expression.RawKind == qualifiedNameSyntaxKind)
+                    {
+                        var left = QualifiedNameToMemberAccess(qualifiedNameSyntaxKind, memberAccessExpressionSyntaxKind, expression.ChildNodes().First(), generator);
+                        var right = expression.ChildNodes().Last();
+                        return generator.MemberAccessExpression(left, right);
+                    }
+
+                    return expression;
+                }
             }
         }
     }

--- a/src/Features/CSharp/Portable/RemoveAsyncModifier/ConvertReturnsToTaskRewriter.cs
+++ b/src/Features/CSharp/Portable/RemoveAsyncModifier/ConvertReturnsToTaskRewriter.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Microsoft.CodeAnalysis.CSharp.RemoveAsyncModifier
+{
+    internal partial class CSharpRemoveAsyncModifierCodeFixProvider
+    {
+        private class ConvertReturnsToTaskRewriter : CSharpSyntaxRewriter
+        {
+            private readonly SyntaxGenerator _generator;
+            private readonly INamedTypeSymbol _taskType;
+
+            public ConvertReturnsToTaskRewriter(SyntaxGenerator generator, INamedTypeSymbol taskType)
+            {
+                _generator = generator;
+                _taskType = taskType;
+            }
+
+            public override SyntaxNode VisitReturnStatement(ReturnStatementSyntax node)
+            {
+                if (node.Expression is null)
+                {
+                    return node.WithExpression((ExpressionSyntax)_generator.MemberAccessExpression(_generator.TypeExpression(_taskType), nameof(Task.CompletedTask)));
+                }
+                return node.WithExpression(WrapWithTaskFromResult(node.Expression));
+            }
+
+            public override SyntaxNode VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
+            {
+                return node.WithExpression(WrapWithTaskFromResult(node.Expression));
+            }
+
+            public ExpressionSyntax WrapWithTaskFromResult(ExpressionSyntax expression)
+            {
+                return (ExpressionSyntax)
+                    _generator.InvocationExpression(
+                        _generator.MemberAccessExpression(
+                            _generator.TypeExpression(_taskType), nameof(Task.FromResult)),
+                            expression);
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2780,4 +2780,7 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Property_reference_cannot_be_updated" xml:space="preserve">
     <value>Property reference cannot be updated</value>
   </data>
+  <data name="Remove_async_modifier" xml:space="preserve">
+    <value>Remove async modifier</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/RemoveAsyncModifier/AbstractRemoveAsyncModifierCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveAsyncModifier/AbstractRemoveAsyncModifierCodeFixProvider.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.MakeMethodAsynchronous.AbstractMakeMethodAsynchronousCodeFixProvider;
+
+namespace Microsoft.CodeAnalysis.RemoveAsyncModifier
+{
+    internal abstract class AbstractRemoveAsyncModifierCodeFixProvider : CodeFixProvider
+    {
+        public static readonly string EquivalenceKey = FeaturesResources.Remove_async_modifier;
+
+        protected abstract bool IsAsyncSupportingFunctionSyntax(SyntaxNode node);
+        protected abstract SyntaxNode RemoveAsyncModifier(IMethodSymbol methodSymbolOpt, SyntaxNode node, KnownTypes knownTypes);
+        protected abstract SyntaxNode ChangeReturnStatements(SyntaxNode node, SyntaxGenerator generator, KnownTypes knownTypes);
+        protected virtual bool CanFix(KnownTypes knownTypes, IMethodSymbol methodSymbolOpt) => true;
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var compilation = await context.Document.Project.GetCompilationAsync(context.CancellationToken).ConfigureAwait(false);
+            var knownTypes = new KnownTypes(compilation);
+
+            var diagnostic = context.Diagnostics.First();
+            var token = diagnostic.Location.FindToken(context.CancellationToken);
+            var node = token.GetAncestor(IsAsyncSupportingFunctionSyntax);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var declaredSymbol = semanticModel.GetDeclaredSymbol(node);
+
+            if (declaredSymbol == null || (declaredSymbol is IMethodSymbol methodSymbolOpt &&
+                !methodSymbolOpt.ReturnsVoid &&
+                CanFix(knownTypes, methodSymbolOpt)))
+            {
+                context.RegisterCodeFix(
+                    new MyCodeAction(c => FixNodeAsync(context.Document, diagnostic, c)),
+                    context.Diagnostics);
+            }
+        }
+
+        private async Task<Document> FixNodeAsync(
+            Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var token = diagnostic.Location.FindToken(cancellationToken);
+            var node = token.GetAncestor(IsAsyncSupportingFunctionSyntax);
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var methodSymbolOpt = semanticModel.GetDeclaredSymbol(node, cancellationToken) as IMethodSymbol;
+
+            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var knownTypes = new KnownTypes(compilation);
+
+            var newNode = RemoveAsyncModifier(methodSymbolOpt, node, knownTypes);
+
+            var generator = SyntaxGenerator.GetGenerator(document);
+
+            newNode = ChangeReturnStatements(newNode, generator, knownTypes);
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var newRoot = root.ReplaceNode(node, newNode);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Remove_async_modifier, createChangedDocument, AbstractRemoveAsyncModifierCodeFixProvider.EquivalenceKey)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Podpisy souvisejících metod nalezené v metadatech se nebudou aktualizovat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Místo {0} použijte {1}</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">In Metadaten gefundene ähnliche Methodensignaturen werden nicht aktualisiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">"{0}" durch "{1}" ersetzen</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Las signaturas de método relacionadas encontradas en los metadatos no se actualizarán.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Reemplazar "{0}" por "{1}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Les signatures de méthode associées dans les métadonnées ne sont pas mises à jour.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Remplacer '{0}' par '{1}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Le firme del metodo correlate trovate nei metadati non verranno aggiornate.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Sostituisci '{0}' con '{1}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">メタデータ内に検出される関連するメソッド シグネチャは更新されません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">'{0}' を '{1}' に置き換える</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">메타데이터에서 찾은 관련 메서드 시그니처가 업데이트되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">'{0}'을(를) '{1}'(으)로 바꾸기</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Sygnatury powiązanych metod znalezione w metadanych nie zostaną zaktualizowane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Zamień element „{0}” na element „{1}”</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">As assinaturas de método relacionadas encontradas nos metadados não serão atualizadas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Substituir '{0}' por '{1}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Связанные сигнатуры методов, найденные в метаданных, не будут обновлены.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">Замените '{0}' на '{1}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Meta verilerde bulunan ilgili metot imzaları güncelleştirilmez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">'{0}' öğesini '{1}' ile değiştir</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">不更新在元数据中发现的相关方法签名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">将 "{0}" 替换为 "{1}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -1785,6 +1785,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">將不會更新中繼資料中所找到的相關方法簽章。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_async_modifier">
+        <source>Remove async modifier</source>
+        <target state="new">Remove async modifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Replace_0_with_1">
         <source>Replace '{0}' with '{1}' </source>
         <target state="translated">將 ‘{0}’ 取代為 ‘{1}'</target>

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsPopulateSwitch = "CodeActions.PopulateSwitch";
             public const string CodeActionsPullMemberUp = "CodeActions.PullMemberUp";
             public const string CodeActionsQualifyMemberAccess = "CodeActions.QualifyMemberAccess";
+            public const string CodeActionsRemoveAsyncModifier = "CodeActions.RemoveAsyncModifier";
             public const string CodeActionsRemoveByVal = "CodeActions.RemoveByVal";
             public const string CodeActionsRemoveDocCommentNode = "CodeActions.RemoveDocCommentNode";
             public const string CodeActionsRemoveInKeyword = "CodeActions.RemoveInKeyword";


### PR DESCRIPTION
Fixes #43445

This is a new code fix for CS1998 that offers to remove the async modifier from the offending code, and rewrites the body as necessary to return either `Task.CompletedTask` or `Task.FromResult(<expr>)` as appropriate.

![image](https://user-images.githubusercontent.com/754264/86428132-61ca9380-bd2f-11ea-857e-2691e76c46ae.png)

Creating this as a draft to get some eyes on it before I continue with the remaining work.

Remaining work:
[ ] VB implementation and tests
[ ] Use code flow to insert a `return Task.CompletedTask;` at the end of a method as apprpriate

Potential future (separate work):
Might be nice to have an analyzer to trigger this if the only `await` in an async method is the last statement, so avoid allocating an async state machine.