### PR TITLE
Align addition of a synthesized record.Equals(record? other) in records with the latest design.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6292,4 +6292,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_ConstOutOfRangeChecked_Title" xml:space="preserve">
     <value>Constant value may overflow at runtime (use 'unchecked' syntax to override)</value>
   </data>
+  <data name="ERR_NotOverridableAPIInRecord" xml:space="preserve">
+    <value>'{0}' disallows overriding and containing 'record' is not sealed.</value>
+  </data>
+  <data name="ERR_NonPublicAPIInRecord" xml:space="preserve">
+    <value>Record member '{0}' must be public.</value>
+  </data>
+  <data name="ERR_SignatureMismatchInRecord" xml:space="preserve">
+    <value>Record member '{0}' must return '{1}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1858,6 +1858,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DoesNotOverrideMethodFromObject = 8869,
         ERR_SealedGetHashCodeInRecord = 8870,
         ERR_DoesNotOverrideBaseEquals = 8871,
+        ERR_NotOverridableAPIInRecord = 8872,
+        ERR_NonPublicAPIInRecord = 8873,
+        ERR_SignatureMismatchInRecord = 8874,
 
         #endregion diagnostics introduced for C# 9.0
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2998,15 +2998,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             addCloneMethod();
 
             PropertySymbol equalityContract = addEqualityContract();
-            var otherEqualsMethods = ArrayBuilder<MethodSymbol>.GetInstance();
-            getOtherEquals(otherEqualsMethods, equalityContract);
 
-            var thisEquals = addThisEquals(equalityContract, otherEqualsMethod: otherEqualsMethods.Count == 0 ? null : otherEqualsMethods[0]);
+            var thisEquals = addThisEquals(equalityContract);
             addOtherEquals();
             addObjectEquals(thisEquals);
             addHashCode(equalityContract);
 
-            otherEqualsMethods.Free();
             memberSignatures.Free();
 
 
@@ -3165,49 +3162,76 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             PropertySymbol addEqualityContract()
             {
-                var property = new SynthesizedRecordEqualityContractProperty(this, isOverride: SynthesizedRecordClone.FindValidCloneMethod(BaseTypeNoUseSiteDiagnostics) is object);
+                var targetProperty = new SignatureOnlyPropertySymbol(SynthesizedRecordEqualityContractProperty.PropertyName,
+                                                                     this,
+                                                                     ImmutableArray<ParameterSymbol>.Empty,
+                                                                     RefKind.None,
+                                                                     TypeWithAnnotations.Create(compilation.GetWellKnownType(WellKnownType.System_Type)),
+                                                                     ImmutableArray<CustomModifier>.Empty,
+                                                                     isStatic: false,
+                                                                     ImmutableArray<PropertySymbol>.Empty);
+
                 // https://github.com/dotnet/roslyn/issues/44903: Check explicit member has expected signature.
-                if (!memberSignatures.ContainsKey(property))
+                if (!memberSignatures.TryGetValue(targetProperty, out Symbol? existingEqualityContractProperty))
                 {
+                    var property = new SynthesizedRecordEqualityContractProperty(this, isOverride: SynthesizedRecordClone.FindValidCloneMethod(BaseTypeNoUseSiteDiagnostics) is object);
                     members.Add(property);
                     members.Add(property.GetMethod);
+                    return property;
                 }
-                return property;
+
+                return (PropertySymbol)existingEqualityContractProperty;
             }
 
-            MethodSymbol addThisEquals(PropertySymbol equalityContract, MethodSymbol? otherEqualsMethod)
+            MethodSymbol addThisEquals(PropertySymbol equalityContract)
             {
-                var thisEquals = new SynthesizedRecordEquals(this, parameterType: this, isOverride: false, equalityContract, otherEqualsMethod, memberOffset: members.Count);
-                if (!memberSignatures.TryGetValue(thisEquals, out var existing))
+                var targetMethod = new SignatureOnlyMethodSymbol(
+                    WellKnownMemberNames.ObjectEquals,
+                    this,
+                    MethodKind.Ordinary,
+                    Cci.CallingConvention.HasThis,
+                    ImmutableArray<TypeParameterSymbol>.Empty,
+                    ImmutableArray.Create<ParameterSymbol>(new SignatureOnlyParameterSymbol(
+                                                                TypeWithAnnotations.Create(this),
+                                                                ImmutableArray<CustomModifier>.Empty,
+                                                                isParams: false,
+                                                                RefKind.None
+                                                                )),
+                    RefKind.None,
+                    isInitOnly: false,
+                    TypeWithAnnotations.Create(compilation.GetSpecialType(SpecialType.System_Boolean)),
+                    ImmutableArray<CustomModifier>.Empty,
+                    ImmutableArray<MethodSymbol>.Empty);
+
+                MethodSymbol thisEquals;
+
+                if (!memberSignatures.TryGetValue(targetMethod, out Symbol? existingEqualsMethod))
                 {
+                    thisEquals = new SynthesizedRecordEquals(this, equalityContract, memberOffset: members.Count, diagnostics);
                     members.Add(thisEquals);
-                    return thisEquals;
                 }
-                return (MethodSymbol)existing;
-            }
-
-            static void getOtherEquals(ArrayBuilder<MethodSymbol> otherEqualsMethods, PropertySymbol equalityContract)
-            {
-                while ((equalityContract = equalityContract.OverriddenProperty) is object)
+                else
                 {
-                    var member = equalityContract.ContainingType.GetMembers("Equals").FirstOrDefault(m =>
+                    thisEquals = (MethodSymbol)existingEqualsMethod;
+
+                    if (thisEquals.DeclaredAccessibility != Accessibility.Public)
                     {
-                        if (m is MethodSymbol method)
-                        {
-                            var parameters = method.Parameters;
-                            if (parameters.Length == 1 && parameters[0].Type.Equals(m.ContainingType, TypeCompareKind.AllIgnoreOptions))
-                            {
-                                return true;
-                            }
-                        }
-                        return false;
-                    });
-                    // https://github.com/dotnet/roslyn/issues/44903: Check explicit member has expected signature.
-                    if (member is MethodSymbol method)
+                        diagnostics.Add(ErrorCode.ERR_NonPublicAPIInRecord, thisEquals.Locations[0], thisEquals);
+                    }
+
+                    if (thisEquals.ReturnType.SpecialType != SpecialType.System_Boolean && !thisEquals.ReturnType.IsErrorType())
                     {
-                        otherEqualsMethods.Add(method);
+                        diagnostics.Add(ErrorCode.ERR_SignatureMismatchInRecord, thisEquals.Locations[0], thisEquals, targetMethod.ReturnType);
+                    }
+
+                    if (!IsSealed &&
+                        ((!thisEquals.IsAbstract && !thisEquals.IsVirtual && !thisEquals.IsOverride) || thisEquals.IsSealed))
+                    {
+                        diagnostics.Add(ErrorCode.ERR_NotOverridableAPIInRecord, thisEquals.Locations[0], thisEquals);
                     }
                 }
