### PR TITLE
Fix "Tuple to Struct" named parameters being cased incorrectly

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -1882,7 +1882,7 @@ End Structure
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type
             })
-            Await TestInRegularAndScriptAsync(text, expected, index:=1)
+            Await TestInRegularAndScriptAsync(text, expected, index:=1, options:=GetTestOptions(host))
         End Function
 
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
@@ -1959,7 +1959,7 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, index:=1)
+            Await TestInRegularAndScriptAsync(text, expected, index:=1, options:=GetTestOptions(host))
         End Function
 
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
@@ -2038,7 +2038,7 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, index:=1)
+            Await TestInRegularAndScriptAsync(text, expected, index:=1, options:=GetTestOptions(host))
         End Function
 
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
@@ -2154,7 +2154,7 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=1)
+            Await TestInRegularAndScriptAsync(text, expected, index:=1, options:=GetTestOptions(host))
         End Function
 
 #End Region
@@ -2278,7 +2278,7 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=2)
+            Await TestInRegularAndScriptAsync(text, expected, index:=2, options:=GetTestOptions(host))
         End Function
 
 #End Region
@@ -2391,7 +2391,7 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=3)
+            Await TestInRegularAndScriptAsync(text, expected, index:=3, options:=GetTestOptions(host))
         End Function
 
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
@@ -2498,7 +2498,7 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=3)
+            Await TestInRegularAndScriptAsync(text, expected, index:=3, options:=GetTestOptions(host))
         End Function
 
 #End Region

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStru
     Public Class ConvertTupleToStructTests
         Inherits AbstractVisualBasicCodeActionTest
 
