### PR TITLE
Fix VB nameof inside async or iterator

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -3227,7 +3227,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case SymbolKind.Local
                     Dim localSymbol = DirectCast(lookupResult.SingleSymbol, LocalSymbol)
 
-                    If localSymbol.IsFunctionValue Then
+                    If localSymbol.IsFunctionValue AndAlso Not IsNameOfArgument(node) Then
                         Dim method = DirectCast(localSymbol.ContainingSymbol, MethodSymbol)
 
                         If method.IsAsync OrElse method.IsIterator Then

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -3652,13 +3652,13 @@ Module Module1
     End Sub
     Async Function M() As Task
         Console.WriteLine(NameOf(M))
-        Await Task.Delay(0)
+        Await Task.CompletedTask
     End Function
 End Module
     </file>
 </compilation>
 
-            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929}, TestOptions.DebugExe)
+            Dim comp = CreateCompilation(compilationDef, options:=TestOptions.DebugExe)
             CompileAndVerify(comp, expectedOutput:=
             <![CDATA[
 M

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -3637,5 +3637,32 @@ BC30469: Reference to a non-shared member requires an object reference.
                    ~~~~~~~~~~~~~~~~~~~~~~~~
 ]]></expected>)
         End Sub
+
+        <Fact, WorkItem(23019, "https://github.com/dotnet/roslyn/issues/23019")>
+        Public Sub NameOfInAsync()
+            Dim compilationDef =
+<compilation>
+    <file name="a.vb">
+Imports System
+Imports System.Threading.Tasks
+
+Module Module1
+    Sub Main()
+        M().GetAwaiter().GetResult()
+    End Sub
+    Async Function M() As Task
+        Console.WriteLine(NameOf(M))
+        Await Task.Delay(0)
+    End Function
+End Module
+    </file>
+</compilation>
+
+            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929}, TestOptions.DebugExe)
+            CompileAndVerify(comp, expectedOutput:=
+            <![CDATA[
+M
+]]>).VerifyDiagnostics()
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Suppress BC 36946 in case of nameof argument, fixes #23019