### PR TITLE
Backport 45942 to dev16.7.  Include information why symbol key resolution has failed to help with debugging

### DIFF
--- a/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
@@ -107,14 +107,14 @@ namespace Microsoft.CodeAnalysis.Remote
             // The server and client should both be talking about the same compilation.  As such
             // locations in symbols are save to resolve as we rehydrate the SymbolKey.
             var symbol = SymbolKey.ResolveString(
-                SymbolKeyData, compilation, cancellationToken: cancellationToken).GetAnySymbol();
+                SymbolKeyData, compilation, out var failureReason, cancellationToken).GetAnySymbol();
 
             if (symbol == null)
             {
                 try
                 {
                     throw new InvalidOperationException(
-                        $"We should always be able to resolve a symbol back on the host side:\r\n{SymbolKeyData}");
+                        $"We should always be able to resolve a symbol back on the host side:\r\n{SymbolKeyData}\r\n{failureReason}");
                 }
                 catch (Exception ex) when (FatalError.ReportWithoutCrash(ex))
                 {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AliasSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AliasSymbolKey.cs
@@ -18,10 +18,16 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteString(FirstOrDefault(symbol.DeclaringSyntaxReferences)?.SyntaxTree.FilePath ?? "");
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var name = reader.ReadString();
-                var targetResolution = reader.ReadSymbolKey();
+                var targetResolution = reader.ReadSymbolKey(out var targetFailureReason);
+                if (targetFailureReason == null)
+                {
+                    failureReason = $"({nameof(AliasSymbolKey)} {nameof(targetResolution)} failed -> {targetFailureReason})";
+                    return default;
+                }
+
                 var filePath = reader.ReadString();
 
                 var syntaxTree = reader.GetSyntaxTree(filePath);
@@ -34,11 +40,13 @@ namespace Microsoft.CodeAnalysis
                         var result = Resolve(semanticModel, syntaxTree.GetRoot(reader.CancellationToken), name, target, reader.CancellationToken);
                         if (result.HasValue)
                         {
+                            failureReason = null;
                             return result.Value;
                         }
                     }
                 }
 
+                failureReason = $"({nameof(AliasSymbolKey)} '{name}' not found)";
                 return default;
             }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AliasSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AliasSymbolKey.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var name = reader.ReadString();
                 var targetResolution = reader.ReadSymbolKey(out var targetFailureReason);
-                if (targetFailureReason == null)
+                if (targetFailureReason != null)
                 {
                     failureReason = $"({nameof(AliasSymbolKey)} {nameof(targetResolution)} failed -> {targetFailureReason})";
                     return default;

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AliasSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AliasSymbolKey.cs
@@ -22,13 +22,13 @@ namespace Microsoft.CodeAnalysis
             {
                 var name = reader.ReadString();
                 var targetResolution = reader.ReadSymbolKey(out var targetFailureReason);
+                var filePath = reader.ReadString();
+
                 if (targetFailureReason != null)
                 {
                     failureReason = $"({nameof(AliasSymbolKey)} {nameof(targetResolution)} failed -> {targetFailureReason})";
                     return default;
                 }
-
-                var filePath = reader.ReadString();
 
                 var syntaxTree = reader.GetSyntaxTree(filePath);
                 if (syntaxTree != null)

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
@@ -31,14 +31,20 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteLocation(FirstOrDefault(symbol.Locations));
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var isAnonymousDelegateType = reader.ReadBoolean();
-                var location = reader.ReadLocation();
+                var location = reader.ReadLocation(out var locationFailureReason);
+                if (locationFailureReason != null)
+                {
+                    failureReason = $"({nameof(AnonymousFunctionOrDelegateSymbolKey)} {nameof(location)} failed -> ${locationFailureReason})";
+                    return default;
+                }
 
                 var syntaxTree = location.SourceTree;
                 if (syntaxTree == null)
                 {
+                    failureReason = $"({nameof(AnonymousFunctionOrDelegateSymbolKey)} {nameof(SyntaxTree)} failed)";
                     return default;
                 }
 
@@ -58,6 +64,7 @@ namespace Microsoft.CodeAnalysis
                     symbol = anonymousDelegate;
                 }
 
+                failureReason = null;
                 return new SymbolKeyResolution(symbol);
             }
         }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var isAnonymousDelegateType = reader.ReadBoolean();
                 var location = reader.ReadLocation(out var locationFailureReason);
+
                 if (locationFailureReason != null)
                 {
                     failureReason = $"({nameof(AnonymousFunctionOrDelegateSymbolKey)} {nameof(location)} failed -> {locationFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
                 var location = reader.ReadLocation(out var locationFailureReason);
                 if (locationFailureReason != null)
                 {
-                    failureReason = $"({nameof(AnonymousFunctionOrDelegateSymbolKey)} {nameof(location)} failed -> ${locationFailureReason})";
+                    failureReason = $"({nameof(AnonymousFunctionOrDelegateSymbolKey)} {nameof(location)} failed -> {locationFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
                 using var propertyTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var propertyTypesFailureReason);
                 if (propertyTypesFailureReason != null)
                 {
-                    failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyTypes)} failed -> ${propertyTypesFailureReason})";
+                    failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyTypes)} failed -> {propertyTypesFailureReason})";
                     return default;
                 }
 
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                 using var propertyLocations = reader.ReadLocationArray(out var propertyLocationsFailureReason);
                 if (propertyLocationsFailureReason != null)
                 {
-                    failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyLocations)} failed -> ${propertyLocationsFailureReason})";
+                    failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyLocations)} failed -> {propertyLocationsFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
@@ -31,15 +31,16 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 using var propertyTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var propertyTypesFailureReason);
+                using var propertyNames = reader.ReadStringArray();
+                using var propertyIsReadOnly = reader.ReadBooleanArray();
+                using var propertyLocations = reader.ReadLocationArray(out var propertyLocationsFailureReason);
+
                 if (propertyTypesFailureReason != null)
                 {
                     failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyTypes)} failed -> {propertyTypesFailureReason})";
                     return default;
                 }
 