-        Protected Overrides Function CreateCodeRefactoringProvider(Workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
+        Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
             Return New VisualBasicConvertTupleToStructCodeRefactoringProvider()
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -900,10 +900,6 @@ End Structure
             Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        Sub foo(a As Integer, b As Integer)
-
-        End Sub
-
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
         Public Async Function TestFixAllMatchesInSingleMethod(host As TestHost) As Task
             Dim text = "

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -89,6 +89,63 @@ End Structure
             Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
+        <WorkItem(45451, "https://github.com/dotnet/roslyn/issues/45451")>
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleType_ChangeArgumentNameCase(host As TestHost) As Task
+            Dim text = "
+class Test
+    sub Method()
+        dim t1 = [||](A:=1, B:=2)
+    end sub
+end class
+"
+            Dim expected = "
+class Test
+    sub Method()
+        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+    end sub
+end class
+
+Friend Structure NewStruct
+    Public A As Integer
+    Public B As Integer
+
+    Public Sub New(a As Integer, b As Integer)
+        Me.A = a
+        Me.B = b
+    End Sub
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        If Not (TypeOf obj Is NewStruct) Then
+            Return False
+        End If
+
+        Dim other = DirectCast(obj, NewStruct)
+        Return A = other.A AndAlso
+               B = other.B
+    End Function
+
+    Public Overrides Function GetHashCode() As Integer
+        Return (A, B).GetHashCode()
+    End Function
+
+    Public Sub Deconstruct(ByRef a As Integer, ByRef b As Integer)
+        a = Me.A
+        b = Me.B
+    End Sub
+
+    Public Shared Widening Operator CType(value As NewStruct) As (A As Integer, B As Integer)
+        Return (value.A, value.B)
+    End Operator
+
+    Public Shared Widening Operator CType(value As (A As Integer, B As Integer)) As NewStruct
+        Return New NewStruct(value.A, value.B)
+    End Operator
+End Structure
+"
+            Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
+        End Function
+
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
         Public Async Function ConvertSingleTupleTypeNoNames(host As TestHost) As Task
             Dim text = "
@@ -671,7 +728,7 @@ end class"
 class Test
     sub Method()
         dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
-        dim t2 = New NewStruct(A:=3, B:=4)
+        dim t2 = New NewStruct(a:=3, b:=4)
     end sub
 end class
 
@@ -1547,7 +1604,7 @@ class Test
         dim t1 = New {|Rename:NewStruct|}(1, 2)
         dim t2 = New NewStruct(1, 2)
         dim t3 = (a:=1, b:=2)
-        dim t4 = New NewStruct(Item1:=1, Item2:=2)
+        dim t4 = New NewStruct(item1:=1, item2:=2)
         dim t5 = New NewStruct(item1:=1, item2:=2)
     end sub
 end class
@@ -1616,7 +1673,7 @@ class Test
         dim t1 = New NewStruct(1, 2)
         dim t2 = New NewStruct(1, 2)
         dim t3 = (a:=1, b:=2)
-        dim t4 = New {|Rename:NewStruct|}(Item1:=1, Item2:=2)
+        dim t4 = New {|Rename:NewStruct|}(item1:=1, item2:=2)
         dim t5 = New NewStruct(item1:=1, item2:=2)
     end sub
 end class

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -1028,8 +1028,8 @@ End Structure
             Await TestInRegularAndScriptAsync(text, expected, options:=GetTestOptions(host))
         End Function
 
-        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
-        Public Async Function NotIfReferencesAnonymousTypeInternally(host As TestHost) As Task
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function NotIfReferencesAnonymousTypeInternally() As Task
             Dim text = "
 class Test
     sub Method()

--- a/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
@@ -9,6 +9,8 @@ using Microsoft.CodeAnalysis.ConvertTupleToStruct;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct
 {
     [ExtensionOrder(Before = PredefinedCodeRefactoringProviderNames.IntroduceVariable)]
@@ -31,6 +33,22 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public CSharpConvertTupleToStructCodeRefactoringProvider()
         {
+        }
+
+        protected override ArgumentSyntax GetArgumentWithChangedName(ArgumentSyntax argument, string name)
+        {
+            return argument.WithNameColon(ChangeName(argument.NameColon, name));
+        }
+
+        private static NameColonSyntax? ChangeName(NameColonSyntax? nameColon, string name)
+        {
+            if (nameColon == null)
+            {
+                return null;
+            }
+
+            var newName = SyntaxFactory.IdentifierName(name).WithTriviaFrom(nameColon.Name);
+            return nameColon.WithName(newName);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertTupleToStruct/CSharpConvertTupleToStructCodeRefactoringProvider.cs
@@ -36,9 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct
         }
 
         protected override ArgumentSyntax GetArgumentWithChangedName(ArgumentSyntax argument, string name)
-        {
-            return argument.WithNameColon(ChangeName(argument.NameColon, name));
-        }
+            => argument.WithNameColon(ChangeName(argument.NameColon, name));
 
         private static NameColonSyntax? ChangeName(NameColonSyntax? nameColon, string name)
         {

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -805,9 +805,9 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             SyntaxGenerator generator, ArrayBuilder<ISymbol> members,
             INamedTypeSymbol tupleType, INamedTypeSymbol structType)
         {
-            const string valueName = "value";
+            const string ValueName = "value";
 
-            var valueNode = generator.IdentifierName(valueName);
+            var valueNode = generator.IdentifierName(ValueName);
             var arguments = tupleType.TupleElements.SelectAsArray<IFieldSymbol, SyntaxNode>(
                 field => generator.Argument(
                     generator.MemberAccessExpression(valueNode, field.Name)));
@@ -823,7 +823,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 Accessibility.Public,
                 DeclarationModifiers.Static,
                 tupleType,
-                CodeGenerationSymbolFactory.CreateParameterSymbol(structType, valueName),
+                CodeGenerationSymbolFactory.CreateParameterSymbol(structType, ValueName),
                 isImplicit: true,
                 ImmutableArray.Create(convertToTupleStatement)));
             members.Add(CodeGenerationSymbolFactory.CreateConversionSymbol(
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 Accessibility.Public,
                 DeclarationModifiers.Static,
                 structType,
-                CodeGenerationSymbolFactory.CreateParameterSymbol(tupleType, valueName),
+                CodeGenerationSymbolFactory.CreateParameterSymbol(tupleType, ValueName),
                 isImplicit: true,
                 ImmutableArray.Create(convertToStructStatement)));
         }

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
         where TTypeBlockSyntax : SyntaxNode
         where TNamespaceDeclarationSyntax : SyntaxNode
     {
+        protected abstract TArgumentSyntax GetArgumentWithChangedName(TArgumentSyntax argument, string name);
+
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
             var (document, textSpan, cancellationToken) = context;
@@ -305,7 +307,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                     // We should only ever get a default array (meaning, update the root), or a
                     // non-empty array.  We should never be asked to update exactly '0' nodes.
                     Debug.Assert(documentToUpdate.NodesToUpdate.IsDefault ||
-                                !documentToUpdate.NodesToUpdate.IsEmpty);
+                                 !documentToUpdate.NodesToUpdate.IsEmpty);
 
                     // If we were given specific nodes to update, only update those.  Otherwise
                     // updated everything from the root down.
