### PR TITLE
No-op SymbolSearchUpdateEngine on non-Windows OS

### DIFF
--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -30,6 +30,9 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         private readonly ConcurrentDictionary<string, IAddReferenceDatabaseWrapper> _sourceToDatabase =
             new ConcurrentDictionary<string, IAddReferenceDatabaseWrapper>();
 
+        /// <summary>
+        /// Don't call directly. Use <see cref="SymbolSearchUpdateEngineFactory"/> instead.
+        /// </summary>
         public SymbolSearchUpdateEngine(
             ISymbolSearchLogService logService,
             ISymbolSearchProgressService progressService)

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     /// other layers can behave differently (for example, running the engine out-of-process).
     /// </summary>
     /// <remarks>
-    /// This returns an No-op engine on non-Windows OS, becuase the backing storage dependes on Windows APIs.
+    /// This returns an No-op engine on non-Windows OS, because the backing storage depends on Windows APIs.
     /// <remarks>
     internal static partial class SymbolSearchUpdateEngineFactory
     {

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     /// </summary>
     /// <remarks>
     /// This returns an No-op engine on non-Windows OS, because the backing storage depends on Windows APIs.
-    /// <remarks>
+    /// </remarks>
     internal static partial class SymbolSearchUpdateEngineFactory
     {
         public static async Task<ISymbolSearchUpdateEngine> CreateEngineAsync(

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 => Task.CompletedTask;
         }
 
-        private sealed partial class RemoteUpdateEngine : ISymbolSearchUpdateEngine
+        private sealed class RemoteUpdateEngine : ISymbolSearchUpdateEngine
         {
             private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
 

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         }
 
         /// <summary>
-        /// This returns a No-op engine if called on non-Windows OS, becuase the backing storage dependes on Windows APIs.
+        /// This returns a No-op engine if called on non-Windows OS, because the backing storage depends on Windows APIs.
         /// </summary>
         public static ISymbolSearchUpdateEngine CreateEngineInProcess(
             ISymbolSearchLogService logService,

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -4,13 +4,12 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
@@ -19,6 +18,9 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     /// implementation produces an engine that will run in-process.  Implementations at
     /// other layers can behave differently (for example, running the engine out-of-process).
     /// </summary>
+    /// <remarks>
+    /// This returns an No-op engine on non-Windows OS, becuase the backing storage dependes on Windows APIs.
+    /// <remarks>
     internal static partial class SymbolSearchUpdateEngineFactory
     {
         public static async Task<ISymbolSearchUpdateEngine> CreateEngineAsync(
@@ -36,7 +38,34 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             }
 
             // Couldn't go out of proc.  Just do everything inside the current process.
-            return new SymbolSearchUpdateEngine(logService, progressService);
+            return CreateEngineInProcess(logService, progressService);
+        }
+
+        /// <summary>
+        /// This returns a No-op engine if called on non-Windows OS, becuase the backing storage dependes on Windows APIs.
+        /// </summary>
+        public static ISymbolSearchUpdateEngine CreateEngineInProcess(
+            ISymbolSearchLogService logService,
+            ISymbolSearchProgressService progressService)
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new SymbolSearchUpdateEngine(logService, progressService)
+                : (ISymbolSearchUpdateEngine)new NoOpUpdateEngine();
+        }
+
+        private sealed class NoOpUpdateEngine : ISymbolSearchUpdateEngine
+        {
+            public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
+
+            public Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
+
+            public Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+
+            public Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory)
+                => Task.CompletedTask;
         }
 
         private sealed partial class RemoteUpdateEngine : ISymbolSearchUpdateEngine

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -13,14 +13,13 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class RemoteSymbolSearchUpdateEngine : ServiceBase, IRemoteSymbolSearchUpdateEngine, ISymbolSearchLogService, ISymbolSearchProgressService
     {
-        private readonly SymbolSearchUpdateEngine _updateEngine;
+        private readonly ISymbolSearchUpdateEngine _updateEngine;
 
         public RemoteSymbolSearchUpdateEngine(
             Stream stream, IServiceProvider serviceProvider)
             : base(serviceProvider, stream)
         {
-            _updateEngine = new SymbolSearchUpdateEngine(
-                logService: this, progressService: this);
+            _updateEngine = SymbolSearchUpdateEngineFactory.CreateEngineInProcess(logService: this, progressService: this);
 
             StartService();
         }
@@ -32,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // In non-test scenarios, we're not cancellable.  Our lifetime will simply be that
                 // of the OOP process itself.  i.e. when it goes away, it will just tear down our
                 // update-loop itself.  So we don't need any additional controls over it.
-                return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory, CancellationToken.None);
+                return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory);
             }, CancellationToken.None);
         }
 


### PR DESCRIPTION
To guard against potential misuse, since it only works on Windows.

@sharwell 