### PR TITLE
Add the name of the current type to the exception we throw in an unsupported case.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -9,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
@@ -51,7 +53,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         protected override void InnerInvoke(IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             // A code action with nested actions is itself never invokable.  So just do nothing if this ever gets asked.
-            Debug.Fail("Invoke should not be called on a SuggestedActionWithNestedActions");
+            // Report a message in debug and log a watson exception so that if this is hit we can try to narrow down how
+            // this happened.
+            Debug.Fail("InnerInvoke should not be called on a SuggestedActionWithNestedActions");
+            try
+            {
+                throw new InvalidOperationException("Invoke should not be called on a SuggestedActionWithNestedActions");
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+            }
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 
@@ -46,5 +47,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         public sealed override Task<IEnumerable<SuggestedActionSet>> GetActionSetsAsync(CancellationToken cancellationToken)
             => Task.FromResult<IEnumerable<SuggestedActionSet>>(NestedActionSets);
+
+        protected override void InnerInvoke(IProgressTracker progressTracker, CancellationToken cancellationToken)
+        {
+            // A code action with nested actions is itself never invokable.  So just do nothing if this ever gets asked.
+            Debug.Fail("Invoke should not be called on a SuggestedActionWithNestedActions");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// </remarks>
         /// <exception cref="NotSupportedException">If this code action does not support changing a single document.</exception>
         protected virtual Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(GetType().FullName);
 
         /// <summary>
         /// used by batch fixer engine to get new solution


### PR DESCRIPTION
We've received a customer report of this exception being thrown.  However, it's in a scenario where many code actions are created.  Adding specific information to the exception to help track down which may be at fault as we cannot repro this ourselves.