+
+                return thisEquals;
             }
 
             void addOtherEquals()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1283,7 +1283,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         //can actually get both, so don't use else if
                         if (!hidingMemberIsNew && hiddenMember.Kind == hidingMember.Kind &&
                             !hidingMember.IsAccessor() &&
-                            (hiddenMember.IsAbstract || hiddenMember.IsVirtual || hiddenMember.IsOverride))
+                            (hiddenMember.IsAbstract || hiddenMember.IsVirtual || hiddenMember.IsOverride) &&
+                            !(hidingMember is SynthesizedRecordEquals))
                         {
                             diagnostics.Add(ErrorCode.WRN_NewOrOverrideExpected, hidingMemberLocation, hidingMember, hiddenMember);
                             diagnosticAdded = true;
@@ -1296,7 +1297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
 
-                if (!hidingMemberIsNew && !diagnosticAdded && !hidingMember.IsAccessor() && !hidingMember.IsOperator())
+                if (!hidingMemberIsNew && !(hidingMember is SynthesizedRecordEquals) && !diagnosticAdded && !hidingMember.IsAccessor() && !hidingMember.IsOperator())
                 {
                     diagnostics.Add(ErrorCode.WRN_NewRequired, hidingMemberLocation, hidingMember, hiddenMembers[0]);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordBaseEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordBaseEquals.cs
@@ -51,11 +51,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var overridden = OverriddenMethod;
 
-            if (overridden is null)
-            {
-                return;
-            }
-
             if (overridden is object &&
                 !overridden.ContainingType.Equals(ContainingType.BaseTypeNoUseSiteDiagnostics, TypeCompareKind.AllIgnoreOptions))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEquals.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -15,155 +16,42 @@ using Microsoft.CodeAnalysis.PooledObjects;
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
-    /// A strongly-typed `public bool Equals(T other)` method.
-    /// There are two types of strongly-typed Equals methods:
-    /// the strongly-typed virtual method where T is the containing type; and
-    /// overrides of the strongly-typed virtual methods from base record types.
+    /// Unless explicitly declared,  a record includes a synthesized strongly-typed overload
+    /// of `Equals(R? other)` where `R` is the record type.
+    /// The method is `public`, and the method is `virtual` unless the record type is `sealed`.
     /// </summary>
-    internal sealed class SynthesizedRecordEquals : SynthesizedInstanceMethodSymbol
+    internal sealed class SynthesizedRecordEquals : SynthesizedRecordOrdinaryMethod
     {
         private readonly PropertySymbol _equalityContract;
-        private readonly MethodSymbol? _otherEqualsMethod;
-        private readonly int _memberOffset;
 
-        public override NamedTypeSymbol ContainingType { get; }
-
-        public SynthesizedRecordEquals(
-            NamedTypeSymbol containingType,
-            TypeSymbol parameterType,
-            bool isOverride,
-            PropertySymbol equalityContract,
-            MethodSymbol? otherEqualsMethod,
-            int memberOffset)
+        public SynthesizedRecordEquals(SourceMemberContainerTypeSymbol containingType, PropertySymbol equalityContract, int memberOffset, DiagnosticBag diagnostics)
+            : base(containingType, WellKnownMemberNames.ObjectEquals, memberOffset, diagnostics)
         {
-            // If the parameter is a struct type, it should be declared `in`
-            // and we need to call EnsureIsReadOnlyAttributeExists().
-            Debug.Assert(!parameterType.IsStructType());
-
-            var compilation = containingType.DeclaringCompilation;
-
             _equalityContract = equalityContract;
-            _otherEqualsMethod = otherEqualsMethod;
-            _memberOffset = memberOffset;
-
-            ContainingType = containingType;
-            IsVirtual = !isOverride;
-            IsOverride = isOverride;
-            Parameters = ImmutableArray.Create(SynthesizedParameterSymbol.Create(
-                this,
-                TypeWithAnnotations.Create(parameterType, nullableAnnotation: NullableAnnotation.Annotated),
-                ordinal: 0,
-                RefKind.None));
-            ReturnTypeWithAnnotations = TypeWithAnnotations.Create(compilation.GetSpecialType(SpecialType.System_Boolean));
         }
 
-        public override string Name => "Equals";
+        protected override DeclarationModifiers MakeDeclarationModifiers(DeclarationModifiers allowedModifiers, DiagnosticBag diagnostics)
+        {
+            DeclarationModifiers result = DeclarationModifiers.Public | (ContainingType.IsSealed ? DeclarationModifiers.None : DeclarationModifiers.Virtual);
+            Debug.Assert((result & ~allowedModifiers) == 0);
+            return result;
+        }
 
-        public override MethodKind MethodKind => MethodKind.Ordinary;
+        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation) MakeParametersAndBindReturnType(DiagnosticBag diagnostics)
+        {
+            var compilation = DeclaringCompilation;
+            var location = ReturnTypeLocation;
+            return (ReturnType: TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Boolean, location, diagnostics)),
+                    Parameters: ImmutableArray.Create<ParameterSymbol>(
+                                    new SourceSimpleParameterSymbol(owner: this,
+                                                                    TypeWithAnnotations.Create(ContainingType, NullableAnnotation.Annotated),
+                                                                    ordinal: 0, RefKind.None, "", isDiscard: false, Locations)),
+                    IsVararg: false,
+                    DeclaredConstraintsForOverrideOrImplementation: ImmutableArray<TypeParameterConstraintClause>.Empty);
+        }
 
