### PR TITLE
Move to the .NET 5 SDK

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -20,7 +20,7 @@ The minimal required version of .NET Framework is 4.7.2.
     - Ensure Visual Studio is on Version "16.5" or greater
     - Ensure "Use previews of the .NET Core SDK" is checked in Tools -> Options -> Environment -> Preview Features
     - Restart Visual Studio
-1. [.NET Core SDK 5.0 Preview 6](https://dotnet.microsoft.com/download/dotnet-core/5.0) [Windows x64 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.7-windows-x64-installer)
+1. [.NET Core SDK 5.0 Preview 7](https://dotnet.microsoft.com/download/dotnet-core/5.0) [Windows x64 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.7-windows-x64-installer)
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on earlier versions of Windows. The download link is under the ["Upgrading existing Windows PowerShell"](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-windows-powershell?view=powershell-6#upgrading-existing-windows-powershell) heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -20,7 +20,7 @@ The minimal required version of .NET Framework is 4.7.2.
     - Ensure Visual Studio is on Version "16.5" or greater
     - Ensure "Use previews of the .NET Core SDK" is checked in Tools -> Options -> Environment -> Preview Features
     - Restart Visual Studio
-1. [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-windows-x64-installer)
+1. [.NET Core SDK 5.0 Preview 6](https://dotnet.microsoft.com/download/dotnet-core/5.0) [Windows x64 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.7-windows-x64-installer)
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on earlier versions of Windows. The download link is under the ["Upgrading existing Windows PowerShell"](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-windows-powershell?view=powershell-6#upgrading-existing-windows-powershell) heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -175,7 +175,7 @@
     <MicrosoftVisualStudioWorkspaceVSIntegrationVersion>16.3.43</MicrosoftVisualStudioWorkspaceVSIntegrationVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MicrosoftWin32RegistryVersion>4.7.0</MicrosoftWin32RegistryVersion>
-    <MSBuildStructuredLoggerVersion>2.0.61</MSBuildStructuredLoggerVersion>
+    <MSBuildStructuredLoggerVersion>2.1.133</MSBuildStructuredLoggerVersion>
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>4.4.0</MonoOptionsVersion>
     <MoqVersion>4.10.1</MoqVersion>

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -79,6 +79,14 @@
 
     <!-- Bypass a check in msbuild that .NET Framework 3.5 is installed on the machine when targeting .NET < 4.0 -->
     <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
+
+    <!-- 
+      Work around for bug in .NET5 P6. This can be removed when moving to P7 or later
+        Original bug: https://github.com/dotnet/sdk/issues/11862
+        Roslyn bug tracking removal: https://github.com/dotnet/roslyn/issues/46182 
+    -->
+    <RepositoryUrl></RepositoryUrl>
+    <PublishRepositoryUrl>false</PublishRepositoryUrl>
   </PropertyGroup>
 
   <!-- 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -79,14 +79,6 @@
 
     <!-- Bypass a check in msbuild that .NET Framework 3.5 is installed on the machine when targeting .NET < 4.0 -->
     <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
-
-    <!-- 
-      Work around for bug in .NET5 P6. This can be removed when moving to P7 or later
-        Original bug: https://github.com/dotnet/sdk/issues/11862
-        Roslyn bug tracking removal: https://github.com/dotnet/roslyn/issues/46182 
-    -->
-    <RepositoryUrl></RepositoryUrl>
-    <PublishRepositoryUrl>false</PublishRepositoryUrl>
   </PropertyGroup>
 
   <!-- 

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.6.20318.15",
+    "version": "5.0.100-preview.7.20366.6",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.6.20318.15",
+    "dotnet": "5.0.100-preview.7.20366.6",
     "vs": {
       "version": "16.6"
     },

--- a/global.json
+++ b/global.json
@@ -1,10 +1,15 @@
 {
+  "sdk": {
+    "version": "5.0.100-preview.6.20318.15",
+    "allowPrerelease": true,
+    "rollForward": "major"
+  },
   "tools": {
-    "dotnet": "3.1.200",
+    "dotnet": "5.0.100-preview.6.20318.15",
     "vs": {
-      "version": "16.4"
+      "version": "16.6"
     },
-    "xcopy-msbuild": "16.4.0-alpha"
+    "xcopy-msbuild": "16.6.5-alpha1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.20365.6"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7565,7 +7565,7 @@ Handler");
             comp.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.WinRTNeedsWindowsDesktop)]
         [WorkItem(16962, "https://github.com/dotnet/roslyn/issues/16962")]
         public void Events_03()
         {
@@ -7612,7 +7612,7 @@ Handler", references: WinRtRefs.Concat(new[] { ValueTupleRef, comp1.ToMetadataRe
             Assert.True(comp2.Compilation.GetMember<IEventSymbol>("C.E").IsWindowsRuntimeEvent);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.WinRTNeedsWindowsDesktop)]
         [WorkItem(16962, "https://github.com/dotnet/roslyn/issues/16962")]
         public void Events_04()
         {

--- a/src/Compilers/CSharp/Test/WinRT/Microsoft.CodeAnalysis.CSharp.WinRT.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/WinRT/Microsoft.CodeAnalysis.CSharp.WinRT.UnitTests.csproj
@@ -4,11 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
-    <!-- 
-      Disable on Linux. See https://github.com/dotnet/roslyn/pull/31026 
-    -->
-    <SkipTests Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(OS)' != 'Windows_NT'">true</SkipTests>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Test\Utilities\Portable\Roslyn.Test.Utilities.csproj" />

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -22,9 +22,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 
             var root1 = Path.GetFullPath(ProjectDir.Path + Path.DirectorySeparatorChar);
             var root2 = Path.GetFullPath(sourcePackageDir.Path + Path.DirectorySeparatorChar);
+            var root3 = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+            root3 ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+            root3 += Path.DirectorySeparatorChar;
 
             var escapedRoot1 = root1.Replace(",", ",,").Replace("=", "==");
             var escapedRoot2 = root2.Replace(",", ",,").Replace("=", "==");
+            var escapedRoot3 = root3.Replace(",", ",,").Replace("=", "==");
 
             var sourceLinkJsonPath = Path.Combine(ObjDir.Path, ProjectName + ".sourcelink.json");
 
@@ -85,17 +89,19 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 },
                 expectedResults: new[]
                 {
-                    $@"{root2}: /_1/",
+                    $@"{root3}: /_1/",
+                    $@"{root2}: /_2/",
                     $@"{root1}: /_/",
                     $@"{root1}sub1{Path.DirectorySeparatorChar}: /_/sub1/",
                     $@"{root1}sub2{Path.DirectorySeparatorChar}: /_/sub2/",
                     "true",
-                    $@"{escapedRoot2}=/_1/,{escapedRoot1}=/_/,PreviousPathMap",
+                    $@"{escapedRoot3}=/_1/,{escapedRoot2}=/_2/,{escapedRoot1}=/_/,PreviousPathMap",
                     "true"
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                "[/_1/]=[https://raw.githubusercontent.com/Source/Package/*]," +
+                "[/_1/]=[]," +
+                "[/_2/]=[https://raw.githubusercontent.com/Source/Package/*]," +
                 "[/_/]=[https://raw.githubusercontent.com/R1/*]," +
                 "[/_/sub1/]=[https://raw.githubusercontent.com/M1/*]," +
                 "[/_/sub2/]=[https://raw.githubusercontent.com/M2/*]",
@@ -123,6 +129,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 },
                 expectedResults: new[]
                 {
+                    $@"{root3}: {root3}",
                     $@"{root2}: {root2}",
                     $@"{root1}: {root1}",
                     $@"{root1}sub1{Path.DirectorySeparatorChar}: {root1}sub1{Path.DirectorySeparatorChar}",
@@ -132,6 +139,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                $@"[{root3}]=[]," +
                 $@"[{root2}]=[https://raw.githubusercontent.com/Source/Package/*]," +
                 $@"[{root1}]=[https://raw.githubusercontent.com/R1/*]," +
                 $@"[{root1}sub1{Path.DirectorySeparatorChar}]=[https://raw.githubusercontent.com/M1/*]," +
@@ -159,6 +167,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 },
                 expectedResults: new[]
                 {
+                    $@"{root3}: {root3}",
                     $@"{root2}: {root2}",
                     $@"{root1}: {root1}",
                     $@"{root1}sub1{Path.DirectorySeparatorChar}: {root1}sub1{Path.DirectorySeparatorChar}",
@@ -168,6 +177,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                $@"[{root3}]=[]," +
                 $@"[{root2}]=[https://raw.githubusercontent.com/Source/Package/*]," +
                 $@"[{root1}]=[https://raw.githubusercontent.com/R1/*]," +
                 $@"[{root1}sub1{Path.DirectorySeparatorChar}]=[https://raw.githubusercontent.com/M1/*]," +
@@ -195,6 +205,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 },
                 expectedResults: new[]
                 {
+                    $@"{root3}: {root3}",
                     $@"{root2}: {root2}",
                     $@"{root1}: {root1}",
                     $@"{root1}sub1{Path.DirectorySeparatorChar}: {root1}sub1{Path.DirectorySeparatorChar}",
@@ -204,6 +215,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                $@"[{root3}]=[]," +
                 $@"[{root2}]=[https://raw.githubusercontent.com/Source/Package/*]," +
                 $@"[{root1}]=[https://raw.githubusercontent.com/R1/*]," +
                 $@"[{root1}sub1{Path.DirectorySeparatorChar}]=[https://raw.githubusercontent.com/M1/*]," +
@@ -237,15 +249,17 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 },
                 expectedResults: new[]
                 {
-                    $@"{root1}: /_/",
-                    $@"{root2}: /_1/",
+                    $@"{root3}: /_/",
+                    $@"{root1}: /_1/",
+                    $@"{root2}: /_2/",
                     @"true",
-                    $@"{escapedRoot1}=/_/,{escapedRoot2}=/_1/,"
+                    $@"{escapedRoot3}=/_/,{escapedRoot1}=/_1/,{escapedRoot2}=/_2/,"
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                $@"[/_/]=[https://raw.githubusercontent.com/R1/*]," +
-                $@"[/_1/]=[https://raw.githubusercontent.com/Source/Package/*]",
+                $@"[/_/]=[]," +
+                $@"[/_1/]=[https://raw.githubusercontent.com/R1/*]," +
+                $@"[/_2/]=[https://raw.githubusercontent.com/Source/Package/*]",
                 File.ReadAllText(sourceLinkJsonPath));
 
             // No SourceLink package:
@@ -275,15 +289,17 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 },
                 expectedResults: new[]
                 {
-                    $@"{root1}: /_/",
-                    $@"{root2}: /_1/",
+                    $@"{root3}: /_/",
+                    $@"{root1}: /_1/",
+                    $@"{root2}: /_2/",
                     @"true",
-                    $@"{escapedRoot1}=/_/,{escapedRoot2}=/_1/,"
+                    $@"{escapedRoot3}=/_/,{escapedRoot1}=/_1/,{escapedRoot2}=/_2/,"
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                $@"[/_/]=[https://raw.githubusercontent.com/R1/*]," +
-                $@"[/_1/]=[https://raw.githubusercontent.com/Source/Package/*]",
+                $@"[/_/]=[]," +
+                $@"[/_1/]=[https://raw.githubusercontent.com/R1/*]," +
+                $@"[/_2/]=[https://raw.githubusercontent.com/Source/Package/*]",
                 File.ReadAllText(sourceLinkJsonPath));
         }
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWinMdEvents.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWinMdEvents.vb
@@ -455,7 +455,7 @@ End Class
         ''' I'm assuming this is why the final dev11 impl uses GetOrCreateEventRegistrationTokenTable.
         ''' </remarks>
         <WorkItem(1003209, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1003209")>
-        <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.TestExecutionNeedsWindowsTypes)>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.WinRTNeedsWindowsDesktop)>
         Public Sub FieldLikeEventSerialization()
 
             Dim source1 =

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
@@ -51,7 +51,7 @@ End Class]]></file>
             comp.AssertNoDiagnostics()
         End Sub
 
