### PR TITLE
F1 help for private protected and protected internal go to their expected places

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -291,10 +291,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         {
             // Contextual keywords can appear in any order, and the user could initiate help from either keyword
             // so to keep the actual checks simple we just check all 4 combinations
-            return TryGetTextForCombinationKeyword(token, token.GetPreviousToken(), out text) ||
-                TryGetTextForCombinationKeyword(token, token.GetNextToken(), out text) ||
-                TryGetTextForCombinationKeyword(token.GetPreviousToken(), token, out text) ||
-                TryGetTextForCombinationKeyword(token.GetNextToken(), token, out text);
+            var previousToken = token.GetPreviousToken();
+            var nextToken = token.GetNextToken();
+            return TryGetTextForCombinationKeyword(token, previousToken, out text) ||
+                TryGetTextForCombinationKeyword(token, nextToken, out text) ||
+                TryGetTextForCombinationKeyword(previousToken, token, out text) ||
+                TryGetTextForCombinationKeyword(nextToken, token, out text);
         }
 
         private static bool TryGetTextForCombinationKeyword(SyntaxToken token1, SyntaxToken token2, out string text)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             return string.Empty;
         }
 
-        private bool IsValid(SyntaxToken token, TextSpan span)
+        private static bool IsValid(SyntaxToken token, TextSpan span)
         {
             // If the token doesn't actually intersect with our position, give up
             return token.Kind() == SyntaxKind.EndIfDirectiveTrivia || token.Span.IntersectsWith(span);
@@ -154,9 +154,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
 
             // Local: return the name if it's the declaration, otherwise the type
-            if (symbol is ILocalSymbol && !symbol.DeclaringSyntaxReferences.Any(d => d.GetSyntax().DescendantTokens().Contains(token)))
+            if (symbol is ILocalSymbol localSymbol && !symbol.DeclaringSyntaxReferences.Any(d => d.GetSyntax().DescendantTokens().Contains(token)))
             {
-                symbol = ((ILocalSymbol)symbol).Type;
+                symbol = localSymbol.Type;
             }
 
             // Range variable: use the type
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             return symbol != null;
         }
 
-        private bool TryGetTextForOperator(SyntaxToken token, Document document, out string text)
+        private static bool TryGetTextForOperator(SyntaxToken token, Document document, out string text)
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             if (syntaxFacts.IsOperator(token) || syntaxFacts.IsPredefinedOperator(token) || SyntaxFacts.IsAssignmentExpressionOperatorToken(token.Kind()))
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             return false;
         }
 
