### PR TITLE
Modify global analyzer config precedence:

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TextWriter consoleOutput,
             TouchedFileLogger touchedFilesLogger,
             ErrorLogger errorLogger,
-            ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions)
+            ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions,
+            AnalyzerConfigOptionsResult globalConfigOptions)
         {
             var parseOptions = Arguments.ParseOptions;
 
@@ -159,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var loggingFileSystem = new LoggingStrongNameFileSystem(touchedFilesLogger, _tempDirectory);
-            var optionsProvider = new CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions);
+            var optionsProvider = new CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions, globalConfigOptions);
 
             return CSharpCompilation.Create(
                 Arguments.CompilationName,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (syntaxTreeOptions is object && syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, out report))
             {
-                // 4. Global analyzer config options
+                // 4. Global analyzer config level
                 isSpecified = true;
             }
             else

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -124,6 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///     2. Syntax tree level
         ///     3. Compilation level
         ///     4. Global warning level
+        ///     5. Global analyzer config
         ///
         /// Pragmas are considered separately. If a diagnostic would not otherwise
         /// be suppressed, but is suppressed by a pragma, <paramref name="hasPragmaSuppression"/>
@@ -261,9 +262,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (severity == DiagnosticSeverity.Warning || severity == DiagnosticSeverity.Info)
                         {
                             report = ReportDiagnostic.Suppress;
+                            isSpecified = true;
                         }
                         break;
                 }
+            }
+
+            // 5. Global analyzer options
+            if (!isSpecified && syntaxTreeOptions is object && syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, out var globalReport))
+            {
+                report = globalReport;
             }
 
             return report;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // 3. Compilation level
                 isSpecified = true;
             }
-            else if (syntaxTreeOptions is object && syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, out report))
+            else if (syntaxTreeOptions is object && syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, cancellationToken, out report))
             {
                 // 4. Global analyzer config level
                 isSpecified = true;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -123,8 +123,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///     1. Warning level
         ///     2. Syntax tree level
         ///     3. Compilation level
-        ///     4. Global warning level
-        ///     5. Global analyzer config
+        ///     4. Global analyzer config
+        ///     5. Global warning level
         ///
         /// Pragmas are considered separately. If a diagnostic would not otherwise
         /// be suppressed, but is suppressed by a pragma, <paramref name="hasPragmaSuppression"/>
@@ -192,6 +192,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // 3. Compilation level
                 isSpecified = true;
             }
+            else if (syntaxTreeOptions is object && syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, out report))
+            {
+                // 4. Global analyzer config options
+                isSpecified = true;
+            }
             else
             {
                 report = isEnabledByDefault ? ReportDiagnostic.Default : ReportDiagnostic.Suppress;
@@ -242,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ReportDiagnostic.Suppress;
             }
 
-            // 4. Global options
+            // 5. Global options
             // Unless specific warning options are defined (/warnaserror[+|-]:<n> or /nowarn:<n>, 
             // follow the global option (/warnaserror[+|-] or /nowarn).
             if (report == ReportDiagnostic.Default)
@@ -266,12 +271,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         break;
                 }
-            }
-
-            // 5. Global analyzer options
-            if (!isSpecified && syntaxTreeOptions is object && syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, out var globalReport))
-            {
-                report = globalReport;
             }
 
             return report;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12795,6 +12795,27 @@ dotnet_diagnostic.CS0164.severity = warning;
 
         [Fact]
         [WorkItem(44087, "https://github.com/dotnet/roslyn/issues/44804")]
+        public void GlobalAnalyzerConfigSpecificDiagnosticOptionsOverrideGeneralCommandLineOptions()
+        {
+            var dir = Temp.CreateDirectory();
+            var src = dir.CreateFile("temp.cs").WriteAllText(@"
+class C
+{
+    void M()
+    {
+label1:;
+    }
+}");
+            var globalConfig = dir.CreateFile(".globalconfig").WriteAllText($@"
+is_global = true
+dotnet_diagnostic.CS0164.severity = none;
+");
+
+            VerifyOutput(dir, src, additionalFlags: new[] { "/warnaserror+", "/analyzerconfig:" + globalConfig.Path }, includeCurrentAssemblyAsAnalyzerReference: false);
+        }
+
+        [Fact]
+        [WorkItem(44087, "https://github.com/dotnet/roslyn/issues/44804")]
         public void GlobalAnalyzerConfigSectionsOverrideCommandLine()
         {
             var dir = Temp.CreateDirectory();

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -198,6 +198,7 @@ long _f = 0l;
             options = TestOptions.DebugDll.WithSyntaxTreeOptionsProvider(
                 new TestSyntaxTreeOptionsProvider(
                     StringComparer.Ordinal,
+                    globalOption: default,
                     (tree, new[] { ("cs0078", ReportDiagnostic.Suppress) }))
             );
 

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -1497,7 +1497,9 @@ is_global = true ", "/.editorconfig"));
             var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out _);
 
             Assert.Single(configs);
-            Assert.Null(globalConfig);
+            Assert.NotNull(globalConfig);
+            Assert.Empty(globalConfig.GlobalSection.Properties);
+            Assert.Empty(globalConfig.NamedSections);
             configs.Free();
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2087,6 +2087,20 @@ option2 = config3
               options);
         }
 
