### PR TITLE
Remove reference to non-existing VisualStudioInteractiveComponents.vsix from deployment VSIX.

### DIFF
--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -29,15 +29,6 @@
                 Location="|VisualStudioSetup;VSIXContainerProjectOutputGroup|"
                 Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
     
-    <Dependency d:ProjectName="VisualStudioInteractiveComponents" 
-                DisplayName="Roslyn Interactive Components" 
-                Version="[|%CurrentProject%;GetVsixVersion|,)"
-                d:Source="Project"  
-                d:InstallSource="Embed" 
-                d:VsixSubPath="Vsixes" 
-                Location="|VisualStudioInteractiveComponents;VSIXContainerProjectOutputGroup|" 
-                Id="500fff63-afcf-4195-8db4-3fa8a5180e79" />
-    
     <Dependency  d:ProjectName="ExpressionEvaluatorPackage" 
                  DisplayName="Roslyn Expression Evaluators" 
                  Version="[|%CurrentProject%;GetVsixVersion|,)"


### PR DESCRIPTION
Fixes Roslyn preview installer.

Does not impact VS insertion.