-                using var propertyNames = reader.ReadStringArray();
-                using var propertyIsReadOnly = reader.ReadBooleanArray();
-                using var propertyLocations = reader.ReadLocationArray(out var propertyLocationsFailureReason);
                 if (propertyLocationsFailureReason != null)
                 {
                     failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyLocations)} failed -> {propertyLocationsFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
@@ -28,12 +28,23 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteLocationArray(propertyLocations);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
-                using var propertyTypes = reader.ReadSymbolKeyArray<ITypeSymbol>();
+                using var propertyTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var propertyTypesFailureReason);
+                if (propertyTypesFailureReason != null)
+                {
+                    failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyTypes)} failed -> ${propertyTypesFailureReason})";
+                    return default;
+                }
+
                 using var propertyNames = reader.ReadStringArray();
                 using var propertyIsReadOnly = reader.ReadBooleanArray();
-                using var propertyLocations = reader.ReadLocationArray();
+                using var propertyLocations = reader.ReadLocationArray(out var propertyLocationsFailureReason);
+                if (propertyLocationsFailureReason != null)
+                {
+                    failureReason = $"({nameof(AnonymousTypeSymbolKey)} {nameof(propertyLocations)} failed -> ${propertyLocationsFailureReason})";
+                    return default;
+                }
 
                 if (!propertyTypes.IsDefault)
                 {
@@ -42,6 +53,7 @@ namespace Microsoft.CodeAnalysis
                         var anonymousType = reader.Compilation.CreateAnonymousTypeSymbol(
                             propertyTypes.ToImmutable(), propertyNames.ToImmutable(),
                             propertyIsReadOnly.ToImmutable(), propertyLocations.ToImmutable());
+                        failureReason = null;
                         return new SymbolKeyResolution(anonymousType);
                     }
                     catch (ArgumentException)
@@ -49,6 +61,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
+                failureReason = null;
                 return new SymbolKeyResolution(reader.Compilation.ObjectType);
             }
         }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ArrayTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ArrayTypeSymbolKey.cs
@@ -17,13 +17,13 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var elementTypeResolution = reader.ReadSymbolKey(out var elementTypeFailureReason);
+                var rank = reader.ReadInteger();
+
                 if (elementTypeFailureReason != null)
                 {
                     failureReason = $"({nameof(ArrayTypeSymbolKey)} {nameof(elementTypeResolution)} failed -> {elementTypeFailureReason})";
                     return default;
                 }
-
-                var rank = reader.ReadInteger();
 
                 using var result = PooledArrayBuilder<IArrayTypeSymbol>.GetInstance(elementTypeResolution.SymbolCount);
                 foreach (var typeSymbol in elementTypeResolution.OfType<ITypeSymbol>())

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AssemblySymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.AssemblySymbolKey.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteString(symbol.Identity.Name);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var assemblyName = reader.ReadString();
                 var compilation = reader.Compilation;
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(AssemblySymbolKey)} '{assemblyName}' not found)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis
                 var locations = reader.ReadLocationArray(out var locationsFailureReason);
                 if (locationsFailureReason != null)
                 {
-                    failureReason = $"({nameof(BodyLevelSymbolKey)} {nameof(locations)} failed -> ${locationsFailureReason})";
+                    failureReason = $"({nameof(BodyLevelSymbolKey)} {nameof(locations)} failed -> {locationsFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -116,13 +116,19 @@ namespace Microsoft.CodeAnalysis
                 return false;
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
                 var cancellationToken = reader.CancellationToken;
 
                 var name = reader.ReadString();
                 var kind = (SymbolKind)reader.ReadInteger();
-                var locations = reader.ReadLocationArray();
+                var locations = reader.ReadLocationArray(out var locationsFailureReason);
+                if (locationsFailureReason != null)
+                {
+                    failureReason = $"({nameof(BodyLevelSymbolKey)} {nameof(locations)} failed -> ${locationsFailureReason})";
+                    return default;
+                }
+
                 var ordinal = reader.ReadInteger();
 
                 // First check if we can recover the symbol just through the original location.
@@ -136,6 +142,7 @@ namespace Microsoft.CodeAnalysis
                         if (symbol?.Kind == kind &&
                             SymbolKey.Equals(reader.Compilation, name, symbol.Name))
                         {
+                            failureReason = null;
                             return resolution;
                         }
                     }
