### PR TITLE
Use ISpanMapper before sending cross file results to LSP

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -2,11 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
@@ -61,7 +65,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             { WellKnownTags.NuGet, LSP.CompletionItemKind.Text }
         };
 
-        public static Uri GetUriFromFilePath(string filePath)
+        public static Uri GetUriFromFilePath(string? filePath)
         {
             if (filePath is null)
             {
@@ -116,48 +120,74 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return LinePositionToRange(linePosSpan);
         }
 
-        public static Task<LSP.Location> DocumentSpanToLocationAsync(DocumentSpan documentSpan, CancellationToken cancellationToken)
+        public static Task<LSP.Location?> DocumentSpanToLocationAsync(DocumentSpan documentSpan, CancellationToken cancellationToken)
             => TextSpanToLocationAsync(documentSpan.Document, documentSpan.SourceSpan, cancellationToken);
 
-        public static async Task<LSP.LocationWithText> DocumentSpanToLocationWithTextAsync(DocumentSpan documentSpan, ClassifiedTextElement text, CancellationToken cancellationToken)
+        public static async Task<LSP.LocationWithText?> DocumentSpanToLocationWithTextAsync(DocumentSpan documentSpan, ClassifiedTextElement text, CancellationToken cancellationToken)
         {
-            var sourceText = await documentSpan.Document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var location = await TextSpanToLocationAsync(documentSpan.Document, documentSpan.SourceSpan, cancellationToken).ConfigureAwait(false);
 
-            var locationWithText = new LSP.LocationWithText
+            return location == null ? null : new LSP.LocationWithText
             {
-                Uri = documentSpan.Document.GetURI(),
-                Range = TextSpanToRange(documentSpan.SourceSpan, sourceText),
+                Uri = location.Uri,
+                Range = location.Range,
                 Text = text
             };
-
-            return locationWithText;
         }
 
-        public static LSP.Location RangeToLocation(LSP.Range range, string uriString)
+        public static async Task<LSP.Location?> TextSpanToLocationAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            return new LSP.Location()
+            var spanMappingService = document.Services.GetService<ISpanMappingService>();
+
+            if (spanMappingService == null)
             {
-                Range = range,
-                Uri = new Uri(uriString)
-            };
-        }
+                return await ConvertTextSpanToLocation(document, textSpan, cancellationToken).ConfigureAwait(false);
+            }
 
-        public static async Task<LSP.Location> TextSpanToLocationAsync(Document document, TextSpan span, CancellationToken cancellationToken)
-        {
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            return TextSpanToLocation(span, text, document.GetURI());
-        }
-
-        public static LSP.Location TextSpanToLocation(TextSpan span, SourceText text, Uri documentUri)
-        {
-            var location = new LSP.Location
+            var mappedSpanResult = await spanMappingService.MapSpansAsync(document, SpecializedCollections.SingletonEnumerable(textSpan), cancellationToken).ConfigureAwait(false);
+            if (mappedSpanResult.IsDefaultOrEmpty)
             {
-                Uri = documentUri,
-                Range = TextSpanToRange(span, text),
+                return await ConvertTextSpanToLocation(document, textSpan, cancellationToken).ConfigureAwait(false);
+            }
+
+            var mappedSpan = mappedSpanResult.Single();
+            if (mappedSpan.IsDefault)
+            {
+                return null;
+            }
+
+            return new LSP.Location
+            {
+                Uri = GetUriFromFilePath(mappedSpan.FilePath),
+                Range = MappedSpanResultToRange(mappedSpan)
             };
 
-            return location;
+            static async Task<LSP.Location> ConvertTextSpanToLocation(Document document, TextSpan span, CancellationToken cancellationToken)
+            {
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                return ConvertTextSpanWithTextToLocation(span, text, document.GetURI());
+            }
+
+            static LSP.Range MappedSpanResultToRange(MappedSpanResult mappedSpanResult)
+            {
+                return new LSP.Range
+                {
+                    Start = LinePositionToPosition(mappedSpanResult.LinePositionSpan.Start),
+                    End = LinePositionToPosition(mappedSpanResult.LinePositionSpan.End)
+                };
+            }
+
+            static LSP.Location ConvertTextSpanWithTextToLocation(TextSpan span, SourceText text, Uri documentUri)
+            {
+                var location = new LSP.Location
+                {
+                    Uri = documentUri,
+                    Range = TextSpanToRange(span, text),
+                };
+
+                return location;
+            }
         }
 
         public static LSP.DiagnosticSeverity DiagnosticSeverityToLspDiagnositcSeverity(DiagnosticSeverity severity)

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -13,6 +13,8 @@ using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -47,12 +49,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         continue;
                     }
 