-        <Fact()>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.WinRTNeedsWindowsDesktop)>
         Public Sub IVectorProjectionTests()
             Dim source =
             <compilation>
@@ -178,7 +178,7 @@ b
 ]]>.Value)
         End Sub
 
-        <Fact()>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.WinRTNeedsWindowsDesktop)>
         Public Sub IVectorViewProjectionTests()
 
             Dim source =
@@ -225,7 +225,7 @@ End Class]]></file>
 }]]>.Value)
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.WinRTNeedsWindowsDesktop)>
         Public Sub IVectorLinqQueryTest()
             Dim source =
                 <compilation>
@@ -287,7 +287,7 @@ End Class
 ]]>.Value)
         End Sub
 
-        <Fact()>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.WinRTNeedsWindowsDesktop)>
         Public Sub IMapProjectionTests()
             Dim source =
             <compilation>

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -446,7 +446,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
             // the implementation differs between .NET Core and .NET FX
             if (str.StartsWith("Enumerable"))
             {
-                Assert.Equal("Enumerable.RangeIterator { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }", str);
+                Assert.Equal("Enumerable.RangeIterator(Count = 10)", str);
             }
             else
             {

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -44,6 +44,8 @@ namespace Roslyn.Test.Utilities
         public const string TestHasWindowsPaths = "Test depends on Windows style paths";
         public const string TestExecutionNeedsFusion = "Test depends on desktop fusion loader API";
 
+        public const string WinRTNeedsWindowsDesktop = "WinRT is only supported on Windows desktop";
+
         /// <summary>
         /// Mono issues around Default Interface Methods
         /// </summary>


### PR DESCRIPTION
This is necessary for us to test features like covariant returns because
we need to be able to target `net5.0` in our unit test projects.

Issues encountered in this update:

- WinRT is no longer supported in .NET 5. As a result we no longer multi-target
.NET Core in our WinRT test assembly as well as having to disabling a
few WinRT tests in others.  dotnet/runtime#37672
- Change our Debugger Proxy tests to react to a runtime change
dotnet/runtime@c362923
- Work around .NET5 P6 bug dotnet/sdk#11862