### PR TITLE
Update null state for add/remove on field-like events

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8633,16 +8633,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitRvalue(node.Argument);
             // https://github.com/dotnet/roslyn/issues/31018: Check for delegate mismatch.
             if (node.Argument.ConstantValue?.IsNull != true
-                && MakeMemberSlot(receiverOpt, @event) is not -1 and var memberSlot)
+                && MakeMemberSlot(receiverOpt, @event) is > 0 and var memberSlot)
             {
-                if (node.IsAddition)
-                {
-                    this.State[memberSlot] = this.State[memberSlot].Meet(ResultType.State);
-                }
-                else
-                {
-                    this.State[memberSlot] = NullableFlowState.MaybeNull;
-                }
+                this.State[memberSlot] = node.IsAddition
+                    ? this.State[memberSlot].Meet(ResultType.State)
+                    : NullableFlowState.MaybeNull;
             }
             SetNotNullResult(node); // https://github.com/dotnet/roslyn/issues/29969 Review whether this is the correct result
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8632,18 +8632,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             VisitRvalue(node.Argument);
             // https://github.com/dotnet/roslyn/issues/31018: Check for delegate mismatch.
-            if (node.Argument.ConstantValue?.IsNull != true)
+            if (node.Argument.ConstantValue?.IsNull != true
+                && MakeMemberSlot(receiverOpt, @event) is not -1 and var memberSlot)
             {
                 if (node.IsAddition)
                 {
-                    if (ResultType.IsNotNull)
-                    {
-                        LearnFromNonNullTest(MakeMemberSlot(receiverOpt, @event), ref State);
-                    }
+                    this.State[memberSlot] = this.State[memberSlot].Meet(ResultType.State);
                 }
                 else
                 {
-                    LearnFromNullTest(MakeMemberSlot(receiverOpt, @event), ResultType.Type, ref State, markDependentSlotsNotNull: false);
+                    this.State[memberSlot] = NullableFlowState.MaybeNull;
                 }
             }
             SetNotNullResult(node); // https://github.com/dotnet/roslyn/issues/29969 Review whether this is the correct result

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -2719,6 +2719,50 @@ class C<T>
         }
 
         [Fact]
+        public void GetSymbolInfo_EventAssignmentFlowState()
+        {
+            var source = @"
+using System;
+class C
+{
+    event Action? Event;
+
+    void M(bool b)
+    {
+        if (b) Event.Invoke(); // 1
+        Event += () => { };
+        Event.Invoke();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,16): warning CS8602: Dereference of a possibly null reference.
+                //         if (b) Event.Invoke(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Event").WithLocation(9, 16)
+                );
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var memberAccess = root.DescendantNodes().OfType<MemberAccessExpressionSyntax>().ToList();
+            Assert.Equal(2, memberAccess.Count);
+
+            var typeInfo = model.GetTypeInfo(memberAccess[0].Expression);
+            Assert.Equal(PublicNullableAnnotation.Annotated, typeInfo.Type.NullableAnnotation);
+            Assert.Equal(PublicNullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+
+            typeInfo = model.GetTypeInfo(memberAccess[1].Expression);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, typeInfo.Type.NullableAnnotation);
+            Assert.Equal(PublicNullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var lhs = root.DescendantNodes().OfType<AssignmentExpressionSyntax>().Single().Left;
+            typeInfo = model.GetTypeInfo(lhs);
+            Assert.Equal(PublicNullableAnnotation.None, typeInfo.Type.NullableAnnotation);
+            Assert.Equal(PublicNullableFlowState.None, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
         public void GetSymbolInfo_ReinferredCollectionInitializerAdd_InstanceMethods()
         {
             var source = @"


### PR DESCRIPTION
Fixes #42557

This work supports the new nullable constructor analysis, since we need to be able to tell that an event no longer contains 'null' after a non-null delegate is added to it.

🦔 