+        [Fact]
+        public void GlobalConfigOptionsAreEmptyWhenNoGlobalConfig()
+        {
+            var set = AnalyzerConfigSet.Create(ImmutableArray<AnalyzerConfig>.Empty);
+            var globalOptions = set.GlobalConfigOptions;
+
+            Assert.NotNull(globalOptions.AnalyzerOptions);
+            Assert.NotNull(globalOptions.TreeOptions);
+
+            Assert.Empty(globalOptions.AnalyzerOptions);
+            Assert.Empty(globalOptions.Diagnostics);
+            Assert.Empty(globalOptions.TreeOptions);
+        }
+
 
         #endregion
     }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -393,22 +393,22 @@ namespace Microsoft.CodeAnalysis
 
         private static void ParseSectionOptions(Section section, TreeOptions.Builder treeBuilder, AnalyzerOptions.Builder analyzerBuilder, ArrayBuilder<Diagnostic> diagnosticBuilder, string analyzerConfigPath, ConcurrentDictionary<ReadOnlyMemory<char>, string> diagIdCache)
         {
-            const string DiagnosticOptionPrefix = "dotnet_diagnostic.";
-            const string DiagnosticOptionSuffix = ".severity";
+            const string diagnosticOptionPrefix = "dotnet_diagnostic.";
+            const string diagnosticOptionSuffix = ".severity";
 
             foreach (var (key, value) in section.Properties)
             {
                 // Keys are lowercased in editorconfig parsing
                 int diagIdLength = -1;
-                if (key.StartsWith(DiagnosticOptionPrefix, StringComparison.Ordinal) &&
-                    key.EndsWith(DiagnosticOptionSuffix, StringComparison.Ordinal))
+                if (key.StartsWith(diagnosticOptionPrefix, StringComparison.Ordinal) &&
+                    key.EndsWith(diagnosticOptionSuffix, StringComparison.Ordinal))
                 {
-                    diagIdLength = key.Length - (DiagnosticOptionPrefix.Length + DiagnosticOptionSuffix.Length);
+                    diagIdLength = key.Length - (diagnosticOptionPrefix.Length + diagnosticOptionSuffix.Length);
                 }
 
                 if (diagIdLength >= 0)
                 {
-                    ReadOnlyMemory<char> idSlice = key.AsMemory().Slice(DiagnosticOptionPrefix.Length, diagIdLength);
+                    ReadOnlyMemory<char> idSlice = key.AsMemory().Slice(diagnosticOptionPrefix.Length, diagIdLength);
                     // PERF: this is similar to a double-checked locking pattern, and trying to fetch the ID first
                     // lets us avoid an allocation if the id has already been added
                     if (!diagIdCache.TryGetValue(idSlice, out var diagId))

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -191,14 +191,11 @@ namespace Microsoft.CodeAnalysis
             var normalizedPath = PathUtilities.NormalizeWithForwardSlash(sourcePath);
 
             // If we have a global config, add any sections that match the full path 
-            if (_globalConfig is object)
+            foreach (var section in _globalConfig.NamedSections)
             {
-                foreach (var section in _globalConfig.NamedSections)
+                if (normalizedPath.Equals(section.Name, Section.NameComparer))
                 {
-                    if (normalizedPath.Equals(section.Name, Section.NameComparer))
-                    {
-                        sectionKey.Add(section);
-                    }
+                    sectionKey.Add(section);
                 }
             }
             int globalConfigOptionsCount = sectionKey.Count;

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         private readonly ImmutableArray<AnalyzerConfig> _analyzerConfigs;
 
-        private readonly GlobalAnalyzerConfig? _globalConfig;
+        private readonly GlobalAnalyzerConfig _globalConfig;
 
         /// <summary>
         /// <see cref="SectionNameMatcher"/>s for each section. The entries in the outer array correspond to entries in <see cref="_analyzerConfigs"/>, and each inner array
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis
             return new AnalyzerConfigSet(sortedAnalyzerConfigs.ToImmutableAndFree(), globalConfig);
         }
 
-        private AnalyzerConfigSet(ImmutableArray<AnalyzerConfig> analyzerConfigs, GlobalAnalyzerConfig? globalConfig)
+        private AnalyzerConfigSet(ImmutableArray<AnalyzerConfig> analyzerConfigs, GlobalAnalyzerConfig globalConfig)
         {
             _analyzerConfigs = analyzerConfigs;
             _globalConfig = globalConfig;
@@ -144,7 +144,34 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(allMatchers.Count == _analyzerConfigs.Length);
 
             _analyzerMatchers = allMatchers.ToImmutableAndFree();
+
+            // parse the global options upfront
+            var treeOptionsBuilder = _treeOptionsPool.Allocate();
+            var analyzerOptionsBuilder = _analyzerOptionsPool.Allocate();
+            var diagnosticBuilder = ArrayBuilder<Diagnostic>.GetInstance();
+
+            ParseSectionOptions(_globalConfig.GlobalSection,
+                        treeOptionsBuilder,
+                        analyzerOptionsBuilder,
+                        diagnosticBuilder,
+                        GlobalAnalyzerConfigBuilder.GlobalConfigPath,
+                        _diagnosticIdCache);
+
+            GlobalConfigOptions = new AnalyzerConfigOptionsResult(
+                treeOptionsBuilder.ToImmutable(),
+                analyzerOptionsBuilder.ToImmutable(),
+                diagnosticBuilder.ToImmutableAndFree());
+
+            treeOptionsBuilder.Clear();
+            analyzerOptionsBuilder.Clear();
+            _treeOptionsPool.Free(treeOptionsBuilder);
+            _analyzerOptionsPool.Free(analyzerOptionsBuilder);
         }
+
+        /// <summary>
+        /// Gets an <see cref="AnalyzerConfigOptionsResult"/> that contain the options that apply globally
+        /// </summary>
+        public AnalyzerConfigOptionsResult GlobalConfigOptions { get; private set; }
 
         /// <summary>
         /// Returns a <see cref="AnalyzerConfigOptionsResult"/> for a source file. This computes which <see cref="AnalyzerConfig"/> rules applies to this file, and correctly applies
@@ -223,31 +250,22 @@ namespace Microsoft.CodeAnalysis
 
                 int sectionKeyIndex = 0;
 
-                if (_globalConfig is object)
+                analyzerOptionsBuilder.AddRange(GlobalConfigOptions.AnalyzerOptions);
+                foreach (var configSection in _globalConfig.NamedSections)
                 {
-                    addOptions(_globalConfig.GlobalSection,
-                                treeOptionsBuilder,
-                                analyzerOptionsBuilder,
-                                diagnosticBuilder,
-                                GlobalAnalyzerConfigBuilder.GlobalConfigPath,
-                                _diagnosticIdCache);
-
-                    foreach (var configSection in _globalConfig.NamedSections)
+                    if (sectionKey.Count > 0 && configSection == sectionKey[sectionKeyIndex])
                     {
-                        if (sectionKey.Count > 0 && configSection == sectionKey[sectionKeyIndex])
+                        ParseSectionOptions(
+                            sectionKey[sectionKeyIndex],
+                            treeOptionsBuilder,
+                            analyzerOptionsBuilder,
+                            diagnosticBuilder,
+                            GlobalAnalyzerConfigBuilder.GlobalConfigPath,
+                            _diagnosticIdCache);
+                        sectionKeyIndex++;
+                        if (sectionKeyIndex == sectionKey.Count)
                         {
-                            addOptions(
-                                sectionKey[sectionKeyIndex],
-                                treeOptionsBuilder,
-                                analyzerOptionsBuilder,
-                                diagnosticBuilder,
-                                GlobalAnalyzerConfigBuilder.GlobalConfigPath,
-                                _diagnosticIdCache);
-                            sectionKeyIndex++;
-                            if (sectionKeyIndex == sectionKey.Count)
-                            {
-                                break;
-                            }
+                            break;
                         }
                     }
                 }
@@ -262,7 +280,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         if (sectionKey[sectionKeyIndex] == config.NamedSections[matcherIndex])
                         {
-                            addOptions(
+                            ParseSectionOptions(
                                 sectionKey[sectionKeyIndex],
                                 treeOptionsBuilder,
                                 analyzerOptionsBuilder,
@@ -312,64 +330,6 @@ namespace Microsoft.CodeAnalysis
                 sectionKey.Clear();
                 pool.Free(sectionKey);
             }
-
-            static void addOptions(
-                AnalyzerConfig.Section section,
-                TreeOptions.Builder treeBuilder,
-                AnalyzerOptions.Builder analyzerBuilder,
-                ArrayBuilder<Diagnostic> diagnosticBuilder,
-                string analyzerConfigPath,
-                ConcurrentDictionary<ReadOnlyMemory<char>, string> diagIdCache)
-            {
-                const string DiagnosticOptionPrefix = "dotnet_diagnostic.";
-                const string DiagnosticOptionSuffix = ".severity";
-
-                foreach (var (key, value) in section.Properties)
-                {
-                    // Keys are lowercased in editorconfig parsing
-                    int diagIdLength = -1;
-                    if (key.StartsWith(DiagnosticOptionPrefix, StringComparison.Ordinal) &&
-                        key.EndsWith(DiagnosticOptionSuffix, StringComparison.Ordinal))
-                    {
-                        diagIdLength = key.Length - (DiagnosticOptionPrefix.Length + DiagnosticOptionSuffix.Length);
-                    }
-
-                    if (diagIdLength >= 0)
-                    {
-                        ReadOnlyMemory<char> idSlice = key.AsMemory().Slice(DiagnosticOptionPrefix.Length, diagIdLength);
-                        // PERF: this is similar to a double-checked locking pattern, and trying to fetch the ID first
-                        // lets us avoid an allocation if the id has already been added
-                        if (!diagIdCache.TryGetValue(idSlice, out var diagId))
-                        {
-                            // We use ReadOnlyMemory<char> to allow allocation-free lookups in the
-                            // dictionary, but the actual keys stored in the dictionary are trimmed
-                            // to avoid holding GC references to larger strings than necessary. The
-                            // GetOrAdd APIs do not allow the key to be manipulated between lookup
-                            // and insertion, so we separate the operations here in code.
-                            diagId = idSlice.ToString();
-                            diagId = diagIdCache.GetOrAdd(diagId.AsMemory(), diagId);
-                        }
-
-                        if (TryParseSeverity(value, out ReportDiagnostic severity))
-                        {
-                            treeBuilder[diagId] = severity;
-                        }
-                        else
-                        {
-                            diagnosticBuilder.Add(Diagnostic.Create(
-                                InvalidAnalyzerConfigSeverityDescriptor,
-                                Location.None,
-                                diagId,
-                                value,
-                                analyzerConfigPath));
-                        }
-                    }
-                    else
-                    {
-                        analyzerBuilder[key] = value;
-                    }
-                }
-            }
         }
 
         internal static bool TryParseSeverity(string value, out ReportDiagnostic severity)
@@ -410,13 +370,65 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
+        private static void ParseSectionOptions(Section section, TreeOptions.Builder treeBuilder, AnalyzerOptions.Builder analyzerBuilder, ArrayBuilder<Diagnostic> diagnosticBuilder, string analyzerConfigPath, ConcurrentDictionary<ReadOnlyMemory<char>, string> diagIdCache)
+        {
+            const string DiagnosticOptionPrefix = "dotnet_diagnostic.";
+            const string DiagnosticOptionSuffix = ".severity";
+
+            foreach (var (key, value) in section.Properties)
+            {
+                // Keys are lowercased in editorconfig parsing
+                int diagIdLength = -1;
+                if (key.StartsWith(DiagnosticOptionPrefix, StringComparison.Ordinal) &&
+                    key.EndsWith(DiagnosticOptionSuffix, StringComparison.Ordinal))
+                {
+                    diagIdLength = key.Length - (DiagnosticOptionPrefix.Length + DiagnosticOptionSuffix.Length);
+                }
+
+                if (diagIdLength >= 0)
+                {
+                    ReadOnlyMemory<char> idSlice = key.AsMemory().Slice(DiagnosticOptionPrefix.Length, diagIdLength);
+                    // PERF: this is similar to a double-checked locking pattern, and trying to fetch the ID first
+                    // lets us avoid an allocation if the id has already been added
+                    if (!diagIdCache.TryGetValue(idSlice, out var diagId))
+                    {
+                        // We use ReadOnlyMemory<char> to allow allocation-free lookups in the
+                        // dictionary, but the actual keys stored in the dictionary are trimmed
+                        // to avoid holding GC references to larger strings than necessary. The
+                        // GetOrAdd APIs do not allow the key to be manipulated between lookup
+                        // and insertion, so we separate the operations here in code.
+                        diagId = idSlice.ToString();
+                        diagId = diagIdCache.GetOrAdd(diagId.AsMemory(), diagId);
+                    }
+
+                    if (TryParseSeverity(value, out ReportDiagnostic severity))
+                    {
+                        treeBuilder[diagId] = severity;
+                    }
+                    else
+                    {
+                        diagnosticBuilder.Add(Diagnostic.Create(
+                            InvalidAnalyzerConfigSeverityDescriptor,
+                            Location.None,
+                            diagId,
+                            value,
+                            analyzerConfigPath));
+                    }
+                }
+                else
+                {
+                    analyzerBuilder[key] = value;
+                }
+            }
+        }
+
         /// <summary>
         /// Merge any partial global configs into a single global config, and remove the partial configs
         /// </summary>
         /// <param name="analyzerConfigs">An <see cref="ArrayBuilder{T}"/> of <see cref="AnalyzerConfig"/> containing a mix of regular and unmerged partial global configs</param>
         /// <param name="diagnostics">Diagnostics produced during merge will be added to this bag</param>
         /// <returns>A <see cref="GlobalAnalyzerConfig" /> that contains the merged partial configs, or <c>null</c> if there were no partial configs</returns>
-        internal static GlobalAnalyzerConfig? MergeGlobalConfigs(ArrayBuilder<AnalyzerConfig> analyzerConfigs, out ImmutableArray<Diagnostic> diagnostics)
+        internal static GlobalAnalyzerConfig MergeGlobalConfigs(ArrayBuilder<AnalyzerConfig> analyzerConfigs, out ImmutableArray<Diagnostic> diagnostics)
         {
             GlobalAnalyzerConfigBuilder globalAnalyzerConfigBuilder = new GlobalAnalyzerConfigBuilder();
             for (int i = 0; i < analyzerConfigs.Count; i++)
@@ -461,11 +473,11 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            internal GlobalAnalyzerConfig? Build(DiagnosticBag diagnostics)
+            internal GlobalAnalyzerConfig Build(DiagnosticBag diagnostics)
             {
                 if (_values is null || _duplicates is null)
                 {
-                    return null;
+                    return new GlobalAnalyzerConfig(new Section(GlobalSectionName, AnalyzerOptions.Empty), ImmutableArray<Section>.Empty);
                 }
 
                 // issue diagnostics for any duplicate keys

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -87,7 +87,8 @@ namespace Microsoft.CodeAnalysis
             TextWriter consoleOutput,
             TouchedFileLogger touchedFilesLogger,
             ErrorLogger errorLoggerOpt,
-            ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions);
+            ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions,
+            AnalyzerConfigOptionsResult globalConfigOptions);
 
         public abstract void PrintLogo(TextWriter consoleOutput);
         public abstract void PrintHelp(TextWriter consoleOutput);
@@ -769,6 +770,7 @@ namespace Microsoft.CodeAnalysis
 
             AnalyzerConfigSet analyzerConfigSet = null;
             ImmutableArray<AnalyzerConfigOptionsResult> sourceFileAnalyzerConfigOptions = default;
+            AnalyzerConfigOptionsResult globalConfigOptions = default;
 
             if (Arguments.AnalyzerConfigPaths.Length > 0)
             {
@@ -779,6 +781,7 @@ namespace Microsoft.CodeAnalysis
                     return Failed;
                 }
 
+                globalConfigOptions = analyzerConfigSet.GlobalConfigOptions;
                 sourceFileAnalyzerConfigOptions = Arguments.SourceFiles.SelectAsArray(f => analyzerConfigSet.GetOptionsForSourcePath(f.Path));
 
                 foreach (var sourceFileAnalyzerConfigOption in sourceFileAnalyzerConfigOptions)
@@ -787,7 +790,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            Compilation compilation = CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, sourceFileAnalyzerConfigOptions);
+            Compilation compilation = CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, sourceFileAnalyzerConfigOptions, globalConfigOptions);
             if (compilation == null)
             {
                 return Failed;

--- a/src/Compilers/Core/Portable/Compilation/SyntaxTreeOptionsProvider.cs
+++ b/src/Compilers/Core/Portable/Compilation/SyntaxTreeOptionsProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Get diagnostic severity set globally for a given diagnostic identifier
         /// </summary>
-        public abstract bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity);
+        public abstract bool TryGetGlobalDiagnosticValue(string diagnosticId, CancellationToken cancellationToken, out ReportDiagnostic severity);
     }
 
     internal sealed class CompilerSyntaxTreeOptionsProvider : SyntaxTreeOptionsProvider
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        public override bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity)
+        public override bool TryGetGlobalDiagnosticValue(string diagnosticId, CancellationToken _, out ReportDiagnostic severity)
         {
             if (_globalOptions.TreeOptions is object)
             {

--- a/src/Compilers/Core/Portable/Compilation/SyntaxTreeOptionsProvider.cs
+++ b/src/Compilers/Core/Portable/Compilation/SyntaxTreeOptionsProvider.cs
@@ -15,9 +15,14 @@ namespace Microsoft.CodeAnalysis
         public abstract bool? IsGenerated(SyntaxTree tree, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Get diagnostic severity setting or a given diagnostic identifier in a given tree.
+        /// Get diagnostic severity setting for a given diagnostic identifier in a given tree.
         /// </summary>
         public abstract bool TryGetDiagnosticValue(SyntaxTree tree, string diagnosticId, CancellationToken cancellationToken, out ReportDiagnostic severity);
+
+        /// <summary>
+        /// Get diagnostic severity set globally for a given diagnostic identifier
+        /// </summary>
+        public abstract bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity);
     }
 
     internal sealed class CompilerSyntaxTreeOptionsProvider : SyntaxTreeOptionsProvider
@@ -44,9 +49,12 @@ namespace Microsoft.CodeAnalysis
 
         private readonly ImmutableDictionary<SyntaxTree, Options> _options;
 
+        private readonly AnalyzerConfigOptionsResult _globalOptions;
+
         public CompilerSyntaxTreeOptionsProvider(
             SyntaxTree?[] trees,
-            ImmutableArray<AnalyzerConfigOptionsResult> results)
+            ImmutableArray<AnalyzerConfigOptionsResult> results,
+            AnalyzerConfigOptionsResult globalResults)
         {
             var builder = ImmutableDictionary.CreateBuilder<SyntaxTree, Options>();
             for (int i = 0; i < trees.Length; i++)
@@ -59,6 +67,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
             _options = builder.ToImmutableDictionary();
+            _globalOptions = globalResults;
         }
 
         public override bool? IsGenerated(SyntaxTree tree, CancellationToken _)
