### PR TITLE
Made some experience changes - Inline Parameter Name Hints

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
@@ -21,11 +21,11 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
 
         /// <summary>
         /// Creates the UIElement on call
-        /// Uses PositionAffinity.Successor because we want the tag to be associated with the following character
+        /// Uses PositionAffinity.Predecessor because we want the tag to be associated with the preceding character
         /// </summary>
         /// <param name="text">The name of the parameter associated with the argument</param>
         public InlineParameterNameHintsTag(string text, double lineHeight, TextFormattingRunProperties format)
-            : base(CreateElement(text, lineHeight, format), removalCallback: null, PositionAffinity.Successor)
+            : base(CreateElement(text, lineHeight, format), removalCallback: null, PositionAffinity.Predecessor)
         {
         }
 

--- a/src/EditorFeatures/Core/InlineParameterNameHints/InlineParameterNameHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineParameterNameHints/InlineParameterNameHintsDataTaggerProvider.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
         private readonly IAsynchronousOperationListener _listener;
 
         protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(FeatureOnOffOptions.InlineParameterNameHints);
+        protected override SpanTrackingMode SpanTrackingMode => SpanTrackingMode.EdgeInclusive;
 
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         [ImportingConstructor]


### PR DESCRIPTION
Hello,

Before, the inline parameter hints would be associated with the character directly succeeding the hint. However, this made it so that you could not type before the first character in an argument. However, this behavior is not ideal, so I changed it so that the hint is now associated with the preceding character.

However, this created an issue where, when typing at the following cursor location:
![image](https://user-images.githubusercontent.com/40616383/89070819-925c1800-d343-11ea-94ae-a3bf05f92055.png)

The value would appear prior to the adornment, like in the following:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/40616383/89071439-bc620a00-d344-11ea-8b56-aba6f12e8e7e.gif)

To change this behavior, in the ```InlineParameterNameHintsDataTaggerProvider``` I overrode the SpanTrackingMode to be EdgeInclusive so that the span expanded on text changes accordingly.