-        public override int Arity => 0;
+        protected override int GetParameterCountFromSyntax() => 1;
 
-        public override bool IsExtensionMethod => false;
-
-        public override bool HidesBaseMethodsByName => true;
-
-        public override bool IsVararg => false;
-
-        public override bool ReturnsVoid => false;
-
-        public override bool IsAsync => false;
-
-        public override RefKind RefKind => RefKind.None;
-
-        public override ImmutableArray<ParameterSymbol> Parameters { get; }
-
-        public override TypeWithAnnotations ReturnTypeWithAnnotations { get; }
-
-        public override FlowAnalysisAnnotations ReturnTypeFlowAnalysisAnnotations => FlowAnalysisAnnotations.None;
-
-        public override ImmutableHashSet<string> ReturnNotNullIfParameterNotNull => ImmutableHashSet<string>.Empty;
-
-        public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
-            => ImmutableArray<TypeWithAnnotations>.Empty;
-
-        public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
-
-        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
-
-        public override ImmutableArray<CustomModifier> RefCustomModifiers => ImmutableArray<CustomModifier>.Empty;
-
-        public override Symbol? AssociatedSymbol => null;
-
-        public override Symbol ContainingSymbol => ContainingType;
-
-        public override ImmutableArray<Location> Locations => ContainingType.Locations;
-
-        public override Accessibility DeclaredAccessibility => Accessibility.Public;
-
-        public override bool IsStatic => false;
-
-        public override bool IsVirtual { get; }
-
-        public override bool IsOverride { get; }
-
-        public override bool IsAbstract => false;
-
-        public override bool IsSealed => false;
-
-        public override bool IsExtern => false;
-
-        internal override bool HasSpecialName => false;
-
-        internal override LexicalSortKey GetLexicalSortKey() => LexicalSortKey.GetSynthesizedMemberKey(_memberOffset);
-
-        internal override MethodImplAttributes ImplementationAttributes => MethodImplAttributes.Managed;
-
-        internal override bool HasDeclarativeSecurity => false;
-
-        internal override MarshalPseudoCustomAttributeData? ReturnValueMarshallingInformation => null;
-
-        internal override bool RequiresSecurityObject => false;
-
-        internal override CallingConvention CallingConvention => CallingConvention.HasThis;
-
-        internal override bool GenerateDebugInfo => false;
-
-        public override DllImportData? GetDllImportData() => null;
-
-        internal override ImmutableArray<string> GetAppliedConditionalSymbols()
-            => ImmutableArray<string>.Empty;
-
-        internal override IEnumerable<SecurityAttribute> GetSecurityInformation()
-            => Array.Empty<SecurityAttribute>();
-
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => !IsOverride;
-
-        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => true;
-
-        internal override bool SynthesizesLoweredBoundBody => true;
-
-        // Consider the following types:
-        //   record A(int X);
-        //   record B(int X, int Y) : A(X);
-        //   record C(int X, int Y, int Z) : B(X, Y);
-        //
-        // Each record class defines a strongly-typed Equals method, with derived
-        // types overriding the methods from base classes:
-        //   class A
-        //   {
-        //       public virtual bool Equals(A other) => other != null && EqualityContract == other.EqualityContract && X == other.X;
-        //   }
-        //   class B : A
-        //   {
-        //       public virtual bool Equals(B other) => base.Equals((A)other) && Y == other.Y;
-        //       public override bool Equals(A other) => Equals(other as B);
-        //   }
-        //   class C : B
-        //   {
-        //       public virtual bool Equals(C other) => base.Equals((B)other) && Z == other.Z;
-        //       public override bool Equals(B other) => Equals(other as C);
-        //       public override bool Equals(A other) => Equals(other as C);
-        //   }
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             var F = new SyntheticBoundNodeFactory(this, ContainingType.GetNonNullSyntaxNode(), compilationState, diagnostics);
@@ -173,87 +61,77 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = F.Parameter(Parameters[0]);
                 BoundExpression? retExpr;
 
