### PR TITLE
Use explicit namespace for proprietary resources

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
-    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.36</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
+    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.37</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
-    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.38</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
+    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.40</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
-    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.37</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
+    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.38</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisCSharpCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
-    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.40</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
+    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.41</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeRefactoringTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -11149,12 +11149,13 @@ class C
 
 #if NET472
         [ConditionalFact(typeof(WindowsDesktopOnly), typeof(IsEnglishLocal), Reason = "https://github.com/dotnet/roslyn/issues/30321")]
-        public void LoadingAnalyzerNetStandard13()
+        public void LoadinganalyzerNetStandard13()
         {
             var analyzerFileName = "AnalyzerNS13.dll";
             var srcFileName = "src.cs";
 
             var analyzerDir = Temp.CreateDirectory();
+
             var analyzerFile = analyzerDir.CreateFile(analyzerFileName).WriteAllBytes(DesktopTestHelpers.CreateCSharpAnalyzerNetStandard13(Path.GetFileNameWithoutExtension(analyzerFileName)));
             var srcFile = analyzerDir.CreateFile(srcFileName).WriteAllText("public class C { }");
 
@@ -11171,6 +11172,7 @@ System.NotImplementedException: 28
             Assert.Equal(0, result.ExitCode);
         }
 #endif
+
         [WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=484417")]
         [ConditionalFact(typeof(WindowsDesktopOnly), typeof(IsEnglishLocal), Reason = "https://github.com/dotnet/roslyn/issues/30321")]
         public void MicrosoftDiaSymReaderNativeAltLoadPath()

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -23,6 +23,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DiaSymReader;
@@ -4130,7 +4131,7 @@ C:\*.cs(100,7): error CS0103: The name 'Goo' does not exist in the current conte
   </runtime>
 </configuration>");
 
-            var silverlight = Temp.CreateFile().WriteAllBytes(TestResources.NetFX.silverlight_v5_0_5_0.System_v5_0_5_0_silverlight).Path;
+            var silverlight = Temp.CreateFile().WriteAllBytes(ProprietaryTestResources.silverlight_v5_0_5_0.System_v5_0_5_0_silverlight).Path;
             var net4_0dll = Temp.CreateFile().WriteAllBytes(ResourcesNet451.System).Path;
 
             // Test linking two appconfig dlls with simple src

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -74,7 +75,7 @@ class C
   </runtime>
 </configuration>").Path;
 
-            var silverlight = Temp.CreateFile().WriteAllBytes(TestResources.NetFX.silverlight_v5_0_5_0.System_v5_0_5_0_silverlight).Path;
+            var silverlight = Temp.CreateFile().WriteAllBytes(ProprietaryTestResources.silverlight_v5_0_5_0.System_v5_0_5_0_silverlight).Path;
             var net4_0dll = Temp.CreateFile().WriteAllBytes(ResourcesNet451.System).Path;
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -15102,7 +15103,7 @@ class Program
     }
 }";
 