@@ -69,6 +78,16 @@ namespace Microsoft.CodeAnalysis
             if (_options.TryGetValue(tree, out var value))
             {
                 return value.DiagnosticOptions.TryGetValue(diagnosticId, out severity);
+            }
+            severity = ReportDiagnostic.Default;
+            return false;
+        }
+
+        public override bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity)
+        {
+            if (_globalOptions.TreeOptions is object)
+            {
+                return _globalOptions.TreeOptions.TryGetValue(diagnosticId, out severity);
             }
             severity = ReportDiagnostic.Default;
             return false;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1247,7 +1247,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var hasUnsuppressedDiagnostic = false;
                 foreach (var descriptor in descriptors)
                 {
-                    options.TryGetGlobalDiagnosticValue(descriptor.Id, out var configuredSeverity);
+                    _ = options.TryGetGlobalDiagnosticValue(descriptor.Id, out var configuredSeverity);
                     if (options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var diagnosticSeverity))
                     {
                         configuredSeverity = diagnosticSeverity;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1247,7 +1247,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var hasUnsuppressedDiagnostic = false;
                 foreach (var descriptor in descriptors)
                 {
-                    _ = options.TryGetGlobalDiagnosticValue(descriptor.Id, out var configuredSeverity);
+                    _ = options.TryGetGlobalDiagnosticValue(descriptor.Id, AnalyzerExecutor.CancellationToken, out var configuredSeverity);
                     if (options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var diagnosticSeverity))
                     {
                         configuredSeverity = diagnosticSeverity;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1247,8 +1247,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var hasUnsuppressedDiagnostic = false;
                 foreach (var descriptor in descriptors)
                 {
-                    if (!options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var configuredSeverity) ||
-                        configuredSeverity != ReportDiagnostic.Suppress)
+                    options.TryGetGlobalDiagnosticValue(descriptor.Id, out var configuredSeverity);
+                    if (options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var diagnosticSeverity))
+                    {
+                        configuredSeverity = diagnosticSeverity;
+                    }
+
+                    if (configuredSeverity != ReportDiagnostic.Suppress)
                     {
                         // Analyzer reports a diagnostic that is not suppressed by the diagnostic options for this tree.
                         hasUnsuppressedDiagnostic = true;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Note that "/warnaserror-:DiagnosticId" adds a diagnostic option with value 'ReportDiagnostic.Default',
                 // which should not alter 'isSuppressed'.
                 if ((diagnosticOptions.TryGetValue(diag.Id, out var severity) ||
-                    options.SyntaxTreeOptionsProvider is object && options.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(diag.Id, out severity)) &&
+                    options.SyntaxTreeOptionsProvider is object && options.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(diag.Id, analyzerExecutor.CancellationToken, out severity)) &&
                     severity != ReportDiagnostic.Default)
                 {
                     isSuppressed = severity == ReportDiagnostic.Suppress;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -321,10 +321,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Is this diagnostic suppressed by default (as written by the rule author)
                 var isSuppressed = !diag.IsEnabledByDefault;
 
-                // Compilation wide user settings from ruleset/nowarn/warnaserror overrides the analyzer author.
+                // Global editorconfig settings overrides the analyzer author
+                // Compilation wide user settings (diagnosticOptions) from ruleset/nowarn/warnaserror overrides the analyzer author and global editorconfig settings.
                 // Note that "/warnaserror-:DiagnosticId" adds a diagnostic option with value 'ReportDiagnostic.Default',
                 // which should not alter 'isSuppressed'.
-                if (diagnosticOptions.TryGetValue(diag.Id, out var severity) &&
+                if ((diagnosticOptions.TryGetValue(diag.Id, out var severity) ||
+                    options.SyntaxTreeOptionsProvider is object && options.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(diag.Id, out severity)) &&
                     severity != ReportDiagnostic.Default)
                 {
                     isSuppressed = severity == ReportDiagnostic.Suppress;
@@ -336,12 +338,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 // Is this diagnostic suppressed due to its severity
                 if (severityFilter.Contains(severity))
-                {
-                    isSuppressed = true;
-                }
-
-                // Global editorconfig settings only apply if it wasn't supressed via commandline already
-                if (!isSuppressed && options.SyntaxTreeOptionsProvider is object && options.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(diag.Id, out severity))
                 {
                     isSuppressed = true;
                 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -340,6 +340,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     isSuppressed = true;
                 }
 
+                // Global editorconfig settings only apply if it wasn't supressed via commandline already
+                if (!isSuppressed && options.SyntaxTreeOptionsProvider is object && options.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(diag.Id, out severity))
+                {
+                    isSuppressed = true;
+                }
+
                 // Editorconfig user settings override compilation wide settings.
                 if (isSuppressed &&
                     isEnabledWithAnalyzerConfigOptions(diag, severityFilter, compilation, analyzerOptions, analyzerExecutor.CancellationToken))

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,56 +2,6 @@
 Microsoft.CodeAnalysis.Compilation.CreateFunctionPointerTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol returnType, Microsoft.CodeAnalysis.RefKind returnRefKind, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> parameterTypes, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.RefKind> parameterRefKinds, System.Reflection.Metadata.SignatureCallingConvention callingConvention = System.Reflection.Metadata.SignatureCallingConvention.Default, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol> callingConventionTypes = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>)) -> Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
 Microsoft.CodeAnalysis.CommandLineArguments.SkipAnalyzers.get -> bool
 Microsoft.CodeAnalysis.AnalyzerConfigSet.GlobalConfigOptions.get -> Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult
-Microsoft.CodeAnalysis.Compilation.CreateFunctionPointerTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol returnType, Microsoft.CodeAnalysis.RefKind returnRefKind, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> parameterTypes, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.RefKind> parameterRefKinds) -> Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
-Microsoft.CodeAnalysis.Compilation.CreateNativeIntegerTypeSymbol(bool signed) -> Microsoft.CodeAnalysis.INamedTypeSymbol
-Microsoft.CodeAnalysis.CompilationOptions.SyntaxTreeOptionsProvider.get -> Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
-Microsoft.CodeAnalysis.CompilationOptions.WithSyntaxTreeOptionsProvider(Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider provider) -> Microsoft.CodeAnalysis.CompilationOptions
-Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.AssemblyLoader.get -> Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader
-Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.Equals(Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference other) -> bool
-Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SemanticModel model, Microsoft.CodeAnalysis.Text.TextSpan? filterSpan, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
-Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SemanticModel model, Microsoft.CodeAnalysis.Text.TextSpan? filterSpan, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
-Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SyntaxTree tree, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
-Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SyntaxTree tree, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
-Microsoft.CodeAnalysis.Emit.EmitOptions.DefaultSourceFileEncoding.get -> System.Text.Encoding
-Microsoft.CodeAnalysis.Emit.EmitOptions.EmitOptions(bool metadataOnly = false, Microsoft.CodeAnalysis.Emit.DebugInformationFormat debugInformationFormat = (Microsoft.CodeAnalysis.Emit.DebugInformationFormat)0, string pdbFilePath = null, string outputNameOverride = null, int fileAlignment = 0, ulong baseAddress = 0, bool highEntropyVirtualAddressSpace = false, Microsoft.CodeAnalysis.SubsystemVersion subsystemVersion = default(Microsoft.CodeAnalysis.SubsystemVersion), string runtimeMetadataVersion = null, bool tolerateErrors = false, bool includePrivateMembers = true, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind> instrumentationKinds = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind>), System.Security.Cryptography.HashAlgorithmName? pdbChecksumAlgorithm = null, System.Text.Encoding defaultSourceFileEncoding = null, System.Text.Encoding fallbackSourceFileEncoding = null) -> void
-Microsoft.CodeAnalysis.Emit.EmitOptions.EmitOptions(bool metadataOnly, Microsoft.CodeAnalysis.Emit.DebugInformationFormat debugInformationFormat, string pdbFilePath, string outputNameOverride, int fileAlignment, ulong baseAddress, bool highEntropyVirtualAddressSpace, Microsoft.CodeAnalysis.SubsystemVersion subsystemVersion, string runtimeMetadataVersion, bool tolerateErrors, bool includePrivateMembers, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind> instrumentationKinds, System.Security.Cryptography.HashAlgorithmName? pdbChecksumAlgorithm) -> void
-Microsoft.CodeAnalysis.Emit.EmitOptions.FallbackSourceFileEncoding.get -> System.Text.Encoding
-Microsoft.CodeAnalysis.Emit.EmitOptions.WithDefaultSourceFileEncoding(System.Text.Encoding defaultSourceFileEncoding) -> Microsoft.CodeAnalysis.Emit.EmitOptions
-Microsoft.CodeAnalysis.Emit.EmitOptions.WithFallbackSourceFileEncoding(System.Text.Encoding fallbackSourceFileEncoding) -> Microsoft.CodeAnalysis.Emit.EmitOptions
-Microsoft.CodeAnalysis.IMethodSymbol.IsInitOnly.get -> bool
-Microsoft.CodeAnalysis.IAssemblySymbol.GetForwardedTypes() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>
-Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
-Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol.Signature.get -> Microsoft.CodeAnalysis.IMethodSymbol
-Microsoft.CodeAnalysis.INamedTypeSymbol.NativeIntegerUnderlyingType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
-Microsoft.CodeAnalysis.ITypeSymbol.IsNativeIntegerType.get -> bool
-Microsoft.CodeAnalysis.MethodKind.FunctionPointerSignature = 18 -> Microsoft.CodeAnalysis.MethodKind
-Microsoft.CodeAnalysis.OperationKind.BinaryPattern = 110 -> Microsoft.CodeAnalysis.OperationKind
-Microsoft.CodeAnalysis.OperationKind.NegatedPattern = 109 -> Microsoft.CodeAnalysis.OperationKind
-Microsoft.CodeAnalysis.OperationKind.RelationalPattern = 112 -> Microsoft.CodeAnalysis.OperationKind
-Microsoft.CodeAnalysis.OperationKind.TypePattern = 111 -> Microsoft.CodeAnalysis.OperationKind
-Microsoft.CodeAnalysis.OperationKind.With = 113 -> Microsoft.CodeAnalysis.OperationKind
-Microsoft.CodeAnalysis.Operations.CommonConversion.IsNullable.get -> bool
-Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation
-Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation.LeftPattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
-Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation.OperatorKind.get -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind
-Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation.RightPattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
-Microsoft.CodeAnalysis.Operations.INegatedPatternOperation
-Microsoft.CodeAnalysis.Operations.INegatedPatternOperation.Pattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
-Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation
-Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.OperatorKind.get -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind
-Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.Value.get -> Microsoft.CodeAnalysis.IOperation
-Microsoft.CodeAnalysis.Operations.ITypePatternOperation
-Microsoft.CodeAnalysis.Operations.ITypePatternOperation.MatchedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
-Microsoft.CodeAnalysis.SourceGeneratorContext.AnalyzerConfigOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider
-Microsoft.CodeAnalysis.Operations.IWithOperation
-Microsoft.CodeAnalysis.Operations.IWithOperation.CloneMethod.get -> Microsoft.CodeAnalysis.IMethodSymbol
-Microsoft.CodeAnalysis.Operations.IWithOperation.Initializer.get -> Microsoft.CodeAnalysis.Operations.IObjectOrCollectionInitializerOperation
-Microsoft.CodeAnalysis.Operations.IWithOperation.Operand.get -> Microsoft.CodeAnalysis.IOperation
-Microsoft.CodeAnalysis.SymbolKind.FunctionPointerType = 20 -> Microsoft.CodeAnalysis.SymbolKind
-Microsoft.CodeAnalysis.TypeKind.FunctionPointer = 13 -> Microsoft.CodeAnalysis.TypeKind
-abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider.GlobalOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions
-abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(string diagnosticId, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
-static Microsoft.CodeAnalysis.AnalyzerConfigSet.Create<TList>(TList analyzerConfigs, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics) -> Microsoft.CodeAnalysis.AnalyzerConfigSet
 Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext
 Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext.AdditionalFile.get -> Microsoft.CodeAnalysis.AdditionalText
 Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext.CancellationToken.get -> System.Threading.CancellationToken
@@ -76,6 +26,7 @@ Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.SyntaxTreeOptionsProvider() -> void
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree, System.Threading.CancellationToken cancellationToken) -> bool?
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetDiagnosticValue(Microsoft.CodeAnalysis.SyntaxTree tree, string diagnosticId, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
+abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(string diagnosticId, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
 Microsoft.CodeAnalysis.GeneratorRunResult.GeneratedSources.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.GeneratedSourceResult>
 const Microsoft.CodeAnalysis.WellKnownMemberNames.TopLevelStatementsEntryPointMethodName = "<Main>$" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.TopLevelStatementsEntryPointTypeName = "<Program>$" -> string

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,57 @@
 *REMOVED*Microsoft.CodeAnalysis.Compilation.CreateFunctionPointerTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol returnType, Microsoft.CodeAnalysis.RefKind returnRefKind, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> parameterTypes, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.RefKind> parameterRefKinds) -> Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
 Microsoft.CodeAnalysis.Compilation.CreateFunctionPointerTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol returnType, Microsoft.CodeAnalysis.RefKind returnRefKind, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> parameterTypes, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.RefKind> parameterRefKinds, System.Reflection.Metadata.SignatureCallingConvention callingConvention = System.Reflection.Metadata.SignatureCallingConvention.Default, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol> callingConventionTypes = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>)) -> Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
 Microsoft.CodeAnalysis.CommandLineArguments.SkipAnalyzers.get -> bool
