### PR TITLE
Simplify code in rename responsible for handling changes in user options.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -32,8 +32,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             private const string AttributeSuffix = "Attribute";
 
-            private readonly object _gate = new object();
-
             private readonly Document _document;
             private readonly IEnumerable<IRefactorNotifyService> _refactorNotifyServices;
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -37,8 +37,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             private readonly Document _document;
             private readonly IEnumerable<IRefactorNotifyService> _refactorNotifyServices;
 
-            private Task<RenameLocations>? _underlyingFindRenameLocationsTask;
-
             /// <summary>
             /// Whether or not we shortened the trigger span (say because we were renaming an attribute,
             /// and we didn't select the 'Attribute' portion of the name).
@@ -190,45 +188,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return replacementText;
             }
 
-            public Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet? optionSet, CancellationToken cancellationToken)
+            public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet? optionSet, CancellationToken cancellationToken)
             {
-                Task<RenameLocations> renameTask;
-                lock (_gate)
-                {
-                    if (_underlyingFindRenameLocationsTask == null)
-                    {
-                        // If this is the first call, then just start finding the initial set of rename
-                        // locations.
-                        var solution = _document.Project.Solution;
-                        _underlyingFindRenameLocationsTask = Renamer.FindRenameLocationsAsync(
-                            solution, this.RenameSymbol, RenameOptionSet.From(solution, optionSet), cancellationToken);
-                        renameTask = _underlyingFindRenameLocationsTask;
+                var solution = _document.Project.Solution;
+                var locations = await Renamer.FindRenameLocationsAsync(
+                    solution, this.RenameSymbol, RenameOptionSet.From(solution, optionSet), cancellationToken).ConfigureAwait(false);
 
-                        // null out the option set.  We don't need it anymore, and this will ensure
-                        // we don't call FindWithUpdatedOptionsAsync below.
-                        optionSet = null;
-                    }
-                    else
-                    {
-                        // We already have a task to figure out the set of rename locations.  Let it
-                        // finish, then ask it to get the rename locations with the updated options.
-                        renameTask = _underlyingFindRenameLocationsTask;
-                    }
-                }
-
-                return GetLocationSetAsync(renameTask, optionSet, cancellationToken);
-            }
-
-            private async Task<IInlineRenameLocationSet> GetLocationSetAsync(Task<RenameLocations> renameTask, OptionSet? optionSet, CancellationToken cancellationToken)
-            {
-                var locationSet = await renameTask.ConfigureAwait(false);
-                if (optionSet != null)
-                {
-                    locationSet = await locationSet.FindWithUpdatedOptionsAsync(
-                        RenameOptionSet.From(_document.Project.Solution, optionSet), cancellationToken).ConfigureAwait(false);
-                }
-
-                return new InlineRenameLocationSet(this, locationSet);
+                return new InlineRenameLocationSet(this, locations);
             }
 
             public bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText)

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamer.cs
@@ -165,7 +165,6 @@ namespace Microsoft.CodeAnalysis.Rename
             {
                 Symbol = SerializableSymbolAndProjectId.Dehydrate(solution, Symbol, cancellationToken),
                 Options = SerializableRenameOptionSet.Dehydrate(Options),
-                OriginalSymbolResult = SerializableSearchResult.Dehydrate(solution, _originalSymbolResult, cancellationToken),
                 MergedResult = SerializableSearchResult.Dehydrate(solution, _mergedResult, cancellationToken),
             };
 
@@ -181,17 +180,12 @@ namespace Microsoft.CodeAnalysis.Rename
             if (symbol == null)
                 return null;
 
-            var originalSymbolResult = locations.OriginalSymbolResult == null
-                ? null
-                : await locations.OriginalSymbolResult.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
-
             Contract.ThrowIfNull(locations.MergedResult);
 
             return new RenameLocations(
                 symbol,
                 solution,
                 locations.Options.Rehydrate(),
-                originalSymbolResult,
                 await locations.MergedResult.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
         }
     }
@@ -200,7 +194,6 @@ namespace Microsoft.CodeAnalysis.Rename
     {
         public SerializableSymbolAndProjectId? Symbol;
         public SerializableRenameOptionSet Options;
-        public SerializableSearchResult? OriginalSymbolResult;
         public SerializableSearchResult? MergedResult;
     }
 

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamer.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Rename
             {
                 Symbol = SerializableSymbolAndProjectId.Dehydrate(solution, Symbol, cancellationToken),
                 Options = SerializableRenameOptionSet.Dehydrate(Options),
-                MergedResult = SerializableSearchResult.Dehydrate(solution, _mergedResult, cancellationToken),
+                Result = SerializableSearchResult.Dehydrate(solution, _result, cancellationToken),
             };
 
         internal static async Task<RenameLocations?> TryRehydrateAsync(Solution solution, SerializableRenameLocations locations, CancellationToken cancellationToken)