-                    var definitionText = await definition.Document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                    locations.Add(new LSP.Location
-                    {
-                        Uri = definition.Document.GetURI(),
-                        Range = ProtocolConversions.TextSpanToRange(definition.SourceSpan, definitionText),
-                    });
+                    var location = await ProtocolConversions.TextSpanToLocationAsync(definition.Document, definition.SourceSpan, cancellationToken).ConfigureAwait(false);
+                    locations.AddIfNotNull(location);
                 }
             }
             else if (document.SupportsSemanticModel && _metadataAsSourceFileService != null)

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
@@ -50,11 +50,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 {
                     if (clientCapabilities?.HasVisualStudioLspCapability() == true)
                     {
-                        locations.Add(await ProtocolConversions.DocumentSpanToLocationWithTextAsync(sourceSpan, text, cancellationToken).ConfigureAwait(false));
+                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationWithTextAsync(sourceSpan, text, cancellationToken).ConfigureAwait(false));
                     }
                     else
                     {
-                        locations.Add(await ProtocolConversions.DocumentSpanToLocationAsync(sourceSpan, cancellationToken).ConfigureAwait(false));
+                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationAsync(sourceSpan, cancellationToken).ConfigureAwait(false));
                     }
                 }
             }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,6 +58,31 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Definitions
 
             var results = await RunGotoDefinitionAsync(workspace.CurrentSolution, locations["caret"].Single());
             AssertLocationsEqual(locations["definition"], results);
+        }
+
+        [Fact]
+        public async Task TestGotoDefinitionAsync_MappedFile()
+        {
+            var markup =
+@"class A
+{
+    string aString = 'hello';
+    void M()
+    {
+        var len = aString.Length;
+    }
+}";
+            using var workspace = CreateTestWorkspace(string.Empty, out var _);
+
+            AddMappedDocument(workspace, markup);
+
+            var position = new LSP.Position { Line = 5, Character = 18 };
+            var results = await RunGotoDefinitionAsync(workspace.CurrentSolution, new LSP.Location
+            {
+                Uri = new Uri($"C:\\{TestSpanMapper.GeneratedFileName}"),
+                Range = new LSP.Range { Start = position, End = position }
+            });
+            AssertLocationsEqual(ImmutableArray.Create(TestSpanMapper.MappedFileLocation), results);
         }
 
         [Fact]

--- a/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             var locations = await GetDefinitionsWithFindUsagesServiceAsync(document, position, cancellationToken).ConfigureAwait(false);
 
             // No definition found - see if we can get metadata as source but that's only applicable for C#\VB.
