### PR TITLE
bump to 500

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/MetadataCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/MetadataCache.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal class MetadataAndSymbolCache
     {
-        // Store 100 entries -- arbitrary number
-        private const int CacheSize = 100;
+        // Store 500 entries -- Out of ~8.7M projects, only about 4,000 had more than 500 references
+        private const int CacheSize = 500;
         private readonly ConcurrentLruCache<FileKey, Metadata> _metadataCache =
             new ConcurrentLruCache<FileKey, Metadata>(CacheSize);
 


### PR DESCRIPTION
fixes #46023
fixes #38357

This updates the number of assemblies cached by the compiler server from 100 to 500. This number was chosen based on telemetry reporting. See linked issues for details.