### PR TITLE
Fix PropertiesInRecursivePattern_PositionalInFirstProperty_AfterComma

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -484,7 +484,7 @@ class D
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/40015")]
         public async Task PropertiesInRecursivePattern_PositionalInFirstProperty_AfterComma()
         {
             var markup =

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -484,7 +484,7 @@ class D
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/40015")]
+        [Fact]
         public async Task PropertiesInRecursivePattern_PositionalInFirstProperty_AfterComma()
         {
             var markup =
@@ -503,7 +503,7 @@ class D
     public int P2 { get; set; }
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact]


### PR DESCRIPTION
<strike>Adds skip back to `PropertiesInRecursivePattern_PositionalInFirstProperty_AfterComma` which was unskipped in https://github.com/dotnet/roslyn/pull/45771/files</strike>
Fixes the test based on Gafter's comment.

Also see https://github.com/dotnet/roslyn/issues/40015 for other skipped pattern tests