### PR TITLE
Fix issue where compiler host dropped connections under load

### DIFF
--- a/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
+++ b/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
@@ -79,14 +79,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
         {
             if (s_loggingStream != null)
             {
-                LogError("Exception '{0}' occurred during '{1}'. Stack trace:\r\n{2}", exception.Message, reason, exception.StackTrace);
+                LogError("'{0}' '{1}' occurred during '{2}'. Stack trace:\r\n{3}", exception.GetType().Name, exception.Message, reason, exception.StackTrace);
 
                 int innerExceptionLevel = 0;
 
                 Exception? e = exception.InnerException;
                 while (e != null)
                 {
-                    Log("Inner exception[{0}] '{1}'. Stack trace: \r\n{1}", innerExceptionLevel, e.Message, e.StackTrace);
+                    Log("Inner exception[{0}] '{1}' '{2}'. Stack trace: \r\n{3}", innerExceptionLevel, e.GetType().Name, e.Message, e.StackTrace);
                     e = e.InnerException;
                     innerExceptionLevel += 1;
                 }

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -72,6 +72,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
 
+            // This represents the maximum number of failed build attempts on the server before we will declare
+            // that the overall build itself failed. 
+            //
+            // The goal is to keep this at zero. The errors here are a mix of repository construction errors (having
+            // incompatible NuGet analyzers) and product errors (having flaky behavior in the server). Any time this
+            // number goes above zero it means we are dropping connections during developer inner loop builds and 
+            // hence measurably slowing down our productivity.
+            //
+            // When we find issues in the server or our infra we can temporarily raise this number while it is
+            // being worked out but should file a bug to track getting this to zero.
             const int maxRejectCount = 0;
             var rejectCount = 0;
             foreach (var tuple in s_failedQueue.ToList())

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -72,14 +72,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
 
-            // The number chosen is arbitrary here.  The goal of this check is to catch cases where a coding error has 
-            // broken our ability to use the compiler server in the bootstrap phase.
-            //
-            // It's possible on completely correct code for the server connection to fail.  There could be simply 
-            // named pipe errors, CPU load causing timeouts, etc ...  Hence flagging a single failure would produce
-            // a lot of false positives.  The current value was chosen as a reasonable number for warranting an 
-            // investigation.
-            const int maxRejectCount = 5;
+            const int maxRejectCount = 0;
             var rejectCount = 0;
             foreach (var tuple in s_failedQueue.ToList())
             {

--- a/src/Compilers/Server/VBCSCompiler/ClientConnectionHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/ClientConnectionHandler.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
         }
 
-        private async Task<CompletionData> WriteBuildResponseAsync(IClientConnection clientConnection, BuildResponse response, CompletionData completionData, CancellationToken cancellationToken)
+        private static async Task<CompletionData> WriteBuildResponseAsync(IClientConnection clientConnection, BuildResponse response, CompletionData completionData, CancellationToken cancellationToken)
         {
             var message = response switch
             {

--- a/src/Compilers/Server/VBCSCompiler/CompletionData.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompletionData.cs
@@ -50,6 +50,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         internal static CompletionData RequestCompleted { get; } = new CompletionData(CompletionReason.RequestCompleted);
 
         internal static CompletionData RequestError { get; } = new CompletionData(CompletionReason.RequestError);
+
+        public override string ToString() => $"{Reason} KeepAlive:{NewKeepAlive} ShutdownRequest:{ShutdownRequest}";
     }
 }
 

--- a/src/Compilers/Server/VBCSCompiler/DiagnosticListener.cs
+++ b/src/Compilers/Server/VBCSCompiler/DiagnosticListener.cs
@@ -19,11 +19,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         void UpdateKeepAlive(TimeSpan keepAlive);
 
         /// <summary>
-        /// Called each time the server listens for new connections.
-        /// </summary>
-        void ConnectionListening();
-
-        /// <summary>
         /// Called when a connection to the server occurs.
         /// </summary>
         void ConnectionReceived();
@@ -42,10 +37,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     internal sealed class EmptyDiagnosticListener : IDiagnosticListener
     {
         public void UpdateKeepAlive(TimeSpan keepAlive)
-        {
-        }
-
-        public void ConnectionListening()
         {
         }
 

--- a/src/Compilers/Server/VBCSCompiler/IClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/IClientConnection.cs
@@ -41,6 +41,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
     internal interface IClientConnectionHost
     {
+        /// <summary>
+        /// True when the host is listening for new connections (after <see cref="BeginListening"/> is
+        /// called but before <see cref="EndListening"/> is called).
+        /// </summary>
         bool IsListening { get; }
 
         /// <summary>

--- a/src/Compilers/Server/VBCSCompiler/IClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/IClientConnection.cs
@@ -41,7 +41,24 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
     internal interface IClientConnectionHost
     {
-        Task<IClientConnection> ListenAsync(CancellationToken cancellationToken);
-    }
+        bool IsListening { get; }
 
+        /// <summary>
+        /// Start listening for new connections
+        /// </summary>
+        void BeginListening();
+
+        /// <summary>
+        /// Returns a <see cref="Task"/> that completes when a new <see cref="IClientConnection"/> is 
+        /// received. If this is called after <see cref="EndListening"/> is called then an exception
+        /// will be thrown.
+        /// </summary>
+        Task<IClientConnection> GetNextClientConnectionAsync();
+
+        /// <summary>
+        /// Stop accepting new connections. It will also ensure that the last return from 
+        /// <see cref="GetNextClientConnectionAsync"/> is in a completed state.
+        /// </summary>
+        void EndListening();
+    }
 }

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnectionHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnectionHost.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
             catch (Exception ex)
             {
-                CompilerServerLogger.LogException(ex, $"Listen tasks threw exception during nameof(EndListening");
+                CompilerServerLogger.LogException(ex, $"Listen tasks threw exception during {nameof(EndListening)}");
             }
 
             _queue.Complete();

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnectionHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnectionHost.cs
@@ -20,12 +20,79 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal sealed class NamedPipeClientConnectionHost : IClientConnectionHost
     {
-        private readonly string _pipeName;
-        private int _clientLoggingIdentifier;
+        private int _clientCount;
+        private CancellationTokenSource? _cancellationTokenSource;
+        private Task<IClientConnection>? _listenTask;
+
+        internal string PipeName { get; }
+        public bool IsListening { get; private set; }
 
         internal NamedPipeClientConnectionHost(string pipeName)
         {
-            _pipeName = pipeName;
+            PipeName = pipeName;
+        }
+
+        public void BeginListening()
+        {
+            if (IsListening)
+            {
+                throw new InvalidOperationException();
+            }
+
+            IsListening = true;
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public void EndListening()
+        {
+            if (!IsListening)
+            {
+                throw new InvalidOperationException();
+            }
+
+            Debug.Assert(_cancellationTokenSource is object);
+            try
+            {
+                _cancellationTokenSource.Cancel();
+
+                if (_listenTask is object && !_listenTask.IsCompleted)
+                {
+                    try
+                    {
+                        _listenTask?.Wait();
+                    }
+                    catch
+                    {
+                        // It's expected the above Wait will cause exceptions to be thrown. 
+                        // - When the named pipe server was actively listening the cancellation
+                        //   will cause OperationCancelled to be thrown on the Wait call
+                        // - When the named pipe server was in the middle of throwing an error
+                        //   that will come through Wait.
+                        // That is not meant to be handled here. The contract is we will ensure
+                        // the last Task returned from 
+                    }
+                }
+            }
+            finally
+            {
+                IsListening = false;
+                _cancellationTokenSource = null;
+                _listenTask = null;
+            }
+        }
+
+        public Task<IClientConnection> GetNextClientConnectionAsync()
+        {
+            if ((_listenTask is object && !_listenTask.IsCompleted) || !IsListening)
+            {
+                throw new InvalidOperationException();
+            }
+
+            Debug.Assert(_cancellationTokenSource is object);
+
+            var clientLoggingIdentifier = $"Client{_clientCount++}";
+            _listenTask = Task.Run(() => ListenCoreAsync(PipeName, clientLoggingIdentifier, _cancellationTokenSource.Token));
+            return _listenTask;
         }
 
         /// <summary>
@@ -33,30 +100,22 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <see cref="NamedPipeServerStream"/> object.  Throws on any connection error.
         /// </summary>
         /// <param name="cancellationToken">Used to cancel the connection sequence.</param>
-        public async Task<IClientConnection> ListenAsync(CancellationToken cancellationToken)
+        private static async Task<IClientConnection> ListenCoreAsync(string pipeName, string clientLoggingIdentifier, CancellationToken cancellationToken)
         {
             // Create the pipe and begin waiting for a connection. This 
             // doesn't block, but could fail in certain circumstances, such
             // as Windows refusing to create the pipe for some reason 
             // (out of handles?), or the pipe was disconnected before we 
             // starting listening.
-            CompilerServerLogger.Log("Constructing pipe '{0}'.", _pipeName);
-            var pipeStream = NamedPipeUtil.CreateServer(_pipeName);
-            CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", _pipeName);
+            CompilerServerLogger.Log("Constructing pipe '{0}'.", pipeName);
+            var pipeStream = NamedPipeUtil.CreateServer(pipeName);
+            CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", pipeName);
 
             CompilerServerLogger.Log("Waiting for new connection");
             await pipeStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
             CompilerServerLogger.Log("Pipe connection detected.");
 
-            if (Environment.Is64BitProcess || MemoryHelper.IsMemoryAvailable())
-            {
-                CompilerServerLogger.Log("Memory available - accepting connection");
-                var clientLoggingIdentifier = $"Client{_clientLoggingIdentifier++}";
-                return new NamedPipeClientConnection(pipeStream, clientLoggingIdentifier);
-            }
-
-            pipeStream.Close();
-            throw new Exception("Insufficient resources to process new connection.");
+            return new NamedPipeClientConnection(pipeStream, clientLoggingIdentifier);
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Server/VBCSCompiler/ServerDispatcher.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             if (_gcTask?.IsCompleted == true)
             {
-                RunGargbageCollection();
+                RunGC();
             }
 
             HandleCompletedConnections();
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             _gcTask = null;
         }
 
-        private void RunGargbageCollection()
+        private void RunGC()
         {
             _gcTask = null;
             for (int i = 0; i < 10; i++)
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         private void MaybeCreateListenTask()
         {
-            if (_listenTask is null && _clientConnectionHost.IsListening)
+            if (_listenTask is null)
             {
                 _listenTask = _clientConnectionHost.GetNextClientConnectionAsync();
             }

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -50,14 +50,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 base.Dispose();
             }
 
-            public static async Task<bool> TryConnectToNamedPipe(string pipeName, int timeoutMs, CancellationToken cancellationToken)
-            {
-                using (var pipeStream = await BuildServerConnection.TryConnectToServerAsync(pipeName, timeoutMs, cancellationToken))
-                {
-                    return pipeStream != null;
-                }
-            }
-
             private BuildClient CreateClient(
                 RequestLanguage? language = null,
                 CompileFunc compileFunc = null,
@@ -143,15 +135,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             [Fact]
             public async Task ConnectToPipe()
             {
-                string pipeName = Guid.NewGuid().ToString("N");
+                string pipeName = ServerUtil.GetPipeName();
 
                 var oneSec = TimeSpan.FromSeconds(1);
 
-                Assert.False(await TryConnectToNamedPipe(pipeName, (int)oneSec.TotalMilliseconds, cancellationToken: default));
+                Assert.False(await TryConnectToNamedPipe((int)oneSec.TotalMilliseconds, cancellationToken: default));
 
                 // Try again with infinite timeout and cancel
                 var cts = new CancellationTokenSource();
-                var connection = TryConnectToNamedPipe(pipeName, Timeout.Infinite, cts.Token);
+                var connection = TryConnectToNamedPipe(Timeout.Infinite, cts.Token);
                 Assert.False(connection.IsCompleted);
                 cts.Cancel();
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -159,7 +151,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
                 // Create server and try again
                 Assert.True(TryCreateServer(pipeName));
-                Assert.True(await TryConnectToNamedPipe(pipeName, Timeout.Infinite, cancellationToken: default));
+                Assert.True(await TryConnectToNamedPipe(Timeout.Infinite, cancellationToken: default));
+
+                async Task<bool> TryConnectToNamedPipe(int timeoutMs, CancellationToken cancellationToken)
+                {
+                    using var pipeStream = await BuildServerConnection.TryConnectToServerAsync(pipeName, timeoutMs, cancellationToken);
+                    return pipeStream != null;
+                }
             }
 
             [ConditionalFact(typeof(DesktopOnly))]

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -159,8 +159,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
                 // Create server and try again
                 Assert.True(TryCreateServer(pipeName));
-                Assert.True(await TryConnectToNamedPipe(pipeName, (int)oneSec.TotalMilliseconds, cancellationToken: default));
-                // With infinite timeout
                 Assert.True(await TryConnectToNamedPipe(pipeName, Timeout.Infinite, cancellationToken: default));
             }
 

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -139,11 +139,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
                 var oneSec = TimeSpan.FromSeconds(1);
 
-                Assert.False(await TryConnectToNamedPipe((int)oneSec.TotalMilliseconds, cancellationToken: default));
+                Assert.False(await tryConnectToNamedPipe((int)oneSec.TotalMilliseconds, cancellationToken: default));
 
                 // Try again with infinite timeout and cancel
                 var cts = new CancellationTokenSource();
-                var connection = TryConnectToNamedPipe(Timeout.Infinite, cts.Token);
+                var connection = tryConnectToNamedPipe(Timeout.Infinite, cts.Token);
                 Assert.False(connection.IsCompleted);
                 cts.Cancel();
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -151,9 +151,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
                 // Create server and try again
                 Assert.True(TryCreateServer(pipeName));
-                Assert.True(await TryConnectToNamedPipe(Timeout.Infinite, cancellationToken: default));
+                Assert.True(await tryConnectToNamedPipe(Timeout.Infinite, cancellationToken: default));
 
-                async Task<bool> TryConnectToNamedPipe(int timeoutMs, CancellationToken cancellationToken)
+                async Task<bool> tryConnectToNamedPipe(int timeoutMs, CancellationToken cancellationToken)
                 {
                     using var pipeStream = await BuildServerConnection.TryConnectToServerAsync(pipeName, timeoutMs, cancellationToken);
                     return pipeStream != null;

--- a/src/Compilers/Server/VBCSCompilerTests/BuildServerControllerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildServerControllerTests.cs
@@ -8,8 +8,15 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
-    public sealed class BuildServerControllerTests
+    public sealed class BuildServerControllerTests : IDisposable
     {
+
+        public void Dispose()
+        {
+            HackUtil.DisposeAll();
+
+        }
+
         public sealed class GetKeepAliveTimeoutTests
         {
             private readonly NameValueCollection _appSettings = new NameValueCollection();

--- a/src/Compilers/Server/VBCSCompilerTests/BuildServerControllerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildServerControllerTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
         public void Dispose()
         {
-            HackUtil.DisposeAll();
+            NamedPipeTestUtil.DisposeAll();
 
         }
 

--- a/src/Compilers/Server/VBCSCompilerTests/ClientConnectionHandlerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ClientConnectionHandlerTests.cs
@@ -119,9 +119,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         [CombinatorialData]
         public async Task ShutdownRequest(bool allowCompilationRequests)
         {
+            var hitCompilation = false;
             var compilerServerHost = new TestableCompilerServerHost(delegate
             {
-                Assert.True(false);
+                hitCompilation = true;
                 throw new Exception("");
             });
 
@@ -141,6 +142,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Task.FromResult<IClientConnection>(clientConnection),
                 allowCompilationRequests: allowCompilationRequests).ConfigureAwait(false);
 
+            Assert.False(hitCompilation);
             Assert.Equal(new CompletionData(CompletionReason.RequestCompleted, shutdownRequested: true), completionData);
             Assert.True(response is ShutdownBuildResponse);
         }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -32,6 +32,12 @@ class Hello
     }
 }";
 
+        public override void Dispose()
+        {
+            base.Dispose();
+            HackUtil.DisposeAll();
+
+        }
         private static Task TaskFromException(Exception e)
         {
             return TaskFromException<bool>(e);
@@ -116,51 +122,49 @@ class Hello
         }
 
         [Fact]
-        public void MutexAcquiredWhenRunningServer()
+        public async Task MutexAcquiredWhenRunningServer()
         {
             var pipeName = Guid.NewGuid().ToString("N");
             var mutexName = BuildServerConnection.GetServerMutexName(pipeName);
-            var host = new Mock<IClientConnectionHost>(MockBehavior.Strict);
-            host.Setup(x => x.BeginListening());
-            host.Setup(x => x.EndListening());
-            host
-                .Setup(x => x.IsListening)
-                .Returns(true);
-            host
-                .Setup(x => x.GetNextClientConnectionAsync())
-                .Returns(() =>
+            var host = new TestableClientConnectionHost();
+            bool? wasServerMutexOpen = null;
+            host.Add(() =>
+            {
+                // Use a thread instead of Task to guarantee this code runs on a different
+                // thread and we can validate the mutex state. 
+                var tcs = new TaskCompletionSource<IClientConnection>();
+                var thread = new Thread(_ =>
                 {
-                    // Use a thread instead of Task to guarantee this code runs on a different
-                    // thread and we can validate the mutex state. 
-                    var source = new TaskCompletionSource<bool>();
-                    var thread = new Thread(_ =>
+                    wasServerMutexOpen = BuildServerConnection.WasServerMutexOpen(mutexName);
+
+                    var client = new TestableClientConnection()
                     {
-                        try
-                        {
-                            Assert.True(BuildServerConnection.WasServerMutexOpen(mutexName));
-                            source.SetResult(true);
-                        }
-                        catch (Exception ex)
-                        {
-                            source.SetException(ex);
-                            throw;
-                        }
-                    });
-
-                    // Synchronously wait here.  Don't returned a Task value because we need to 
-                    // ensure the above check completes before the server hits a timeout and 
-                    // releases the mutex. 
-                    thread.Start();
-                    source.Task.Wait();
-
-                    return new TaskCompletionSource<IClientConnection>().Task;
+                        ReadBuildRequestFunc = _ => Task.FromResult(ProtocolUtil.EmptyCSharpBuildRequest),
+                        WriteBuildResponseFunc = (r, _) => Task.CompletedTask,
+                    };
+                    tcs.SetResult(client);
                 });
+
+                thread.Start();
+                return tcs.Task;
+            });
+
+            host.Add(() =>
+            {
+                var client = new TestableClientConnection()
+                {
+                    ReadBuildRequestFunc = _ => Task.FromResult(BuildRequest.CreateShutdown()),
+                    WriteBuildResponseFunc = (r, _) => Task.CompletedTask,
+                };
+                return Task.FromResult<IClientConnection>(client);
+            });
 
             var result = BuildServerController.CreateAndRunServer(
                 pipeName,
-                clientConnectionHost: host.Object,
-                keepAlive: TimeSpan.FromSeconds(1));
+                clientConnectionHost: host,
+                keepAlive: TimeSpan.FromMilliseconds(-1));
             Assert.Equal(CommonCompiler.Succeeded, result);
+            Assert.True(wasServerMutexOpen);
         }
 
         [WorkItem(13995, "https://github.com/dotnet/roslyn/issues/13995")]
@@ -171,7 +175,9 @@ class Hello
             using var serverData = await ServerUtil.CreateServer().ConfigureAwait(false);
             var request = BuildRequest.Create(RequestLanguage.CSharpCompile, workingDirectory: temp.CreateDirectory().Path, tempDirectory: null, compilerHash: BuildProtocolConstants.GetCommitHash(), libDirectory: null, args: Array.Empty<string>());
             var response = await serverData.SendAsync(request).ConfigureAwait(false);
+            CompilerServerLogger.Log("here we are1");
             Assert.Equal(ResponseType.Rejected, response.Type);
+            CompilerServerLogger.Log("here we are2");
         }
 
         [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -32,12 +32,6 @@ class Hello
     }
 }";
 
-        public override void Dispose()
-        {
-            base.Dispose();
-            HackUtil.DisposeAll();
-
-        }
         private static Task TaskFromException(Exception e)
         {
             return TaskFromException<bool>(e);
@@ -175,9 +169,7 @@ class Hello
             using var serverData = await ServerUtil.CreateServer().ConfigureAwait(false);
             var request = BuildRequest.Create(RequestLanguage.CSharpCompile, workingDirectory: temp.CreateDirectory().Path, tempDirectory: null, compilerHash: BuildProtocolConstants.GetCommitHash(), libDirectory: null, args: Array.Empty<string>());
             var response = await serverData.SendAsync(request).ConfigureAwait(false);
-            CompilerServerLogger.Log("here we are1");
             Assert.Equal(ResponseType.Rejected, response.Type);
-            CompilerServerLogger.Log("here we are2");
         }
 
         [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -116,7 +116,7 @@ class Hello
         }
 
         [Fact]
-        public async Task MutexAcquiredWhenRunningServer()
+        public void MutexAcquiredWhenRunningServer()
         {
             var pipeName = Guid.NewGuid().ToString("N");
             var mutexName = BuildServerConnection.GetServerMutexName(pipeName);

--- a/src/Compilers/Server/VBCSCompilerTests/HackUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/HackUtil.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Reflection;
+using System.Net.Sockets;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
+{
+    /// <summary>
+    /// This is a HACK that allows you to get at the underlying Socket for a given NamedPipeServerStream 
+    /// instance. It is very useful it proactively diagnosing bugs in the server code by letting us inspect
+    /// the socket to see if it's disposed, not available, etc ... vs. experiencing flaky bugs that are 
+    /// incredibly difficult to track down.
+    ///
+    /// Do NOT check this into production, it's a unit test utility only
+    /// </summary>
+    internal static class HackUtil
+    {
+        private static IDictionary GetSharedServersDictionary()
+        {
+            var sharedServerFullName = typeof(NamedPipeServerStream).FullName + "+SharedServer";
+            var sharedServerType = typeof(NamedPipeServerStream).Assembly.GetType(sharedServerFullName);
+            var serversField = sharedServerType?.GetField("s_servers", BindingFlags.NonPublic | BindingFlags.Static);
+            var servers = (IDictionary?)serversField?.GetValue(null);
+            if (servers is null)
+            {
+                throw new Exception("Cannot locate the SharedServer dictionary");
+            }
+
+            return servers;
+        }
+
+        private static Socket GetSocket(object sharedServer)
+        {
+            var listeningSocketProperty = sharedServer!.GetType()?.GetProperty("ListeningSocket", BindingFlags.NonPublic | BindingFlags.Instance);
+            var socket = (Socket?)listeningSocketProperty?.GetValue(sharedServer, null);
+            if (socket is null)
+            {
+                throw new Exception("Socket is unexpectedly null");
+            }
+
+            return socket;
+        }
+
+        private static Socket? GetSocketForPipeName(string pipeName)
+        {
+            if (!ExecutionConditionUtil.IsUnix || !ExecutionConditionUtil.IsCoreClr)
+            {
+                return null;
+            }
+
+            pipeName = "/tmp/" + pipeName;
+            var servers = GetSharedServersDictionary();
+            lock (servers)
+            {
+                if (!servers.Contains(pipeName))
+                {
+                    return null;
+                }
+
+                var sharedServer = servers[pipeName];
+                Debug.Assert(sharedServer is object);
+                return GetSocket(sharedServer);
+            }
+        }
+
+        internal static void AssertPipeFullyClosed(string pipeName)
+        {
+            var socket = GetSocketForPipeName(pipeName);
+            Assert.Null(socket);
+        }
+
+        internal static void DisposeAll()
+        {
+            if (!ExecutionConditionUtil.IsUnix || !ExecutionConditionUtil.IsCoreClr)
+            {
+                return;
+            }
+
+            var list = new List<(string PipeName, Socket Socket)>();
+            var servers = GetSharedServersDictionary();
+
+            lock (servers)
+            {
+                var e = servers.GetEnumerator();
+                while (e.MoveNext())
+                {
+                    var sharedServer = e.Value!;
+                    var socket = GetSocket(sharedServer);
+                    socket.Dispose();
+                    list.Add(((string)e.Key!, socket));
+                }
+
+                servers.Clear();
+            }
+        }
+    }
+}

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CommandLine;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
+{
+    public class NamedPipeClientConnectionHostTests : IDisposable
+    {
+        private NamedPipeClientConnectionHost _host;
+
+        public NamedPipeClientConnectionHostTests()
+        {
+            _host = new NamedPipeClientConnectionHost(ServerUtil.GetPipeName());
+        }
+
+        public void Dispose()
+        {
+            if (_host.IsListening)
+            {
+                _host.EndListening();
+            }
+        }
+
+        private Task<NamedPipeClientStream> ConnectAsync(CancellationToken cancellationToken = default) => BuildServerConnection.TryConnectToServerAsync(
+            _host.PipeName,
+            timeoutMs: (int)(TimeSpan.FromMinutes(1).TotalMilliseconds),
+            cancellationToken);
+
+        public class GetNextClientConnectionAsyncTests : NamedPipeClientConnectionHostTests
+        {
+            /// <summary>
+            /// Not legal to call this until the previous task has completed.
+            /// </summary>
+            [Fact]
+            public async Task CallBeforePreviousComplete()
+            {
+                _host.BeginListening();
+                var task = _host.GetNextClientConnectionAsync();
+                await Assert.ThrowsAsync<InvalidOperationException>(() => _host.GetNextClientConnectionAsync()).ConfigureAwait(false);
+                _host.EndListening();
+            }
+
+            [Fact]
+            public async Task CallBeforeListen()
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(() => _host.GetNextClientConnectionAsync()).ConfigureAwait(false);
+            }
+
+            [Fact]
+            public async Task CallAfterComplete()
+            {
+                _host.BeginListening();
+                var task = _host.GetNextClientConnectionAsync();
+                using var clientStream = await ConnectAsync().ConfigureAwait(false);
+                await task.ConfigureAwait(false);
+                Assert.NotNull( _host.GetNextClientConnectionAsync());
+                _host.EndListening();
+            }
+
+            [Fact]
+            public void EndListenCancelsIncompleteTask()
+            {
+                _host.BeginListening();
+                var task = _host.GetNextClientConnectionAsync();
+                _host.EndListening();
+
+                Assert.ThrowsAsync<OperationCanceledException>(() => task).ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// It is the responsibility of the caller of <see cref="NamedPipeClientConnectionHost.GetNextClientConnectionAsync"/>
+            /// to dispose the returned client, not the hosts
+            /// </summary>
+            [Fact]
+            public async Task EndListenDoesNotDisposeCompletedConnection()
+            {
+                _host.BeginListening();
+                var task = _host.GetNextClientConnectionAsync();
+                using var clientStream = await ConnectAsync().ConfigureAwait(false);
+                using var namedPipeClientConnection = (NamedPipeClientConnection)(await task.ConfigureAwait(false));
+                _host.EndListening();
+                Assert.False(namedPipeClientConnection.IsDisposed);
+            }
+        }
+    }
+}

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     public class NamedPipeClientConnectionHostTests : IDisposable
     {
-        private NamedPipeClientConnectionHost _host;
+        private readonly NamedPipeClientConnectionHost _host;
 
         public NamedPipeClientConnectionHostTests()
         {
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 _host.EndListening();
             }
 
-            HackUtil.AssertPipeFullyClosed(_host.PipeName);
+            Assert.True(NamedPipeTestUtil.IsPipeFullyClosed(_host.PipeName));
         }
 
         private Task<NamedPipeClientStream> ConnectAsync(CancellationToken cancellationToken = default) => BuildServerConnection.TryConnectToServerAsync(

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var task = _host.GetNextClientConnectionAsync();
             using var clientStream = await ConnectAsync().ConfigureAwait(false);
             await task.ConfigureAwait(false);
-            Assert.NotNull( _host.GetNextClientConnectionAsync());
+            Assert.NotNull(_host.GetNextClientConnectionAsync());
             _host.EndListening();
         }
 
@@ -128,6 +128,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 var readCount = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                 Assert.Equal(0, readCount);
                 Assert.False(stream.IsConnected);
+            }
+        }
+
+        [Fact]
+        public async Task SupportsMultipleBeginEndCycles()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                _host.BeginListening();
+                using var client = await ConnectAsync().ConfigureAwait(false);
+                _host.EndListening();
             }
         }
     }

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             timeoutMs: (int)(TimeSpan.FromMinutes(1).TotalMilliseconds),
             cancellationToken);
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOrLinuxOnly), Reason = "https://github.com/dotnet/runtime/issues/40301")]
         public async Task CallBeforeListen()
         {
             await Assert.ThrowsAsync<InvalidOperationException>(() => _host.GetNextClientConnectionAsync()).ConfigureAwait(false);
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             _host.EndListening();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOrLinuxOnly), Reason = "https://github.com/dotnet/runtime/issues/40301")]
         public void EndListenCancelsIncompleteTask()
         {
             _host.BeginListening();

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeTestUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeTestUtil.cs
@@ -82,7 +82,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 return;
             }
 
