### PR TITLE
Reduce nested testing level in x86 release E2E tests.

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                 _ when ExecutionConditionUtil.IsCoreClrUnix => 1200, // 1200
                 _ when ExecutionConditionUtil.IsMonoDesktop => 730, // 730
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 460, // 270
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1310, // 1290
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1290, // 1290
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 260, // 170
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 730, // 730
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")


### PR DESCRIPTION
We're seeing occasional hitting of the limit in CI, so reducing the level while we try and get more stability in this test.
