### PR TITLE
Fix #46157

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -170,7 +170,7 @@
     <!-- VB specific settings -->
     <When Condition="'$(Language)' == 'VB'">
       <PropertyGroup>
-        <LangVersion>15.5</LangVersion>
+        <LangVersion>16</LangVersion>
         <NoWarn>$(NoWarn);40057</NoWarn>
         <VBRuntime>Embed</VBRuntime>
       </PropertyGroup>

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
@@ -76,7 +76,8 @@ End Class
                            </Project>
                        </Workspace>
 
-            AssertCommitsStatement(test, expectCommit:=False)
+            AssertCommitsStatement(test, _ ' Test that Roslyn supports VB16 Continuation Comments After Line Continuation internally
+                                   expectCommit:=False)
         End Sub
 
         <WpfFact>

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
@@ -76,8 +76,7 @@ End Class
                            </Project>
                        </Workspace>
 
-            AssertCommitsStatement(test, _ ' Test that Roslyn supports VB16 Continuation Comments After Line Continuation internally
-                                   expectCommit:=False)
+            AssertCommitsStatement(test, expectCommit:=False)
         End Sub
 
         <WpfFact>


### PR DESCRIPTION
Allow Roslyn Code to use features of VB16