### PR TITLE
Single overload - Inline Parameter Name Hints

### DIFF
--- a/src/EditorFeatures/Test2/InlineParameterNameHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineParameterNameHints/CSharpInlineParameterNameHintsTests.vb
@@ -312,5 +312,29 @@ class Foo
 
             Await VerifyParamHints(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineParameterNameHints)>
+        Public Async Function TestIncompleteFunctionCall() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class A
+{
+    int testMethod(int x, object y)
+    {
+        return x;
+    }
+    void Main() 
+    {
+        testMethod({|x:-(int)5.5|},);
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineParameterNameHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineParameterNameHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -308,5 +308,27 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineParameterNameHints
 
             Await VerifyParamHints(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineParameterNameHints)>
+        Public Async Function TestIncompleteFunctionCall() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+                        Class Foo
+                            Sub Main(args As String())
+                                TestMethod({|x:5|},)
+                            End Sub
+
+                            Sub TestMethod(x As Integer, y As Double)
+
+                            End Sub
+                        End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ArgumentSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ArgumentSyntaxExtensions.cs
@@ -59,7 +59,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return null;
             }
 
-            var symbol = semanticModel.GetSymbolInfo(invocableExpression, cancellationToken).Symbol;
+            // Get the symbol as long if it's not null or if there is only one candidate symbol
+            var symbolInfo = semanticModel.GetSymbolInfo(invocableExpression, cancellationToken);
+            var symbol = symbolInfo.Symbol;
+            if (symbol == null && symbolInfo.CandidateSymbols.Length == 1)
+            {
+                symbol = symbolInfo.CandidateSymbols[0];
+            }
+
             if (symbol == null)
             {
                 return null;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/ArgumentSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/ArgumentSyntaxExtensions.vb
@@ -31,7 +31,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return Nothing
             End If
 
-            Dim symbol = semanticModel.GetSymbolInfo(argumentList.Parent, cancellationToken).Symbol
+            ' Get the symbol if it is not Nothing or if there is a singular candidate symbol
+            Dim symbolInfo = semanticModel.GetSymbolInfo(argumentList.Parent, cancellationToken)
+            Dim symbol = symbolInfo.Symbol
+
+            If symbol Is Nothing AndAlso symbolInfo.CandidateSymbols.Length = 1 Then
+                symbol = symbolInfo.CandidateSymbols.Item(0)
+            End If
+
             If symbol Is Nothing Then
                 Return Nothing
             End If


### PR DESCRIPTION
Hello,

I am requesting to merge my changes to my branch involving single overload cases. Before, if there was a function call with multiple parameters, it did not add the adornments until you had typed every argument. Now, if there is only one function with that name, it will add the adornments while you're typing.

Modified Files:
```ArgumentSyntaxExtensions.cs``` and ```ArgumentSyntaxExtensions.vb```
I did the same logic in both files, I just check to see if the symbolInfo CandidateSymbols length is 1 if the symbol is null, and if it is I say the symbol is that CandidateSymbol.

Please let me know if there are any questions/concerns!