### PR TITLE
Revert "Delete a workaround from InvisibleEditor.cs"

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _needsSave = needsSave;
 
             var invisibleEditorManager = (IIntPtrReturningVsInvisibleEditorManager)serviceProvider.GetService(typeof(SVsInvisibleEditorManager));
-            var vsProject = hierarchy as IVsProject;
+            var vsProject = TryGetProjectOfHierarchy(hierarchy);
             Marshal.ThrowExceptionForHR(invisibleEditorManager.RegisterInvisibleEditor(filePath, vsProject, 0, null, out var invisibleEditorPtr));
 
             try
@@ -86,6 +86,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // We need to clean up the extra reference we have, now that we have an RCW holding onto the object.
                 Marshal.Release(invisibleEditorPtr);
             }
+        }
+
+        private IVsProject? TryGetProjectOfHierarchy(IVsHierarchy? hierarchy)
+        {
+            // The invisible editor manager will fail in cases where the IVsProject passed to it is not consistent with
+            // the IVsProject known to IVsSolution (e.g. if the object is a wrapper like AbstractHostObject created by
+            // the CPS-based project system). This method returns an IVsProject instance known to the solution, or null
+            // if the project could not be determined.
+            if (hierarchy == null)
+            {
+                return null;
+            }
+
+            if (!ErrorHandler.Succeeded(hierarchy.GetGuidProperty(
+                (uint)VSConstants.VSITEMID.Root,
+                (int)__VSHPROPID.VSHPROPID_ProjectIDGuid,
+                out var projectId)))
+            {
+                return null;
+            }
+
+            var solution = (IVsSolution)_serviceProvider.GetService(typeof(SVsSolution));
+            if (!ErrorHandler.Succeeded(solution.GetProjectOfGuid(projectId, out var projectHierarchy)))
+            {
+                return null;
+            }
+
+            return projectHierarchy as IVsProject;
         }
 
         public IVsTextLines VsTextLines


### PR DESCRIPTION
Reverts dotnet/roslyn#46491

Turns out locking the GitHub branch so people can't merge isn't helpful when the person who didn't read the email has admin access. Like, say, me.