-            var list = new List<(string PipeName, Socket Socket)>();
             var servers = GetSharedServersDictionary();
 
             lock (servers)
@@ -93,7 +92,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     var sharedServer = e.Value!;
                     var socket = GetSocket(sharedServer);
                     socket.Dispose();
-                    list.Add(((string)e.Key!, socket));
                 }
 
                 servers.Clear();

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeTestUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeTestUtil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,6 @@ using System.IO.Pipes;
 using System.Reflection;
 using System.Net.Sockets;
 using Roslyn.Test.Utilities;
-using Xunit;
 
 #nullable enable
 
@@ -24,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     ///
     /// Do NOT check this into production, it's a unit test utility only
     /// </summary>
-    internal static class HackUtil
+    internal static class NamedPipeTestUtil
     {
         private static IDictionary GetSharedServersDictionary()
         {
@@ -74,11 +73,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             }
         }
 
-        internal static void AssertPipeFullyClosed(string pipeName)
-        {
-            var socket = GetSocketForPipeName(pipeName);
-            Assert.Null(socket);
-        }
+        internal static bool IsPipeFullyClosed(string pipeName) => GetSocketForPipeName(pipeName) is null;
 
         internal static void DisposeAll()
         {

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -86,6 +86,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             }
 
             ServerTask.Wait();
