### PR TITLE
Specify full path to InteractiveHost.exe for NGENing.

### DIFF
--- a/src/Interactive/HostProcess/InteractiveHost32.csproj
+++ b/src/Interactive/HostProcess/InteractiveHost32.csproj
@@ -31,7 +31,7 @@
         <Ngen>true</Ngen>
         <NgenPriority>3</NgenPriority>
         <NgenArchitecture>X86</NgenArchitecture>
-        <NgenApplication>/InteractiveHost/Desktop/InteractiveHost32.exe</NgenApplication>
+        <NgenApplication>[installDir]\Common7\IDE\$(CommonExtensionInstallationRoot)\$(LanguageServicesExtensionInstallationFolder)\InteractiveHost\Desktop\InteractiveHost32.exe</NgenApplication>
       </_PublishProjectOutputGroup>
       <_PublishProjectOutputGroup Include="$(TargetPath).config" TargetPath="$(TargetFileName).config"/>
     </ItemGroup>

--- a/src/Interactive/HostProcess/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/InteractiveHost64.csproj
@@ -41,7 +41,7 @@
         <NgenPriority>3</NgenPriority>
         <NgenArchitecture Condition="'%(Filename)' != 'InteractiveHost64'">All</NgenArchitecture>
         <NgenArchitecture Condition="'%(Filename)' == 'InteractiveHost64'">X64</NgenArchitecture>
-        <NgenApplication>/InteractiveHost/Desktop/InteractiveHost64.exe</NgenApplication>
+        <NgenApplication>[installDir]\Common7\IDE\$(CommonExtensionInstallationRoot)\$(LanguageServicesExtensionInstallationFolder)\InteractiveHost\Desktop\InteractiveHost64.exe</NgenApplication>
       </_PublishedFiles>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
E.g.
`[installDir]\Common7\IDE\CommonExtensions\Microsoft\ManagedLanguages\VBCSharp\LanguageServices\InteractiveHost\Desktop\InteractiveHost64.exe`

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1157948