### PR TITLE
methodimpl(.override) should be accompanied by [PreserveBaseOverridesAttribute]

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -874,10 +874,9 @@ done:
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNullableContextAttribute(this, nullableContextValue));
             }
 
-            bool isCovariantOverride = this.IsOverride && !this.OverriddenMethod.ReturnType.Equals(this.ReturnType, TypeCompareKind.AllIgnoreOptions);
-            if (isCovariantOverride)
+            if (this.RequiresExplicitOverride(out _))
             {
-                // If present, we add PreserveBaseOverridesAttribute to covariant overrides.
+                // If present, we add PreserveBaseOverridesAttribute when a methodimpl is used to override a class method.
                 var attr = moduleBuilder.Compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor, isOptionalUse: true);
                 AddSynthesizedAttribute(ref attributes, attr);
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -290,8 +290,9 @@ namespace System.Runtime.CompilerServices
                     var checkMetadata = hasReturnConversion(property.Type, overriddenProperty.Type);
                     if (checkMetadata)
                     {
-                        Assert.Equal(isCovariant, getMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
-                        Assert.Equal(isCovariant, getMethod.RequiresExplicitOverride(out _)); // implies the presence of a methodimpl
+                        requiresMethodimpl = isCovariant | requiresMethodimpl;
+                        Assert.Equal(requiresMethodimpl, getMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
+                        Assert.Equal(requiresMethodimpl, getMethod.RequiresExplicitOverride(out _)); // implies the presence of a methodimpl
                     }
                 }
                 if (property.SetMethod is MethodSymbol setMethod && overriddenProperty.SetMethod is MethodSymbol overriddenSetMethod)
@@ -2957,6 +2958,46 @@ public class Derived : Mid
                 // virtual slot unification that the runtime does.
                 VerifyOverride(comp, "Derived.M", "System.String Derived.M()", "System.Object Base.M()");
                 VerifyOverride(comp, "Mid.M", "System.Object Mid.M()", "System.Object Base.M()");
+            }
+        }
+
+        [Fact]
+        public void LegacyMethodimplRequirements_01()
+        {
+            var source = @"
+public class A
+{
+    public virtual string get_P() => null;
+}
+
+public class B : A
+{
+    public virtual string P => null;
+}
+
+public class C : B
+{
+    public override string get_P() => null;
+}
+
+public class D : C
+{
+    public override string P => null;
+}
+";
+            var assignments = "";
+            var comp = CreateCompilationWithoutCovariantReturns(source).VerifyDiagnostics(
+                );
+            verify(SourceView(comp, assignments));
+            verify(CompilationReferenceView(comp, assignments));
+            verify(MetadataView(comp, assignments));
+            verify(RetargetingView(comp, assignments));
+
+            static void verify(CSharpCompilation comp)
+            {
+                VerifyOverride(comp, "C.get_P", "System.String C.get_P()", "System.String A.get_P()", requiresMethodimpl: true);
+                VerifyOverride(comp, "D.P", "System.String D.P { get; }", "System.String B.P { get; }", requiresMethodimpl: true);
+                VerifyOverride(comp, "D.get_P", "System.String D.P.get", "System.String B.P.get", requiresMethodimpl: true);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -293,6 +293,11 @@ namespace System.Runtime.CompilerServices
                         requiresMethodimpl = isCovariant | requiresMethodimpl;
                         Assert.Equal(requiresMethodimpl, getMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
                         Assert.Equal(requiresMethodimpl, getMethod.RequiresExplicitOverride(out _)); // implies the presence of a methodimpl
+                        if (getMethod.OriginalDefinition is PEMethodSymbol originalMethod &&
+                            comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor) is MethodSymbol attrConstructor)
+                        {
+                            Assert.Equal(requiresMethodimpl, originalMethod.HasAttribute(attrConstructor));
+                        }
                     }
                 }
                 if (property.SetMethod is MethodSymbol setMethod && overriddenProperty.SetMethod is MethodSymbol overriddenSetMethod)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -250,8 +250,14 @@ namespace System.Runtime.CompilerServices
                 var checkMetadata = hasReturnConversion(method.ReturnType, overriddenMethod.ReturnType);
                 if (checkMetadata)
                 {
-                    Assert.Equal(isCovariant | requiresMethodimpl, method.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
-                    Assert.Equal(isCovariant | requiresMethodimpl, method.RequiresExplicitOverride(out _)); // implies the presence of a methodimpl
+                    requiresMethodimpl = isCovariant | requiresMethodimpl;
+                    Assert.Equal(requiresMethodimpl, method.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
+                    Assert.Equal(requiresMethodimpl, method.RequiresExplicitOverride(out _));
+                    if (method.OriginalDefinition is PEMethodSymbol originalMethod &&
+                        comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor) is MethodSymbol attrConstructor)
+                    {
+                        Assert.Equal(requiresMethodimpl, originalMethod.HasAttribute(attrConstructor));
+                    }
                 }
                 switch (member)
                 {

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -354,6 +354,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     select a).ToList().First();
         }
 
+        public static bool HasAttribute(this Symbol @this, MethodSymbol m)
+        {
+            return (from a in @this.GetAttributes()
+                    where a.AttributeConstructor.Equals(m)
+                    select a).ToList().FirstOrDefault() != null;
+        }
+
         public static void VerifyValue<T>(this CSharpAttributeData attr, int i, TypedConstantKind kind, T v)
         {
             var arg = attr.CommonConstructorArguments[i];


### PR DESCRIPTION
Fixes #45372
Relates to #44208
