### PR TITLE
Revert "Tweak delays we have before we start incrementally analyzing in OOP."

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -107,15 +107,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
         private async Task StartWorkerAsync(CancellationToken cancellationToken)
         {
-            // Set a short batch time so we update VS in a timely manner.  We still want to batch things up though as we
-            // might receive many notifications about files in a project, and it would be better to notify VS of them
-            // all at once rather than saturating the UI work queue with a lot of work that keeps being processed in
-            // between everything else that is going on.
-            //
-            // In manual testing, 250 ms proved more than enough time to analyze full projects, while also making sure
-            // that updated data made it to the final UI quickly.
             _workQueue = new AsyncBatchingWorkQueue<DesignerAttributeData>(
-                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromMilliseconds(500),
                 this.NotifyProjectSystemAsync,
                 cancellationToken);
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -17,17 +17,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
     internal static class RemoteHostOptions
     {
-        // Update primary workspace on OOP twice a second if VS is not running any global operation (such as build,
-        // solution open/close, rename, etc.)
+        // Update primary workspace on OOP every 4 seconds if VS is not running any global operation 
+        // such as build, solution open/close, rename and etc.
+        // Even if primary workspace is not updated, OOP will work as expected. updating primary workspace 
+        // on OOP should let latest data to be synched pre-emptively rather than on demand.
         //
-        // Even if primary workspace is not updated, other OOP queries will work as expected. Updating primary workspace
-        // on OOP should let latest data to be synced pre-emptively rather than on demand, and will kick off
-        // incremental analyzer tasks.
+        // 2 second is our usual long running interactive operation delay and 
+        // 5 second is usual ambient long running operation delay. 
+        // I chose one in between. among 3 and 4 seconds, I chose slower one - 4 second. 
         //
-        // When primary workspace is staled, missing data will be synced to OOP on demand and cached for 3 min. enough
-        // for primary workspace in OOP to be synced to latest.
+        // When primary workspace is staled, missing data will be synced to OOP on
+        // demand and cached for 3 min. enough for primary workspace in OOP to be synced to latest.
         public static readonly Option<int> SolutionChecksumMonitorBackOffTimeSpanInMS = new Option<int>(
-            nameof(InternalFeatureOnOffOptions), nameof(SolutionChecksumMonitorBackOffTimeSpanInMS), defaultValue: 500,
+            nameof(InternalFeatureOnOffOptions), nameof(SolutionChecksumMonitorBackOffTimeSpanInMS), defaultValue: 4000,
             storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(SolutionChecksumMonitorBackOffTimeSpanInMS)));
 
         // use 64bit OOP

--- a/src/Workspaces/Remote/ServiceHub/Services/DesignerAttribute/RemoteDesignerAttributeIncrementalAnalyzer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DesignerAttribute/RemoteDesignerAttributeIncrementalAnalyzer.cs
@@ -90,8 +90,9 @@ namespace Microsoft.CodeAnalysis.Remote
             // in this project.
             var projectVersion = await project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
 
-            // Now get all the values that actually changed and notify VS about them. We only need to report any data
-            // for files we haven't reported for, or for files where the data has changed.
+            // Now get all the values that actually changed and notify VS about them. We don't need
+            // to tell it about the ones that didn't change since that will have no effect on the
+            // user experience.
             var latestData = await ComputeLatestDataAsync(
                 project, specificDocument, projectVersion, cancellationToken).ConfigureAwait(false);
 
@@ -125,8 +126,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (specificDocument != null && document != specificDocument)
                     continue;
 
-                // If we don't have a path for this document, we can't proceed with it. We need that path to inform the
-                // project system which file we're referring to.
+                // If we don't have a path for this document, we cant proceed with it.
+                // We need that path to inform the project system which file we're referring to.
                 if (document.FilePath == null)
                     continue;
 
@@ -151,6 +152,9 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 Contract.ThrowIfNull(document.FilePath);
 
+                // We either haven't computed the designer info, or our data was out of date.  We need
+                // So recompute here.  Figure out what the current category is, and if that's different
+                // from what we previously stored.
                 var category = await DesignerAttributeHelpers.ComputeDesignerAttributeCategoryAsync(
                     designerCategoryType, document, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DesignerAttribute/RemoteDesignerAttributeIncrementalAnalyzer_Serialization.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DesignerAttribute/RemoteDesignerAttributeIncrementalAnalyzer_Serialization.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using Microsoft.CodeAnalysis.DesignerAttribute;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    internal partial class RemoteDesignerAttributeIncrementalAnalyzer
+    {
+        /// <summary>
+        /// Our current serialization format.  Increment whenever it changes so that we don't read
+        /// bogus data when reading older persisted data.
+        /// </summary>
+        private const string SerializationFormat = "1";
+
+        private static (string? category, VersionStamp projectVersion) TryReadPersistedInfo(ObjectReader reader)
+        {
+            try
+            {
+                // if we couldn't get a reader then we have no persisted category/version to read out.
+                if (reader == null)
+                    return default;
+
+                // check to make sure whatever we persisted matches our current format for this info
+                // type. If not, then we can't read this out.
+                var format = reader.ReadString();
+                if (format != SerializationFormat)
+                    return default;
+
+                // Looks good, pull out the stored data.
+                var category = reader.ReadString();
+                var projectVersion = VersionStamp.ReadFrom(reader);
+
+                return (category, projectVersion);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                // can happen if the DB got edited outside of our control.
+                return default;
+            }
+        }
+
+        private static void PersistInfoTo(ObjectWriter writer, DesignerAttributeData data, VersionStamp projectVersion)
+        {
+            writer.WriteString(SerializationFormat);
+            writer.WriteString(data.Category);
+            projectVersion.WriteTo(writer);
+        }
+    }
+}


### PR DESCRIPTION
Reverts dotnet/roslyn#46426. We suspect this is related to some new RPS issues so opening the PR in order to test a revert of the change.