### PR TITLE
Fix KeyNotFound exception in RemoveUnnecessaryInlineSuppressionsDiagn…

### DIFF
--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -190,9 +190,12 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessarySuppressions
             // Remove entries for unhandled diagnostic ids.
             foreach (var id in unhandledIds)
             {
-                foreach (var (pragma, _) in idToPragmasMap[id])
+                if (idToPragmasMap.TryGetValue(id, out var pragmas))
                 {
-                    pragmasToIsUsedMap.Remove(pragma);
+                    foreach (var (pragma, _) in pragmas)
+                    {
+                        pragmasToIsUsedMap.Remove(pragma);
+                    }
                 }
 
                 if (idToSuppressMessageAttributesMap.TryGetValue(id, out var attributeNodes))

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveUnnecessaryPragmaSuppressionsTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveUnnecessaryPragmaSuppressionsTests.cs
@@ -265,23 +265,34 @@ class Class
                 }
             }
 
+            public enum TestKind
+            {
+                Pragmas,
+                SuppressMessageAttributes,
+                PragmasAndSuppressMessageAttributes
+            }
+
             [Theory, CombinatorialData]
-            public async Task TestDoNotRemoveUnsupportedDiagnosticSuppression(bool disable)
+            [WorkItem(46047, "https://github.com/dotnet/roslyn/issues/46047")]
+            public async Task TestDoNotRemoveUnsupportedDiagnosticSuppression(bool disable, TestKind testKind)
             {
                 var disableOrRestore = disable ? "disable" : "restore";
                 var pragmas = new StringBuilder();
                 var suppressMessageAttribtes = new StringBuilder();
                 foreach (var id in UnsupportedDiagnosticIds)
                 {
-                    pragmas.AppendLine($@"#pragma warning {disableOrRestore} {id}");
-                    suppressMessageAttribtes.AppendLine($@"[System.Diagnostics.CodeAnalysis.SuppressMessage(""Category"", ""{id}"")]");
+                    if (testKind == TestKind.Pragmas || testKind == TestKind.PragmasAndSuppressMessageAttributes)
+                        pragmas.AppendLine($@"#pragma warning {disableOrRestore} {id}");
+
+                    if (testKind == TestKind.SuppressMessageAttributes || testKind == TestKind.PragmasAndSuppressMessageAttributes)
+                        suppressMessageAttribtes.AppendLine($@"[System.Diagnostics.CodeAnalysis.SuppressMessage(""Category"", ""{id}"")]");
                 }
 
                 var source = $@"{{|FixAllInDocument:{pragmas}{suppressMessageAttribtes}|}}class Class {{ }}";
 
                 // Compiler diagnostics cannot be suppressed with SuppressMessageAttribute.
                 // Hence, attribute suppressions for compiler diagnostics are always unnecessary.
-                if (!IsCompilerDiagnosticsTest)
+                if (!IsCompilerDiagnosticsTest || testKind == TestKind.Pragmas)
                 {
                     await TestMissingInRegularAndScriptAsync(source);
                 }


### PR DESCRIPTION
…osticAnalyzer

Fixes #46047

#45765 enhanced this analyzer to support detecting unnecessary inline SuppressMessageAttribute suppressions. This led to a regression when processing `idToPragmasMap` for unhandled IDs, which is fixed by this change.