-                if (IsOverride)
+                // This method is the strongly-typed Equals method where the parameter type is
+                // the containing type.
+
+                if (ContainingType.BaseTypeNoUseSiteDiagnostics.IsObjectType())
                 {
-                    // This method is an override of a strongly-typed Equals method from a base record type.
-                    // The definition of the method is as follows, and _otherEqualsMethod
-                    // is the method to delegate to (see B.Equals(A), C.Equals(A), C.Equals(B) above):
+                    // https://github.com/dotnet/roslyn/issues/45296 Deal with type mismatch for the EqualityContract
+
+                    // There are no base record types.
+                    // The definition of the method is as follows
                     //
-                    // override bool Equals(Base other) => Equals(other as Derived);
-                    retExpr = F.Call(
-                        F.This(),
-                        _otherEqualsMethod!,
-                        F.As(other, ContainingType));
+                    // virtual bool Equals(T other) =>
+                    //     other != null &&
+                    //     EqualityContract == other.EqualityContract &&
+                    //     field1 == other.field1 && ... && fieldN == other.fieldN;
+
+                    // other != null
+                    Debug.Assert(!other.Type.IsStructType());
+                    retExpr = F.ObjectNotEqual(other, F.Null(F.SpecialType(SpecialType.System_Object)));
+
+                    // EqualityContract == other.EqualityContract
+                    var contractsEqual = F.Call(receiver: null, F.WellKnownMethod(WellKnownMember.System_Type__op_Equality),
+                                                F.Property(F.This(), _equalityContract),
+                                                F.Property(other, _equalityContract));
+
+                    retExpr = retExpr is null ? (BoundExpression)contractsEqual : F.LogicalAnd(retExpr, contractsEqual);
                 }
                 else
                 {
-                    // This method is the strongly-typed Equals method where the parameter type is
-                    // the containing type.
+                    MethodSymbol? baseEquals = ContainingType.GetMembersUnordered().OfType<SynthesizedRecordBaseEquals>().Single().OverriddenMethod;
 
-                    if (_otherEqualsMethod is null)
+                    if (baseEquals is null || !baseEquals.ContainingType.Equals(ContainingType.BaseTypeNoUseSiteDiagnostics, TypeCompareKind.AllIgnoreOptions) ||
+                        baseEquals.ReturnType.SpecialType != SpecialType.System_Boolean)
                     {
-                        // There are no base record types.
-                        // The definition of the method is as follows (see A.Equals(A) above):
-                        //
-                        // virtual bool Equals(T other) =>
-                        //     other != null &&
-                        //     EqualityContract == other.EqualityContract &&
-                        //     field1 == other.field1 && ... && fieldN == other.fieldN;
-
-                        // other != null
-                        Debug.Assert(!other.Type.IsStructType());
-                        retExpr = F.ObjectNotEqual(other, F.Null(F.SpecialType(SpecialType.System_Object)));
-
-                        // EqualityContract == other.EqualityContract
-                        var contractsEqual = F.Call(receiver: null, F.WellKnownMethod(WellKnownMember.System_Type__op_Equality),
-                                                    F.Property(F.This(), _equalityContract),
-                                                    F.Property(other, _equalityContract));
-
-                        retExpr = retExpr is null ? (BoundExpression)contractsEqual : F.LogicalAnd(retExpr, contractsEqual);
-                    }
-                    else
-                    {
-                        if (_otherEqualsMethod.ReturnType.SpecialType != SpecialType.System_Boolean)
-                        {
-                            // There was a problem with overriding, an error was reported elsewhere
-                            F.CloseMethod(F.ThrowNull());
-                            return;
-                        }
-
-                        // There are base record types.
-                        // The definition of the method is as follows, and _otherEqualsMethod
-                        // is the corresponding method on the nearest base record type to
-                        // delegate to (see B.Equals(B), C.Equals(C) above):
-                        //
-                        // virtual bool Equals(Derived other) =>
-                        //     base.Equals((Base)other) &&
-                        //     field1 == other.field1 && ... && fieldN == other.fieldN;
-                        retExpr = F.Call(
-                            F.Base(_otherEqualsMethod.ContainingType),
-                            _otherEqualsMethod!,
-                            F.Convert(_otherEqualsMethod.Parameters[0].Type, other));
+                        // There was a problem with overriding of base equals, an error was reported elsewhere
+                        F.CloseMethod(F.ThrowNull());
+                        return;
                     }
 
-                    // field1 == other.field1 && ... && fieldN == other.fieldN
-                    // https://github.com/dotnet/roslyn/issues/44895: Should compare fields from non-record base classes.
-                    var fields = ArrayBuilder<FieldSymbol>.GetInstance();
-                    foreach (var f in ContainingType.GetFieldsToEmit())
-                    {
-                        if (!f.IsStatic)
-                        {
-                            fields.Add(f);
-                        }
-                    }
-                    if (fields.Count > 0)
-                    {
-                        retExpr = MethodBodySynthesizer.GenerateFieldEquals(
-                            retExpr,
-                            other,
-                            fields,
-                            F);
-                    }
-                    fields.Free();
+                    // There are base record types.
+                    // The definition of the method is as follows, and baseEquals
+                    // is the corresponding method on the nearest base record type to
+                    // delegate to:
+                    //
+                    // virtual bool Equals(Derived other) =>
+                    //     base.Equals((Base)other) &&
+                    //     field1 == other.field1 && ... && fieldN == other.fieldN;
+                    retExpr = F.Call(
+                        F.Base(baseEquals.ContainingType),
+                        baseEquals,
+                        F.Convert(baseEquals.Parameters[0].Type, other));
                 }
