### PR TITLE
Fix vscode-run-tests for dotnet path with spaces

### DIFF
--- a/scripts/vscode-run-tests.ps1
+++ b/scripts/vscode-run-tests.ps1
@@ -30,7 +30,7 @@ if ($projectFileInfo) {
   # Remove old run logs with the same prefix
   Remove-Item (Join-Path $resultsPath "$logFilePrefix*.html") -ErrorAction SilentlyContinue
 
-  $invocation = "$dotnetPath test $projectDir" + $filterArg + $frameworkArg + " --logger `"html;LogFilePrefix=$logfilePrefix`" --results-directory $resultsPath --no-build"
+  $invocation = "& `"$dotnetPath`" test $projectDir" + $filterArg + $frameworkArg + " --logger `"html;LogFilePrefix=$logfilePrefix`" --results-directory $resultsPath --no-build"
   Write-Output "> $invocation"
   Invoke-Expression $invocation
 


### PR DESCRIPTION
Ensure-DotNetSdk recently started pulling in my user-level installation of .NET 5 Preview 7, which is under Program Files, thus breaking this test script.