+Microsoft.CodeAnalysis.AnalyzerConfigSet.GlobalConfigOptions.get -> Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult
+Microsoft.CodeAnalysis.Compilation.CreateFunctionPointerTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol returnType, Microsoft.CodeAnalysis.RefKind returnRefKind, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> parameterTypes, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.RefKind> parameterRefKinds) -> Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
+Microsoft.CodeAnalysis.Compilation.CreateNativeIntegerTypeSymbol(bool signed) -> Microsoft.CodeAnalysis.INamedTypeSymbol
+Microsoft.CodeAnalysis.CompilationOptions.SyntaxTreeOptionsProvider.get -> Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
+Microsoft.CodeAnalysis.CompilationOptions.WithSyntaxTreeOptionsProvider(Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider provider) -> Microsoft.CodeAnalysis.CompilationOptions
+Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.AssemblyLoader.get -> Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader
+Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.Equals(Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference other) -> bool
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SemanticModel model, Microsoft.CodeAnalysis.Text.TextSpan? filterSpan, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SemanticModel model, Microsoft.CodeAnalysis.Text.TextSpan? filterSpan, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SyntaxTree tree, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.SyntaxTree tree, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
+Microsoft.CodeAnalysis.Emit.EmitOptions.DefaultSourceFileEncoding.get -> System.Text.Encoding
+Microsoft.CodeAnalysis.Emit.EmitOptions.EmitOptions(bool metadataOnly = false, Microsoft.CodeAnalysis.Emit.DebugInformationFormat debugInformationFormat = (Microsoft.CodeAnalysis.Emit.DebugInformationFormat)0, string pdbFilePath = null, string outputNameOverride = null, int fileAlignment = 0, ulong baseAddress = 0, bool highEntropyVirtualAddressSpace = false, Microsoft.CodeAnalysis.SubsystemVersion subsystemVersion = default(Microsoft.CodeAnalysis.SubsystemVersion), string runtimeMetadataVersion = null, bool tolerateErrors = false, bool includePrivateMembers = true, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind> instrumentationKinds = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind>), System.Security.Cryptography.HashAlgorithmName? pdbChecksumAlgorithm = null, System.Text.Encoding defaultSourceFileEncoding = null, System.Text.Encoding fallbackSourceFileEncoding = null) -> void
+Microsoft.CodeAnalysis.Emit.EmitOptions.EmitOptions(bool metadataOnly, Microsoft.CodeAnalysis.Emit.DebugInformationFormat debugInformationFormat, string pdbFilePath, string outputNameOverride, int fileAlignment, ulong baseAddress, bool highEntropyVirtualAddressSpace, Microsoft.CodeAnalysis.SubsystemVersion subsystemVersion, string runtimeMetadataVersion, bool tolerateErrors, bool includePrivateMembers, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind> instrumentationKinds, System.Security.Cryptography.HashAlgorithmName? pdbChecksumAlgorithm) -> void
+Microsoft.CodeAnalysis.Emit.EmitOptions.FallbackSourceFileEncoding.get -> System.Text.Encoding
+Microsoft.CodeAnalysis.Emit.EmitOptions.WithDefaultSourceFileEncoding(System.Text.Encoding defaultSourceFileEncoding) -> Microsoft.CodeAnalysis.Emit.EmitOptions
+Microsoft.CodeAnalysis.Emit.EmitOptions.WithFallbackSourceFileEncoding(System.Text.Encoding fallbackSourceFileEncoding) -> Microsoft.CodeAnalysis.Emit.EmitOptions
+Microsoft.CodeAnalysis.IMethodSymbol.IsInitOnly.get -> bool
+Microsoft.CodeAnalysis.IAssemblySymbol.GetForwardedTypes() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>
+Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol
+Microsoft.CodeAnalysis.IFunctionPointerTypeSymbol.Signature.get -> Microsoft.CodeAnalysis.IMethodSymbol
+Microsoft.CodeAnalysis.INamedTypeSymbol.NativeIntegerUnderlyingType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
+Microsoft.CodeAnalysis.ITypeSymbol.IsNativeIntegerType.get -> bool
+Microsoft.CodeAnalysis.MethodKind.FunctionPointerSignature = 18 -> Microsoft.CodeAnalysis.MethodKind
+Microsoft.CodeAnalysis.OperationKind.BinaryPattern = 110 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.NegatedPattern = 109 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.RelationalPattern = 112 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.TypePattern = 111 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.With = 113 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.Operations.CommonConversion.IsNullable.get -> bool
+Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation
+Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation.LeftPattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
+Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation.OperatorKind.get -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind
+Microsoft.CodeAnalysis.Operations.IBinaryPatternOperation.RightPattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
+Microsoft.CodeAnalysis.Operations.INegatedPatternOperation
+Microsoft.CodeAnalysis.Operations.INegatedPatternOperation.Pattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
+Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation
+Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.OperatorKind.get -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind
+Microsoft.CodeAnalysis.Operations.IRelationalPatternOperation.Value.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Operations.ITypePatternOperation
+Microsoft.CodeAnalysis.Operations.ITypePatternOperation.MatchedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
+Microsoft.CodeAnalysis.SourceGeneratorContext.AnalyzerConfigOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider
+Microsoft.CodeAnalysis.Operations.IWithOperation
+Microsoft.CodeAnalysis.Operations.IWithOperation.CloneMethod.get -> Microsoft.CodeAnalysis.IMethodSymbol
+Microsoft.CodeAnalysis.Operations.IWithOperation.Initializer.get -> Microsoft.CodeAnalysis.Operations.IObjectOrCollectionInitializerOperation
+Microsoft.CodeAnalysis.Operations.IWithOperation.Operand.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.SymbolKind.FunctionPointerType = 20 -> Microsoft.CodeAnalysis.SymbolKind
+Microsoft.CodeAnalysis.TypeKind.FunctionPointer = 13 -> Microsoft.CodeAnalysis.TypeKind
+abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider.GlobalOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions
+abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(string diagnosticId, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
+static Microsoft.CodeAnalysis.AnalyzerConfigSet.Create<TList>(TList analyzerConfigs, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics) -> Microsoft.CodeAnalysis.AnalyzerConfigSet
 Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext
 Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext.AdditionalFile.get -> Microsoft.CodeAnalysis.AdditionalText
 Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext.CancellationToken.get -> System.Threading.CancellationToken

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -26,7 +26,7 @@ Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.SyntaxTreeOptionsProvider() -> void
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree, System.Threading.CancellationToken cancellationToken) -> bool?
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetDiagnosticValue(Microsoft.CodeAnalysis.SyntaxTree tree, string diagnosticId, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
-abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(string diagnosticId, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
+abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(string diagnosticId, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
 Microsoft.CodeAnalysis.GeneratorRunResult.GeneratedSources.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.GeneratedSourceResult>
 const Microsoft.CodeAnalysis.WellKnownMemberNames.TopLevelStatementsEntryPointMethodName = "<Main>$" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.TopLevelStatementsEntryPointTypeName = "<Program>$" -> string

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -55,15 +55,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             TextWriter consoleOutput,
             TouchedFileLogger touchedFilesLogger,
             ErrorLogger errorLogger)
-            => CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt: default);
+            => CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt: default, globalDiagnosticOptionsOpt: default);
 
         public override Compilation CreateCompilation(
             TextWriter consoleOutput,
             TouchedFileLogger touchedFilesLogger,
             ErrorLogger errorLogger,
-            ImmutableArray<AnalyzerConfigOptionsResult> syntaxDiagOptionsOpt)
+            ImmutableArray<AnalyzerConfigOptionsResult> syntaxDiagOptionsOpt,
+            AnalyzerConfigOptionsResult globalDiagnosticOptionsOpt)
         {
-            Compilation = base.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt);
+            Compilation = base.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt, globalDiagnosticOptionsOpt);
             return Compilation;
         }
 

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -54,8 +54,12 @@ Friend Class MockVisualBasicCompiler
         End If
     End Sub
 