@@ -148,10 +155,14 @@ namespace Microsoft.CodeAnalysis
                     foreach (var symbol in EnumerateSymbols(semanticModel, kind, name, cancellationToken))
                     {
                         if (symbol.ordinal == ordinal)
+                        {
+                            failureReason = null;
                             return new SymbolKeyResolution(symbol.symbol);
+                        }
                     }
                 }
 
+                failureReason = $"({nameof(BodyLevelSymbolKey)} '{name}' not found)";
                 return default;
             }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -123,13 +123,13 @@ namespace Microsoft.CodeAnalysis
                 var name = reader.ReadString();
                 var kind = (SymbolKind)reader.ReadInteger();
                 var locations = reader.ReadLocationArray(out var locationsFailureReason);
+                var ordinal = reader.ReadInteger();
+
                 if (locationsFailureReason != null)
                 {
                     failureReason = $"({nameof(BodyLevelSymbolKey)} {nameof(locations)} failed -> {locationsFailureReason})";
                     return default;
                 }
-
-                var ordinal = reader.ReadInteger();
 
                 // First check if we can recover the symbol just through the original location.
                 foreach (var loc in locations)

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.DynamicTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.DynamicTypeSymbolKey.cs
@@ -14,8 +14,11 @@ namespace Microsoft.CodeAnalysis
                 // per compilation.
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
-                => new SymbolKeyResolution(reader.Compilation.DynamicType);
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
+            {
+                failureReason = null;
+                return new SymbolKeyResolution(reader.Compilation.DynamicType);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis
                 var containingSymbolResolution = ResolveContainer(reader, out var containingSymbolFailureReason);
                 if (containingSymbolFailureReason != null)
                 {
-                    failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis
                 using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
                 if (containingSymbolFailureReason != null)
                 {
-                    failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(typeArguments)} failed -> ${typeArgumentsFailureReason})";
+                    failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
@@ -62,16 +62,17 @@ namespace Microsoft.CodeAnalysis
                 var name = reader.ReadString();
 
                 var containingSymbolResolution = ResolveContainer(reader, out var containingSymbolFailureReason);
+                var arity = reader.ReadInteger();
+
+                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
+
                 if (containingSymbolFailureReason != null)
                 {
                     failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 
-                var arity = reader.ReadInteger();
-
-                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
-                if (containingSymbolFailureReason != null)
+                if (typeArgumentsFailureReason != null)
                 {
                     failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
                     return default;

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.EventSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.EventSymbolKey.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
                 var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
                 if (containingTypeFailureReason != null)
                 {
-                    failureReason = $"({nameof(EventSymbolKey)} {nameof(containingTypeResolution)} failed -> ${containingTypeFailureReason})";
+                    failureReason = $"({nameof(EventSymbolKey)} {nameof(containingTypeResolution)} failed -> {containingTypeFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.EventSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.EventSymbolKey.cs
@@ -14,13 +14,18 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteSymbolKey(symbol.ContainingType);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey();
+                var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                if (containingTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(EventSymbolKey)} {nameof(containingTypeResolution)} failed -> ${containingTypeFailureReason})";
+                    return default;
+                }
 
                 using var result = GetMembersOfNamedType<IEventSymbol>(containingTypeResolution, metadataName);
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(EventSymbolKey)} '{metadataName}' not found)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.EventSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.EventSymbolKey.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var metadataName = reader.ReadString();
                 var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+
                 if (containingTypeFailureReason != null)
                 {
                     failureReason = $"({nameof(EventSymbolKey)} {nameof(containingTypeResolution)} failed -> {containingTypeFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FieldSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FieldSymbolKey.cs
@@ -14,13 +14,18 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteSymbolKey(symbol.ContainingType);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey();
+                var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                if (containingTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(FieldSymbolKey)} {nameof(containingTypeResolution)} failed -> ${containingTypeFailureReason})";
+                    return default;
+                }
 
                 using var result = GetMembersOfNamedType<IFieldSymbol>(containingTypeResolution, metadataName);
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(FieldSymbolKey)} '{metadataName}' not found)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FieldSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FieldSymbolKey.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var metadataName = reader.ReadString();
                 var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+
                 if (containingTypeFailureReason != null)
                 {
                     failureReason = $"({nameof(FieldSymbolKey)} {nameof(containingTypeResolution)} failed -> {containingTypeFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FieldSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FieldSymbolKey.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
                 var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
                 if (containingTypeFailureReason != null)
                 {
-                    failureReason = $"({nameof(FieldSymbolKey)} {nameof(containingTypeResolution)} failed -> ${containingTypeFailureReason})";
+                    failureReason = $"({nameof(FieldSymbolKey)} {nameof(containingTypeResolution)} failed -> {containingTypeFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FunctionPointerTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FunctionPointerTypeSymbolKey.cs
@@ -20,14 +20,15 @@ namespace Microsoft.CodeAnalysis
             {
                 var returnRefKind = reader.ReadRefKind();
                 var returnType = reader.ReadSymbolKey(out var returnTypeFailureReason);
+                using var paramRefKinds = reader.ReadRefKindArray();
+                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var parameterTypesFailureReason);
+
                 if (returnTypeFailureReason != null)
                 {
                     failureReason = $"({nameof(FunctionPointerTypeSymbolKey)} {nameof(returnType)} failed -> {returnTypeFailureReason})";
                     return default;
                 }
 
-                using var paramRefKinds = reader.ReadRefKindArray();
-                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var parameterTypesFailureReason);
                 if (parameterTypesFailureReason != null)
                 {
                     failureReason = $"({nameof(FunctionPointerTypeSymbolKey)} {nameof(parameterTypes)} failed -> {parameterTypesFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -137,12 +137,6 @@ namespace Microsoft.CodeAnalysis
                 var metadataName = reader.ReadString();
 
                 var containingType = reader.ReadSymbolKey(out var containingTypeFailureReason);
-                if (containingTypeFailureReason != null)
-                {
-                    failureReason = $"({nameof(MethodSymbolKey)} {nameof(containingType)} failed -> {containingTypeFailureReason})";
-                    return default;
-                }
-
                 var arity = reader.ReadInteger();
                 var isPartialMethodImplementationPart = reader.ReadBoolean();
                 using var parameterRefKinds = reader.ReadRefKindArray();
@@ -193,6 +187,12 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     reader.PopMethod(methodOpt: null);
+                }
+
+                if (containingTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(MethodSymbolKey)} {nameof(containingType)} failed -> {containingTypeFailureReason})";
+                    return default;
                 }
 
                 return CreateResolution(result, $"({nameof(MethodSymbolKey)} '{metadataName}' not found)", out failureReason);

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -23,14 +23,14 @@ namespace Microsoft.CodeAnalysis
                 var reducedFromResolution = reader.ReadSymbolKey(out var reducedFromFailureReason);
                 if (reducedFromFailureReason != null)
                 {
-                    failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(reducedFromResolution)} failed -> ${reducedFromFailureReason})";
+                    failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(reducedFromResolution)} failed -> {reducedFromFailureReason})";
                     return default;
                 }
 
                 var receiverTypeResolution = reader.ReadSymbolKey(out var receiverTypeFailureReason);
                 if (receiverTypeFailureReason != null)
                 {
-                    failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(receiverTypeResolution)} failed -> ${receiverTypeFailureReason})";
+                    failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(receiverTypeResolution)} failed -> {receiverTypeFailureReason})";
                     return default;
                 }
 
