### PR TITLE
workspace.TryApplyChanges should respect changes to DefaultNamespace, and other project information

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -279,6 +279,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 case ApplyChangesKind.RemoveAnalyzerReference:
                 case ApplyChangesKind.AddSolutionAnalyzerReference:
                 case ApplyChangesKind.RemoveSolutionAnalyzerReference:
+                case ApplyChangesKind.ChangeProjectInfo:
                     return true;
 
                 case ApplyChangesKind.ChangeDocument:

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -460,6 +460,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 case ApplyChangesKind.ChangeAnalyzerConfigDocument:
                 case ApplyChangesKind.AddSolutionAnalyzerReference:
                 case ApplyChangesKind.RemoveSolutionAnalyzerReference:
+                case ApplyChangesKind.ChangeProjectInfo:
                     return true;
 
                 default:

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -277,6 +277,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 case ApplyChangesKind.RemoveProjectReference:
                 case ApplyChangesKind.AddAnalyzerReference:
                 case ApplyChangesKind.RemoveAnalyzerReference:
+                case ApplyChangesKind.ChangeProjectInfo:
                     return true;
                 default:
                     return false;

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,15 +2,7 @@
 *REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
 *REMOVED*static Microsoft.CodeAnalysis.SolutionInfo.Create(Microsoft.CodeAnalysis.SolutionId id, Microsoft.CodeAnalysis.VersionStamp version, string filePath = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ProjectInfo> projects = null) -> Microsoft.CodeAnalysis.SolutionInfo
 *REMOVED*static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindDerivedClassesAsync(Microsoft.CodeAnalysis.INamedTypeSymbol type, Microsoft.CodeAnalysis.Solution solution, System.Collections.Immutable.IImmutableSet<Microsoft.CodeAnalysis.Project> projects = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.INamedTypeSymbol>>
-abstract Microsoft.CodeAnalysis.Rename.Renamer.RenameDocumentAction.GetDescription(System.Globalization.CultureInfo culture = null) -> string
-Microsoft.CodeAnalysis.ApplyChangesKind.AddSolutionAnalyzerReference = 20 -> Microsoft.CodeAnalysis.ApplyChangesKind
-Microsoft.CodeAnalysis.ApplyChangesKind.RemoveSolutionAnalyzerReference = 21 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeProjectInfo = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
-Microsoft.CodeAnalysis.CompilationOutputInfo
-Microsoft.CodeAnalysis.CompilationOutputInfo.AssemblyPath.get -> string
-Microsoft.CodeAnalysis.CompilationOutputInfo.Equals(Microsoft.CodeAnalysis.CompilationOutputInfo other) -> bool
-Microsoft.CodeAnalysis.CompilationOutputInfo.WithAssemblyPath(string path) -> Microsoft.CodeAnalysis.CompilationOutputInfo
-Microsoft.CodeAnalysis.Project.CompilationOutputInfo.get -> Microsoft.CodeAnalysis.CompilationOutputInfo
 Microsoft.CodeAnalysis.Project.DefaultNamespace.get -> string
 Microsoft.CodeAnalysis.Project.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.Project
 Microsoft.CodeAnalysis.ProjectInfo.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.ProjectInfo

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,16 @@
-Microsoft.CodeAnalysis.ApplyChangesKind.ChangeDefaultNamespace = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
+*REMOVED*abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+*REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+*REMOVED*static Microsoft.CodeAnalysis.SolutionInfo.Create(Microsoft.CodeAnalysis.SolutionId id, Microsoft.CodeAnalysis.VersionStamp version, string filePath = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ProjectInfo> projects = null) -> Microsoft.CodeAnalysis.SolutionInfo
+*REMOVED*static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindDerivedClassesAsync(Microsoft.CodeAnalysis.INamedTypeSymbol type, Microsoft.CodeAnalysis.Solution solution, System.Collections.Immutable.IImmutableSet<Microsoft.CodeAnalysis.Project> projects = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.INamedTypeSymbol>>
+abstract Microsoft.CodeAnalysis.Rename.Renamer.RenameDocumentAction.GetDescription(System.Globalization.CultureInfo culture = null) -> string
+Microsoft.CodeAnalysis.ApplyChangesKind.AddSolutionAnalyzerReference = 20 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.ApplyChangesKind.RemoveSolutionAnalyzerReference = 21 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.ApplyChangesKind.ChangeProjectInfo = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.CompilationOutputInfo
+Microsoft.CodeAnalysis.CompilationOutputInfo.AssemblyPath.get -> string
+Microsoft.CodeAnalysis.CompilationOutputInfo.Equals(Microsoft.CodeAnalysis.CompilationOutputInfo other) -> bool
+Microsoft.CodeAnalysis.CompilationOutputInfo.WithAssemblyPath(string path) -> Microsoft.CodeAnalysis.CompilationOutputInfo
+Microsoft.CodeAnalysis.Project.CompilationOutputInfo.get -> Microsoft.CodeAnalysis.CompilationOutputInfo
 Microsoft.CodeAnalysis.Project.DefaultNamespace.get -> string
 Microsoft.CodeAnalysis.Project.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.Project
 Microsoft.CodeAnalysis.ProjectInfo.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.ProjectInfo

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,7 +1,3 @@
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeProjectInfo = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
-Microsoft.CodeAnalysis.Project.DefaultNamespace.get -> string
-Microsoft.CodeAnalysis.Project.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.Project
-Microsoft.CodeAnalysis.ProjectInfo.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.ProjectInfo
-Microsoft.CodeAnalysis.Solution.WithProjectDefaultNamespace(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> Microsoft.CodeAnalysis.Solution
 virtual Microsoft.CodeAnalysis.Workspace.ApplyDefaultNamespaceChanged(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> void
 virtual Microsoft.CodeAnalysis.Workspace.ApplyProjectNameChanged(Microsoft.CodeAnalysis.ProjectId projectId, string name, string filePath)

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ Microsoft.CodeAnalysis.Project.WithDefaultNamespace(string defaultNamespace) -> 
 Microsoft.CodeAnalysis.ProjectInfo.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.ProjectInfo
 Microsoft.CodeAnalysis.Solution.WithProjectDefaultNamespace(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> Microsoft.CodeAnalysis.Solution
 virtual Microsoft.CodeAnalysis.Workspace.ApplyDefaultNamespaceChanged(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> void
+virtual Microsoft.CodeAnalysis.Workspace.ApplyProjectNameChanged(Microsoft.CodeAnalysis.ProjectId projectId, string name, string filePath)

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeProjectInfo = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
 virtual Microsoft.CodeAnalysis.Workspace.ApplyDefaultNamespaceChanged(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> void
-virtual Microsoft.CodeAnalysis.Workspace.ApplyProjectNameChanged(Microsoft.CodeAnalysis.ProjectId projectId, string name, string filePath)
+virtual Microsoft.CodeAnalysis.Workspace.ApplyProjectNameChanged(Microsoft.CodeAnalysis.ProjectId projectId, string name, string filePath) -> void

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,7 +1,3 @@
-*REMOVED*abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
-*REMOVED*override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
-*REMOVED*static Microsoft.CodeAnalysis.SolutionInfo.Create(Microsoft.CodeAnalysis.SolutionId id, Microsoft.CodeAnalysis.VersionStamp version, string filePath = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ProjectInfo> projects = null) -> Microsoft.CodeAnalysis.SolutionInfo
-*REMOVED*static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindDerivedClassesAsync(Microsoft.CodeAnalysis.INamedTypeSymbol type, Microsoft.CodeAnalysis.Solution solution, System.Collections.Immutable.IImmutableSet<Microsoft.CodeAnalysis.Project> projects = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.INamedTypeSymbol>>
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeProjectInfo = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.Project.DefaultNamespace.get -> string
 Microsoft.CodeAnalysis.Project.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.Project

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
-
+Microsoft.CodeAnalysis.ApplyChangesKind.ChangeDefaultNamespace = 22 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.Project.DefaultNamespace.get -> string
+Microsoft.CodeAnalysis.Project.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.Project
+Microsoft.CodeAnalysis.ProjectInfo.WithDefaultNamespace(string defaultNamespace) -> Microsoft.CodeAnalysis.ProjectInfo
+Microsoft.CodeAnalysis.Solution.WithProjectDefaultNamespace(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> Microsoft.CodeAnalysis.Solution
+virtual Microsoft.CodeAnalysis.Workspace.ApplyDefaultNamespaceChanged(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> void

--- a/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
@@ -28,5 +28,6 @@ namespace Microsoft.CodeAnalysis
         ChangeAnalyzerConfigDocument = 19,
         AddSolutionAnalyzerReference = 20,
         RemoveSolutionAnalyzerReference = 21,
+        ChangeDefaultNamespace = 22
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
@@ -28,6 +28,6 @@ namespace Microsoft.CodeAnalysis
         ChangeAnalyzerConfigDocument = 19,
         AddSolutionAnalyzerReference = 20,
         RemoveSolutionAnalyzerReference = 21,
-        ChangeDefaultNamespace = 22
+        ChangeProjectInfo = 22
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1686,7 +1686,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string? defaultNamespace)
         {
-            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeDefaultNamespace));
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeProjectInfo));
             this.OnDefaultNamespaceChanged(projectId, defaultNamespace);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1432,6 +1432,12 @@ namespace Microsoft.CodeAnalysis
                 this.ApplyParseOptionsChanged(projectChanges.ProjectId, projectChanges.NewProject.ParseOptions!);
             }
 
+            // changed default namespace
+            if (projectChanges.OldProject.DefaultNamespace != projectChanges.NewProject.DefaultNamespace)
+            {
+                this.ApplyDefaultNamespaceChanged(projectChanges.ProjectId, projectChanges.NewProject.DefaultNamespace);
+            }
+
             // removed project references
             foreach (var removedProjectReference in projectChanges.GetRemovedProjectReferences())
             {
@@ -1671,6 +1677,17 @@ namespace Microsoft.CodeAnalysis
 #endif
 
             this.OnCompilationOptionsChanged(projectId, options);
+        }
+
+        /// <summary>
+        /// This method is called during <see cref="TryApplyChanges(Solution)"/> to change the default namespace.
+        ///
+        /// Override this method to implement the capability of changing default namespace.
+        /// </summary>
+        protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string defaultNamespace)
+        {
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeDefaultNamespace));
+            this.OnDefaultNamespaceChanged(projectId, defaultNamespace);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1684,7 +1684,7 @@ namespace Microsoft.CodeAnalysis
         ///
         /// Override this method to implement the capability of changing default namespace.
         /// </summary>
-        protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string defaultNamespace)
+        protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string? defaultNamespace)
         {
             Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeDefaultNamespace));
             this.OnDefaultNamespaceChanged(projectId, defaultNamespace);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1444,6 +1444,15 @@ namespace Microsoft.CodeAnalysis
                 this.ApplyDefaultNamespaceChanged(projectChanges.ProjectId, projectChanges.NewProject.DefaultNamespace);
             }
 
