### PR TITLE
Remove c#_lsp from tools options

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/LiveShare/Impl/PackageRegistration.pkgdef
@@ -19,3 +19,10 @@
 @="{bb7e83f4-eaf6-456c-b140-f8c027a7ed8a}"
 "Name"="CSharpLspLanguageService"
 
+;; Set the C#_LSP NotALanguage attribute for this package.
+;; This will suppress the duplicate C#_LSP entry from appearing in Tools > Options > Text Editor
+;; This can be removed once we remove the CSharpLspPackage
+[$RootKey$\Languages\Language Services\C#_LSP]
+"Package"="{BB7E83F4-EAF6-456C-B140-F8C027A7ED8A}"
+"NotALanguage"=dword:00000001
+


### PR DESCRIPTION
This removes one of them.  liveshare has a corresponding PR to remove the other.

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/Cascade/pullrequest/261297?_a=files

Verified that after this PR there is only one (other pending liveshare insertion).