### PR TITLE
Update optprof pipeline for 16.7

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -137,7 +137,7 @@
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
       "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
       "channels": [ "dev16.7", "dev16.7p4" ],
-      "vsBranch": "master",
+      "vsBranch": "rel/d16.7",
       "vsMajorVersion": 16
     },
     "master-vs-deps": {


### PR DESCRIPTION
This should get us back on track for pulling the correct 16.7 data in signed builds.