+
+                // field1 == other.field1 && ... && fieldN == other.fieldN
+                var fields = ArrayBuilder<FieldSymbol>.GetInstance();
+                foreach (var f in ContainingType.GetFieldsToEmit())
+                {
+                    if (!f.IsStatic)
+                    {
+                        fields.Add(f);
+                    }
+                }
+                if (fields.Count > 0)
+                {
+                    retExpr = MethodBodySynthesizer.GenerateFieldEquals(
+                        retExpr,
+                        other,
+                        fields,
+                        F);
+                }
+
+                fields.Free();
 
                 F.CloseMethod(F.Block(F.Return(retExpr)));
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
@@ -100,8 +100,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static void ensureEqualityComparerHelpers(SyntheticBoundNodeFactory F, ref MethodSymbol? equalityComparer_GetHashCode, ref MethodSymbol? equalityComparer_get_Default)
             {
-                equalityComparer_GetHashCode ??= F.WellKnownMethod(WellKnownMember.System_Collections_Generic_EqualityComparer_T__GetHashCode, isOptional: false)!;
-                equalityComparer_get_Default ??= F.WellKnownMethod(WellKnownMember.System_Collections_Generic_EqualityComparer_T__get_Default, isOptional: false)!;
+                equalityComparer_GetHashCode ??= F.WellKnownMethod(WellKnownMember.System_Collections_Generic_EqualityComparer_T__GetHashCode);
+                equalityComparer_get_Default ??= F.WellKnownMethod(WellKnownMember.System_Collections_Generic_EqualityComparer_T__get_Default);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
@@ -54,6 +54,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
+                    if (_typedRecordEquals.ReturnType.SpecialType != SpecialType.System_Boolean)
+                    {
+                        // There is a signature mismatch, an error was reported elsewhere
+                        F.CloseMethod(F.ThrowNull());
+                        return;
+                    }
+
                     // For classes:
                     //      return this.Equals(param as ContainingType);
                     expression = F.Call(F.This(), _typedRecordEquals, F.As(paramAccess, ContainingType));

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Očekávala se hodnota enable, disable nebo restore.</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">"enable", "disable" oder "restore" erwartet.</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Se esperaba "enable", "disable" o "restore".</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable', 'disable' ou 'restore' attendu</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">È previsto 'enable', 'disable' o 'restore'</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable'、'disable'、'restore' のいずれかが必要でした</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable', 'disable' 또는 'restore'가 필요합니다.</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Oczekiwano opcji „enable”, „disable” lub „restore”</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Esperava-se 'enable', 'disable' ou 'restore'</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">Ожидается "enable", "disable" или "restore"</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">'enable', 'disable' veya 'restore' bekleniyor</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">应为 "enable"、"disable" 或 "restore"</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -532,6 +532,16 @@
         <target state="new">The receiver type '{0}' is not a valid record type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NonPublicAPIInRecord">
+        <source>Record member '{0}' must be public.</source>
+        <target state="new">Record member '{0}' must be public.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NotOverridableAPIInRecord">
+        <source>'{0}' disallows overriding and containing 'record' is not sealed.</source>
+        <target state="new">'{0}' disallows overriding and containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
         <source>Expected 'enable', 'disable', or 'restore'</source>
         <target state="translated">應為 'enable'、'disable' 或 'restore'</target>
@@ -670,6 +680,11 @@
       <trans-unit id="ERR_SealedGetHashCodeInRecord">
         <source>'{0}' cannot be sealed because containing 'record' is not sealed.</source>
         <target state="new">'{0}' cannot be sealed because containing 'record' is not sealed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SignatureMismatchInRecord">
+        <source>Record member '{0}' must return '{1}'.</source>
+        <target state="new">Record member '{0}' must return '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SimpleProgramDisallowsMainType">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -5061,7 +5061,7 @@ class Program
 
       IL_0000: ldnull
       IL_0001: throw
-  } // end of method A::Equals
+  } // end of method B::Equals
 }";
             var refA = CompileIL(sourceA);
 
@@ -8446,6 +8446,80 @@ public record B : A {
         }
 
         [Fact]