@@ -63,14 +63,14 @@ namespace Microsoft.CodeAnalysis
                 var constructedFrom = reader.ReadSymbolKey(out var constructedFromFailureReason);
                 if (constructedFromFailureReason != null)
                 {
-                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(constructedFrom)} failed -> ${constructedFromFailureReason})";
+                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(constructedFrom)} failed -> {constructedFromFailureReason})";
                     return default;
                 }
 
                 using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
                 if (typeArgumentsFailureReason != null)
                 {
-                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(typeArguments)} failed -> ${typeArgumentsFailureReason})";
+                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
                     return default;
                 }
 
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis
                 var containingType = reader.ReadSymbolKey(out var containingTypeFailureReason);
                 if (containingTypeFailureReason != null)
                 {
-                    failureReason = $"({nameof(MethodSymbolKey)} {nameof(containingType)} failed -> ${containingTypeFailureReason})";
+                    failureReason = $"({nameof(MethodSymbolKey)} {nameof(containingType)} failed -> {containingTypeFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -18,10 +18,21 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteSymbolKey(symbol.ReceiverType);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
-                var reducedFromResolution = reader.ReadSymbolKey();
-                var receiverTypeResolution = reader.ReadSymbolKey();
+                var reducedFromResolution = reader.ReadSymbolKey(out var reducedFromFailureReason);
+                if (reducedFromFailureReason != null)
+                {
+                    failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(reducedFromResolution)} failed -> ${reducedFromFailureReason})";
+                    return default;
+                }
+
+                var receiverTypeResolution = reader.ReadSymbolKey(out var receiverTypeFailureReason);
+                if (receiverTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(receiverTypeResolution)} failed -> ${receiverTypeFailureReason})";
+                    return default;
+                }
 
                 using var result = PooledArrayBuilder<IMethodSymbol>.GetInstance();
                 foreach (var reducedFrom in reducedFromResolution.OfType<IMethodSymbol>())
@@ -32,7 +43,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(ReducedExtensionMethodSymbolKey)} failed)", out failureReason);
             }
         }
     }
@@ -47,14 +58,25 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteSymbolKeyArray(symbol.TypeArguments);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
-                var constructedFrom = reader.ReadSymbolKey();
-                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>();
-
-                if (constructedFrom.SymbolCount == 0 ||
-                    typeArguments.IsDefault)
+                var constructedFrom = reader.ReadSymbolKey(out var constructedFromFailureReason);
+                if (constructedFromFailureReason != null)
                 {
+                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(constructedFrom)} failed -> ${constructedFromFailureReason})";
+                    return default;
+                }
+
+                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
+                if (typeArgumentsFailureReason != null)
+                {
+                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(typeArguments)} failed -> ${typeArgumentsFailureReason})";
+                    return default;
+                }
+
+                if (constructedFrom.SymbolCount == 0 || typeArguments.IsDefault)
+                {
+                    failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(typeArguments)} failed -> 'constructedFrom.SymbolCount == 0 || typeArguments.IsDefault')";
                     return default;
                 }
 
@@ -69,7 +91,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(ConstructedMethodSymbolKey)} could not successfully construct)", out failureReason);
             }
         }
     }