@@ -180,13 +180,13 @@ namespace Microsoft.CodeAnalysis.Rename
             if (symbol == null)
                 return null;
 
-            Contract.ThrowIfNull(locations.MergedResult);
+            Contract.ThrowIfNull(locations.Result);
 
             return new RenameLocations(
                 symbol,
                 solution,
                 locations.Options.Rehydrate(),
-                await locations.MergedResult.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
+                await locations.Result.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
         }
     }
 
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Rename
     {
         public SerializableSymbolAndProjectId? Symbol;
         public SerializableRenameOptionSet Options;
-        public SerializableSearchResult? MergedResult;
+        public SerializableSearchResult? Result;
     }
 
     internal class SerializableComplexifiedSpan

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -429,7 +429,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 return results;
             }
 
-            internal static async Task<(ImmutableArray<RenameLocation>, ImmutableArray<RenameLocation>)> GetRenamableLocationsInStringsAndCommentsAsync(
+            internal static async Task<(ImmutableArray<RenameLocation> strings, ImmutableArray<RenameLocation> comments)> GetRenamableLocationsInStringsAndCommentsAsync(
                 ISymbol originalSymbol,
                 Solution solution,
                 ISet<RenameLocation> renameLocations,

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -35,28 +35,18 @@ namespace Microsoft.CodeAnalysis.Rename
 
         private readonly SearchResult _mergedResult;
 
-        private readonly ImmutableArray<SearchResult> _overloadsResult;
-        private readonly ImmutableArray<RenameLocation> _stringsResult;
-        private readonly ImmutableArray<RenameLocation> _commentsResult;
-
         private RenameLocations(
             ISymbol symbol,
             Solution solution,
             RenameOptionSet options,
             SearchResult? originalSymbolResult,
-            SearchResult mergedResult,
-            ImmutableArray<SearchResult> overloadsResult,
-            ImmutableArray<RenameLocation> stringsResult,
-            ImmutableArray<RenameLocation> commentsResult)
+            SearchResult mergedResult)
         {
             Solution = solution;
             Symbol = symbol;
             Options = options;
             _originalSymbolResult = originalSymbolResult;
             _mergedResult = mergedResult;
-            _overloadsResult = overloadsResult;
-            _stringsResult = stringsResult;
-            _commentsResult = commentsResult;
         }
 
         internal static RenameLocations Create(
@@ -69,8 +59,7 @@ namespace Microsoft.CodeAnalysis.Rename
         {
             return new RenameLocations(
                 symbol, solution, options, originalSymbolResult: null,
-                new SearchResult(locations, implicitLocations, referencedSymbols),
-                overloadsResult: default, stringsResult: default, commentsResult: default);
+                new SearchResult(locations, implicitLocations, referencedSymbols));
         }
 
         private static RenameLocations Create(
@@ -108,8 +97,7 @@ namespace Microsoft.CodeAnalysis.Rename
 
             return new RenameLocations(
                 symbol, solution, options, originalSymbolResult,
-                new SearchResult(mergedLocations.ToImmutable(), mergedImplicitLocations.ToImmutable(), mergedReferencedSymbols.ToImmutable()),
-                overloadsResult, stringsResult, commentsResult);
+                new SearchResult(mergedLocations.ToImmutable(), mergedImplicitLocations.ToImmutable(), mergedReferencedSymbols.ToImmutable()));
         }
 
         public ISet<RenameLocation> Locations => _mergedResult.Locations;
@@ -207,8 +195,7 @@ namespace Microsoft.CodeAnalysis.Rename
 
                 return new RenameLocations(
                     symbol, solution, optionSet, originalSymbolResult,
-                    new SearchResult(mergedLocations.ToImmutable(), mergedImplicitLocations.ToImmutable(), mergedReferencedSymbols.ToImmutable()),
-                    overloadsResult, strings, comments);
+                    new SearchResult(mergedLocations.ToImmutable(), mergedImplicitLocations.ToImmutable(), mergedReferencedSymbols.ToImmutable()));
             }
         }
 

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -33,6 +33,10 @@ namespace Microsoft.CodeAnalysis.Rename
 
         private readonly SearchResult _mergedResult;
 
+        public ISet<RenameLocation> Locations => _mergedResult.Locations;
+        public ImmutableArray<ISymbol> ReferencedSymbols => _mergedResult.ReferencedSymbols;
+        public ImmutableArray<ReferenceLocation> ImplicitLocations => _mergedResult.ImplicitLocations;
+
         private RenameLocations(
             ISymbol symbol,
             Solution solution,
@@ -98,10 +102,6 @@ namespace Microsoft.CodeAnalysis.Rename
                     mergedImplicitLocations.ToImmutable(),
                     mergedReferencedSymbols.ToImmutable()));
         }