@@ -679,8 +681,6 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             return (TArgumentSyntax)generator.Argument(expr).WithTriviaFrom(argument);
         }
 
-        protected abstract TArgumentSyntax GetArgumentWithChangedName(TArgumentSyntax argument, string name);
-
         private static async Task<bool> ReplaceMatchingTupleTypesAsync(
             Document document, SyntaxEditor editor, SyntaxNode startingNode,
             INamedTypeSymbol tupleType, TNameSyntax qualifiedTypeName,
@@ -879,7 +879,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
         }
 
         private static string GetConstructorParameterName(string name)
-            => name.ToCamelCase(trimLeadingTypePrefix: false);
+            => name.ToCamelCase(trimLeadingTypePrefix: false); // TODO: This is the common case, but should ideally match the users style preference
 
         private class MyCodeAction : CodeAction.SolutionChangeAction
         {

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                     // We should only ever get a default array (meaning, update the root), or a
                     // non-empty array.  We should never be asked to update exactly '0' nodes.
                     Debug.Assert(documentToUpdate.NodesToUpdate.IsDefault ||
-                                 documentToUpdate.NodesToUpdate.Length >= 1);
+                                !documentToUpdate.NodesToUpdate.IsEmpty);
 
                     // If we were given specific nodes to update, only update those.  Otherwise
                     // updated everything from the root down.
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 structNameToken = structNameToken.WithAdditionalAnnotations(RenameAnnotation.Create());
             }
 
-            return typeParameters.Length == 0
+            return typeParameters.IsEmpty
                 ? (TNameSyntax)generator.IdentifierName(structNameToken)
                 : (TNameSyntax)generator.GenericName(structNameToken, typeParameters.Select(tp => generator.IdentifierName(tp.Name)));
         }

--- a/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
@@ -40,14 +40,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct
 
             Dim nameColonEquals = simpleArgument.NameColonEquals
 
-            If nameColonEquals Is Nothing Then
-                Return argument
-            End If
-
             Return simpleArgument.WithNameColonEquals(ChangeName(nameColonEquals, name))
         End Function
 
         Private Shared Function ChangeName(nameColonEquals As NameColonEqualsSyntax, name As String) As NameColonEqualsSyntax
+            If nameColonEquals Is Nothing Then
+                Return Nothing
+            End If
+
             Dim newName = SyntaxFactory.IdentifierName(name).WithTriviaFrom(nameColonEquals.Name)
             Return nameColonEquals.WithName(newName)
         End Function

--- a/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertTupleToStruct/VisualBasicConvertTupleToStructCodeRefactoringProvider.vb
@@ -30,5 +30,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
         Public Sub New()
         End Sub
+
+        Protected Overrides Function GetArgumentWithChangedName(argument As ArgumentSyntax, name As String) As ArgumentSyntax
+            Dim simpleArgument = TryCast(argument, SimpleArgumentSyntax)
+
+            If simpleArgument Is Nothing Then
+                Return argument
+            End If
+
+            Dim nameColonEquals = simpleArgument.NameColonEquals
+
+            If nameColonEquals Is Nothing Then
+                Return argument
+            End If
+
+            Return simpleArgument.WithNameColonEquals(ChangeName(nameColonEquals, name))
+        End Function
+
+        Private Shared Function ChangeName(nameColonEquals As NameColonEqualsSyntax, name As String) As NameColonEqualsSyntax
+            Dim newName = SyntaxFactory.IdentifierName(name).WithTriviaFrom(nameColonEquals.Name)
+            Return nameColonEquals.WithName(newName)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #45451 

When converting a tuple to a struct the casing was changed for the parameters of the generated constructor but the call sites weren't changed resulting in a compile error.

Reviewing commit-by-commit might be best, as there were a few analyzer warnings to clean up, but not enough that I thought it was worth a separate PR.