-    Public Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger, syntaxTreeDiagnosticOptionsOpt As ImmutableArray(Of AnalyzerConfigOptionsResult)) As Compilation
-        Compilation = MyBase.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt)
+    Public Overloads Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger, syntaxTreeDiagnosticOptionsOpt As ImmutableArray(Of AnalyzerConfigOptionsResult)) As Compilation
+        Return Me.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt, Nothing)
+    End Function
+
+    Public Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger, syntaxTreeDiagnosticOptionsOpt As ImmutableArray(Of AnalyzerConfigOptionsResult), globalConfigOptions As AnalyzerConfigOptionsResult) As Compilation
+        Compilation = MyBase.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt, globalConfigOptions)
         Return Compilation
     End Function
 

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -85,7 +85,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides Function CreateCompilation(consoleOutput As TextWriter,
                                                     touchedFilesLogger As TouchedFileLogger,
                                                     errorLogger As ErrorLogger,
-                                                    analyzerConfigOptions As ImmutableArray(Of AnalyzerConfigOptionsResult)) As Compilation
+                                                    analyzerConfigOptions As ImmutableArray(Of AnalyzerConfigOptionsResult),
+                                                    globalAnalyzerConfigOptions As AnalyzerConfigOptionsResult) As Compilation
             Dim parseOptions = Arguments.ParseOptions
 
             ' We compute script parse options once so we don't have to do it repeatedly in