+            // changed project name
+            // todo: The underlying OnProjectNameChanged method also optionally changes the FilePath.
+            // should that be checked here too?
+            if (projectChanges.OldProject.Name != projectChanges.NewProject.Name)
+            {
+                var newFilePath = projectChanges.NewProject.FilePath ?? projectChanges.OldProject.FilePath;
+                this.ApplyProjectNameChanged(projectChanges.OldProject.Id, projectChanges.NewProject.Name, newFilePath);
+            }
+
             // removed project references
             foreach (var removedProjectReference in projectChanges.GetRemovedProjectReferences())
             {
@@ -1694,6 +1703,17 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeProjectInfo));
             this.OnDefaultNamespaceChanged(projectId, defaultNamespace);
+        }
+
+        /// <summary>
+        /// This method is called during <see cref="TryApplyChanges(Solution)"/> to change the default namespace.
+        ///
+        /// Override this method to implement the capability of changing a project's name.
+        /// </summary>
+        protected virtual void ApplyProjectNameChanged(ProjectId projectId, string name, string? filePath)
+        {
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeProjectInfo));
+            this.OnProjectNameChanged(projectId, name, filePath);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1281,6 +1281,12 @@ namespace Microsoft.CodeAnalysis
                 throw new NotSupportedException(WorkspacesResources.Changing_compilation_options_is_not_supported);
             }
 
