### PR TITLE
Add basic test cases for feature/convertNameOf

### DIFF
--- a/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
+++ b/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AddBraces\AddBracesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AddRequiredParentheses\AddRequiredPatternParenthesesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AddRequiredParentheses\AddRequiredExpressionParenthesesTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ConvertNameOf\ConvertNameOfTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConvertAnonymousTypeToTuple\ConvertAnonymousTypeToTupleTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InlineDeclaration\CSharpInlineDeclarationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InlineDeclaration\CSharpInlineDeclarationTests_FixAllTests.cs" />

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -79,5 +79,19 @@ class Test
 ";
             await TestMissingInRegularAndScriptAsync(text);
         }
+
+        [Fact]
+        public async Task NotOnPrimitiveType()
+        {
+            var text = @"class Test
+{
+    void Method()
+    {
+        var typeName = [||]typeof(int).Name;
+    }
+}
+";
+            await TestMissingInRegularAndScriptAsync(text);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -40,5 +40,29 @@ class Test
 ";
             await TestInRegularAndScriptAsync(text, expected);
         }
+
+        [Fact]
+        public async Task ClassLibraryType()
+        {
+            var text = @"
+class Test
+{
+    void Method()
+    {
+        var typeName = [||]typeof(String).Name;
+    }
+}
+";
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var typeName = [||]nameof(String);
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -94,5 +94,20 @@ class Test
 ";
             await TestMissingInRegularAndScriptAsync(text);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ConvertNameOf)]
+        public async Task NotOnGenericType()
+        {
+            var text = @"class Test<T>
+{
+    void Method()[||]
+    {
+        var typeName = typeof(T).Name;
+    }
+}
+";
+";
+            await TestMissingInRegularAndScriptAsync(text);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -73,7 +73,7 @@ class Test
     void Method()
     {
         var typeVar = String;
-        var typeName = [||]nameof(typeVar);
+        var typeName = [||]typeof(typeVar).Name;
     }
 }
 ";

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.ConvertNameOf;
+using Microsoft.CodeAnalysis.CSharp.CSharpConvertNameOfCodeFixProvider;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNameOf
+{
+    public partial class ConvertNameOfTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpConvertNameOfDiagnosticAnalyzer(), new CSharpConvertNameOfCodeFixProvider());
+
+       
+
+    }
+}

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.ConvertNameOf;
 using Microsoft.CodeAnalysis.CSharp.CSharpConvertNameOfCodeFixProvider;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNameOf
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNameOf
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (new CSharpConvertNameOfDiagnosticAnalyzer(), new CSharpConvertNameOfCodeFixProvider());
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.ConvertNameOf)]
         public async Task BasicType()
         {
             var text = @"
@@ -41,7 +42,7 @@ class Test
             await TestInRegularAndScriptAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.ConvertNameOf)]
         public async Task ClassLibraryType()
         {
             var text = @"
@@ -65,7 +66,7 @@ class Test
             await TestInRegularAndScriptAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.ConvertNameOf)]
         public async Task NotOnVariableContainingType()
         {
             var text = @"class Test
@@ -80,7 +81,7 @@ class Test
             await TestMissingInRegularAndScriptAsync(text);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.ConvertNameOf)]
         public async Task NotOnPrimitiveType()
         {
             var text = @"class Test

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -106,6 +106,21 @@ class Test
     }
 }
 ";
+            await TestMissingInRegularAndScriptAsync(text);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ConvertNameOf)]
+        public async Task NotOnSimilarStatements()
+        {
+            var text = @"class Test
+{
+    void Method()[||]
+    {
+        var typeName1 = typeof(Test);
+        var typeName2 = typeof(Test).toString();
+        var typeName3 = typeof(Test).FullName;
+    }
+}
 ";
             await TestMissingInRegularAndScriptAsync(text);
         }

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -64,5 +64,20 @@ class Test
 ";
             await TestInRegularAndScriptAsync(text, expected);
         }
+
+        [Fact]
+        public async Task NotOnVariableContainingType()
+        {
+            var text = @"class Test
+{
+    void Method()
+    {
+        var typeVar = String;
+        var typeName = [||]nameof(typeVar);
+    }
+}
+";
+            await TestMissingInRegularAndScriptAsync(text);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -72,8 +72,8 @@ class Test
 {
     void Method()
     {
-        var typeVar = String;
-        var typeName = [||]typeof(typeVar).Name;
+        var typeVar = typeof(String);[||]
+        var typeName = typeVar.Name;
     }
 }
 ";

--- a/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNameOf/ConvertNameOfTests.cs
@@ -17,7 +17,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNameOf
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (new CSharpConvertNameOfDiagnosticAnalyzer(), new CSharpConvertNameOfCodeFixProvider());
 
-       
-
+        [Fact]
+        public async Task BasicType()
+        {
+            var text = @"
+class Test
+{
+    void Method()
+    {
+        var typeName = [||]typeof(Test).Name;
+    }
+}
+";
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var typeName = [||]nameof(Test);
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected);
+        }
     }
 }

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -200,6 +200,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CompleteStatement = nameof(CompleteStatement);
             public const string Completion = nameof(Completion);
             public const string ConvertAutoPropertyToFullProperty = nameof(ConvertAutoPropertyToFullProperty);
+            public const string ConvertNameOf = nameof(ConvertNameOf);
             public const string DebuggingBreakpoints = "Debugging.Breakpoints";
             public const string DebuggingDataTips = "Debugging.DataTips";
             public const string DebuggingEditAndContinue = "Debugging.EditAndContinue";


### PR DESCRIPTION
CC: @m-redding , @JavierMatosD , @jmarolf 

Adds 3 test cases for testing the analyzer and fixer for the convertNameOf feature.

- a basic test using the class containing the test method stub
- a test using a Framework Test type
- a test checking that the analyzer does not flag typeof on variables containing Types