@@ -158,7 +159,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim sourceFileResolver = New LoggingSourceFileResolver(ImmutableArray(Of String).Empty, Arguments.BaseDirectory, Arguments.PathMap, touchedFilesLogger)
 
             Dim loggingFileSystem = New LoggingStrongNameFileSystem(touchedFilesLogger, _tempDirectory)
-            Dim syntaxTreeOptions = New CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions)
+            Dim syntaxTreeOptions = New CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions, globalAnalyzerConfigOptions)
 
             Return VisualBasicCompilation.Create(
                  Arguments.CompilationName,

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
@@ -131,7 +131,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             hasDisableDirectiveSuppression = False
 
             Dim report As ReportDiagnostic
-            Dim tree = If(location IsNot Nothing, location.SourceTree, Nothing)
+            Dim tree = location?.SourceTree
             Dim isSpecified As Boolean = False
 
             ' Global options depend on other options, so calculate those first
@@ -178,6 +178,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If (Not isSpecified) AndAlso (report = ReportDiagnostic.Default) Then
                     Return ReportDiagnostic.Error
                 End If
+            End If
+
+            Dim globalReport As ReportDiagnostic
+            If (Not isSpecified) AndAlso syntaxTreeOptions IsNot Nothing AndAlso syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, globalReport) Then
+                report = globalReport
             End If
 
             Return report

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
@@ -142,6 +142,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ElseIf caseInsensitiveSpecificDiagnosticOptions.TryGetValue(id, report) Then
                 ' 3. Compilation level
                 isSpecified = True
