### PR TITLE
Remove experimental feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,8 +7,6 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <!-- Microsoft.VisualStudio.* packages (e.g. Microsoft.VisualStudio.LanguageServer.Protocol.Extensions): https://github.com/dotnet/roslyn/issues/43242 -->
-    <add key="experimental-vs-packages" value="https://dotnet.myget.org/F/experimental-vs-packages/api/v3/index.json" />
     <!-- Microsoft.CodeAnalysis.Test.Resource.Proprietary -->
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <CodeStyleAnalyzerVersion>3.7.0-3.20271.4</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>16.4.248</VisualStudioEditorPackagesVersion>
     <ILToolsPackageVersion>5.0.0-alpha1.19409.1</ILToolsPackageVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.7.29</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.8.5</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
   </PropertyGroup>
   <!--
     Dependency versions


### PR DESCRIPTION
Removes the experimental-vs-packages feed for Roslyn restore now that all the packages are available on ado feeds.

Partially completes https://github.com/dotnet/roslyn/issues/43242