### PR TITLE
Do not offer to simplify ToString when shadowed

### DIFF
--- a/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -935,5 +935,16 @@ ref struct RefStruct
     public override string ToString() => ""A"";
 }");
         }
+
+        [Fact, WorkItem(46011, "https://github.com/dotnet/roslyn/issues/46011")]
+        public async Task ShadowedToString()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    public new string ToString() => ""Shadow"";
+    static string M(C c) => $""{c[||].ToString()}"";
+}");
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
@@ -90,7 +90,9 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                     return;
                 }
 
-                if (invocation.Arguments.Length == 0)
+                if (invocation.Arguments.Length == 0 &&
+                    (invocation.TargetMethod.ContainingType.SpecialType == SpecialType.System_Object ||
+                    invocation.TargetMethod.OverriddenMethod?.ContainingType.SpecialType == SpecialType.System_Object))
                 {
                     // A call to `.ToString()` at the end of the interpolation.  This is unnecessary.
                     // Just remove entirely.

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
@@ -90,9 +90,14 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                     return;
                 }
 
-                if (invocation.Arguments.Length == 0 &&
-                    (invocation.TargetMethod.ContainingType.SpecialType == SpecialType.System_Object ||
-                    invocation.TargetMethod.OverriddenMethod?.ContainingType.SpecialType == SpecialType.System_Object))
+                var method = invocation.TargetMethod;
+                while (method.OverriddenMethod != null)
+                {
+                    method = method.OverriddenMethod;
+                }
+
+                if (method.ContainingType.SpecialType == SpecialType.System_Object &&
+                    method.Name == nameof(ToString))
                 {
                     // A call to `.ToString()` at the end of the interpolation.  This is unnecessary.
                     // Just remove entirely.


### PR DESCRIPTION
Fixes #46011

Checks that parameterless calls to `ToString` within a string interpolation refer to `System.Object.ToString` or an overriding implementation.

I think the same sort of check should be done for the `IFormattable` path (i.e. the call is to `IFormattable.ToString`), but that's a separate issue.