### PR TITLE
Fix nullable semantic model threading issue

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1931,29 +1931,27 @@ done:
             var bindableRoot = GetBindableSyntaxNode(Root);
             using var upgradeableLock = _nodeMapLock.DisposableUpgradeableRead();
 
-            if (_guardedNodeMap.ContainsKey(bindableRoot)
-#if DEBUG
-                // In DEBUG mode, we don't want to increase test run times, so if
-                // nullable analysis isn't enabled and some node has already been bound
-                // we assume we've already done this test binding and just return
-                || (!Compilation.NullableSemanticAnalysisEnabled && _guardedNodeMap.Count > 0)
-#endif
-                )
+            // If there are already nodes in the map, then we've already done work here. Since
+            // EnsureNullabilityAnalysis is guaranteed to have run first, that means we've
+            // already bound the root node and we can just exit. We can't just assert that Root
+            // is in the map, as there are some models for which there is no BoundNode for the
+            // Root elements (such as fields, where the root is a VariableDeclarator but the
+            // first BoundNode corresponds to the underlying EqualsValueSyntax of the initializer)
+            if (_guardedNodeMap.Count > 0)
             {
+                Debug.Assert(_guardedNodeMap.ContainsKey(bindableRoot) ||
+                             _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax));
                 return;
             }
-
-            Debug.Assert(_guardedNodeMap.Count == 0);
 
             upgradeableLock.EnterWrite();
 
             NullableWalker.SnapshotManager snapshotManager;
             var remappedSymbols = _parentRemappedSymbolsOpt;
-            BoundNode boundRoot;
             Binder binder;
             DiagnosticBag diagnosticBag = getDiagnosticBag();
 
-            bind(bindableRoot, diagnosticBag, out binder, out boundRoot);
+            BoundNode boundRoot = bind(bindableRoot, diagnosticBag, out binder);
 
             if (IsSpeculativeSemanticModel)
             {
@@ -1974,10 +1972,10 @@ done:
                 rewriteAndCache(diagnosticBag);
             }
 
-            void bind(CSharpSyntaxNode root, DiagnosticBag diagnosticBag, out Binder binder, out BoundNode boundRoot)
+            BoundNode bind(CSharpSyntaxNode root, DiagnosticBag diagnosticBag, out Binder binder)
             {
                 binder = GetEnclosingBinder(GetAdjustedNodePosition(root));
-                boundRoot = Bind(binder, root, diagnosticBag);
+                return Bind(binder, root, diagnosticBag);
             }
 
             void rewriteAndCache(DiagnosticBag diagnosticBag)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1939,8 +1939,13 @@ done:
             // first BoundNode corresponds to the underlying EqualsValueSyntax of the initializer)
             if (_guardedNodeMap.Count > 0)
             {
-                Debug.Assert(_guardedNodeMap.ContainsKey(bindableRoot) ||
-                             _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax));
+                Debug.Assert(
+#if DEBUG
+                             !Compilation.NullableSemanticAnalysisEnabled ||
+#endif
+                             _guardedNodeMap.ContainsKey(bindableRoot) ||
+                             _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax)
+                             );
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1939,13 +1939,9 @@ done:
             // first BoundNode corresponds to the underlying EqualsValueSyntax of the initializer)
             if (_guardedNodeMap.Count > 0)
             {
-                Debug.Assert(
-#if DEBUG
-                             !Compilation.NullableSemanticAnalysisEnabled ||
-#endif
+                Debug.Assert(!Compilation.NullableSemanticAnalysisEnabled ||
                              _guardedNodeMap.ContainsKey(bindableRoot) ||
-                             _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax)
-                             );
+                             _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax));
                 return;
             }
 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests.cs
@@ -693,7 +693,7 @@ class C
             }
         }
 
-        [Fact]
+        [Fact, WorkItem(45955, "https://github.com/dotnet/roslyn/issues/45955")]
         public void SemanticModelFieldInitializerRace()
         {
             var source = $@"


### PR DESCRIPTION
Before taking the read lock on the node map, we check to ensure that no one else has done the work before us. After the lock is acquired, we would attempt to see if the Root was in the map and then exit if the work had already been done. However, this isn't precise enough for some cases, particularly field initializers. For FieldInitializers, the Root of the MemberSemanticModel is a VariableDeclaratorSyntax node. This node doesn't have a corresponding BoundNode in this case, however. Instead, the root BoundNode is a EqualsValueClauseSyntax node, so the existing check would return false, the root has not already been bound. We can replace this search with a simpler check of the count: since EnsureNullabilityAnalysisPerformedIfNecessary is called before attempting to do any individual node binding, we're guaranteed that if any nodes are in the map, they include the result of binding the root.

Fixes https://github.com/dotnet/roslyn/issues/45955
