### PR TITLE
Bump versions of System.Collections.Immutable and System.Reflection.Metadata to consume the new function pointer metadata changes.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -252,8 +252,8 @@
     -->
     <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
     <StreamJsonRpcVersion>2.4.34</StreamJsonRpcVersion>
-    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
+    <SystemCollectionsImmutableVersion>5.0.0-preview.8.20371.14</SystemCollectionsImmutableVersion>
+    <SystemReflectionMetadataVersion>5.0.0-preview.8.20371.14</SystemReflectionMetadataVersion>
     <MicrosoftVisualStudioStaticReviewsEmbeddableVersion>0.1.102-alpha</MicrosoftVisualStudioStaticReviewsEmbeddableVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
   </PropertyGroup>

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessarySuppressions
                 var methodInfo = compilerAnalyzerType.GetMethod("GetSupportedErrorCodes", BindingFlags.Instance | BindingFlags.NonPublic)!;
                 var compilerAnalyzerInstance = Activator.CreateInstance(compilerAnalyzerType);
                 var supportedCodes = methodInfo.Invoke(compilerAnalyzerInstance, Array.Empty<object>()) as IEnumerable<int>;
-                return supportedCodes.ToImmutableHashSet();
+                return supportedCodes?.ToImmutableHashSet() ?? ImmutableHashSet<int>.Empty;
             }
             catch (Exception ex)
             {

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1005,7 +1005,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 IValueSet fromTestPassing = valueFac.Related(relation.Operator(), value);
                 IValueSet fromTestFailing = fromTestPassing.Complement();
-                if (values.TryGetValue(test.Input, out IValueSet tempValuesBeforeTest))
+                if (values.TryGetValue(test.Input, out IValueSet? tempValuesBeforeTest))
                 {
                     fromTestPassing = fromTestPassing.Intersect(tempValuesBeforeTest);
                     fromTestFailing = fromTestFailing.Intersect(tempValuesBeforeTest);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3664,7 +3664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private ImmutableArray<string> GetPreprocessorSymbols()
         {
-            CSharpSyntaxTree firstTree = (CSharpSyntaxTree)SyntaxTrees.FirstOrDefault();
+            CSharpSyntaxTree? firstTree = (CSharpSyntaxTree?)SyntaxTrees.FirstOrDefault();
 
             if (firstTree is null)
             {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -704,7 +704,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             EnsureNullabilityAnalysisPerformedIfNecessary();
             if (_lazyRemappedSymbols is null) return originalSymbol;
 
-            if (_lazyRemappedSymbols.TryGetValue(originalSymbol, out Symbol remappedSymbol))
+            if (_lazyRemappedSymbols.TryGetValue(originalSymbol, out Symbol? remappedSymbol))
             {
                 RoslynDebug.Assert(remappedSymbol is object);
                 return (T)remappedSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -98,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            internal bool TryGetUpdatedSymbol(BoundNode node, Symbol symbol, out Symbol updatedSymbol)
+            internal bool TryGetUpdatedSymbol(BoundNode node, Symbol symbol, [NotNullWhen(true)] out Symbol? updatedSymbol)
             {
                 return _updatedSymbolsMap.TryGetValue((node, symbol), out updatedSymbol);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1514,7 +1514,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var pair in membersByName)
             {
                 var name = pair.Key;
-                Symbol lastSym = GetTypeMembers(name).FirstOrDefault();
+                Symbol? lastSym = GetTypeMembers(name).FirstOrDefault();
                 methodsBySignature.Clear();
                 // Conversion collisions do not consider the name of the conversion,
                 // so do not clear that dictionary.
@@ -1561,7 +1561,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     //   following a field of the same name, or a field and a nested type of the same name.
                     //
 
-                    if ((object)lastSym != null)
+                    if ((object?)lastSym != null)
                     {
                         if (symbol.Kind != SymbolKind.Method || lastSym.Kind != SymbolKind.Method)
                         {

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceAppDomainTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceAppDomainTests.cs
@@ -91,6 +91,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new SyntaxTree[] { CSharp.SyntaxFactory.ParseSyntaxTree(analyzerSource) },
                 new MetadataReference[]
                 {
+                    TestMetadata.NetStandard20.mscorlib,
                     TestMetadata.NetStandard20.netstandard,
                     TestMetadata.NetStandard20.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),

--- a/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerAssemblyLoaderTests.cs
@@ -57,6 +57,7 @@ public abstract class AbstractTestAnalyzer : DiagnosticAnalyzer
                    new SyntaxTree[] { CSharp.SyntaxFactory.ParseSyntaxTree(analyzerDependencySource) },
                    new MetadataReference[]
                    {
+                    TestMetadata.NetStandard20.mscorlib,
                     TestMetadata.NetStandard20.netstandard,
                     TestMetadata.NetStandard20.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),
@@ -83,6 +84,7 @@ public sealed class TestAnalyzer : AbstractTestAnalyzer
                    new SyntaxTree[] { CSharp.SyntaxFactory.ParseSyntaxTree(analyzerMainSource) },
                    new MetadataReference[]
                    {
+                        TestMetadata.NetStandard20.mscorlib,
                         TestMetadata.NetStandard20.netstandard,
                         TestMetadata.NetStandard20.SystemRuntime,
                         MetadataReference.CreateFromFile(immutable.Path),

--- a/src/Compilers/Core/Portable/Collections/StaticCast.cs
+++ b/src/Compilers/Core/Portable/Collections/StaticCast.cs
@@ -12,7 +12,10 @@ namespace Microsoft.CodeAnalysis
     {
         internal static ImmutableArray<T> From<TDerived>(ImmutableArray<TDerived> from) where TDerived : class?, T
         {
+            // Remove the pragma when we get a version with https://github.com/dotnet/runtime/issues/39799 fixed
+#pragma warning disable CS8634
             return ImmutableArray<T>.CastUp(from);
+#pragma warning restore CS8634
         }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets whether this editorconfig is a topmost editorconfig.
         /// </summary>
-        internal bool IsRoot => GlobalSection.Properties.TryGetValue("root", out string val) && val == "true";
+        internal bool IsRoot => GlobalSection.Properties.TryGetValue("root", out string? val) && val == "true";
 
         /// <summary>
         /// Gets whether this editorconfig is a global editorconfig.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResult.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResult.cs
@@ -114,6 +114,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableDictionary<T, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>> localDiagnostics,
             ImmutableHashSet<DiagnosticAnalyzer> excludedAnalyzers,
             ImmutableArray<Diagnostic>.Builder builder)
+            where T : notnull
         {
             foreach (var diagnosticsByTree in localDiagnostics)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private readonly AttributePredicate _attributePredicate;
             private readonly AttributeLanguagesFunc _languagesFunc;
             private ImmutableArray<TExtension> _lazyAllExtensions;
-            private ImmutableDictionary<string, ImmutableArray<TExtension>>? _lazyExtensionsPerLanguage;
+            private ImmutableDictionary<string, ImmutableArray<TExtension>> _lazyExtensionsPerLanguage;
             private ImmutableDictionary<string, ImmutableHashSet<string>>? _lazyExtensionTypeNameMap;
 
             internal Extensions(AnalyzerFileReference reference, AttributePredicate attributePredicate, AttributeLanguagesFunc languagesFunc)
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private ImmutableArray<TExtension> GetLanguageSpecificAnalyzers(Assembly analyzerAssembly, ImmutableDictionary<string, ImmutableHashSet<string>> analyzerTypeNameMap, string language, ref bool reportedError)
             {
-                ImmutableHashSet<string> languageSpecificAnalyzerTypeNames;
+                ImmutableHashSet<string>? languageSpecificAnalyzerTypeNames;
                 if (!analyzerTypeNameMap.TryGetValue(language, out languageSpecificAnalyzerTypeNames))
                 {
                     return ImmutableArray<TExtension>.Empty;

--- a/src/Compilers/Core/Portable/InternalUtilities/GeneratedCodeUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/GeneratedCodeUtilities.cs
@@ -151,7 +151,7 @@ namespace Roslyn.Utilities
         {
             // Check for explicit user configuration for generated code.
             //     generated_code = true | false
-            if (options.TryGetValue("generated_code", out string optionValue) &&
+            if (options.TryGetValue("generated_code", out string? optionValue) &&
                 bool.TryParse(optionValue, out var boolValue))
             {
                 return boolValue;

--- a/src/Compilers/Core/Portable/InternalUtilities/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ImmutableArrayExtensions.cs
@@ -49,7 +49,10 @@ namespace Roslyn.Utilities
 
         internal static ImmutableArray<TDerived> CastDown<TOriginal, TDerived>(this ImmutableArray<TOriginal> array) where TDerived : class?, TOriginal
         {
+            // Remove the pragma when we get a version with https://github.com/dotnet/runtime/issues/39799 fixed
+#pragma warning disable CS8634
             return array.CastArray<TDerived>();
+#pragma warning restore CS8634
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             return solution.GetDocument(document.Id) ?? throw new NotSupportedException(EditorFeaturesResources.Removal_of_document_not_supported);
         }
 
-        private bool TryGetWorkspaceFixersMap(Document document, out Lazy<ImmutableDictionary<DiagnosticId, ImmutableArray<CodeFixProvider>>> fixerMap)
+        private bool TryGetWorkspaceFixersMap(Document document, [NotNullWhen(true)] out Lazy<ImmutableDictionary<DiagnosticId, ImmutableArray<CodeFixProvider>>>? fixerMap)
         {
             if (_lazyWorkspaceFixersMap == null)
             {
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             return _lazyWorkspaceFixersMap.TryGetValue(document.Project.Language, out fixerMap);
         }
 
-        private bool TryGetWorkspaceFixersPriorityMap(Document document, out Lazy<ImmutableDictionary<CodeFixProvider, int>> fixersPriorityMap)
+        private bool TryGetWorkspaceFixersPriorityMap(Document document, [NotNullWhen(true)] out Lazy<ImmutableDictionary<CodeFixProvider, int>>? fixersPriorityMap)
         {
             if (_lazyFixerPriorityMap == null)
             {
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     allFixers.AddRange(projectFixers);
                 }
 
-                if (hasAnySharedFixer && fixerMap.Value.TryGetValue(diagnosticId, out var workspaceFixers))
+                if (hasAnySharedFixer && fixerMap!.Value.TryGetValue(diagnosticId, out var workspaceFixers))
                 {
                     if (isInteractive)
                     {
@@ -706,14 +706,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             if (hasAnyProjectFixer)
             {
-                allFixers = allFixers.AddRange(projectFixers);
+                allFixers = allFixers.AddRange(projectFixers!);
             }
 
             var dx = await diagnostic.ToDiagnosticAsync(document.Project, cancellationToken).ConfigureAwait(false);
 
             if (hasConfigurationFixer)
             {
-                foreach (var lazyConfigurationProvider in lazyConfigurationProviders.Value)
+                foreach (var lazyConfigurationProvider in lazyConfigurationProviders!.Value)
                 {
                     if (lazyConfigurationProvider.IsFixableDiagnostic(dx))
                     {

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         {
         }
 
-        public override async Task<(ISymbol symbol, int selectedIndex)> GetInvocationSymbolAsync(
+        public override async Task<(ISymbol? symbol, int selectedIndex)> GetInvocationSymbolAsync(
             Document document, int position, bool restrictToDeclarations, CancellationToken cancellationToken)
         {
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         /// <summary>
         /// Determines the symbol on which we are invoking ReorderParameters
         /// </summary>
-        public abstract Task<(ISymbol symbol, int selectedIndex)> GetInvocationSymbolAsync(Document document, int position, bool restrictToDeclarations, CancellationToken cancellationToken);
+        public abstract Task<(ISymbol? symbol, int selectedIndex)> GetInvocationSymbolAsync(Document document, int position, bool restrictToDeclarations, CancellationToken cancellationToken);
 
         /// <summary>
         /// Given a SyntaxNode for which we want to reorder parameters/arguments, find the 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -449,6 +449,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     // both old and new has items in them. update existing items
                     RoslynDebug.Assert(oldAnalysisResult.DocumentIds != null);
+                    RoslynDebug.Assert(newAnalysisResult.DocumentIds != null);
 
                     // first remove ones no longer needed.
                     var documentsToRemove = oldAnalysisResult.DocumentIds.Except(newAnalysisResult.DocumentIds);

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -3004,7 +3004,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return false;
         }
 
-        private static ISymbol TryGetParameterlessConstructor(INamedTypeSymbol type, bool isStatic)
+        private static ISymbol? TryGetParameterlessConstructor(INamedTypeSymbol type, bool isStatic)
         {
             var oldCtors = isStatic ? type.StaticConstructors : type.InstanceConstructors;
             if (isStatic)

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -282,6 +282,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         private static ImmutableDictionary<K, ImmutableArray<V>> GroupToImmutableDictionary<K, V>(IEnumerable<IGrouping<K, V>> items)
+            where K : notnull
         {
             var builder = ImmutableDictionary.CreateBuilder<K, ImmutableArray<V>>();
 

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                     Contract.ThrowIfFalse(unused.Count == 0);
                 }
 
-                var thisParameterBeingRead = (IParameterSymbol)dataFlowAnalysisData.ReadInside.FirstOrDefault(s => IsThisParameter(s));
+                var thisParameterBeingRead = (IParameterSymbol?)dataFlowAnalysisData.ReadInside.FirstOrDefault(s => IsThisParameter(s));
                 var isThisParameterWritten = dataFlowAnalysisData.WrittenInside.Any(s => IsThisParameter(s));
 
                 var localFunctionCallsNotWithinSpan = symbolMap.Keys.Where(s => s.IsLocalFunction() && !s.Locations.Any(l => SelectionResult.FinalSpan.Contains(l.SourceSpan)));

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.ErrorVisitor.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.ErrorVisitor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
         {
             private static readonly ErrorVisitor s_instance = new ErrorVisitor();
 
-            public static bool ContainsError(ISymbol symbol)
+            public static bool ContainsError(ISymbol? symbol)
                 => s_instance.Visit(symbol);
 
             public override bool DefaultVisit(ISymbol symbol)

--- a/src/Test/Utilities/Portable/Platform/Desktop/TestHelpers.cs
+++ b/src/Test/Utilities/Portable/Platform/Desktop/TestHelpers.cs
@@ -83,6 +83,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(analyzerSource) },
                 new MetadataReference[]
                 {
+                    TestMetadata.NetStandard20.mscorlib,
                     TestMetadata.NetStandard20.netstandard,
                     TestMetadata.NetStandard20.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         }
 
         public bool WouldNotifyToSpecificSymbol(
-            DefinitionItem definitionItem, string rqName, CancellationToken cancellationToken,
+            DefinitionItem definitionItem, string? rqName, CancellationToken cancellationToken,
             [NotNullWhen(true)] out string? filePath, out int lineNumber, out int charOffset)
         {
             AssertIsForeground();
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         private bool TryGetNavigationAPIRequiredArguments(
             DefinitionItem definitionItem,
-            string rqName,
+            string? rqName,
             CancellationToken cancellationToken,
             [NotNullWhen(true)] out IVsHierarchy? hierarchy,
             out uint itemID,

--- a/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/AbstractGoToDefinitionWithFindUsagesServiceHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             if ((locations.Length == 0) && document.SupportsSemanticModel && this._metadataAsSourceService != null)
             {
                 var symbol = await SymbolFinder.FindSymbolAtPositionAsync(document, position, cancellationToken).ConfigureAwait(false);
-                if (symbol?.Locations.FirstOrDefault().IsInMetadata == true)
+                if (symbol?.Locations.FirstOrDefault()?.IsInMetadata == true)
                 {
                     var declarationFile = await this._metadataAsSourceService.GetGeneratedFileAsync(document.Project, symbol, false, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
 
             private readonly ISymbol _renamedSymbol;
             private readonly IAliasSymbol? _aliasSymbol;
-            private readonly Location _renamableDeclarationLocation;
+            private readonly Location? _renamableDeclarationLocation;
 
             private readonly RenamedSpansTracker _renameSpansTracker;
             private readonly bool _isVerbatim;

--- a/src/Workspaces/Core/Portable/CodeActions/CodeActionWithOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeActionWithOptions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             var options = this.GetOptions(cancellationToken);
-            return (await this.GetOperationsAsync(options, cancellationToken).ConfigureAwait(false)).ToImmutableArray();
+            return (await this.GetOperationsAsync(options, cancellationToken).ConfigureAwait(false)).ToImmutableArrayOrEmpty();
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultMap.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultMap.cs
@@ -17,12 +17,14 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
         public static DiagnosticAnalysisResultMap<TKey, TValue> Create<TKey, TValue>(
             ImmutableDictionary<TKey, TValue> analysisResult,
             ImmutableDictionary<TKey, AnalyzerTelemetryInfo> telemetryInfo)
+            where TKey : notnull
         {
             return new DiagnosticAnalysisResultMap<TKey, TValue>(analysisResult, telemetryInfo);
         }
     }
 
     internal struct DiagnosticAnalysisResultMap<TKey, TValue>
+        where TKey : notnull
     {
         public static readonly DiagnosticAnalysisResultMap<TKey, TValue> Empty = new DiagnosticAnalysisResultMap<TKey, TValue>(
             ImmutableDictionary<TKey, TValue>.Empty,

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamer.cs
@@ -317,11 +317,11 @@ namespace Microsoft.CodeAnalysis.Rename
                 newSolutionWithoutRenamedDocument,
                 ReplacementTextValid,
                 RenamedDocument,
-                DocumentIds.ToImmutableArray(),
+                DocumentIds.ToImmutableArrayOrEmpty(),
                 RelatedLocations.SelectAsArray(loc => loc.Rehydrate()),
-                DocumentToModifiedSpansMap.ToImmutableDictionary(t => t.Item1, t => t.Item2),
-                DocumentToComplexifiedSpansMap.ToImmutableDictionary(t => t.Item1, t => t.Item2.SelectAsArray(c => c.Rehydrate())),
-                DocumentToRelatedLocationsMap.ToImmutableDictionary(t => t.Item1, t => t.Item2.SelectAsArray(c => c.Rehydrate())));
+                DocumentToModifiedSpansMap.ToImmutableDictionaryOrEmpty(t => t.Item1, t => t.Item2),
+                DocumentToComplexifiedSpansMap.ToImmutableDictionaryOrEmpty(t => t.Item1, t => t.Item2.SelectAsArray(c => c.Rehydrate())),
+                DocumentToRelatedLocationsMap.ToImmutableDictionaryOrEmpty(t => t.Item1, t => t.Item2.SelectAsArray(c => c.Rehydrate())));
         }
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -313,7 +314,7 @@ namespace Microsoft.CodeAnalysis
                 public WorkspaceAnalyzerConfigOptions(AnalyzerConfigOptionsResult analyzerConfigOptions)
                     => _backing = analyzerConfigOptions.AnalyzerOptions;
 
-                public override bool TryGetValue(string key, out string value) => _backing.TryGetValue(key, out value);
+                public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value) => _backing.TryGetValue(key, out value);
             }
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableDictionaryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableDictionaryExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -39,6 +40,18 @@ namespace Roslyn.Utilities
             }
 
             return map.Remove(key);
+        }
+
+#nullable enable
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionaryOrEmpty<TSource, TKey, TValue>(this IEnumerable<TSource>? source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector)
+            where TKey : notnull
+        {
+            if (source is null)
+            {
+                return ImmutableDictionary<TKey, TValue>.Empty;
+            }
+
+            return source.ToImmutableDictionary(keySelector, elementSelector);
         }
     }
 }


### PR DESCRIPTION
We're going to use this to run PR validation for inserting into VS.