@@ -110,10 +132,17 @@ namespace Microsoft.CodeAnalysis
                 visitor.PopMethod(symbol);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingType = reader.ReadSymbolKey();
+
+                var containingType = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                if (containingTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(MethodSymbolKey)} {nameof(containingType)} failed -> ${containingTypeFailureReason})";
+                    return default;
+                }
+
                 var arity = reader.ReadInteger();
                 var isPartialMethodImplementationPart = reader.ReadBoolean();
                 using var parameterRefKinds = reader.ReadRefKindArray();
@@ -158,15 +187,15 @@ namespace Microsoft.CodeAnalysis
                     // read out the values.  We don't actually need to use them, but we have
                     // to effectively read past them in the string.
 
-                    using (reader.ReadSymbolKeyArray<ITypeSymbol>())
+                    using (reader.ReadSymbolKeyArray<ITypeSymbol>(out _))
                     {
-                        _ = reader.ReadSymbolKey();
+                        _ = reader.ReadSymbolKey(out _);
                     }
 
                     reader.PopMethod(methodOpt: null);
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(MethodSymbolKey)} '{metadataName}' not found)", out failureReason);
             }
 
             private static IMethodSymbol Resolve(
@@ -207,8 +236,8 @@ namespace Microsoft.CodeAnalysis
             private static IMethodSymbol Resolve(
                 SymbolKeyReader reader, bool isPartialMethodImplementationPart, IMethodSymbol method)
             {
-                using var originalParameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>();
-                var returnType = (ITypeSymbol)reader.ReadSymbolKey().GetAnySymbol();
+                using var originalParameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out _);
+                var returnType = (ITypeSymbol)reader.ReadSymbolKey(out _).GetAnySymbol();
 
                 if (reader.ParameterTypesMatch(method.OriginalDefinition.Parameters, originalParameterTypes))
                 {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ModuleSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ModuleSymbolKey.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+
                 if (containingSymbolFailureReason != null)
                 {
                     failureReason = $"({nameof(ModuleSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ModuleSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ModuleSymbolKey.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
                 if (containingSymbolFailureReason != null)
                 {
-                    failureReason = $"({nameof(ModuleSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    failureReason = $"({nameof(ModuleSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ModuleSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ModuleSymbolKey.cs
@@ -11,9 +11,14 @@ namespace Microsoft.CodeAnalysis
             public static void Create(IModuleSymbol symbol, SymbolKeyWriter visitor)
                 => visitor.WriteSymbolKey(symbol.ContainingSymbol);
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
-                var containingSymbolResolution = reader.ReadSymbolKey();
+                var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                if (containingSymbolFailureReason != null)
+                {
+                    failureReason = $"({nameof(ModuleSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    return default;
+                }
 
                 using var result = PooledArrayBuilder<IModuleSymbol>.GetInstance();
                 foreach (var assembly in containingSymbolResolution.OfType<IAssemblySymbol>())
@@ -23,7 +28,7 @@ namespace Microsoft.CodeAnalysis
                     result.AddValuesIfNotNull(assembly.Modules);
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(ModuleSymbolKey)} failed)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
@@ -31,17 +31,17 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                var arity = reader.ReadInteger();
+                var isUnboundGenericType = reader.ReadBoolean();
+                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
+
                 if (containingSymbolFailureReason != null)
                 {
                     failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(containingSymbolFailureReason)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 
-                var arity = reader.ReadInteger();
-                var isUnboundGenericType = reader.ReadBoolean();
-                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
                 if (typeArgumentsFailureReason != null)
                 {
                     failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
@@ -28,16 +28,29 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingSymbolResolution = reader.ReadSymbolKey();
+
+                var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                if (containingSymbolFailureReason != null)
+                {
+                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(containingSymbolFailureReason)} failed -> ${containingSymbolFailureReason})";
+                    return default;
+                }
+
                 var arity = reader.ReadInteger();
                 var isUnboundGenericType = reader.ReadBoolean();
-                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>();
+                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
+                if (typeArgumentsFailureReason != null)
+                {
+                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed -> ${typeArgumentsFailureReason})";
+                    return default;
+                }
 
                 if (typeArguments.IsDefault)
                 {
+                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed)";
                     return default;
                 }
 
@@ -52,7 +65,7 @@ namespace Microsoft.CodeAnalysis
                         isUnboundGenericType, typeArgumentArray);
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(NamedTypeSymbolKey)} failed)", out failureReason);
             }
 
             private static void Resolve(

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
                 if (containingSymbolFailureReason != null)
                 {
-                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(containingSymbolFailureReason)} failed -> ${containingSymbolFailureReason})";
+                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(containingSymbolFailureReason)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis
                 using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
                 if (typeArgumentsFailureReason != null)
                 {
-                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed -> ${typeArgumentsFailureReason})";
+                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamespaceSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamespaceSymbolKey.cs
@@ -52,14 +52,21 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
                 var isCompilationGlobalNamespace = reader.ReadBoolean();
-                var containingSymbolResolution = reader.ReadSymbolKey();
+
+                var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                if (containingSymbolFailureReason != null)
+                {
+                    failureReason = $"({nameof(EventSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    return default;
+                }
 
                 if (isCompilationGlobalNamespace)
                 {
+                    failureReason = null;
                     return new SymbolKeyResolution(reader.Compilation.GlobalNamespace);
                 }
 
