### PR TITLE
Update GetLeastOverriddenProperty/Event for overload resolution changes

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -168,8 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal EventSymbol GetLeastOverriddenEvent(NamedTypeSymbol? accessingTypeOpt)
         {
-            var accessingType = ((object?)accessingTypeOpt == null ? this.ContainingType : accessingTypeOpt).OriginalDefinition;
-
+            accessingTypeOpt = accessingTypeOpt?.OriginalDefinition;
             EventSymbol e = this;
             while (e.IsOverride && !e.HidesBaseEventsByName)
             {
@@ -195,7 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // See InternalsVisibleToAndStrongNameTests: IvtVirtualCall1, IvtVirtualCall2, IvtVirtual_ParamsAndDynamic.
                 EventSymbol? overridden = e.OverriddenEvent;
                 HashSet<DiagnosticInfo>? useSiteDiagnostics = null;
-                if ((object?)overridden == null || !AccessCheck.IsSymbolAccessible(overridden, accessingType, ref useSiteDiagnostics))
+                if ((object?)overridden == null ||
+                    (accessingTypeOpt is { } && !AccessCheck.IsSymbolAccessible(overridden, accessingTypeOpt, ref useSiteDiagnostics)))
                 {
                     break;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -253,8 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal PropertySymbol GetLeastOverriddenProperty(NamedTypeSymbol accessingTypeOpt)
         {
-            var accessingType = ((object)accessingTypeOpt == null ? this.ContainingType : accessingTypeOpt).OriginalDefinition;
-
+            accessingTypeOpt = accessingTypeOpt?.OriginalDefinition;
             PropertySymbol p = this;
             while (p.IsOverride && !p.HidesBasePropertiesByName)
             {
@@ -280,7 +279,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // See InternalsVisibleToAndStrongNameTests: IvtVirtualCall1, IvtVirtualCall2, IvtVirtual_ParamsAndDynamic.
                 PropertySymbol overridden = p.OverriddenProperty;
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                if ((object)overridden == null || !AccessCheck.IsSymbolAccessible(overridden, accessingType, ref useSiteDiagnostics))
+                if ((object)overridden == null ||
+                    (accessingTypeOpt is { } && !AccessCheck.IsSymbolAccessible(overridden, accessingTypeOpt, ref useSiteDiagnostics)))
                 {
                     break;
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -11274,8 +11274,6 @@ public static class Extensions
 {
     public virtual TValue F(TKey key) => throw null;
 }";
-            var ref0 = CreateCompilation(source0).EmitToImageReference();
-
             var source1 =
 @"public class A { }
 public class Derived<TValue> : Base<A, TValue>
@@ -11283,8 +11281,6 @@ public class Derived<TValue> : Base<A, TValue>
 {
     public override TValue F(A key) => throw null;
 }";
-            var ref1 = CreateCompilation(source1, references: new[] { ref0 }).EmitToImageReference();
-
             var source2 =
 @"class B { }
 class Program
@@ -11294,7 +11290,13 @@ class Program
         _ = d.F(a);
     }
 }";
-            var comp = CreateCompilation(source2, references: new[] { ref0, ref1 });
+
+            var comp = CreateCompilation(new[] { source0, source1, source2 });
+            comp.VerifyEmitDiagnostics();
+
+            var ref0 = CreateCompilation(source0).EmitToImageReference();
+            var ref1 = CreateCompilation(source1, references: new[] { ref0 }).EmitToImageReference();
+            comp = CreateCompilation(source2, references: new[] { ref0, ref1 });
             comp.VerifyEmitDiagnostics();
         }
 
@@ -11309,8 +11311,6 @@ class Program
 {
     public virtual TValue this[TKey key] => throw null;
 }";
-            var ref0 = CreateCompilation(source0).EmitToImageReference();
-
             var source1 =
 @"public class A { }
 public class Derived<TValue> : Base<A, TValue>
@@ -11318,8 +11318,6 @@ public class Derived<TValue> : Base<A, TValue>
 {
     public override TValue this[A key] => throw null;
 }";
-            var ref1 = CreateCompilation(source1, references: new[] { ref0 }).EmitToImageReference();
-
             var source2 =
 @"class B { }
 class Program
@@ -11329,7 +11327,13 @@ class Program
         _ = d[a];
     }
 }";
-            var comp = CreateCompilation(source2, references: new[] { ref0, ref1 });
+
+            var comp = CreateCompilation(new[] { source0, source1, source2 });
+            comp.VerifyEmitDiagnostics();
+
+            var ref0 = CreateCompilation(source0).EmitToImageReference();
+            var ref1 = CreateCompilation(source1, references: new[] { ref0 }).EmitToImageReference();
+            comp = CreateCompilation(source2, references: new[] { ref0, ref1 });
             comp.VerifyEmitDiagnostics();
         }
     }


### PR DESCRIPTION
Update `GetLeastOverriddenProperty()` and `GetLeastOverriddenEvent()` based on recent changes to overload resolution. (See [#46367](https://github.com/dotnet/roslyn/pull/46367/files#diff-7cf7f5a021b16f665e0df18828368ed7) for corresponding change to `GetLeastOverriddenMethod()`.)

Fixes #46549

Fix suggested by @gafter.