+            ElseIf syntaxTreeOptions IsNot Nothing AndAlso syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, report) Then
+                ' 4. Global analyzer config level
+                isSpecified = True
             Else
                 report = If(isEnabledByDefault, ReportDiagnostic.Default, ReportDiagnostic.Suppress)
             End If
@@ -178,11 +181,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If (Not isSpecified) AndAlso (report = ReportDiagnostic.Default) Then
                     Return ReportDiagnostic.Error
                 End If
-            End If
-
-            Dim globalReport As ReportDiagnostic
-            If (Not isSpecified) AndAlso syntaxTreeOptions IsNot Nothing AndAlso syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, globalReport) Then
-                report = globalReport
             End If
 
             Return report

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ElseIf caseInsensitiveSpecificDiagnosticOptions.TryGetValue(id, report) Then
                 ' 3. Compilation level
                 isSpecified = True
-            ElseIf syntaxTreeOptions IsNot Nothing AndAlso syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, report) Then
+            ElseIf syntaxTreeOptions IsNot Nothing AndAlso syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, cancellationToken, report) Then
                 ' 4. Global analyzer config level
                 isSpecified = True
             Else

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -10060,7 +10060,7 @@ End Class")
 
         <Fact>
         <WorkItem(44087, "https://github.com/dotnet/roslyn/issues/44804")>
-        Public Sub GlobalAnalyzerConfigDiagnosticOptionsCanBeOverridenByCommandLine_VB()
+        Public Sub GlobalAnalyzerConfigDiagnosticOptionsCanBeOverridenByCommandLine()
             Dim dir = Temp.CreateDirectory()
             Dim src = dir.CreateFile("temp.vb").WriteAllText("
 Class C
@@ -10089,6 +10089,25 @@ dotnet_diagnostic.BC42024.severity = warning;
 
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedWarningCount:=1, additionalFlags:={globalOption, specificOption})
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedWarningCount:=1, additionalFlags:={"/nowarn:BC42024", globalOption, specificOption})
+        End Sub
+
+        <Fact>
+        <WorkItem(44087, "https://github.com/dotnet/roslyn/issues/44804")>
+        Public Sub GlobalAnalyzerConfigSpecificDiagnosticOptionsOverrideGeneralCommandLineOptions()
+            Dim dir = Temp.CreateDirectory()
+            Dim src = dir.CreateFile("temp.vb").WriteAllText("
+Class C
+    Private Sub M()
+        Dim a As String
+    End Sub
+End Class
+")
+            Dim globalConfig = dir.CreateFile(".globalconfig").WriteAllText("
+is_global = true
+dotnet_diagnostic.BC42024.severity = none;
+")
+
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, additionalFlags:={"/warnaserror+", "/analyzerconfig:" + globalConfig.Path})
         End Sub
 
         <Theory, CombinatorialData>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -10058,6 +10058,39 @@ End Class")
             End If
         End Sub
 
+        <Fact>
+        <WorkItem(44087, "https://github.com/dotnet/roslyn/issues/44804")>
+        Public Sub GlobalAnalyzerConfigDiagnosticOptionsCanBeOverridenByCommandLine_VB()
+            Dim dir = Temp.CreateDirectory()
+            Dim src = dir.CreateFile("temp.vb").WriteAllText("
+Class C
+    Private Sub M()
+        Dim a As String
+    End Sub
+End Class
+")
+            Dim globalConfig = dir.CreateFile(".globalconfig").WriteAllText("
+is_global = true
+dotnet_diagnostic.BC42024.severity = error;
+")
+            Dim analyzerConfig = dir.CreateFile(".editorconfig").WriteAllText("
+[*.vb]
+dotnet_diagnostic.BC42024.severity = warning;
+")
+            Dim globalOption = "/analyzerconfig:" + globalConfig.Path
+            Dim specificOption = "/analyzerconfig:" + analyzerConfig.Path
+
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedWarningCount:=1)
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedWarningCount:=0, additionalFlags:={"/nowarn:BC42024"})
+
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedErrorCount:=1, additionalFlags:={globalOption})
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, additionalFlags:={"/nowarn:BC42024", globalOption})
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, additionalFlags:={"/nowarn:42024", globalOption})
+
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedWarningCount:=1, additionalFlags:={globalOption, specificOption})
+            VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference:=False, expectedWarningCount:=1, additionalFlags:={"/nowarn:BC42024", globalOption, specificOption})
+        End Sub
+
         <Theory, CombinatorialData>
         Public Sub TestAdditionalFileAnalyzer(registerFromInitialize As Boolean)
             Dim srcDirectory = Temp.CreateDirectory()

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -141,7 +141,8 @@ Class D
 End Class")
 
             Dim options = TestOptions.DebugDll.WithSyntaxTreeOptionsProvider(
-                new TestSyntaxTreeOptionsProvider(
+                New TestSyntaxTreeOptionsProvider(
+                    Nothing,
                     (tree, {("BC42024", ReportDiagnostic.Suppress)}),
                     (newTree, {("BC4024", ReportDiagnostic.Error)})))
             Dim comp = CreateCompilationWithMscorlib45({tree, newTree}, options:=options)
@@ -168,8 +169,9 @@ End Class")
             comp.AssertNoDiagnostics()
 
             options = options.WithSyntaxTreeOptionsProvider(
-                new TestSyntaxTreeOptionsProvider(
+                New TestSyntaxTreeOptionsProvider(
                     StringComparer.Ordinal,
+                    Nothing,
                     (tree, {("bc42024", ReportDiagnostic.Suppress)}))
             )
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -142,7 +142,6 @@ End Class")
 
             Dim options = TestOptions.DebugDll.WithSyntaxTreeOptionsProvider(
                 New TestSyntaxTreeOptionsProvider(
-                    Nothing,
                     (tree, {("BC42024", ReportDiagnostic.Suppress)}),
                     (newTree, {("BC4024", ReportDiagnostic.Error)})))
             Dim comp = CreateCompilationWithMscorlib45({tree, newTree}, options:=options)

--- a/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using static Microsoft.CodeAnalysis.AnalyzerConfig;
 
 namespace Roslyn.Utilities
 {
@@ -30,7 +31,7 @@ namespace Roslyn.Utilities
             );
             if (globalOption.key is object)
             {
-                _globalOptions = new Dictionary<string, ReportDiagnostic>() { { globalOption.key, globalOption.diagnostic } };
+                _globalOptions = new Dictionary<string, ReportDiagnostic>(Section.PropertiesKeyComparer) { { globalOption.key, globalOption.diagnostic } };
             }
             _isGenerated = null;
         }

--- a/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
@@ -36,6 +36,11 @@ namespace Roslyn.Utilities
         }
 
         public TestSyntaxTreeOptionsProvider(
+            params (SyntaxTree, (string, ReportDiagnostic)[])[] options)
+            : this(CaseInsensitiveComparison.Comparer, globalOption: default, options)
+        { }
+
+        public TestSyntaxTreeOptionsProvider(
             (string, ReportDiagnostic) globalOption,
             params (SyntaxTree, (string, ReportDiagnostic)[])[] options)
             : this(CaseInsensitiveComparison.Comparer, globalOption: globalOption, options)