@@ -88,7 +95,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(NamespaceSymbolKey)} '{metadataName}' not found)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamespaceSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamespaceSymbolKey.cs
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis
             {
                 var metadataName = reader.ReadString();
                 var isCompilationGlobalNamespace = reader.ReadBoolean();
-
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+
                 if (containingSymbolFailureReason != null)
                 {
                     failureReason = $"({nameof(EventSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamespaceSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.NamespaceSymbolKey.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
                 if (containingSymbolFailureReason != null)
                 {
-                    failureReason = $"({nameof(EventSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    failureReason = $"({nameof(EventSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
@@ -16,10 +16,15 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteSymbolKey(symbol.ContainingSymbol);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingSymbolResolution = reader.ReadSymbolKey();
+                var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                if (containingSymbolFailureReason != null)
+                {
+                    failureReason = $"({nameof(ParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    return default;
+                }
 
                 using var result = PooledArrayBuilder<IParameterSymbol>.GetInstance();
                 foreach (var container in containingSymbolResolution)
@@ -55,7 +60,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(ParameterSymbolKey)} '{metadataName}' not found)", out failureReason);
             }
 
             private static void Resolve(

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
                 if (containingSymbolFailureReason != null)
                 {
-                    failureReason = $"({nameof(ParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                    failureReason = $"({nameof(ParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var metadataName = reader.ReadString();
                 var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+
                 if (containingSymbolFailureReason != null)
                 {
                     failureReason = $"({nameof(ParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis
                 var pointedAtTypeResolution = reader.ReadSymbolKey(out var pointedAtTypeFailureReason);
                 if (pointedAtTypeFailureReason != null)
                 {
-                    failureReason = $"({nameof(PointerTypeSymbolKey)} {nameof(pointedAtTypeResolution)} failed -> ${pointedAtTypeFailureReason})";
+                    failureReason = $"({nameof(PointerTypeSymbolKey)} {nameof(pointedAtTypeResolution)} failed -> {pointedAtTypeFailureReason})";
                     return default;
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
@@ -11,9 +11,14 @@ namespace Microsoft.CodeAnalysis
             public static void Create(IPointerTypeSymbol symbol, SymbolKeyWriter visitor)
                 => visitor.WriteSymbolKey(symbol.PointedAtType);
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
-                var pointedAtTypeResolution = reader.ReadSymbolKey();
+                var pointedAtTypeResolution = reader.ReadSymbolKey(out var pointedAtTypeFailureReason);
+                if (pointedAtTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(PointerTypeSymbolKey)} {nameof(pointedAtTypeResolution)} failed -> ${pointedAtTypeFailureReason})";
+                    return default;
+                }
 
                 using var result = PooledArrayBuilder<IPointerTypeSymbol>.GetInstance(pointedAtTypeResolution.SymbolCount);
                 foreach (var typeSymbol in pointedAtTypeResolution.OfType<ITypeSymbol>())
@@ -21,7 +26,7 @@ namespace Microsoft.CodeAnalysis
                     result.AddIfNotNull(reader.Compilation.CreatePointerTypeSymbol(typeSymbol));
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(PointerTypeSymbolKey)} could not resolve)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var pointedAtTypeResolution = reader.ReadSymbolKey(out var pointedAtTypeFailureReason);
+
                 if (pointedAtTypeFailureReason != null)
                 {
                     failureReason = $"({nameof(PointerTypeSymbolKey)} {nameof(pointedAtTypeResolution)} failed -> {pointedAtTypeFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PropertySymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PropertySymbolKey.cs
@@ -17,17 +17,30 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteParameterTypesArray(symbol.OriginalDefinition.Parameters);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey();
+                var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+
+                if (containingTypeFailureReason != null)
+                {
+                    failureReason = $"({nameof(PropertySymbolKey)} {nameof(containingTypeResolution)} failed -> {containingTypeFailureReason})";
+                    return default;
+                }
+
                 var isIndexer = reader.ReadBoolean();
 
                 using var refKinds = reader.ReadRefKindArray();
-                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>();
+                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var parameterTypesFailureReason);
+                if (parameterTypesFailureReason != null)
+                {
+                    failureReason = $"({nameof(PropertySymbolKey)} {nameof(parameterTypes)} failed -> {parameterTypesFailureReason})";
+                    return default;
+                }
 
                 if (parameterTypes.IsDefault)
                 {
+                    failureReason = $"({nameof(PropertySymbolKey)} no parameter types)";
                     return default;
                 }
 
@@ -45,7 +58,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                return CreateResolution(result);
+                return CreateResolution(result, $"({nameof(PropertySymbolKey)} '{metadataName}' not found)", out failureReason);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PropertySymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.PropertySymbolKey.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis
             {
                 var metadataName = reader.ReadString();
                 var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                var isIndexer = reader.ReadBoolean();
+                using var refKinds = reader.ReadRefKindArray();
+                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var parameterTypesFailureReason);
 
                 if (containingTypeFailureReason != null)
                 {
@@ -28,10 +31,6 @@ namespace Microsoft.CodeAnalysis
                     return default;
                 }
 
-                var isIndexer = reader.ReadBoolean();
-
-                using var refKinds = reader.ReadRefKindArray();
-                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var parameterTypesFailureReason);
                 if (parameterTypesFailureReason != null)
                 {
                     failureReason = $"({nameof(PropertySymbolKey)} {nameof(parameterTypes)} failed -> {parameterTypesFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -549,7 +549,7 @@ namespace Microsoft.CodeAnalysis
                     var syntaxTree = GetSyntaxTree(filePath);
                     if (syntaxTree != null)
                     {
-                        failureReason = $"{nameof(ReadLocation)} {nameof(SyntaxTree)} not found";
+                        failureReason = null;
                         return Location.Create(syntaxTree, new TextSpan(start, length));
                     }
                 }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -556,13 +556,13 @@ namespace Microsoft.CodeAnalysis
                 else if (kind == LocationKind.MetadataFile)
                 {
                     var assemblyResolution = ReadSymbolKey(out var assemblyFailureReason);
+                    var moduleName = ReadString();
+
                     if (assemblyFailureReason != null)
                     {
                         failureReason = $"{nameof(ReadLocation)} {nameof(assemblyResolution)} failed -> " + assemblyFailureReason;
                         return Location.None;
                     }
-
-                    var moduleName = ReadString();
 
                     // We may be resolving in a compilation where we don't have a module
                     // with this name.  In that case, just map this location to none.

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
@@ -20,6 +20,15 @@ namespace Microsoft.CodeAnalysis
                 var friendlyNames = ArrayBuilder<string>.GetInstance();
                 var locations = ArrayBuilder<Location>.GetInstance();
 
+                foreach (var element in symbol.TupleElements)
+                {
+                    friendlyNames.Add(element.IsImplicitlyDeclared ? null : element.Name);
+                    locations.Add(FirstOrDefault(element.Locations) ?? Location.None);
+                }
+
+                visitor.WriteStringArray(friendlyNames.ToImmutableAndFree());
+                visitor.WriteLocationArray(locations.ToImmutableAndFree());
+
                 var isError = symbol.TupleUnderlyingType.TypeKind == TypeKind.Error;
                 visitor.WriteBoolean(isError);
 
@@ -38,25 +47,27 @@ namespace Microsoft.CodeAnalysis
                 {
                     visitor.WriteSymbolKey(symbol.TupleUnderlyingType);
                 }
-
-                foreach (var element in symbol.TupleElements)
-                {
-                    friendlyNames.Add(element.IsImplicitlyDeclared ? null : element.Name);
-                    locations.Add(FirstOrDefault(element.Locations) ?? Location.None);
-                }
-
-                visitor.WriteStringArray(friendlyNames.ToImmutableAndFree());
-                visitor.WriteLocationArray(locations.ToImmutableAndFree());
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
+                using var elementNames = reader.ReadStringArray();
+                var elementLocations = ReadElementLocations(reader, out var elementLocationsFailureReason);
+                if (elementLocationsFailureReason != null)
+                {
+                    failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(elementLocations)} failed -> ${elementLocationsFailureReason})";
+                    return default;
+                }
+
                 var isError = reader.ReadBoolean();
                 if (isError)
                 {
-                    using var elementTypes = reader.ReadSymbolKeyArray<ITypeSymbol>();
-                    using var elementNames = reader.ReadStringArray();
-                    var elementLocations = ReadElementLocations(reader);
+                    using var elementTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var elementTypesFailureReason);
+                    if (elementTypesFailureReason != null)
+                    {
+                        failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(elementTypes)} failed -> ${elementTypesFailureReason})";
+                        return default;
+                    }
 
                     if (!elementTypes.IsDefault)
                     {
@@ -64,6 +75,7 @@ namespace Microsoft.CodeAnalysis
                         {
                             var result = reader.Compilation.CreateTupleTypeSymbol(
                                 elementTypes.ToImmutable(), elementNames.ToImmutable(), elementLocations);
+                            failureReason = null;
                             return new SymbolKeyResolution(result);
                         }
                         catch (ArgumentException)
@@ -73,41 +85,45 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    var underlyingTypeResolution = reader.ReadSymbolKey();
-                    using var elementNamesBuilder = reader.ReadStringArray();
-                    var elementLocations = ReadElementLocations(reader);
+                    var underlyingTypeResolution = reader.ReadSymbolKey(out var underlyingTypeFailureReason);
+                    if (underlyingTypeFailureReason != null)
+                    {
+                        failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(underlyingTypeResolution)} failed -> ${underlyingTypeFailureReason})";
+                        return default;
+                    }
 
                     try
                     {
                         using var result = PooledArrayBuilder<INamedTypeSymbol>.GetInstance();
 
-                        var elementNames = elementNamesBuilder.ToImmutable();
+                        var elementNamesArray = elementNames.ToImmutable();
                         foreach (var namedType in underlyingTypeResolution.OfType<INamedTypeSymbol>())
                         {
                             result.AddIfNotNull(reader.Compilation.CreateTupleTypeSymbol(
-                                namedType, elementNames, elementLocations));
+                                namedType, elementNamesArray, elementLocations));
                         }
 