-            var testReference = AssemblyMetadata.CreateFromImage(TestResources.Repros.BadDefaultParameterValue).GetReference();
+            var testReference = AssemblyMetadata.CreateFromImage(ProprietaryTestResources.Repros.BadDefaultParameterValue).GetReference();
             var compilation = CompileAndVerify(source, references: new[] { testReference });
             compilation.VerifyIL("Program.Main", @"
 {

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdDumpTest.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdDumpTest.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata
         private readonly MetadataReference _windowsRef = MetadataReference.CreateFromImage(TestResources.WinRt.Windows.AsImmutableOrNull());
         private readonly MetadataReference _systemRuntimeRef = MetadataReference.CreateFromImage(TestMetadata.ResourcesNet451.SystemRuntime.AsImmutableOrNull());
         private readonly MetadataReference _systemObjectModelRef = MetadataReference.CreateFromImage(TestMetadata.ResourcesNet451.SystemObjectModel.AsImmutableOrNull());
-        private readonly MetadataReference _windowsRuntimeUIXamlRef = MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30319_17929.System_Runtime_WindowsRuntime_UI_Xaml.AsImmutableOrNull());
+        private readonly MetadataReference _windowsRuntimeUIXamlRef = MetadataReference.CreateFromImage(ProprietaryTestResources.v4_0_30319_17929.System_Runtime_WindowsRuntime_UI_Xaml.AsImmutableOrNull());
         private readonly MetadataReference _interopServicesWindowsRuntimeRef = MetadataReference.CreateFromImage(TestMetadata.ResourcesNet451.SystemRuntimeInteropServicesWindowsRuntime.AsImmutableOrNull());
 
         private void AppendMembers(StringBuilder result, NamespaceOrTypeSymbol container, string indent)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Reflection
 Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Test.Resources.Proprietary
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
@@ -13504,7 +13505,7 @@ End Module
     </file>
 </compilation>
 
-            Dim testReference = AssemblyMetadata.CreateFromImage(TestResources.Repros.BadDefaultParameterValue).GetReference()
+            Dim testReference = AssemblyMetadata.CreateFromImage(ProprietaryTestResources.Repros.BadDefaultParameterValue).GetReference()
             Dim compilation = CompileAndVerify(source, references:=New MetadataReference() {testReference})
             compilation.VerifyIL("C.Main",
             <![CDATA[

--- a/src/Test/Utilities/Portable/Mocks/TestReferences.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestReferences.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Roslyn.Test.Utilities;
 
 public static class TestReferences
@@ -95,7 +96,7 @@ public static class TestReferences
         public static class silverlight_v5_0_5_0
         {
             private static readonly Lazy<PortableExecutableReference> s_system = new Lazy<PortableExecutableReference>(
-                () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.silverlight_v5_0_5_0.System_v5_0_5_0_silverlight).GetReference(display: "System.v5.0.5.0_silverlight.dll"),
+                () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.silverlight_v5_0_5_0.System_v5_0_5_0_silverlight).GetReference(display: "System.v5.0.5.0_silverlight.dll"),
                 LazyThreadSafetyMode.PublicationOnly);
             public static PortableExecutableReference System => s_system.Value;
         }
@@ -104,7 +105,7 @@ public static class TestReferences
     public static class NetStandard13
     {
         private static readonly Lazy<PortableExecutableReference> s_systemRuntime = new Lazy<PortableExecutableReference>(
-            () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.netstandard13.System_Runtime).GetReference(display: @"System.Runtime.dll (netstandard13 ref)"),
+            () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.netstandard13.System_Runtime).GetReference(display: @"System.Runtime.dll (netstandard13 ref)"),
             LazyThreadSafetyMode.PublicationOnly);
         public static PortableExecutableReference SystemRuntime => s_systemRuntime.Value;
     }
@@ -694,7 +695,7 @@ public static class TestReferences
         public static class NoPia
         {
             private static readonly Lazy<PortableExecutableReference> s_stdOle = new Lazy<PortableExecutableReference>(
-        () => AssemblyMetadata.CreateFromImage(TestResources.ProprietaryPias.stdole).GetReference(display: "stdole.dll"),
+        () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.ProprietaryPias.stdole).GetReference(display: "stdole.dll"),
         LazyThreadSafetyMode.PublicationOnly);
             public static PortableExecutableReference StdOle => s_stdOle.Value;
 

--- a/src/Test/Utilities/Portable/Platform/Desktop/TestHelpers.cs
+++ b/src/Test/Utilities/Portable/Platform/Desktop/TestHelpers.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.Win32;
 
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis
             var minSystemCollectionsImmutableImage = CSharpCompilation.Create(
                 "System.Collections.Immutable",
                 new[] { SyntaxFactory.ParseSyntaxTree(minSystemCollectionsImmutableSource) },
-                new[] { MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Runtime) },
+                new[] { MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Runtime) },
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_b03f5f7f11d50a3a)).EmitToArray();
 
             var minSystemCollectionsImmutableRef = MetadataReference.CreateFromImage(minSystemCollectionsImmutableImage);
