### PR TITLE
Fix string expansion in ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -8,7 +8,7 @@
 
   <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
           BeforeTargets="CoreCompile"
-          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
+          Condition="'@(ReferencePathWithRefAssemblies->Count())' == '0'">
     <!-- 
       FindReferenceAssembliesForReferences target in Common targets populate this item 
       since dev15.3. The compiler targets may be used (via NuGet package) on earlier MSBuilds. 


### PR DESCRIPTION
Context: https://github.com/dotnet/msbuild/pull/5553
Context: https://github.com/dotnet/msbuild/issues/5315

When building this repo:

https://github.com/xamarin/net6-samples

With the command:

    dotnet build .\HelloAndroid\HelloAndroid.csproj -bl

Even if the project is already built completely, a second call
generates a log message such as:

    Target "ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies" skipped, due to false condition; ('@(ReferencePathWithRefAssemblies)' == '') was evaluated as ('C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Java.Interop.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.CSharp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.Win32.Primitives.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.Export.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\mscorlib.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\netstandard.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.AppContext.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Buffers.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Concurrent.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Immutable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.NonGeneric.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Specialized.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Annotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.DataAnnotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.EventBasedAsync.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.TypeConverter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Configuration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Console.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.Common.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.DataSetExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Contracts.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Debug.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.DiagnosticSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.FileVersionInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Process.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.StackTrace.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TextWriterTraceListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tools.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TraceSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tracing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Dynamic.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Formats.Asn1.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Calendars.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.Brotli.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.ZipFile.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.DriveInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Watcher.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.IsolatedStorage.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.MemoryMappedFiles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Pipes.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.UnmanagedMemoryStream.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Expressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Queryable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Memory.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.HttpListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Mail.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NameResolution.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NetworkInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Ping.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Requests.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.ServicePoint.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Sockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebClient.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebHeaderCollection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.Client.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.Vectors.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ObjectModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.DispatchProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.ILGeneration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.Lightweight.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Metadata.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.TypeExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Reader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.ResourceManager.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Writer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.Unsafe.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.VisualC.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Handles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.JavaScript.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.RuntimeInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Intrinsics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Loader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Formatters.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Claims.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Algorithms.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Csp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.X509Certificates.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Principal.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.SecureString.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceModel.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceProcess.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.CodePages.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encodings.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.RegularExpressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Channels.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Overlapped.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Dataflow.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Thread.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.ThreadPool.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Timer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.Local.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ValueTuple.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.HttpUtility.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Windows.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.ReaderWriter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlSerializer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\WindowsBase.dll' == '').Target "ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies" skipped, due to false condition; ('@(ReferencePathWithRefAssemblies)' == '') was evaluated as ('C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Java.Interop.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.CSharp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.Win32.Primitives.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.Export.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\mscorlib.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\netstandard.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.AppContext.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Buffers.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Concurrent.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Immutable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.NonGeneric.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Specialized.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Annotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.DataAnnotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.EventBasedAsync.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.TypeConverter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Configuration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Console.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.Common.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.DataSetExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Contracts.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Debug.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.DiagnosticSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.FileVersionInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Process.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.StackTrace.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TextWriterTraceListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tools.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TraceSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tracing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Dynamic.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Formats.Asn1.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Calendars.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.Brotli.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.ZipFile.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.DriveInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Watcher.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.IsolatedStorage.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.MemoryMappedFiles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Pipes.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.UnmanagedMemoryStream.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Expressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Queryable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Memory.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.HttpListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Mail.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NameResolution.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NetworkInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Ping.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Requests.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.ServicePoint.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Sockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebClient.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebHeaderCollection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.Client.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.Vectors.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ObjectModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.DispatchProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.ILGeneration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.Lightweight.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Metadata.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.TypeExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Reader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.ResourceManager.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Writer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.Unsafe.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.VisualC.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Handles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.JavaScript.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.RuntimeInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Intrinsics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Loader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Formatters.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Claims.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Algorithms.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Csp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.X509Certificates.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Principal.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.SecureString.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceModel.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceProcess.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.CodePages.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encodings.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.RegularExpressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Channels.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Overlapped.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Dataflow.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Thread.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.ThreadPool.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Timer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.Local.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ValueTuple.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.HttpUtility.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Windows.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.ReaderWriter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlSerializer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\WindowsBase.dll' == '').

This means that MSBuild is expanding a 36,619 character string then
checking if it matches `''`.

Changing this to use the `->Count()` item function, the log message
changes to:

    Target "ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies" skipped, due to false condition; ('@(ReferencePathWithRefAssemblies->Count())' == '0') was evaluated as ('156' == '0').

`->Count()` should also return 0 when the item group is
non-existent/empty:

https://docs.microsoft.com/visualstudio/msbuild/item-functions

Someone might know a better option than `->Count()`, let me know.

I ran PerfView before and after, and although these numbers from the
`GC Heap Alloc Ignore Free` report fluctuate we can see a decent
improvement in `String` allocations:

    Name               	Exc %	        Exc	  Exc Ct	Inc %	          Inc	  Inc Ct
    Type System.String 	 23.1	 41,994,992	 194,066	 23.1	   41,994,992	 194,066
    Type System.String 	 23.1	 41,842,544	 194,033	 23.1	   41,842,544	 194,033