-
-        public ISet<RenameLocation> Locations => _mergedResult.Locations;
-        public ImmutableArray<ISymbol> ReferencedSymbols => _mergedResult.ReferencedSymbols;
-        public ImmutableArray<ReferenceLocation> ImplicitLocations => _mergedResult.ImplicitLocations;
 
         /// <summary>
         /// Find the locations that need to be renamed.

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -31,22 +31,22 @@ namespace Microsoft.CodeAnalysis.Rename
         public readonly ISymbol Symbol;
         public readonly RenameOptionSet Options;
 
-        private readonly SearchResult _mergedResult;
+        private readonly SearchResult _result;
 
-        public ISet<RenameLocation> Locations => _mergedResult.Locations;
-        public ImmutableArray<ISymbol> ReferencedSymbols => _mergedResult.ReferencedSymbols;
-        public ImmutableArray<ReferenceLocation> ImplicitLocations => _mergedResult.ImplicitLocations;
+        public ISet<RenameLocation> Locations => _result.Locations;
+        public ImmutableArray<ISymbol> ReferencedSymbols => _result.ReferencedSymbols;
+        public ImmutableArray<ReferenceLocation> ImplicitLocations => _result.ImplicitLocations;
 
         private RenameLocations(
             ISymbol symbol,
             Solution solution,
             RenameOptionSet options,
-            SearchResult mergedResult)
+            SearchResult result)
         {
             Solution = solution;
             Symbol = symbol;
             Options = options;
-            _mergedResult = mergedResult;
+            _result = result;
         }
 
         internal static RenameLocations Create(

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -31,21 +31,17 @@ namespace Microsoft.CodeAnalysis.Rename
         public readonly ISymbol Symbol;
         public readonly RenameOptionSet Options;
 
-        private readonly SearchResult? _originalSymbolResult;
-
         private readonly SearchResult _mergedResult;
 
         private RenameLocations(
             ISymbol symbol,
             Solution solution,
             RenameOptionSet options,
-            SearchResult? originalSymbolResult,
             SearchResult mergedResult)
         {
             Solution = solution;
             Symbol = symbol;
             Options = options;
-            _originalSymbolResult = originalSymbolResult;
             _mergedResult = mergedResult;
         }
 
@@ -58,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Rename
             RenameOptionSet options)
         {
             return new RenameLocations(
-                symbol, solution, options, originalSymbolResult: null,
+                symbol, solution, options,
                 new SearchResult(locations, implicitLocations, referencedSymbols));
         }
 
@@ -96,8 +92,11 @@ namespace Microsoft.CodeAnalysis.Rename
             }
 
             return new RenameLocations(
-                symbol, solution, options, originalSymbolResult,
-                new SearchResult(mergedLocations.ToImmutable(), mergedImplicitLocations.ToImmutable(), mergedReferencedSymbols.ToImmutable()));
+                symbol, solution, options,
+                new SearchResult(
+                    mergedLocations.ToImmutable(),
+                    mergedImplicitLocations.ToImmutable(),
+                    mergedReferencedSymbols.ToImmutable()));
         }
 
         public ISet<RenameLocation> Locations => _mergedResult.Locations;
@@ -194,8 +193,11 @@ namespace Microsoft.CodeAnalysis.Rename
                 }
 
                 return new RenameLocations(
-                    symbol, solution, optionSet, originalSymbolResult,
-                    new SearchResult(mergedLocations.ToImmutable(), mergedImplicitLocations.ToImmutable(), mergedReferencedSymbols.ToImmutable()));
+                    symbol, solution, optionSet,
+                    new SearchResult(
+                        mergedLocations.ToImmutable(),
+                        mergedImplicitLocations.ToImmutable(),
+                        mergedReferencedSymbols.ToImmutable()));
             }
         }
 


### PR DESCRIPTION
The existing code tries to aggressively use completed parts of previous computations.  This is relevant only in the case of:

1. the previous computations have completed.
2. teh user waits long enough for the results to be there.
3. the user then changes an option and again waits for it to complete.

In practice though, i could not perceive any benefit to these optimizations given that:

1. changing an option again causes recompute of the non-standard symbols.  
2. the expensive parts of the operation (FAR), have cached a lot of data, so just recomputing the full set (with the new options) is effectively extremely cheap
3. users are not going to be toggling those options many times during a rename.  They will effectively do the rename and just set the options they want.

On small projects none of this matters (since we're fast enough).  And on large projects this didn't seem to provide value.  So i'm removing the code as it helps simplify this part of the rename system (esp. wrt OOP).