-            if ((locations.Count() == 0) && document.SupportsSemanticModel && this._metadataAsSourceService != null)
+            if ((locations.Length == 0) && document.SupportsSemanticModel && this._metadataAsSourceService != null)
             {
                 var symbol = await SymbolFinder.FindSymbolAtPositionAsync(document, position, cancellationToken).ConfigureAwait(false);
                 if (symbol?.Locations.FirstOrDefault().IsInMetadata == true)

--- a/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -49,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             var locations = await GetDefinitionsWithFindUsagesServiceAsync(document, position, cancellationToken).ConfigureAwait(false);
 
             // No definition found - see if we can get metadata as source but that's only applicable for C#\VB.
-            if ((locations.Count == 0) && document.SupportsSemanticModel && this._metadataAsSourceService != null)
+            if ((locations.Count() == 0) && document.SupportsSemanticModel && this._metadataAsSourceService != null)
             {
                 var symbol = await SymbolFinder.FindSymbolAtPositionAsync(document, position, cancellationToken).ConfigureAwait(false);
                 if (symbol?.Locations.FirstOrDefault().IsInMetadata == true)
@@ -57,11 +59,10 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                     var declarationFile = await this._metadataAsSourceService.GetGeneratedFileAsync(document.Project, symbol, false, cancellationToken).ConfigureAwait(false);
 
                     var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
-                    locations.Add(new LSP.Location
+                    return new LSP.Location[]
                     {
-                        Uri = new Uri(declarationFile.FilePath),
-                        Range = ProtocolConversions.LinePositionToRange(linePosSpan)
-                    });
+                        new LSP.Location { Uri = new Uri(declarationFile.FilePath), Range = ProtocolConversions.LinePositionToRange(linePosSpan) }
+                    };
                 }
             }
 
@@ -72,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         ///  Using the find usages service is more expensive than using the definitions service because a lot of unnecessary information is computed. However,
         ///  TypeScript doesn't provide an <see cref="IGoToDefinitionService"/> implementation that will return definitions so we must use <see cref="IFindUsagesService"/>.
         /// </summary>
-        private async Task<List<LSP.Location>> GetDefinitionsWithFindUsagesServiceAsync(Document document, int pos, CancellationToken cancellationToken)
+        private async Task<ImmutableArray<LSP.Location>> GetDefinitionsWithFindUsagesServiceAsync(Document document, int pos, CancellationToken cancellationToken)
         {
             var findUsagesService = document.Project.LanguageServices.GetRequiredService<IFindUsagesService>();
 
@@ -83,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             await findUsagesService.FindReferencesAsync(document, pos, context).ConfigureAwait(false);
 
-            var locations = new List<LSP.Location>();
+            using var _ = ArrayBuilder<LSP.Location>.GetInstance(out var locations);
 
             var definitions = context.GetDefinitions();
             if (definitions != null)
@@ -92,12 +93,12 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 {
                     foreach (var docSpan in definition.SourceSpans)
                     {
-                        locations.Add(await ProtocolConversions.DocumentSpanToLocationAsync(docSpan, cancellationToken).ConfigureAwait(false));
+                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationAsync(docSpan, cancellationToken).ConfigureAwait(false));
                     }
                 }
             }
 
-            return locations;
+            return locations.ToImmutable();
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/LanguageServer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/LanguageServer.cs
@@ -138,18 +138,12 @@ namespace Microsoft.CodeAnalysis.Remote
 
             foreach (var result in results)
             {
-                var text = await result.NavigableItem.Document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
                 symbols.Add(new VSSymbolInformation()
                 {
                     Name = result.Name,
                     ContainerName = result.AdditionalInformation,
                     Kind = ProtocolConversions.NavigateToKindToSymbolKind(result.Kind),
-                    Location = new LSP.Location()
-                    {
-                        Uri = result.NavigableItem.Document.GetURI(),
-                        Range = ProtocolConversions.TextSpanToRange(result.NavigableItem.SourceSpan, text)
-                    },
+                    Location = await ProtocolConversions.TextSpanToLocationAsync(result.NavigableItem.Document, result.NavigableItem.SourceSpan, cancellationToken).ConfigureAwait(false),
                     Icon = new VisualStudio.Text.Adornments.ImageElement(result.NavigableItem.Glyph.GetImageId())
                 });
             }


### PR DESCRIPTION
Razor is not able to intercept cross file requests made from the LSP client to C# files (these results could contain references to types in a razor file).  So for cloud environments, we need to return the mapped paths to the LSP client so that these results can be displayed and navigated to.

This modifies the conversion helpers to map paths before converting to the LSP type and adds some tests.

Resolves https://github.com/dotnet/roslyn/issues/45063 for cloud environments (except rename).