### PR TITLE
Don't clear diagnostics from analyzers if they haven't been loaded

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -119,6 +119,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _diagnosticAnalyzers.GetExtensions(language);
         }
 
+        public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            if (_diagnosticAnalyzers.IsLoaded(language))
+            {
+                analyzers = _diagnosticAnalyzers.GetExtensions(language);
+                return true;
+            }
+
+            analyzers = default;
+            return false;
+        }
+
         public override ImmutableArray<ISourceGenerator> GetGenerators()
         {
             return _generators.GetExtensionsForAllLanguages();
@@ -312,7 +324,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private readonly AttributePredicate _attributePredicate;
             private readonly AttributeLanguagesFunc _languagesFunc;
             private ImmutableArray<TExtension> _lazyAllExtensions;
-            private ImmutableDictionary<string, ImmutableArray<TExtension>>? _lazyExtensionsPerLanguage;
+            private ImmutableDictionary<string, ImmutableArray<TExtension>> _lazyExtensionsPerLanguage;
             private ImmutableDictionary<string, ImmutableHashSet<string>>? _lazyExtensionTypeNameMap;
 
             internal Extensions(AnalyzerFileReference reference, AttributePredicate attributePredicate, AttributeLanguagesFunc languagesFunc)
@@ -348,6 +360,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 return builder.ToImmutable();
             }
+
+            internal bool IsLoaded(string language)
+                => _lazyExtensionsPerLanguage.ContainsKey(language);
 
             internal ImmutableArray<TExtension> GetExtensions(string language)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerImageReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerImageReference.cs
@@ -46,6 +46,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _analyzers;
         }
 
+        public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            analyzers = _analyzers;
+            return true;
+        }
+
         public override string? FullPath
         {
             get

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerReference.cs
@@ -66,7 +66,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Tries to get the cached list of analyzers for this assembly reference for the given <paramref name="language"/>, if
         /// it has already been created and is still cached.
         /// </summary>
-        public abstract bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers);
+        public virtual bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            analyzers = default;
+            return false;
+        }
 
         /// <summary>
         /// Gets all the source generators defined in this assembly reference.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerReference.cs
@@ -63,6 +63,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public abstract ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language);
 
         /// <summary>
+        /// Tries to get the cached list of analyzers for this assembly reference for the given <paramref name="language"/>, if
+        /// it has already been created and is still cached.
+        /// </summary>
+        public abstract bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers);
+
+        /// <summary>
         /// Gets all the source generators defined in this assembly reference.
         /// </summary>
         public virtual ImmutableArray<ISourceGenerator> GetGenerators() { return ImmutableArray<ISourceGenerator>.Empty; }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/UnresolvedAnalyzerReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/UnresolvedAnalyzerReference.cs
@@ -62,5 +62,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             return ImmutableArray<DiagnosticAnalyzer>.Empty;
         }
+
+        public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            analyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
+            return true;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 Microsoft.CodeAnalysis.Operations.IPatternOperation.NarrowedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
-abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerImageReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
 override Microsoft.CodeAnalysis.Diagnostics.UnresolvedAnalyzerReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
+virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 Microsoft.CodeAnalysis.Operations.IPatternOperation.NarrowedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
+abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
+override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
+override Microsoft.CodeAnalysis.Diagnostics.AnalyzerImageReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool
+override Microsoft.CodeAnalysis.Diagnostics.UnresolvedAnalyzerReference.TryGetAnalyzers(string language, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers) -> bool

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -328,6 +328,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             public ImmutableArray<CodeFixProvider> GetFixers()
                 => Fixer != null ? ImmutableArray.Create(Fixer) : ImmutableArray<CodeFixProvider>.Empty;
 
+            public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+            {
+                analyzers = Analyzers;
+                return true;
+            }
+
             public class MockDiagnosticAnalyzer : DiagnosticAnalyzer
             {
                 public MockDiagnosticAnalyzer(ImmutableArray<(string id, string category)> reportedDiagnosticIdsWithCategories)

--- a/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
@@ -100,6 +100,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
 
             public ImmutableArray<CodeRefactoringProvider> GetRefactorings()
                 => ImmutableArray.Create(Refactoring);
+
+            public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+            {
+                analyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
+                return true;
+            }
         }
     }
 }

--- a/src/EditorFeatures/Test/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/Test/Completion/CompletionServiceTests.cs
@@ -70,6 +70,12 @@ class Test {
 
             public ImmutableArray<CompletionProvider> GetCompletionProviders()
                 => ImmutableArray.Create(_completionProvider);
+
+            public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+            {
+                analyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
+                return true;
+            }
         }
 
         private sealed class DebugAssertTestCompletionProvider : CompletionProvider

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -77,8 +77,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public void ClearAnalyzerReferenceDiagnostics(AnalyzerFileReference analyzerReference, string language, ProjectId projectId)
         {
-            var analyzers = analyzerReference.GetAnalyzers(language);
-            ClearAnalyzerDiagnostics(analyzers, projectId);
+            if (analyzerReference.TryGetAnalyzers(language, out var analyzers))
+            {
+                ClearAnalyzerDiagnostics(analyzers, projectId);
+            }
         }
 
         public void ClearAnalyzerDiagnostics(ImmutableArray<DiagnosticAnalyzer> analyzers, ProjectId projectId)

--- a/src/Test/Utilities/Portable/Mocks/TestAnalyzerReference.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestAnalyzerReference.cs
@@ -29,5 +29,6 @@ namespace Roslyn.Test.Utilities
 
         public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => throw new NotImplementedException();
         public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => throw new NotImplementedException();
+        public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers) => throw new NotImplementedException();
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -152,6 +152,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
             public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => ImmutableArray<DiagnosticAnalyzer>.Empty;
             public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => ImmutableArray<DiagnosticAnalyzer>.Empty;
             public override ImmutableArray<ISourceGenerator> GetGenerators() => ImmutableArray.Create(_generator);
+            public override bool TryGetAnalyzers(string language, out ImmutableArray<DiagnosticAnalyzer> analyzers)
+            {
+                analyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
+                return true;
+            }
         }
 
         // TODO: find a way to reuse this implementation from the compiler unit tests


### PR DESCRIPTION
This is a bit of a speculative change to fix #45833

From the trace linked in that issue it looks like we load analyzers from disk as part of clearing diagnostics from them, which is unnecessary and wasteful.