+            if (projectChanges.OldProject.DefaultNamespace != projectChanges.NewProject.DefaultNamespace
+                && !this.CanApplyChange(ApplyChangesKind.ChangeProjectInfo))
+            {
+                throw new NotSupportedException(WorkspacesResources.Changing_project_properties_is_not_supported);
+            }
+
             if (projectChanges.OldProject.ParseOptions != projectChanges.NewProject.ParseOptions
                 && !this.CanApplyChange(ApplyChangesKind.ChangeParseOptions)
                 && !this.CanApplyParseOptionChange(

--- a/src/Workspaces/CoreTest/SolutionTests/TryApplyChangesTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/TryApplyChangesTests.cs
@@ -167,5 +167,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.True(workspace.TryApplyChanges(project.AddAnalyzerConfigDocument(".editorconfig", SourceText.From("")).Project.Solution));
         }
+
+        [Fact]
+        public void TryApplyWorksWhenProjectNameChanges()
+        {
+            using var workspace = new CustomizedCanApplyWorkspace(allowedKinds: ApplyChangesKind.AddAnalyzerConfigDocument);
+
+            var project = workspace.CurrentSolution.Projects.Single();
+
+            var changedSolution = workspace.CurrentSolution.WithProjectName(project.Id, "NewName");
+
+            Assert.True(workspace.TryApplyChanges(changedSolution));
+            Assert.True(workspace.CurrentSolution.Projects.Single().Name == "NewName");
+        }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/TryApplyChangesTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/TryApplyChangesTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TryApplyWorksWhenProjectNameChanges()
         {
-            using var workspace = new CustomizedCanApplyWorkspace(allowedKinds: ApplyChangesKind.AddAnalyzerConfigDocument);
+            using var workspace = new CustomizedCanApplyWorkspace(allowedKinds: ApplyChangesKind.ChangeProjectInfo);
 
             var project = workspace.CurrentSolution.Projects.Single();
 

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -646,5 +646,17 @@ language: LanguageNames.CSharp);
             Assert.NotNull(service);
             Assert.Equal(typeof(DefaultDocumentTextDifferencingService), service.GetType());
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestChangeDefaultNamespace_TryApplyChanges()
+        {
+            using var ws = new AdhocWorkspace();
+            var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).WithDefaultNamespace("OriginalName").Id;
+
+            var newName = "ChangedName";
+            var newSolution = ws.CurrentSolution.WithProjectDefaultNamespace(projectId, newName);
+            Assert.True(ws.TryApplyChanges(newSolution));
+            Assert.Equal(newName, ws.CurrentSolution.Projects.First(p => p.Id == projectId).DefaultNamespace);
+        }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
@@ -144,6 +144,30 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestChangeDefaultNamespace_TryApplyChanges_Throws()
+        {
+            using var ws = new NoChangesAllowedWorkspace();
+            var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).WithDefaultNamespace("OriginalName").Id;
+
+            var newName = "ChangedName";
+            var newSolution = ws.CurrentSolution.WithProjectDefaultNamespace(projectId, newName);
+
+            NotSupportedException e = null;
+            try
+            {
+                ws.TryApplyChanges(newSolution);
+
+            }
+            catch (NotSupportedException x)
+            {
+                e = x;
+            }
+
+            Assert.NotNull(e);
+            Assert.Equal(WorkspacesResources.Changing_project_properties_is_not_supported, e.Message);
+        }
+
         private class NoChangesAllowedWorkspace : Workspace
         {
             public NoChangesAllowedWorkspace(HostServices services, string workspaceKind = "Custom")

--- a/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
@@ -22,19 +22,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var changedDoc = originalDoc.WithText(SourceText.From("new"));
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_documents_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_documents_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -49,18 +38,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var changedDoc = originalDoc.WithName(newName);
             Assert.Equal(newName, changedDoc.Name);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -77,18 +56,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("A", changedDoc.Folders[0]);
             Assert.Equal("B", changedDoc.Folders[1]);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -104,18 +73,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var changedDoc = originalDoc.WithFilePath(newPath);
             Assert.Equal(newPath, changedDoc.FilePath);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -130,18 +89,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var changedDoc = originalDoc.WithSourceCodeKind(SourceCodeKind.Script);
             Assert.Equal(SourceCodeKind.Script, changedDoc.SourceCodeKind);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -153,19 +102,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var newName = "ChangedName";
             var newSolution = ws.CurrentSolution.WithProjectDefaultNamespace(projectId, newName);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(newSolution);
-
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_project_properties_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(newSolution));
+            Assert.Equal(WorkspacesResources.Changing_project_properties_is_not_supported, exception.Message);
         }
 
         private class NoChangesAllowedWorkspace : Workspace


