### PR TITLE
Don't offer Use Explicit Type for target typed new

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2793,5 +2793,21 @@ class C
     private readonly Action<object, EventArgs> f2;
 }", parameters: new TestParameters(options: ImplicitTypeEverywhere()));
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task DoNotSuggestVarForTargetTypedNew()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class Program
+{
+    void Method()
+    {
+        [|string|] p = new('c', 1);
+    }
+
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpUseImplicitTypeHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpUseImplicitTypeHelper.cs
@@ -286,6 +286,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 return false;
             }
 
+            // var cannot be used with target typed new
+#if CODE_STYLE
+            if (expression.IsKind(Formatting.SyntaxKindEx.ImplicitObjectCreationExpression))
+#else
+            if (expression.IsKind(SyntaxKind.ImplicitObjectCreationExpression))
+#endif
+            {
+                return false;
+            }
+
             // cannot use implicit typing on method group or on dynamic
             var declaredType = semanticModel.GetTypeInfo(typeName.StripRefIfNeeded(), cancellationToken).Type;
             if (declaredType != null && declaredType.TypeKind == TypeKind.Dynamic)


### PR DESCRIPTION
Noticed this today while doing something else. Couldn't find a bug for it, should I log one?