-                        return CreateResolution(result);
+                        return CreateResolution(result, $"({nameof(TupleTypeSymbolKey)} failed)", out failureReason);
                     }
                     catch (ArgumentException)
                     {
                     }
                 }
 
+                failureReason = null;
                 return new SymbolKeyResolution(reader.Compilation.ObjectType);
             }
 
-            private static ImmutableArray<Location> ReadElementLocations(SymbolKeyReader reader)
+            private static ImmutableArray<Location> ReadElementLocations(SymbolKeyReader reader, out string failureReason)
             {
-                using var elementLocations = reader.ReadLocationArray();
+                using var elementLocations = reader.ReadLocationArray(out failureReason);
+                if (failureReason != null)
+                    return default;
 
                 // Compiler API requires that all the locations are non-null, or that there is a default
                 // immutable array passed in.
                 if (elementLocations.Builder.All(loc => loc == null))
-                {
                     return default;
-                }
 
                 return elementLocations.ToImmutable();
             }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis
                 var elementLocations = ReadElementLocations(reader, out var elementLocationsFailureReason);
                 if (elementLocationsFailureReason != null)
                 {
-                    failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(elementLocations)} failed -> ${elementLocationsFailureReason})";
+                    failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(elementLocations)} failed -> {elementLocationsFailureReason})";
                     return default;
                 }
 
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis
                     using var elementTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var elementTypesFailureReason);
                     if (elementTypesFailureReason != null)
                     {
-                        failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(elementTypes)} failed -> ${elementTypesFailureReason})";
+                        failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(elementTypes)} failed -> {elementTypesFailureReason})";
                         return default;
                     }
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
                     var underlyingTypeResolution = reader.ReadSymbolKey(out var underlyingTypeFailureReason);
                     if (underlyingTypeFailureReason != null)
                     {
-                        failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(underlyingTypeResolution)} failed -> ${underlyingTypeFailureReason})";
+                        failureReason = $"({nameof(TupleTypeSymbolKey)} {nameof(underlyingTypeResolution)} failed -> {underlyingTypeFailureReason})";
                         return default;
                     }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterOrdinalSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterOrdinalSymbolKey.cs