### PR DESCRIPTION
Attempted resurrection of #37755 in order to group with changes intended to fix #45710. Previous attempt was in PR #45769.

Potential TODOs/Outstanding questions:

- [ ] Determine what level of granularity to add to ApplyChangesKind.
- [ ] Add CanApplyProjectNameChange?
- [ ] Add separate FilePath change?
- [ ] Add other missing changes?
- [ ] Consolidate TryApplyChangesTests & GeneralWorkspaceTests?

## ApplyChangesKind / CanApplyProjectNameChange Addition

If we add something like `ApplyChangesKind.ProjectNameChange` to this I see a few ramifications. If someone passes changes to `Workspace.TryApplyChanges` that include a project name changes they will fail for all Workspace types that don't add the new `ApplyChangesKind` enum as supported.

## Separate FilePath Change Addition

Today `OnProjectNameChanged` changes both the project name and the file path. Should they be two separate changes? Should the added if conditional in `ApplyProjectChanges` check for FilePath changes?

## Add Missing Changes

There's additional properties that are missing as well.

- AssemblyName
- OutputFilePath
- OutputRefFilePath

Should these get similar paths like ProjectNameChange?

### Consolidate TryApplyChangesTests and GeneralWorkspaceTests

These test classes look very similar in spirit. I am not even sure if TryApplyChangesTests belongs in the existing test assembly that it lives in.

  Additionally they seem to follow two different naming styles for test names. TryApplyChangesTests seems to go against MSDN best practices for test names. GeneralWorkspaceTests seems to follow it. 