### PR TITLE
Change GacFileResolver.IsAvailable to check a type from System.Core

### DIFF
--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GacFileResolver.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GacFileResolver.cs
@@ -20,7 +20,9 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         /// <summary>
         /// Returns true if GAC is available on the current platform.
         /// </summary>
-        public static bool IsAvailable => typeof(object).Assembly.GlobalAssemblyCache;
+        public static bool IsAvailable
+            // Check a type from System.Core since Mono doesn't load mscorlib from the GAC.
+            => typeof(Enumerable).Assembly.GlobalAssemblyCache;
 
         /// <summary>
         /// Architecture filter used when resolving assembly references.

--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GacFileResolver.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GacFileResolver.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         /// Returns true if GAC is available on the current platform.
         /// </summary>
         public static bool IsAvailable
-            // Check a type from System.Core since Mono doesn't load mscorlib from the GAC.
-            => typeof(Enumerable).Assembly.GlobalAssemblyCache;
+            // Since mscorlib may not be loaded from the GAC on Mono, also check if the platform is Mono which supports a GAC.
+            => typeof(object).Assembly.GlobalAssemblyCache || PlatformInformation.IsRunningOnMono;
 
         /// <summary>
         /// Architecture filter used when resolving assembly references.
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         /// Creates an instance of a <see cref="GacFileResolver"/>, if available on the platform (check <see cref="IsAvailable"/>).
         /// </summary>
         /// <param name="architectures">Supported architectures used to filter GAC assemblies.</param>
-        /// <param name="preferredCulture">A culture to use when choosing the best assembly from 
+        /// <param name="preferredCulture">A culture to use when choosing the best assembly from
         /// among the set filtered by <paramref name="architectures"/></param>
         /// <exception cref="PlatformNotSupportedException">The platform doesn't support GAC.</exception>
         public GacFileResolver(


### PR DESCRIPTION
I've been looking at unit test failure on Mono platforms in an OmniSharp-Roslyn PR (https://github.com/OmniSharp/omnisharp-roslyn/pull/1867) where I update to a more recent build of Roslyn.

It is unable to resolve "System.Xml" with the [RuntimeMetadataReferenceResolver](https://github.com/dotnet/roslyn/blob/master/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs#L61). This is because the `gacFileResolver` is being set to `null` and the `AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")` is also coming back `null`.

For the `object` type which is in mscorlib, I am seeing mscorlib loaded from "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/4.5/mscorlib.dll" and returns `false` for `Assembly.GlobalAssemblyCache`.

However, the `Enumerable` type from System.Core loads from "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/gac/System.Core/4.0.0.0__b77a5c561934e089/System.Core.dll" and returns `true` for `Assembly.GlobalAssemblyCache`.