+        public void ObjectEquals_05()
+        {
+            var source0 =
+@"namespace System
+{
+    public class Object
+    {
+        public virtual int Equals(object other) => default;
+        public virtual int GetHashCode() => default;
+    }
+    public class String { }
+    public abstract class ValueType { }
+    public struct Void { }
+    public struct Boolean { }
+    public struct Int32 { }
+    public interface IEquatable<T>
+    {
+        bool Equals(T other);
+    }
+}
+";
+            var comp = CreateEmptyCompilation(source0);
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source1 =
+@"
+public record A {
+}
+";
+            comp = CreateEmptyCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (2,15): error CS0508: 'A.Equals(object?)': return type must be 'int' to match overridden member 'object.Equals(object)'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "A").WithArguments("A.Equals(object?)", "object.Equals(object)", "int").WithLocation(2, 15),
+
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Byte' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Byte").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", ".ctor").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.AllowMultiple'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "AllowMultiple").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.Inherited'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "Inherited").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Byte' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Byte").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", ".ctor").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.AllowMultiple'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "AllowMultiple").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.Inherited'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "Inherited").WithLocation(1, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"public record A {
+}").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(2, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Collections.Generic.EqualityComparer`1.GetHashCode'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"public record A {
+}").WithArguments("System.Collections.Generic.EqualityComparer`1", "GetHashCode").WithLocation(2, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Type.op_Equality'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"public record A {
+}").WithArguments("System.Type", "op_Equality").WithLocation(2, 1)
+                );
+        }
+
+        [Fact]
         public void ObjectGetHashCode_01()
         {
             var ilSource = @"
@@ -9432,6 +9506,80 @@ public record A {
         }
 
         [Fact]
+        public void ObjectGetHashCode_17()
+        {
+            var source0 =
+@"namespace System
+{
+    public class Object
+    {
+        public virtual bool Equals(object other) => false;
+        public virtual bool GetHashCode() => default;
+    }
+    public class String { }
+    public abstract class ValueType { }
+    public struct Void { }
+    public struct Boolean { }
+    public struct Int32 { }
+    public interface IEquatable<T>
+    {
+        bool Equals(T other);
+    }
+}
+";
+            var comp = CreateEmptyCompilation(source0);
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source1 =
+@"
+public record A {
+}
+";
+            comp = CreateEmptyCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (2,15): error CS0508: 'A.GetHashCode()': return type must be 'bool' to match overridden member 'object.GetHashCode()'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "A").WithArguments("A.GetHashCode()", "object.GetHashCode()", "bool").WithLocation(2, 15),
+
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Byte' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Byte").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", ".ctor").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.AllowMultiple'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "AllowMultiple").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.Inherited'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "Inherited").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Byte' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Byte").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", ".ctor").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.AllowMultiple'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "AllowMultiple").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.Inherited'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "Inherited").WithLocation(1, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"public record A {
+}").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(2, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Collections.Generic.EqualityComparer`1.GetHashCode'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"public record A {
+}").WithArguments("System.Collections.Generic.EqualityComparer`1", "GetHashCode").WithLocation(2, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Type.op_Equality'
+                // public record A {
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"public record A {
+}").WithArguments("System.Type", "op_Equality").WithLocation(2, 1)
+                );
+        }
+
+        [Fact]
         public void BaseEquals_01()
         {
             var ilSource = @"
@@ -9860,7 +10008,7 @@ public record B : A {
 
         IL_0000: ldnull
         IL_0001: throw
-    } // end of method A::.ctor
+    } // end of method B::.ctor
 
     .method public hidebysig specialname rtspecialname 
         instance void .ctor () cil managed 
@@ -9918,6 +10066,586 @@ record B : A
                 //     public override bool Equals(A x) => throw null;
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Equals").WithArguments("Equals", "B").WithLocation(8, 26)
                 );
+        }
+
+        [Fact]
+        public void RecordEquals_01()
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(A x);
+}
+record B : A
+{
+    public virtual bool Equals(B other) => Report(""B.Equals(B)"");
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        A a2 = new B();
+
+        System.Console.WriteLine(a1.Equals(a2));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+B.Equals(B)
+False
+");
+        }
+
+        [Fact]
+        public void RecordEquals_02()
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(B x);
+}
+record B : A
+{
+    public override bool Equals(B other) => Report(""B.Equals(B)"");
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        B b2 = new B();
+
+        System.Console.WriteLine(a1.Equals(b2));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+B.Equals(B)
+False
+");
+            var recordEquals = comp.GetMembers("A.Equals").OfType<SynthesizedRecordEquals>().Single();
+            Assert.Equal("System.Boolean A.Equals(A? )", recordEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, recordEquals.DeclaredAccessibility);
+            Assert.False(recordEquals.IsAbstract);
+            Assert.True(recordEquals.IsVirtual);
+            Assert.False(recordEquals.IsOverride);
+            Assert.False(recordEquals.IsSealed);
+            Assert.True(recordEquals.IsImplicitlyDeclared);
+        }
+
+        [Fact]
+        public void RecordEquals_03()
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(B x);
+}
+record B : A
+{
+    public sealed override bool Equals(B other) => Report(""B.Equals(B)"");
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (9,33): error CS8872: 'B.Equals(B)' disallows overriding and containing 'record' is not sealed.
+                //     public sealed override bool Equals(B other) => Report("B.Equals(B)");
+                Diagnostic(ErrorCode.ERR_NotOverridableAPIInRecord, "Equals").WithArguments("B.Equals(B)").WithLocation(9, 33)
+                );
+        }
+
+        [Fact]
+        public void RecordEquals_04()
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(B x);
+}
+sealed record B : A
+{
+    public sealed override bool Equals(B other) => Report(""B.Equals(B)"");
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        B b2 = new B();
+
+        System.Console.WriteLine(a1.Equals(b2));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+B.Equals(B)
+False
+");
+        }
+
+        [Fact]
+        public void RecordEquals_05()
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(B x);
+}
+abstract record B : A
+{
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (7,17): error CS0533: 'B.Equals(B?)' hides inherited abstract member 'A.Equals(B)'
+                // abstract record B : A
+                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "B").WithArguments("B.Equals(B?)", "A.Equals(B)").WithLocation(7, 17)
+                );
+
+            var recordEquals = comp.GetMembers("B.Equals").OfType<SynthesizedRecordEquals>().Single();
+            Assert.Equal("System.Boolean B.Equals(B? )", recordEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, recordEquals.DeclaredAccessibility);
+            Assert.False(recordEquals.IsAbstract);
+            Assert.True(recordEquals.IsVirtual);
+            Assert.False(recordEquals.IsOverride);
+            Assert.False(recordEquals.IsSealed);
+            Assert.True(recordEquals.IsImplicitlyDeclared);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("sealed ")]
+        public void RecordEquals_06(string modifiers)
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(B x);
+}
+" + modifiers + @"
+record B : A
+{
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (8,8): error CS0534: 'B' does not implement inherited abstract member 'A.Equals(B)'
+                // record B : A
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.Equals(B)").WithLocation(8, 8)
+                );
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("sealed ")]
+        public void RecordEquals_07(string modifiers)
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public virtual bool Equals(B x) => Report(""A.Equals(B)"");
+}
+" + modifiers + @"
+record B : A
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        B b2 = new B();
+
+        System.Console.WriteLine(a1.Equals(b2));
+        System.Console.WriteLine(b2.Equals(a1));
+        System.Console.WriteLine(b2.Equals((B)a1));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+A.Equals(B)
+False
+True
+True
+");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("sealed ")]
+        public void RecordEquals_08(string modifiers)
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public abstract bool Equals(C x);
+}
+record B : A
+{
+    public override bool Equals(C x) => Report(""B.Equals(C)"");
+}
+" + modifiers + @"
+record C : B
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new C();
+        C c2 = new C();
+
+        System.Console.WriteLine(a1.Equals(c2));
+        System.Console.WriteLine(c2.Equals(a1));
+        System.Console.WriteLine(c2.Equals((C)a1));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+B.Equals(C)
+False
+True
+True
+");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("sealed ")]
+        public void RecordEquals_09(string modifiers)
+        {
+            var source =
+@"
+abstract record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public bool Equals(B x) => Report(""A.Equals(B)"");
+}
+" + modifiers + @"
+record B : A
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        B b2 = new B();
+
+        System.Console.WriteLine(a1.Equals(b2));
+        System.Console.WriteLine(b2.Equals(a1));
+        System.Console.WriteLine(b2.Equals((B)a1));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+A.Equals(B)
+False
+True
+True
+");
+        }
+
+        [Theory]
+        [InlineData("protected")]
+        [InlineData("internal")]
+        [InlineData("private protected")]
+        [InlineData("internal protected")]
+        public void RecordEquals_10(string accessibility)
+        {
+            var source =
+$@"
+record A
+{{
+    { accessibility } virtual bool Equals(A x)
+        => throw null;
+
+    bool System.IEquatable<A>.Equals(A x) => throw null;
+}}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (4,...): error CS8873: Record member 'A.Equals(A)' must be public.
+                //     { accessibility } virtual bool Equals(A x)
+                Diagnostic(ErrorCode.ERR_NonPublicAPIInRecord, "Equals").WithArguments("A.Equals(A)").WithLocation(4, 19 + accessibility.Length)
+                );
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("private")]
+        public void RecordEquals_11(string accessibility)
+        {
+            var source =
+$@"
+record A
+{{
+    { accessibility } virtual bool Equals(A x)
+        => throw null;
+
+    bool System.IEquatable<A>.Equals(A x) => throw null;
+}}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (4,...): error CS0621: 'A.Equals(A)': virtual or abstract members cannot be private
+                //      virtual bool Equals(A x)
+                Diagnostic(ErrorCode.ERR_VirtualPrivate, "Equals").WithArguments("A.Equals(A)").WithLocation(4, 19 + accessibility.Length),
+                // (4,...): error CS8873: Record member 'A.Equals(A)' must be public.
+                //     { accessibility } virtual bool Equals(A x)
+                Diagnostic(ErrorCode.ERR_NonPublicAPIInRecord, "Equals").WithArguments("A.Equals(A)").WithLocation(4, 19 + accessibility.Length)
+                );
+        }
+
+        [Fact]
+        public void RecordEquals_12()
+        {
+            var source =
+@"
+record A
+{
+    internal static bool Report(string s) { System.Console.WriteLine(s); return false; }
+    public virtual bool Equals(B other) => Report(""A.Equals(B)"");
+}
+class B
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new A();
+        A a2 = new A();
+
+        System.Console.WriteLine(a1.Equals(a2));
+        System.Console.WriteLine(a1.Equals((object)a2));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+True
+True
+");
+            var recordEquals = comp.GetMembers("A.Equals").OfType<SynthesizedRecordEquals>().Single();
+            Assert.Equal("System.Boolean A.Equals(A? )", recordEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, recordEquals.DeclaredAccessibility);
+            Assert.False(recordEquals.IsAbstract);
+            Assert.True(recordEquals.IsVirtual);
+            Assert.False(recordEquals.IsOverride);
+            Assert.False(recordEquals.IsSealed);
+            Assert.True(recordEquals.IsImplicitlyDeclared);
+        }
+
+        [Fact]
+        public void RecordEquals_13()
+        {
+            var source =
+@"
+record A
+{
+    public virtual int Equals(A other)
+        => throw null;
+
+    bool System.IEquatable<A>.Equals(A x) => throw null;
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (4,24): error CS8874: Record member 'A.Equals(A)' must return 'bool'.
+                //     public virtual int Equals(A other)
+                Diagnostic(ErrorCode.ERR_SignatureMismatchInRecord, "Equals").WithArguments("A.Equals(A)", "bool").WithLocation(4, 24)
+                );
+        }
+
+        [Fact]
+        public void RecordEquals_14()
+        {
+            var source =
+@"
+record A
+{
+    public virtual bool Equals(A other)
+        => throw null;
+
+    System.Boolean System.IEquatable<A>.Equals(A x) => throw null;
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.MakeTypeMissing(SpecialType.System_Boolean);
+            comp.VerifyEmitDiagnostics(
+                // (2,8): error CS0518: Predefined type 'System.Boolean' is not defined or imported
+                // record A
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "A").WithArguments("System.Boolean").WithLocation(2, 8),
+                // (4,20): error CS0518: Predefined type 'System.Boolean' is not defined or imported
+                //     public virtual bool Equals(A other)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(4, 20)
+                );
+        }
+
+        [Fact]
+        public void RecordEquals_15()
+        {
+            var source =
+@"
+record A
+{
+    public virtual Boolean Equals(A other)
+        => throw null;
+
+    bool System.IEquatable<A>.Equals(A x) => throw null;
+}
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll);
+            comp.VerifyEmitDiagnostics(
+                // (4,20): error CS0246: The type or namespace name 'Boolean' could not be found (are you missing a using directive or an assembly reference?)
+                //     public virtual Boolean Equals(A other)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Boolean").WithArguments("Boolean").WithLocation(4, 20)
+                );
+        }
+
+        [Fact]
+        public void RecordEquals_16()
+        {
+            var source =
+@"
+abstract record A
+{
+}
+record B : A
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        B b2 = new B();
+
+        System.Console.WriteLine(a1.Equals(b2));
+        System.Console.WriteLine(b2.Equals(a1));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+True
+True
+");
+            var recordEquals = comp.GetMembers("B.Equals").OfType<SynthesizedRecordEquals>().Single();
+            Assert.Equal("System.Boolean B.Equals(B? )", recordEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, recordEquals.DeclaredAccessibility);
+            Assert.False(recordEquals.IsAbstract);
+            Assert.True(recordEquals.IsVirtual);
+            Assert.False(recordEquals.IsOverride);
+            Assert.False(recordEquals.IsSealed);
+            Assert.True(recordEquals.IsImplicitlyDeclared);
+        }
+
+        [Fact]
+        public void RecordEquals_17()
+        {
+            var source =
+@"
+abstract record A
+{
+}
+sealed record B : A
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new B();
+        B b2 = new B();
+
+        System.Console.WriteLine(a1.Equals(b2));
+        System.Console.WriteLine(b2.Equals(a1));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+True
+True
+");
+            var recordEquals = comp.GetMembers("B.Equals").OfType<SynthesizedRecordEquals>().Single();
+            Assert.Equal("System.Boolean B.Equals(B? )", recordEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, recordEquals.DeclaredAccessibility);
+            Assert.False(recordEquals.IsAbstract);
+            Assert.False(recordEquals.IsVirtual);
+            Assert.False(recordEquals.IsOverride);
+            Assert.False(recordEquals.IsSealed);
+            Assert.True(recordEquals.IsImplicitlyDeclared);
+        }
+
+        [Fact]
+        public void RecordEquals_18()
+        {
+            var source =
+@"
+sealed record A
+{
+}
+class Program
+{
+    static void Main()
+    {
+        A a1 = new A();
+        A a2 = new A();
+
+        System.Console.WriteLine(a1.Equals(a2));
+        System.Console.WriteLine(a2.Equals(a1));
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"
+True
+True
+");
+            var recordEquals = comp.GetMembers("A.Equals").OfType<SynthesizedRecordEquals>().Single();
+            Assert.Equal("System.Boolean A.Equals(A? )", recordEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, recordEquals.DeclaredAccessibility);
+            Assert.False(recordEquals.IsAbstract);
+            Assert.False(recordEquals.IsVirtual);
+            Assert.False(recordEquals.IsOverride);
+            Assert.False(recordEquals.IsSealed);
+            Assert.True(recordEquals.IsImplicitlyDeclared);
         }
 
         [WorkItem(44692, "https://github.com/dotnet/roslyn/issues/44692")]
@@ -12544,9 +13272,9 @@ False");
         {
             var sourceA = @"public record A;";
             var comp = CreateCompilation(sourceA);
+            var refA = useCompilationReference ? comp.ToMetadataReference() : comp.EmitToImageReference();
             VerifyVirtualMethod(comp.GetMember<MethodSymbol>("A.get_EqualityContract"), isOverride: false);
             VerifyVirtualMethods(comp.GetMembers("A.Equals"), ("System.Boolean A.Equals(A? )", false), ("System.Boolean A.Equals(System.Object? obj)", true));
-            var refA = useCompilationReference ? comp.ToMetadataReference() : comp.EmitToImageReference();
 
             var sourceB = @"record B : A;";
             comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.RegularPreview);
@@ -12812,6 +13540,9 @@ record B : A<object>, IEquatable<A<object>>, IEquatable<B>
 {
     public virtual bool Equals(B other) => Report(""B.Equals(B)"");
 }
+record C : A<object>, IEquatable<A<object>>, IEquatable<C>
+{
+}
 class Program
 {
     static void Main()
@@ -12836,7 +13567,14 @@ B.Equals(B)
 B.Equals(B)
 A<T>.Equals(A<T>)
 B.Equals(B)
-B.Equals(B)");
+B.Equals(B)",
+                symbolValidator: m =>
+                {
+                    var b = m.GlobalNamespace.GetTypeMember("B");
+                    Assert.Equal("B.Equals(B)", b.FindImplementationForInterfaceMember(b.InterfacesNoUseSiteDiagnostics()[1].GetMember("Equals")).ToDisplayString());
+                    var c = m.GlobalNamespace.GetTypeMember("C");
+                    Assert.Equal("C.Equals(C?)", c.FindImplementationForInterfaceMember(c.InterfacesNoUseSiteDiagnostics()[1].GetMember("Equals")).ToDisplayString());
+                });
 
             var type = comp.GetMember<NamedTypeSymbol>("A");
             AssertEx.Equal(new[] { "System.IEquatable<A<T>>" }, type.InterfacesNoUseSiteDiagnostics().ToTestDisplayStrings());
@@ -13183,7 +13921,11 @@ class Program
             comp.VerifyDiagnostics(
                 // (1,8): error CS0737: 'A' does not implement interface member 'IEquatable<A>.Equals(A)'. 'A.Equals(A)' cannot implement an interface member because it is not public.
                 // record A
-                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberNotPublic, "A").WithArguments("A", "System.IEquatable<A>.Equals(A)", "A.Equals(A)").WithLocation(1, 8));
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberNotPublic, "A").WithArguments("A", "System.IEquatable<A>.Equals(A)", "A.Equals(A)").WithLocation(1, 8),
+                // (3,27): error CS8873: Record member 'A.Equals(A)' must be public.
+                //     internal virtual bool Equals(A other) => false;
+                Diagnostic(ErrorCode.ERR_NonPublicAPIInRecord, "Equals").WithArguments("A.Equals(A)").WithLocation(3, 27)
+                );
         }
 
         [Fact]
@@ -13199,6 +13941,9 @@ record B : A
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // (3,17): error CS8872: 'A.Equals(A)' disallows overriding and containing 'record' is not sealed.
+                //     public bool Equals(A other) => false;
+                Diagnostic(ErrorCode.ERR_NotOverridableAPIInRecord, "Equals").WithArguments("A.Equals(A)").WithLocation(3, 17),
                 // (5,8): error CS0506: 'B.Equals(A?)': cannot override inherited member 'A.Equals(A)' because it is not marked virtual, abstract, or override
                 // record B : A
                 Diagnostic(ErrorCode.ERR_CantOverrideNonVirtual, "B").WithArguments("B.Equals(A?)", "A.Equals(A)").WithLocation(5, 8));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
@@ -225,6 +225,9 @@ record C(int X, int Y)
 }
 ");
             comp.VerifyDiagnostics(
+                // (4,17): error CS8872: 'C.Equals(C)' disallows overriding and containing 'record' is not sealed.
+                //     public bool Equals(C c) => throw null;
+                Diagnostic(ErrorCode.ERR_NotOverridableAPIInRecord, "Equals").WithArguments("C.Equals(C)").WithLocation(4, 17),
                 // (5,26): error CS0111: Type 'C' already defines a member called 'Equals' with the same parameter types
                 //     public override bool Equals(object o) => false;
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Equals").WithArguments("Equals", "C").WithLocation(5, 26)
@@ -258,7 +261,7 @@ record C(int X, int Y)
         object c = new C(0, 0);
         Console.WriteLine(c.Equals(c));
     }
-    public bool Equals(C c) => false;
+    public virtual bool Equals(C c) => false;
 }", expectedOutput: "False");
         }
 
@@ -285,7 +288,7 @@ True");
         {
             var verifier = CompileAndVerify(@"
 using System;
-record C(int X, int Y)
+sealed record C(int X, int Y)
 {
     public static void Main()
     {


### PR DESCRIPTION
Related to #45296.

From specification:
includes a synthesized strongly-typed overload of `Equals(R? other)` where `R` is the record type.
The method is `public`, and the method is `virtual` unless the record type is `sealed`.
The method can be declared explicitly.
It is an error if the explicit declaration does not match the expected signature or accessibility, or the explicit declaration is not `virtual` and the record type is not `sealed`.
```C#
public virtual bool Equals(R? other);
```