-        private bool TryGetTextForPreProcessor(SyntaxToken token, ISyntaxFactsService syntaxFacts, out string text)
+        private static bool TryGetTextForPreProcessor(SyntaxToken token, ISyntaxFactsService syntaxFacts, out string text)
         {
             if (syntaxFacts.IsPreprocessorKeyword(token))
             {
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             return false;
         }
 
-        private bool TryGetTextForContextualKeyword(SyntaxToken token, out string text)
+        private static bool TryGetTextForContextualKeyword(SyntaxToken token, out string text)
         {
             if (token.Text == "nameof")
             {
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             text = null;
             return false;
         }
-        private bool TryGetTextForCombinationKeyword(SyntaxToken token, out string text)
+        private static bool TryGetTextForCombinationKeyword(SyntaxToken token, out string text)
         {
             // Contextual keywords can appear in any order, and the user could initiate help from either keyword
             // so to keep the actual checks simple we just check all 4 combinations
@@ -297,7 +297,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 TryGetTextForCombinationKeyword(token.GetNextToken(), token, out text);
         }
 
-        private bool TryGetTextForCombinationKeyword(SyntaxToken token1, SyntaxToken token2, out string text)
+        private static bool TryGetTextForCombinationKeyword(SyntaxToken token1, SyntaxToken token2, out string text)
         {
             if (token1.Kind() == SyntaxKind.PrivateKeyword && token2.Kind() == SyntaxKind.ProtectedKeyword)
             {
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             return false;
         }
 
-        private bool TryGetTextForKeyword(SyntaxToken token, ISyntaxFactsService syntaxFacts, out string text)
+        private static bool TryGetTextForKeyword(SyntaxToken token, ISyntaxFactsService syntaxFacts, out string text)
         {
             if (token.Kind() == SyntaxKind.InKeyword)
             {
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
 
             if (token.ValueText == "var" && token.IsKind(SyntaxKind.IdentifierToken) &&
-                token.Parent.Parent is VariableDeclarationSyntax && token.Parent == ((VariableDeclarationSyntax)token.Parent.Parent).Type)
+                token.Parent.Parent is VariableDeclarationSyntax declaration && token.Parent == declaration.Type)
             {
                 text = "var_CSharpKeyword";
                 return true;

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -40,6 +40,85 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestInternal()
+        {
+            await Test_KeywordAsync(
+@"intern[||]al class C
+{
+}", "internal");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestProtected()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    protec[||]ted void goo();
+}", "protected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestProtectedInternal1()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    internal protec[||]ted void goo();
+}", "protectedinternal");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestProtectedInternal2()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    protec[||]ted internal void goo();
+}", "protectedinternal");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestPrivateProtected1()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    private protec[||]ted void goo();
+}", "privateprotected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestPrivateProtected2()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    priv[||]ate protected void goo();
+}", "privateprotected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestPrivateProtected3()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    protected priv[||]ate void goo();
+}", "privateprotected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestPrivateProtected4()
+        {
+            await Test_KeywordAsync(
+@"public class C
+{
+    prot[||]ected private void goo();
+}", "privateprotected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestVoid()
         {
             await Test_KeywordAsync(

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -119,6 +119,28 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestModifierSoup()
+        {
+            await Test_KeywordAsync(
+    @"public class C
+{
+    private new prot[||]ected static unsafe void foo()
+    {
+    }
+}", "privateprotected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestModifierSoupField()
+        {
+            await Test_KeywordAsync(
+    @"public class C
+{
+    new prot[||]ected static unsafe private goo;
+}", "privateprotected");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestVoid()
         {
             await Test_KeywordAsync(

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         private static readonly ComposableCatalog s_catalog = TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic.WithPart(typeof(CSharpHelpContextService));
         private static readonly IExportProviderFactory s_exportProviderFactory = ExportProviderCache.GetOrCreateExportProviderFactory(s_catalog);
 
-        private async Task TestAsync(string markup, string expectedText)
+        private static async Task TestAsync(string markup, string expectedText)
         {
             using var workspace = TestWorkspace.CreateCSharp(markup, exportProvider: s_exportProviderFactory.CreateExportProvider());
             var caret = workspace.Documents.First().CursorPosition;
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
             Assert.Equal(expectedText, actualText);
         }
 
-        private async Task Test_KeywordAsync(string markup, string expectedText)
+        private static async Task Test_KeywordAsync(string markup, string expectedText)
         {
             await TestAsync(markup, expectedText + "_CSharpKeyword");
         }

--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -108,6 +108,27 @@ End Class</a>
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestModifierSoup() As Task
+            Dim text = <a>
+Public Class G
+    Protec[||]ted Async Shared Private Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.PrivateProtected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestModifierSoupField() As Task
+            Dim text = <a>
+Public Class G
+    Private Shadows Shared Prot[||]ected foo as Boolean
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.PrivateProtected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestAddHandler1() As Task
             Dim text = <a>
 Class G

--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -13,7 +13,7 @@ Imports Roslyn.Utilities
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Help
     <[UseExportProvider]>
     Public Class HelpTests
-        Public Async Function TestAsync(markup As String, expected As String) As Tasks.Task
+        Public Shared Async Function TestAsync(markup As String, expected As String) As Tasks.Task
             Using workspace = TestWorkspace.CreateVisualBasic(markup)
                 Dim caret = workspace.Documents.First().CursorPosition
                 Dim service = New VisualBasicHelpContextService()

--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -22,6 +22,92 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Help
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestFriend() As Task
+            Dim text = <a>
+Fri[||]end Class G
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.Friend")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestProtected() As Task
+            Dim text = <a>
+Public Class G
+    Protec[||]ted Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.Protected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestProtectedFriend1() As Task
+            Dim text = <a>
+Public Class G
+    Protec[||]ted Friend Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.ProtectedFriend")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestProtectedFriend2() As Task
+            Dim text = <a>
+Public Class G
+    Friend Protec[||]ted Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.ProtectedFriend")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestPrivateProtected1() As Task
+            Dim text = <a>
+Public Class G
+    Private Protec[||]ted Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.PrivateProtected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestPrivateProtected2() As Task
+            Dim text = <a>
+Public Class G
+    Priv[||]ate Protected Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.PrivateProtected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestPrivateProtected3() As Task
+            Dim text = <a>
+Public Class G
+    Protected Priv[||]ate Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.PrivateProtected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function TestPrivateProtected4() As Task
+            Dim text = <a>
+Public Class G
+    Protec[||]ted Private Sub M()
+    End Sub
+End Class</a>
+
+            Await TestAsync(text.Value, "vb.PrivateProtected")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestAddHandler1() As Task
             Dim text = <a>
 Class G

--- a/src/VisualStudio/VisualBasic/Impl/Help/HelpKeywords.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Help/HelpKeywords.vb
@@ -91,6 +91,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
         Friend Const Iterator As String = "vb.Iterator"
         Friend Const Await As String = "vb.Await"
         Friend Const Yield As String = "vb.Yield"
+        Friend Const PrivateProtected As String = "vb.PrivateProtected"
+        Friend Const ProtectedFriend As String = "vb.ProtectedFriend"
 
     End Class
 

--- a/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
         Private Class Visitor
             Inherits VisualBasicSyntaxVisitor
 
-            Public result As String = Nothing
+            Public result As String
             Private ReadOnly _span As TextSpan
             Private ReadOnly _semanticModel As SemanticModel
             Private ReadOnly _service As VisualBasicHelpContextService
@@ -30,11 +30,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
                 Me._cancellationToken = cancellationToken
             End Sub
 
-            Private Function Keyword(text As String) As String
+            Private Shared Function Keyword(text As String) As String
                 Return "vb." + text
             End Function
 
-            Private Function Keyword(kind As SyntaxKind) As String
+            Private Shared Function Keyword(kind As SyntaxKind) As String
                 Return Keyword(kind.GetText())
             End Function
 

--- a/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
@@ -765,29 +765,42 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
             End Sub
 
             Private Function SelectModifier(list As SyntaxTokenList) As Boolean
-                Dim previousToken As SyntaxToken
                 For i As Integer = 0 To list.Count - 1
                     Dim modifier = list(i)
                     If modifier.Span.IntersectsWith(_span) Then
-                        ' For combination tokens we check current vs previous in any order
-                        If SelectCombinationModifier(previousToken, modifier) OrElse SelectCombinationModifier(modifier, previousToken) Then
-                            Return True
-                        Else
-                            If i < list.Count - 1 Then
-                                Dim nextToken = list(i + 1)
-                                ' Now check current vs next in any order
-                                If SelectCombinationModifier(nextToken, modifier) OrElse SelectCombinationModifier(modifier, nextToken) Then
-                                    Return True
-                                End If
-                            End If
 
-                            ' Not a combination token, just normal keyword help
-                            result = Keyword(modifier.Text)
+                        If SelectCombinationModifier(modifier, i, list) Then
                             Return True
                         End If
+
+                        ' Not a combination token, just normal keyword help
+                        result = Keyword(modifier.Text)
+                        Return True
                     End If
-                    previousToken = modifier
                 Next
+
+                Return False
+            End Function
+
+            Private Function SelectCombinationModifier(token As SyntaxToken, index As Integer, list As SyntaxTokenList) As Boolean
+                Dim previousToken As SyntaxToken
+                Dim nextToken As SyntaxToken
+
+                If index > 0 Then
+                    previousToken = list(index - 1)
+                End If
+
+                If index < list.Count - 1 Then
+                    nextToken = list(index + 1)
+                End If
+
+                ' For combination tokens we check current vs previous in any order
+                If SelectCombinationModifier(previousToken, token) OrElse
+                    SelectCombinationModifier(token, previousToken) OrElse
+                    SelectCombinationModifier(nextToken, token) OrElse
+                    SelectCombinationModifier(token, nextToken) Then
+                    Return True
+                End If
 
                 Return False
             End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/46142

Can't be merged until https://github.com/dotnet/docs/pull/19700 otherwise the confusion gets worse.

The code is a little messier than you'd hope because these modifiers can appear in any order.