@@ -17,15 +17,21 @@ namespace Microsoft.CodeAnalysis
                 visitor.WriteInteger(symbol.Ordinal);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var methodIndex = reader.ReadInteger();
                 var ordinal = reader.ReadInteger();
                 var method = reader.ResolveMethod(methodIndex);
+
                 var typeParameter = method?.TypeParameters[ordinal];
-                return typeParameter == null
-                    ? default
-                    : new SymbolKeyResolution(typeParameter);
+                if (typeParameter == null)
+                {
+                    failureReason = $"({nameof(TypeParameterOrdinalSymbolKey)} failed)";
+                    return default;
+                }
+
+                failureReason = null;
+                return new SymbolKeyResolution(typeParameter);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     var metadataName = reader.ReadString();
                     var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+
                     if (containingSymbolFailureReason != null)
                     {
                         failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
@@ -25,20 +25,33 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
+            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string failureReason)
             {
                 var isCref = reader.ReadBoolean();
 
                 if (isCref)
                 {
-                    var location = reader.ReadLocation();
+                    var location = reader.ReadLocation(out var locationFailureReason);
+                    if (locationFailureReason != null)
+                    {
+                        failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(location)} failed -> ${locationFailureReason})";
+                        return default;
+                    }
+
                     var resolution = reader.ResolveLocation(location);
+
+                    failureReason = null;
                     return resolution.GetValueOrDefault();
                 }
                 else
                 {
                     var metadataName = reader.ReadString();
-                    var containingSymbolResolution = reader.ReadSymbolKey();
+                    var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                    if (containingSymbolFailureReason != null)
+                    {
+                        failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                        return default;
+                    }
 
                     using var result = PooledArrayBuilder<ITypeParameterSymbol>.GetInstance();
                     foreach (var containingSymbol in containingSymbolResolution)
@@ -52,7 +65,7 @@ namespace Microsoft.CodeAnalysis
                         }
                     }
 
-                    return CreateResolution(result);
+                    return CreateResolution(result, $"({nameof(TypeParameterSymbolKey)} '{metadataName}' not found)", out failureReason);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis
                     var location = reader.ReadLocation(out var locationFailureReason);
                     if (locationFailureReason != null)
                     {
-                        failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(location)} failed -> ${locationFailureReason})";
+                        failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(location)} failed -> {locationFailureReason})";
                         return default;
                     }
 
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis
                     var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
                     if (containingSymbolFailureReason != null)
                     {
-                        failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> ${containingSymbolFailureReason})";
+                        failureReason = $"({nameof(TypeParameterSymbolKey)} {nameof(containingSymbolResolution)} failed -> {containingSymbolFailureReason})";
                         return default;
                     }
 


### PR DESCRIPTION
This PR originally went into master as https://github.com/dotnet/roslyn/pull/45942.  We would like to pull it into 16.7 to get reports from teh wild as to what's possibly going on.

Needs QB approval.

--

We've been getting a few crashes with OOP where symbol keys fail to resolve to/from the oop/host side. Previously, one thing that caused this was an inability tou roundtrip some error symbols. However, that issue was fixed and we're still seeing some sporatic failures.

This PR updates symbolkeys to report back a detailed reasoning on why they failed so that we can get that information in teh dump and potentially determine any commonality between the failures (i.e. maybe it's something to do with certain types of symbols).

This does not get rid of any issues, but only seeks to include more information to make future investigations more fruitful.