### PR TITLE
Correctly use JoinableTaskCollection

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1311,7 +1311,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _projectionBufferFactoryService.ProjectionBufferCreated -= AddTextBufferCloneServiceToBuffer;
                 FileWatchedReferenceFactory.ReferenceChanged -= RefreshMetadataReferencesForFile;
 
-                _deferredJoinableTasks.Join();
+                _threadingContext.JoinableTaskFactory.Run(() => _deferredJoinableTasks.JoinTillEmptyAsync());
             }
 
             base.Dispose(finalize);

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _cancellationTokenSource.Cancel();
 
             // Now wait for all our cleanup tasks to finish before we return.
-            _deferredCleanupTasks.Join();
+            _threadingContext.JoinableTaskFactory.Run(() => _deferredCleanupTasks.JoinTillEmptyAsync());
         }
     }
 }


### PR DESCRIPTION
I was incorrectly using JoinableTaskCollection.Join() under the impression that it actually did the wait; instead it just grants the ability for any of the JoinableTasks in the collection to use the current thread you're on, but doesn't actually do any waiting. This replaces it with the correct behavior.