@@ -149,7 +150,7 @@ namespace Microsoft.CodeAnalysis
                 new[] { SyntaxFactory.ParseSyntaxTree(minCodeAnalysisSource) },
                 new[]
                 {
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Runtime),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Runtime),
                     minSystemCollectionsImmutableRef
                 },
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_31bf3856ad364e35)).EmitToArray();
@@ -241,41 +242,41 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 {
                     minCodeAnalysisRef,
                     minSystemCollectionsImmutableRef,
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.Microsoft_Win32_Primitives),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_AppContext),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Console),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_ValueTuple),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Diagnostics_FileVersionInfo),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Diagnostics_Process),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Diagnostics_StackTrace),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Globalization_Calendars),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_IO_Compression),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_IO_Compression_ZipFile),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_IO_FileSystem),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_IO_FileSystem_Primitives),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_IO_Pipes),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Net_Http),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Net_Security),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Net_Sockets),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Reflection_TypeExtensions),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Runtime),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Runtime_InteropServices_RuntimeInformation),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Runtime_Serialization_Primitives),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_AccessControl),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Claims),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Cryptography_Algorithms),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Cryptography_Csp),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Cryptography_Encoding),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Cryptography_Primitives),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Cryptography_X509Certificates),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Security_Principal_Windows),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Threading_Thread),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Threading_Tasks_Extensions),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Xml_ReaderWriter),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Xml_XmlDocument),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Xml_XPath),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Xml_XPath_XDocument),
-                    MetadataReference.CreateFromImage(TestResources.NetFX.netstandard13.System_Text_Encoding_CodePages)
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.Microsoft_Win32_Primitives),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_AppContext),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Console),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_ValueTuple),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Diagnostics_FileVersionInfo),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Diagnostics_Process),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Diagnostics_StackTrace),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Globalization_Calendars),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_IO_Compression),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_IO_Compression_ZipFile),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_IO_FileSystem),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_IO_FileSystem_Primitives),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_IO_Pipes),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Net_Http),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Net_Security),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Net_Sockets),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Reflection_TypeExtensions),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Runtime),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Runtime_InteropServices_RuntimeInformation),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Runtime_Serialization_Primitives),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_AccessControl),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Claims),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Cryptography_Algorithms),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Cryptography_Csp),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Cryptography_Encoding),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Cryptography_Primitives),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Cryptography_X509Certificates),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Security_Principal_Windows),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Threading_Thread),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Threading_Tasks_Extensions),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Xml_ReaderWriter),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Xml_XmlDocument),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Xml_XPath),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Xml_XPath_XDocument),
+                    MetadataReference.CreateFromImage(ProprietaryTestResources.netstandard13.System_Text_Encoding_CodePages)
                 },
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)).EmitToArray();
 

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using static TestReferences.NetFx;
 using static Roslyn.Test.Utilities.TestMetadata;
+using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 
 namespace Roslyn.Test.Utilities
 {
@@ -94,7 +95,7 @@ namespace Roslyn.Test.Utilities
                 var winmd = AssemblyMetadata.CreateFromImage(TestResources.WinRt.Windows).GetReference(display: "Windows");
 
                 var windowsruntime =
-                    AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319_17929.System_Runtime_WindowsRuntime).GetReference(display: "System.Runtime.WindowsRuntime.dll");
+                    AssemblyMetadata.CreateFromImage(ProprietaryTestResources.v4_0_30319_17929.System_Runtime_WindowsRuntime).GetReference(display: "System.Runtime.WindowsRuntime.dll");
 
                 var runtime =
                     AssemblyMetadata.CreateFromImage(ResourcesNet451.SystemRuntime).GetReference(display: "System.Runtime.dll");
@@ -102,7 +103,7 @@ namespace Roslyn.Test.Utilities
                 var objectModel =
                     AssemblyMetadata.CreateFromImage(ResourcesNet451.SystemObjectModel).GetReference(display: "System.ObjectModel.dll");
 
