### PR TITLE
Add 3.1 runtime for IDE tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,6 +6,9 @@
   },
   "tools": {
     "dotnet": "5.0.100-preview.7.20366.6",
+    "runtimes": {
+      "dotnet": [ "3.1.6" ]
+    },
     "vs": {
       "version": "16.6"
     },

--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
   "tools": {
     "dotnet": "5.0.100-preview.7.20366.6",
     "runtimes": {
-      "dotnet": [ "3.1.6" ]
+      "dotnet": [ "3.1.600" ]
     },
     "vs": {
       "version": "16.6"


### PR DESCRIPTION
This adds back 3.1 runtime so IDE tests (after multi-targeting to .netcoreapp3.1) would be executed on 3.1 runtime instead of net5.
#45813 should be merged first.

See this for more details: https://github.com/dotnet/arcade/blob/master/Documentation/ArcadeSdk.md#example-restoring-multiple-net-core-runtimes-for-running-tests

FYI @jaredpar 