### PR TITLE
Remove requirement to list all transitively referenced projects in Pr…

### DIFF
--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -102,7 +102,6 @@ namespace BuildBoss
             var declaredList = declaredEntryList.Select(x => x.ProjectKey).ToList();
             allGood &= CheckProjectReferencesComplete(textWriter, declaredList);
             allGood &= CheckUnitTestReferenceRestriction(textWriter, declaredList);
-            allGood &= CheckTransitiveReferences(textWriter, declaredList);
             allGood &= CheckNoGuidsOnProjectReferences(textWriter, declaredEntryList);
 
             return allGood;
@@ -259,63 +258,6 @@ namespace BuildBoss
             }
 
             return allGood;
-        }
-
-        /// <summary>
-        /// In order to ensure all dependencies are properly copied on deployment projects, the declared reference
-        /// set much match the transitive dependency set.  When there is a difference it represents dependencies that
-        /// MSBuild won't deploy on build.
-        /// </summary>
-        private bool CheckTransitiveReferences(TextWriter textWriter, IEnumerable<ProjectKey> declaredReferences)
-        {
-            if (!_projectUtil.IsDeploymentProject)
-            {
-                return true;
-            }
-
-            var list = GetProjectReferencesTransitive(declaredReferences);
-            var set = new HashSet<ProjectKey>(declaredReferences);
-            var allGood = true;
-            foreach (var key in list)
-            {
-                if (!set.Contains(key))
-                {
-                    textWriter.WriteLine($"Missing project reference {key.FileName}");
-                    allGood = false;
-                }
-            }
-
-            return allGood;
-        }
-
-        private List<ProjectKey> GetProjectReferencesTransitive(IEnumerable<ProjectKey> declaredReferences)
-        {
-            var list = new List<ProjectKey>();
-            var toVisit = new Queue<ProjectKey>(declaredReferences);
-            var seen = new HashSet<ProjectKey>();
-
-            while (toVisit.Count > 0)
-            {
-                var current = toVisit.Dequeue();
-                if (!seen.Add(current))
-                {
-                    continue;
-                }
-
-                if (!_solutionMap.TryGetValue(current, out var data))
-                {
-                    continue;
-                }
-
-                list.Add(current);
-                foreach (var dep in data.ProjectUtil.GetDeclaredProjectReferences())
-                {
-                    toVisit.Enqueue(dep.ProjectKey);
-                }
-            }
-
-            list.Sort((x, y) => x.FileName.CompareTo(y.FileName));
-            return list;
         }
 
         private bool CheckTargetFrameworks(TextWriter textWriter)

--- a/src/Tools/BuildBoss/ProjectUtil.cs
+++ b/src/Tools/BuildBoss/ProjectUtil.cs
@@ -44,8 +44,6 @@ namespace BuildBoss
             OutputType = FindSingleProperty("OutputType")?.Value.Trim().ToLowerInvariant();
         }
 
-        internal bool IsDeploymentProject => IsTestProject || OutputType switch { "exe" => true, "winexe" => true, _ => false };
-
         internal XElement GetTargetFramework() => Document.XPathSelectElements("//mb:TargetFramework", Manager).FirstOrDefault();
 
         internal XElement GetTargetFrameworks() => Document.XPathSelectElements("//mb:TargetFrameworks", Manager).FirstOrDefault();


### PR DESCRIPTION
…ojectReferences of each project

We believe this check is no longer necessary. It used to be an issue when using legacy projects.