+            HackUtil.AssertPipeFullyClosed(PipeName);
         }
     }
 

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             }
 
             ServerTask.Wait();
-            HackUtil.AssertPipeFullyClosed(PipeName);
+            Assert.True(NamedPipeTestUtil.IsPipeFullyClosed(PipeName));
         }
     }
 

--- a/src/Compilers/Server/VBCSCompilerTests/TestableClientConnectionHost.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TestableClientConnectionHost.cs
@@ -14,12 +14,24 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     {
         private TaskCompletionSource<IClientConnection> _listenTask;
 
+        public bool IsListening { get; set; }
+
         public TestableClientConnectionHost()
         {
             _listenTask = new TaskCompletionSource<IClientConnection>();
         }
 
-        public Task<IClientConnection> ListenAsync(CancellationToken cancellationToken) => _listenTask.Task;
+        public void BeginListening()
+        {
+            IsListening = true;
+        }
+
+        public void EndListening()
+        {
+            IsListening = false;
+        }
+
+        public Task<IClientConnection> GetNextClientConnectionAsync() => _listenTask.Task;
 
         public void Add(Action<TaskCompletionSource<IClientConnection>> action)
         {

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -14,8 +14,9 @@ using Xunit;
 using static Roslyn.Test.Utilities.SharedResourceHelpers;
 using System.Reflection;
 using Microsoft.CodeAnalysis.CompilerServer;
+using Microsoft.CodeAnalysis.CSharp;
 
-namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     public class TouchedFileLoggingTests : TestBase
     {

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 var hitCompilation = false;
                 var compilerServerHost = new TestableCompilerServerHost(delegate
-                { 
+                {
                     hitCompilation = true;
                     throw new Exception("");
                 });
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public async Task AnalyzerInconsistencyShouldShutdown()
             {
                 var compilerServerHost = new TestableCompilerServerHost(delegate
-                { 
+                {
                     return new AnalyzerInconsistencyBuildResponse();
                 });
 


### PR DESCRIPTION
Under load the compiler server was failing to accept client connections faster than the client connect timeout period (one second). This lead clients to abandon the server and shell out to csc / vbc directly. This is a net negative for customers, even when the compiler server is under extreme load, because the new csc / vbc processes and the compiler server will essentially be competing for the same CPU resources. Part of the benefit of the compiler server is to avoid this competition.

The most immediate cause of this problem is that the server only creates a single `NamedPipeServerStream` for accepting connections and there was a significant amount of processing that had to occur between accepting one connection and creating a new `NamedPipeServerStream` for accepting new connections. Particularly problematic is that the work required several thread transitions. Under normal processing that was fast enough but under load that was not. 

The solution here is essentially two fold:

1. The code between accepting a new connection and creating a new listen pipe is trivial and requires no thread transitions. 
1. The server now spins up multiple `NamedPipeServerStream` instances in parallel to ensure that we can accept connections even when a single thread gets stalled under load.

This change also tightens the tolerance level we have in our dogfood builds for failed connections to zero. This should help us catch regressions in this area in the future.

**Note**: This change is best read commit by commit. 