--- a/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Utilities
         private readonly Dictionary<string, ReportDiagnostic>? _globalOptions;
         public TestSyntaxTreeOptionsProvider(
             IEqualityComparer<string> comparer,
-            (string, ReportDiagnostic) globalOption,
+            (string? key, ReportDiagnostic diagnostic) globalOption,
             params (SyntaxTree, (string, ReportDiagnostic)[])[] options)
         {
             _options = options.ToDictionary(
@@ -28,9 +28,9 @@ namespace Roslyn.Utilities
                     x => x.Item2,
                     comparer)
             );
-            if (globalOption.Item1 is object)
+            if (globalOption.key is object)
             {
-                _globalOptions = new Dictionary<string, ReportDiagnostic>() { { globalOption.Item1, globalOption.Item2 } };
+                _globalOptions = new Dictionary<string, ReportDiagnostic>() { { globalOption.key, globalOption.diagnostic } };
             }
             _isGenerated = null;
         }
@@ -58,7 +58,7 @@ namespace Roslyn.Utilities
             _options = null;
             _isGenerated = isGenerated.ToDictionary(
                 x => x.Item1,
-                x => x.Item2
+                x => x.isGenerated
             );
         }
 

--- a/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
@@ -82,7 +82,7 @@ namespace Roslyn.Utilities
             return false;
         }
 
-        public override bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity)
+        public override bool TryGetGlobalDiagnosticValue(string diagnosticId, CancellationToken cancellationToken, out ReportDiagnostic severity)
         {
             if (_globalOptions is object &&
                 _globalOptions.TryGetValue(diagnosticId, out severity))

--- a/src/Workspaces/Core/Portable/Workspace/Solution/CachingAnalyzerConfigSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/CachingAnalyzerConfigSet.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis
         private readonly Func<string, AnalyzerConfigOptionsResult> _computeFunction;
         private readonly AnalyzerConfigSet _underlyingSet;
 
+        public AnalyzerConfigOptionsResult GlobalConfigOptions => _underlyingSet.GlobalConfigOptions;
+
         public CachingAnalyzerConfigSet(AnalyzerConfigSet underlyingSet)
         {
             _underlyingSet = underlyingSet;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -355,10 +355,10 @@ namespace Microsoft.CodeAnalysis
                 return options.TreeOptions.TryGetValue(diagnosticId, out severity);
             }
 
-            public override bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity)
+            public override bool TryGetGlobalDiagnosticValue(string diagnosticId, CancellationToken cancellationToken, out ReportDiagnostic severity)
             {
                 var options = _lazyAnalyzerConfigSet
-                    .GetValue(CancellationToken.None).GlobalConfigOptions;
+                    .GetValue(cancellationToken).GlobalConfigOptions;
                 return options.TreeOptions.TryGetValue(diagnosticId, out severity);
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -355,6 +355,13 @@ namespace Microsoft.CodeAnalysis
                 return options.TreeOptions.TryGetValue(diagnosticId, out severity);
             }
 
+            public override bool TryGetGlobalDiagnosticValue(string diagnosticId, out ReportDiagnostic severity)
+            {
+                var options = _lazyAnalyzerConfigSet
+                    .GetValue(CancellationToken.None).GlobalConfigOptions;
+                return options.TreeOptions.TryGetValue(diagnosticId, out severity);
+            }
+
             public override bool Equals(object? obj)
             {
                 return obj is WorkspaceSyntaxTreeOptionsProvider other

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2939,18 +2939,16 @@ public class C : A {
             Assert.True(finalCompilation.ContainsSyntaxTree(syntaxTreeAfterEditorConfigChange));
         }
 
-        [Theory]
-        [CombinatorialData]
-        public void TestAddingAndRemovingGlobalEditorConfigFileWithDiagnosticSeverity([CombinatorialValues(LanguageNames.CSharp, LanguageNames.VisualBasic)] string languageName, bool useRecoverableTrees)
+        [Fact]
+        public void TestAddingAndRemovingGlobalEditorConfigFileWithDiagnosticSeverity()
         {
-            using var workspace = useRecoverableTrees ? CreateWorkspaceWithRecoverableSyntaxTrees() : CreateWorkspace();
+            using var workspace = CreateWorkspace();
             var solution = workspace.CurrentSolution;
-            var extension = languageName == LanguageNames.CSharp ? ".cs" : ".vb";
             var projectId = ProjectId.CreateNewId();
             var sourceDocumentId = DocumentId.CreateNewId(projectId);
 
-            solution = solution.AddProject(projectId, "Test", "Test.dll", languageName);
-            solution = solution.AddDocument(sourceDocumentId, "Test" + extension, "", filePath: @"Z:\Test" + extension);
+            solution = solution.AddProject(projectId, "Test", "Test.dll", LanguageNames.CSharp);
+            solution = solution.AddDocument(sourceDocumentId, "Test.cs", "", filePath: @"Z:\Test.cs");
 
             var originalProvider = solution.GetProject(projectId).CompilationOptions.SyntaxTreeOptionsProvider;
             Assert.False(originalProvider.TryGetGlobalDiagnosticValue("CA1234", out _));

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2943,7 +2943,8 @@ public class C : A {
         [CombinatorialData]
         public void TestAddingAndRemovingGlobalEditorConfigFileWithDiagnosticSeverity([CombinatorialValues(LanguageNames.CSharp, LanguageNames.VisualBasic)] string languageName, bool useRecoverableTrees)
         {
-            var solution = useRecoverableTrees ? CreateNotKeptAliveSolution() : CreateSolution();
+            using var workspace = useRecoverableTrees ? CreateWorkspaceWithRecoverableSyntaxTrees() : CreateWorkspace();
+            var solution = workspace.CurrentSolution;
             var extension = languageName == LanguageNames.CSharp ? ".cs" : ".vb";
             var projectId = ProjectId.CreateNewId();
             var sourceDocumentId = DocumentId.CreateNewId(projectId);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2951,7 +2951,7 @@ public class C : A {
             solution = solution.AddDocument(sourceDocumentId, "Test.cs", "", filePath: @"Z:\Test.cs");
 
             var originalProvider = solution.GetProject(projectId).CompilationOptions.SyntaxTreeOptionsProvider;
-            Assert.False(originalProvider.TryGetGlobalDiagnosticValue("CA1234", out _));
+            Assert.False(originalProvider.TryGetGlobalDiagnosticValue("CA1234", default, out _));
 
             var editorConfigDocumentId = DocumentId.CreateNewId(projectId);
             solution = solution.AddAnalyzerConfigDocuments(ImmutableArray.Create(
@@ -2962,12 +2962,12 @@ public class C : A {
                     loader: TextLoader.From(TextAndVersion.Create(SourceText.From("is_global = true\r\n\r\ndotnet_diagnostic.CA1234.severity = error"), VersionStamp.Default)))));
 
             var newProvider = solution.GetProject(projectId).CompilationOptions.SyntaxTreeOptionsProvider;
-            Assert.True(newProvider.TryGetGlobalDiagnosticValue("CA1234", out var severity));
+            Assert.True(newProvider.TryGetGlobalDiagnosticValue("CA1234", default, out var severity));
             Assert.Equal(ReportDiagnostic.Error, severity);
 
             solution = solution.RemoveAnalyzerConfigDocument(editorConfigDocumentId);
             var finalProvider = solution.GetProject(projectId).CompilationOptions.SyntaxTreeOptionsProvider;
-            Assert.False(finalProvider.TryGetGlobalDiagnosticValue("CA1234", out _));
+            Assert.False(finalProvider.TryGetGlobalDiagnosticValue("CA1234", default, out _));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #44804
- Pre-parse the global options into their own collection
- Don't put global diagnostics on the tree level options
- Add global diagnostics onto the tree options provider
- Pass through the global diagnostics during compilation
- Update the analyzer supression code
- Add tests

Precedence level is now:

1. Warning level
 2. Syntax tree level
 3. Compilation level
4. Global analyzer level
5. Global warning level