### PR TITLE
Change signature accessibility - add screenreader header for empty column

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -203,6 +203,11 @@
                     <!-- This column appears empty to sighted users, but provides an improved screenreader 
                     experience that avoids moving cell-by-cell through the DataGrid -->
                     <DataGridTextColumn x:Name="automationHeader" IsReadOnly="True" Width="0">
+                        <DataGridTextColumn.HeaderStyle>
+                            <Style TargetType="{x:Type DataGridColumnHeader}">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding ElementName=dialog, Path=CurrentParameter}" />
+                            </Style>
+                        </DataGridTextColumn.HeaderStyle>
                         <DataGridTextColumn.CellStyle>
                             <Style TargetType="DataGridCell" BasedOn="{StaticResource DataGridCellStyle}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding FullAutomationText}"/>

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 
         // Expose localized strings for binding
         public string ChangeSignatureDialogTitle { get { return ServicesVSResources.Change_Signature; } }
+        public string CurrentParameter { get { return ServicesVSResources.Current_parameter; } }
         public string Parameters { get { return ServicesVSResources.Parameters_colon2; } }
         public string PreviewMethodSignature { get { return ServicesVSResources.Preview_method_signature_colon; } }
         public string PreviewReferenceChanges { get { return ServicesVSResources.Preview_reference_changes; } }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1529,4 +1529,7 @@ I agree to all of the foregoing:</value>
   <data name="Warning_colon_type_does_not_bind" xml:space="preserve">
     <value>Warning: type does not bind</value>
   </data>
+  <data name="Current_parameter" xml:space="preserve">
+    <value>Current parameter</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Aktuální dokument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Aktuelles Dokument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Documento actual</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Document en cours</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Documento corrente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -157,6 +157,11 @@
         <target state="translated">現在のドキュメント</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -157,6 +157,11 @@
         <target state="translated">현재 문서</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Bieżący dokument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Documento atual</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Текущий документ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Geçerli belge</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -157,6 +157,11 @@
         <target state="translated">当前文档</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -157,6 +157,11 @@
         <target state="translated">目前的文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="Current_parameter">
+        <source>Current parameter</source>
+        <target state="new">Current parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Edit">
         <source>_Edit</source>
         <target state="new">_Edit</target>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_queries/edit/1135706/

**Description:**
In #44986, a new empty column was added to the Change Signature UI that does not provide any added functionality for non-Narrator users, but provides a summary description of the row's parameters for those who do use Narrator:

![image](https://user-images.githubusercontent.com/235241/84189779-b0e01a00-aa4a-11ea-9bdd-2e2fac8f20b7.png)

This change adds a Narrator-only verbal header to the empty column.

**For non-Narrator users:** UI/UX will look/behave exactly the same.
**For Narrator users:** Narrator will now read out a header ("Parameter Summary") along with the existing summary of the row when the user focuses on a cell in the empty column.

**Other notes:** After discussion with our accessibility champ, Abhitej, it was determined that this is likely not a permanent fix, but enough to address the issue for now. We determined it would be best if the empty column was eventually deleted and we keep focus at a datarow level by default (currently it is cell level by default), and allow users to go to individual data cells if desired, similar to how Error List and Test Explorer behave today. However, this is more of a stretch goal (and appears more complicated, from the time I spent trying to implement this behavior), and for now the current implementation with this PR does meet the accessibility requirements and should suffice. I've opened up #45838 to track how we eventually want the accessibility UI to behave.