### PR TITLE
Make MetadataTypeName non-copyable

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReader/MetadataTypeName.Key.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataTypeName.Key.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             private readonly byte _useCLSCompliantNameArityEncoding; // Using byte instead of bool for denser packing and smaller structure size
             private readonly short _forcedArity;
 
-            internal Key(MetadataTypeName mdTypeName)
+            internal Key(in MetadataTypeName mdTypeName)
             {
                 if (mdTypeName.IsNull)
                 {
@@ -113,9 +113,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public Key ToKey()
+        public readonly Key ToKey()
         {
-            return new Key(this);
+            return new Key(in this);
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataTypeName.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataTypeName.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis
     /// Also, allows us to stop using strings in the APIs that accept only metadata names, 
     /// making usage of them less bug prone.
     /// </summary>
+    [NonCopyable]
     internal partial struct MetadataTypeName
     {
         /// <summary>
@@ -244,7 +245,7 @@ namespace Microsoft.CodeAnalysis
         /// I.e. arity is inferred from the name and matching type must have the same
         /// emitted name and arity.
         /// </summary>
-        public bool UseCLSCompliantNameArityEncoding
+        public readonly bool UseCLSCompliantNameArityEncoding
         {
             get
             {
@@ -258,7 +259,7 @@ namespace Microsoft.CodeAnalysis
         /// If ForcedArity >= 0 and UseCLSCompliantNameArityEncoding, lookup may
         /// fail because ForcedArity doesn't match the one encoded in the name.
         /// </summary>
-        public int ForcedArity
+        public readonly int ForcedArity
         {
             get
             {
@@ -282,7 +283,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public bool IsNull
+        public readonly bool IsNull
         {
             get
             {


### PR DESCRIPTION
This mutable value type caches computed values to improve performance. Marking it as non-copyable helps ensure it is only used in a manner that preserves optimum performance.