-                var uixaml = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319_17929.System_Runtime_WindowsRuntime_UI_Xaml).
+                var uixaml = AssemblyMetadata.CreateFromImage(ProprietaryTestResources.v4_0_30319_17929.System_Runtime_WindowsRuntime_UI_Xaml).
                     GetReference(display: "System.Runtime.WindowsRuntime.UI.Xaml.dll");
 
                 var interop = AssemblyMetadata.CreateFromImage(ResourcesNet451.SystemRuntimeInteropServicesWindowsRuntime).
@@ -173,7 +174,7 @@ namespace Roslyn.Test.Utilities
         public static MetadataReference MscorlibRef => s_mscorlibRef.Value;
 
         private static readonly Lazy<MetadataReference> s_mscorlibRefPortable = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.mscorlib_portable).GetReference(display: "mscorlib.v4_0_30319.portable.dll"),
+            () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.v4_0_30319.mscorlib_portable).GetReference(display: "mscorlib.v4_0_30319.portable.dll"),
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference MscorlibRefPortable => s_mscorlibRefPortable.Value;
 
@@ -213,7 +214,7 @@ namespace Roslyn.Test.Utilities
         /// Reference to an mscorlib silverlight assembly in which the System.Array does not contain the special member LongLength.
         /// </summary>
         private static readonly Lazy<MetadataReference> s_mscorlibRef_silverlight = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.silverlight_v5_0_5_0.mscorlib_v5_0_5_0_silverlight).GetReference(display: "mscorlib.v5.0.5.0_silverlight.dll"),
+            () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.silverlight_v5_0_5_0.mscorlib_v5_0_5_0_silverlight).GetReference(display: "mscorlib.v5.0.5.0_silverlight.dll"),
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference MscorlibRefSilverlight => s_mscorlibRef_silverlight.Value;
 
@@ -247,7 +248,7 @@ namespace Roslyn.Test.Utilities
         public static MetadataReference Net46StandardFacade => s_46NetStandardFacade.Value;
 
         private static readonly Lazy<MetadataReference> s_systemDynamicRuntimeRef = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.netstandard13.System_Dynamic_Runtime).GetReference(display: "System.Dynamic.Runtime.dll (netstandard 1.3 ref)"),
+            () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.netstandard13.System_Dynamic_Runtime).GetReference(display: "System.Dynamic.Runtime.dll (netstandard 1.3 ref)"),
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference SystemDynamicRuntimeRef => s_systemDynamicRuntimeRef.Value;
 
@@ -302,12 +303,12 @@ namespace Roslyn.Test.Utilities
         public static MetadataReference SystemThreadingTaskFacadeRef => s_systemThreadingTasksFacadeRef.Value;
 
         private static readonly Lazy<MetadataReference> s_mscorlibPP7Ref = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.ReferenceAssemblies_PortableProfile7.mscorlib).GetReference(display: "mscorlib.dll"),
+            () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.ReferenceAssemblies_PortableProfile7.mscorlib).GetReference(display: "mscorlib.dll"),
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference MscorlibPP7Ref => s_mscorlibPP7Ref.Value;
 
         private static readonly Lazy<MetadataReference> s_systemRuntimePP7Ref = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.ReferenceAssemblies_PortableProfile7.System_Runtime).GetReference(display: "System.Runtime.dll"),
+            () => AssemblyMetadata.CreateFromImage(ProprietaryTestResources.ReferenceAssemblies_PortableProfile7.System_Runtime).GetReference(display: "System.Runtime.dll"),
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference SystemRuntimePP7Ref => s_systemRuntimePP7Ref.Value;
 


### PR DESCRIPTION
The Roslyn code base originated with all of our resource reference /
impl DLLs being checked into a single utility project. At the point we
moved to Git and went OSS these single utility project was factored into
two projects for a number of reasons.

1. Keeping DLLs we didn't have license for private
1. Letting us put large binaries into a NuPkg file vs. polluting Git
   history

When this split occured the namespaces for the utility projects were not
updated. That means many types in our public and private resource
projects have the same name. This makes it **really** difficult to
determine where types and resources are coming from.

This change adds an explicit namespace to the proprietary resource
assembly. This will help make it clear which resources come from it.