### PR TITLE
Remove LSP base from Xaml content type definition to avoid regressing…

### DIFF
--- a/src/VisualStudio/Xaml/Impl/XamlStaticTypeDefinitions.cs
+++ b/src/VisualStudio/Xaml/Impl/XamlStaticTypeDefinitions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml
         /// </summary>
         [Export]
         [Name(ContentTypeNames.XamlContentType)]
-        [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
+        [BaseDefinition("code")]
         internal static readonly ContentTypeDefinition XamlContentType;
 
         // Associate .xaml as the Xaml content type.


### PR DESCRIPTION
Temporarily remove change from https://github.com/dotnet/roslyn/commit/b22765bab41edf4f2ecb448295a2219b113c6cf6#diff-ba855a22bd726cabe64629cddc07c279R17 to avoid loading LSP textmate dlls in RPS.

This content type will be added in the VS repo, then this entire file can be removed from roslyn.

cc @mgoertz-msft @333fred @RikkiGibson 