### PR TITLE
Introduce request context

### DIFF
--- a/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
@@ -43,7 +43,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var handler = (IRequestHandler<RequestType, ResponseType>?)_requestHandlers[methodName]?.Value;
             Contract.ThrowIfNull(handler, string.Format("Request handler not found for method {0}", methodName));
 
-            return handler.HandleRequestAsync(request, clientCapabilities, clientName, cancellationToken);
+            var context = CreateContext(clientCapabilities, clientName, cancellationToken);
+            return handler.HandleRequestAsync(request, context);
         }
+
+        private static RequestContext CreateContext(LSP.ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
+            => new RequestContext(clientCapabilities, clientName, cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
@@ -43,11 +43,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var handler = (IRequestHandler<RequestType, ResponseType>?)_requestHandlers[methodName]?.Value;
             Contract.ThrowIfNull(handler, string.Format("Request handler not found for method {0}", methodName));
 
-            var context = CreateContext(clientCapabilities, clientName, cancellationToken);
-            return handler.HandleRequestAsync(request, context);
+            var context = CreateContext(clientCapabilities, clientName);
+            return handler.HandleRequestAsync(request, context, cancellationToken);
         }
 
-        private static RequestContext CreateContext(LSP.ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
-            => new RequestContext(clientCapabilities, clientName, cancellationToken);
+        private static RequestContext CreateContext(LSP.ClientCapabilities clientCapabilities, string? clientName)
+            => new RequestContext(clientCapabilities, clientName);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/AbstractRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/AbstractRequestHandler.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -17,6 +18,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             SolutionProvider = solutionProvider;
         }
 
-        public abstract Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context);
+        public abstract Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/AbstractRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/AbstractRequestHandler.cs
@@ -4,9 +4,7 @@
 
 #nullable enable
 
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
@@ -19,6 +17,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             SolutionProvider = solutionProvider;
         }
 
-        public abstract Task<ResponseType> HandleRequestAsync(RequestType request, ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken);
+        public abstract Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _codeRefactoringService = codeRefactoringService;
         }
 
-        public override async Task<LSP.VSCodeAction> HandleRequestAsync(LSP.VSCodeAction codeAction, RequestContext context)
+        public override async Task<LSP.VSCodeAction> HandleRequestAsync(LSP.VSCodeAction codeAction, RequestContext context, CancellationToken cancellationToken)
         {
             var data = ((JToken)codeAction.Data).ToObject<CodeActionResolveData>();
             var document = SolutionProvider.GetDocument(data.TextDocument, context.ClientName);
@@ -60,13 +60,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 _codeFixService,
                 _codeRefactoringService,
                 data.Range,
-                context.CancellationToken).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             var codeActionToResolve = CodeActionHelpers.GetCodeActionToResolve(
                 data.UniqueIdentifier, codeActions.ToImmutableArray());
             Contract.ThrowIfNull(codeActionToResolve);
 
-            var operations = await codeActionToResolve.GetOperationsAsync(context.CancellationToken).ConfigureAwait(false);
+            var operations = await codeActionToResolve.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
             if (operations.IsEmpty)
             {
                 return codeAction;
@@ -117,19 +117,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     await AddTextDocumentEdits(
                         textDocumentEdits, applyChangesOperation, solution, changedDocuments,
                         applyChangesOperation.ChangedSolution.GetDocument, solution.GetDocument,
-                        context.CancellationToken).ConfigureAwait(false);
+                        cancellationToken).ConfigureAwait(false);
 
                     // Changed analyzer config documents
                     await AddTextDocumentEdits(
                         textDocumentEdits, applyChangesOperation, solution, changedAnalyzerConfigDocuments,
                         applyChangesOperation.ChangedSolution.GetAnalyzerConfigDocument, solution.GetAnalyzerConfigDocument,
-                        context.CancellationToken).ConfigureAwait(false);
+                        cancellationToken).ConfigureAwait(false);
 
                     // Changed additional documents
                     await AddTextDocumentEdits(
                         textDocumentEdits, applyChangesOperation, solution, changedAdditionalDocuments,
                         applyChangesOperation.ChangedSolution.GetAdditionalDocument, solution.GetAdditionalDocument,
-                        context.CancellationToken).ConfigureAwait(false);
+                        cancellationToken).ConfigureAwait(false);
                 }
 
                 codeAction.Edit = new LSP.WorkspaceEdit { DocumentChanges = textDocumentEdits.ToArray() };

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -8,8 +8,6 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -49,13 +47,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _codeRefactoringService = codeRefactoringService;
         }
 
-        public override async Task<LSP.VSCodeAction[]> HandleRequestAsync(
-            LSP.CodeActionParams request,
-            LSP.ClientCapabilities clientCapabilities,
-            string? clientName,
-            CancellationToken cancellationToken)
+        public override async Task<LSP.VSCodeAction[]> HandleRequestAsync(LSP.CodeActionParams request, RequestContext context)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, clientName);
+            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document == null)
             {
                 return Array.Empty<VSCodeAction>();
@@ -63,7 +57,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var (codeFixCollections, codeRefactorings) = await CodeActionHelpers.GetCodeFixesAndRefactoringsAsync(
                 document, _codeFixService, _codeRefactoringService,
-                request.Range, cancellationToken).ConfigureAwait(false);
+                request.Range, context.CancellationToken).ConfigureAwait(false);
 
             var codeFixes = codeFixCollections.SelectMany(c => c.Fixes);
             using var _ = ArrayBuilder<VSCodeAction>.GetInstance(out var results);

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -47,7 +48,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _codeRefactoringService = codeRefactoringService;
         }
 
-        public override async Task<LSP.VSCodeAction[]> HandleRequestAsync(LSP.CodeActionParams request, RequestContext context)
+        public override async Task<LSP.VSCodeAction[]> HandleRequestAsync(LSP.CodeActionParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document == null)
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var (codeFixCollections, codeRefactorings) = await CodeActionHelpers.GetCodeFixesAndRefactoringsAsync(
                 document, _codeFixService, _codeRefactoringService,
-                request.Range, context.CancellationToken).ConfigureAwait(false);
+                request.Range, cancellationToken).ConfigureAwait(false);
 
             var codeFixes = codeFixCollections.SelectMany(c => c.Fixes);
             using var _ = ArrayBuilder<VSCodeAction>.GetInstance(out var results);

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/RunCodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/RunCodeActionsHandler.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -50,29 +49,26 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _threadingContext = threadingContext;
         }
 
-        public async Task<object> HandleRequestAsync(
-            LSP.ExecuteCommandParams request,
-            LSP.ClientCapabilities clientCapabilities,
-            CancellationToken cancellationToken)
+        public async Task<object> HandleRequestAsync(LSP.ExecuteCommandParams request, RequestContext context)
         {
             var runRequest = ((JToken)request.Arguments.Single()).ToObject<CodeActionResolveData>();
             var document = _solutionProvider.GetDocument(runRequest.TextDocument);
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
-                document, _codeFixService, _codeRefactoringService, runRequest.Range, cancellationToken).ConfigureAwait(false);
+                document, _codeFixService, _codeRefactoringService, runRequest.Range, context.CancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(codeActions);
 
             var actionToRun = CodeActionHelpers.GetCodeActionToResolve(runRequest.UniqueIdentifier, codeActions.ToImmutableArray());
             Contract.ThrowIfNull(actionToRun);
 
-            var operations = await actionToRun.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
+            var operations = await actionToRun.GetOperationsAsync(context.CancellationToken).ConfigureAwait(false);
 
             // TODO - This UI thread dependency should be removed.
             // https://github.com/dotnet/roslyn/projects/45#card-20619668
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(context.CancellationToken);
 
             foreach (var operation in operations)
             {
-                operation.Apply(document.Project.Solution.Workspace, cancellationToken);
+                operation.Apply(document.Project.Solution.Workspace, context.CancellationToken);
             }
 
             return true;

--- a/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// Handles an <see cref="LSP.Methods.WorkspaceExecuteCommand"/>
         /// by delegating to a handler for the specific command requested.
         /// </summary>
-        public Task<object> HandleRequestAsync(LSP.ExecuteCommandParams request, RequestContext context)
+        public Task<object> HandleRequestAsync(LSP.ExecuteCommandParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var commandName = request.Command;
             if (string.IsNullOrEmpty(commandName) || !_executeCommandHandlers.TryGetValue(commandName, out var executeCommandHandler))
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 throw new ArgumentException(string.Format("Command name ({0}) is invalid", commandName));
             }
 
-            return executeCommandHandler.Value.HandleRequestAsync(request, context);
+            return executeCommandHandler.Value.HandleRequestAsync(request, context, cancellationToken);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
@@ -43,8 +42,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// Handles an <see cref="LSP.Methods.WorkspaceExecuteCommand"/>
         /// by delegating to a handler for the specific command requested.
         /// </summary>
-        public Task<object> HandleRequestAsync(LSP.ExecuteCommandParams request, LSP.ClientCapabilities clientCapabilities, string? clientName,
-            CancellationToken cancellationToken)
+        public Task<object> HandleRequestAsync(LSP.ExecuteCommandParams request, RequestContext context)
         {
             var commandName = request.Command;
             if (string.IsNullOrEmpty(commandName) || !_executeCommandHandlers.TryGetValue(commandName, out var executeCommandHandler))
@@ -52,7 +50,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 throw new ArgumentException(string.Format("Command name ({0}) is invalid", commandName));
             }
 
-            return executeCommandHandler.Value.HandleRequestAsync(request, clientCapabilities, cancellationToken);
+            return executeCommandHandler.Value.HandleRequestAsync(request, context);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Commands/IExecuteWorkspaceCommandHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Commands/IExecuteWorkspaceCommandHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -12,6 +13,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Commands
         /// <summary>
         /// Handles a specific command from a <see cref="Methods.WorkspaceExecuteCommandName"/> request.
         /// </summary>
-        Task<object> HandleRequestAsync(ExecuteCommandParams request, RequestContext context);
+        Task<object> HandleRequestAsync(ExecuteCommandParams request, RequestContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Commands/IExecuteWorkspaceCommandHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Commands/IExecuteWorkspaceCommandHandler.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -13,6 +12,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Commands
         /// <summary>
         /// Handles a specific command from a <see cref="Methods.WorkspaceExecuteCommandName"/> request.
         /// </summary>
-        Task<object> HandleRequestAsync(ExecuteCommandParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken);
+        Task<object> HandleRequestAsync(ExecuteCommandParams request, RequestContext context);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<LSP.CompletionItem[]> HandleRequestAsync(LSP.CompletionParams request, RequestContext context)
+        public override async Task<LSP.CompletionItem[]> HandleRequestAsync(LSP.CompletionParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document == null)
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return Array.Empty<LSP.CompletionItem>();
             }
 
-            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), context.CancellationToken).ConfigureAwait(false);
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
 
             // Filter out snippets as they are not supported in the LSP client
             // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1139740
@@ -49,14 +50,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // 2.  We need to figure out how to provide the text edits along with the completion item or provide them in the resolve request.
             //     https://devdiv.visualstudio.com/DevDiv/_workitems/edit/985860/
             // 3.  LSP client should support completion filters / expanders
-            var documentOptions = await document.GetOptionsAsync(context.CancellationToken).ConfigureAwait(false);
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var completionOptions = documentOptions
                 .WithChangedOption(CompletionOptions.SnippetsBehavior, SnippetsRule.NeverInclude)
                 .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, false)
                 .WithChangedOption(CompletionServiceOptions.IsExpandedCompletion, false);
 
             var completionService = document.Project.LanguageServices.GetRequiredService<CompletionService>();
-            var list = await completionService.GetCompletionsAsync(document, position, options: completionOptions, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+            var list = await completionService.GetCompletionsAsync(document, position, options: completionOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (list == null)
             {
                 return Array.Empty<LSP.CompletionItem>();

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -30,7 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, RequestContext context)
+        public override async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, RequestContext context, CancellationToken cancellationToken)
         {
             CompletionResolveData data;
             if (completionItem.Data is CompletionResolveData)
@@ -48,10 +49,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return completionItem;
             }
 
-            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), context.CancellationToken).ConfigureAwait(false);
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), cancellationToken).ConfigureAwait(false);
 
             var completionService = document.Project.LanguageServices.GetRequiredService<CompletionService>();
-            var list = await completionService.GetCompletionsAsync(document, position, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+            var list = await completionService.GetCompletionsAsync(document, position, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (list == null)
             {
                 return completionItem;
@@ -63,7 +64,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return completionItem;
             }
 
-            var description = await completionService.GetDescriptionAsync(document, selectedItem, context.CancellationToken).ConfigureAwait(false);
+            var description = await completionService.GetDescriptionAsync(document, selectedItem, cancellationToken).ConfigureAwait(false);
 
             var lspVSClientCapability = context.ClientCapabilities?.HasVisualStudioLspCapability() == true;
             LSP.CompletionItem resolvedCompletionItem;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -31,8 +30,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, LSP.ClientCapabilities clientCapabilities,
-            string? clientName, CancellationToken cancellationToken)
+        public override async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, RequestContext context)
         {
             CompletionResolveData data;
             if (completionItem.Data is CompletionResolveData)
@@ -44,16 +42,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 data = ((JToken)completionItem.Data).ToObject<CompletionResolveData>();
             }
 
-            var document = SolutionProvider.GetDocument(data.TextDocument, clientName);
+            var document = SolutionProvider.GetDocument(data.TextDocument, context.ClientName);
             if (document == null)
             {
                 return completionItem;
             }
 
-            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), cancellationToken).ConfigureAwait(false);
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), context.CancellationToken).ConfigureAwait(false);
 
             var completionService = document.Project.LanguageServices.GetRequiredService<CompletionService>();
-            var list = await completionService.GetCompletionsAsync(document, position, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var list = await completionService.GetCompletionsAsync(document, position, cancellationToken: context.CancellationToken).ConfigureAwait(false);
             if (list == null)
             {
                 return completionItem;
@@ -65,9 +63,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return completionItem;
             }
 
-            var description = await completionService.GetDescriptionAsync(document, selectedItem, cancellationToken).ConfigureAwait(false);
+            var description = await completionService.GetDescriptionAsync(document, selectedItem, context.CancellationToken).ConfigureAwait(false);
 
-            var lspVSClientCapability = clientCapabilities?.HasVisualStudioLspCapability() == true;
+            var lspVSClientCapability = context.ClientCapabilities?.HasVisualStudioLspCapability() == true;
             LSP.CompletionItem resolvedCompletionItem;
             if (lspVSClientCapability)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MetadataAsSource;
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context)
-            => GetDefinitionAsync(request, typeOnly: false, context);
+        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
+            => GetDefinitionAsync(request, typeOnly: false, context, cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MetadataAsSource;
@@ -25,8 +24,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, LSP.ClientCapabilities clientCapabilities,
-            string? clientName, CancellationToken cancellationToken)
-            => GetDefinitionAsync(request, typeOnly: false, clientName, cancellationToken: cancellationToken);
+        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context)
+            => GetDefinitionAsync(request, typeOnly: false, context);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
@@ -1,12 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MetadataAsSource;
@@ -25,8 +23,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, LSP.ClientCapabilities clientCapabilities,
-            string? clientName, CancellationToken cancellationToken)
-            => GetDefinitionAsync(request, typeOnly: true, clientName, cancellationToken: cancellationToken);
+        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context)
+            => GetDefinitionAsync(request, typeOnly: true, context);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
@@ -1,10 +1,12 @@
-﻿// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MetadataAsSource;
@@ -23,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context)
-            => GetDefinitionAsync(request, typeOnly: true, context);
+        public override Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
+            => GetDefinitionAsync(request, typeOnly: true, context, cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -25,12 +24,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, ClientCapabilities clientCapabilities,
-            string? clientName, CancellationToken cancellationToken)
+        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context)
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
-            var document = SolutionProvider.GetDocument(request.TextDocument, clientName);
+            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document == null)
             {
                 return foldingRanges.ToArrayAndFree();
@@ -42,13 +40,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var blockStructure = await blockStructureService.GetBlockStructureAsync(document, cancellationToken).ConfigureAwait(false);
+            var blockStructure = await blockStructureService.GetBlockStructureAsync(document, context.CancellationToken).ConfigureAwait(false);
             if (blockStructure == null)
             {
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
 
             foreach (var span in blockStructure.Spans)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context)
+        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
@@ -40,13 +41,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var blockStructure = await blockStructureService.GetBlockStructureAsync(document, context.CancellationToken).ConfigureAwait(false);
+            var blockStructure = await blockStructureService.GetBlockStructureAsync(document, cancellationToken).ConfigureAwait(false);
             if (blockStructure == null)
             {
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var span in blockStructure.Spans)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(LSP.TextDocumentIdentifier documentIdentifier, RequestContext context, LSP.Range? range = null)
+        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(LSP.TextDocumentIdentifier documentIdentifier, RequestContext context, CancellationToken cancellationToken, LSP.Range? range = null)
         {
             var edits = new ArrayBuilder<LSP.TextEdit>();
             var document = SolutionProvider.GetDocument(documentIdentifier, context.ClientName);
@@ -29,14 +29,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (document != null)
             {
                 var formattingService = document.Project.LanguageServices.GetRequiredService<IEditorFormattingService>();
-                var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 TextSpan? textSpan = null;
                 if (range != null)
                 {
                     textSpan = ProtocolConversions.RangeToTextSpan(range, text);
                 }
 
-                var textChanges = await GetFormattingChangesAsync(formattingService, document, textSpan, context.CancellationToken).ConfigureAwait(false);
+                var textChanges = await GetFormattingChangesAsync(formattingService, document, textSpan, cancellationToken).ConfigureAwait(false);
                 edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));
             }
 

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -21,22 +21,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(LSP.TextDocumentIdentifier documentIdentifier, string? clientName, CancellationToken cancellationToken, LSP.Range? range = null)
+        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(LSP.TextDocumentIdentifier documentIdentifier, RequestContext context, LSP.Range? range = null)
         {
             var edits = new ArrayBuilder<LSP.TextEdit>();
-            var document = SolutionProvider.GetDocument(documentIdentifier, clientName);
+            var document = SolutionProvider.GetDocument(documentIdentifier, context.ClientName);
 
             if (document != null)
             {
                 var formattingService = document.Project.LanguageServices.GetRequiredService<IEditorFormattingService>();
-                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
                 TextSpan? textSpan = null;
                 if (range != null)
                 {
                     textSpan = ProtocolConversions.RangeToTextSpan(range, text);
                 }
 
-                var textChanges = await GetFormattingChangesAsync(formattingService, document, textSpan, cancellationToken).ConfigureAwait(false);
+                var textChanges = await GetFormattingChangesAsync(formattingService, document, textSpan, context.CancellationToken).ConfigureAwait(false);
                 edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));
             }
 

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -23,8 +22,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.TextEdit[]> HandleRequestAsync(LSP.DocumentFormattingParams request, LSP.ClientCapabilities clientCapabilities, string? clientName,
-            CancellationToken cancellationToken)
-            => GetTextEditsAsync(request.TextDocument, clientName, cancellationToken);
+        public override Task<LSP.TextEdit[]> HandleRequestAsync(LSP.DocumentFormattingParams request, RequestContext context)
+            => GetTextEditsAsync(request.TextDocument, context);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.TextEdit[]> HandleRequestAsync(LSP.DocumentFormattingParams request, RequestContext context)
-            => GetTextEditsAsync(request.TextDocument, context);
+        public override Task<LSP.TextEdit[]> HandleRequestAsync(LSP.DocumentFormattingParams request, RequestContext context, CancellationToken cancellationToken)
+            => GetTextEditsAsync(request.TextDocument, context, cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -29,14 +29,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, RequestContext context)
+        public override async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var edits = new ArrayBuilder<TextEdit>();
             var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document != null)
             {
                 var formattingService = document.Project.LanguageServices.GetRequiredService<IEditorFormattingService>();
-                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), context.CancellationToken).ConfigureAwait(false);
+                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
 
                 if (string.IsNullOrEmpty(request.Character))
                 {
@@ -46,14 +46,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 IList<TextChange>? textChanges;
                 if (SyntaxFacts.IsNewLine(request.Character[0]))
                 {
-                    textChanges = await GetFormattingChangesOnReturnAsync(formattingService, document, position, context.CancellationToken).ConfigureAwait(false);
+                    textChanges = await GetFormattingChangesOnReturnAsync(formattingService, document, position, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    textChanges = await GetFormattingChangesAsync(formattingService, document, request.Character[0], position, context.CancellationToken).ConfigureAwait(false);
+                    textChanges = await GetFormattingChangesAsync(formattingService, document, request.Character[0], position, cancellationToken).ConfigureAwait(false);
                 }
 
-                var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 if (textChanges != null)
                 {
                     edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -29,15 +29,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, ClientCapabilities? clientCapabilities, string? clientName,
-            CancellationToken cancellationToken)
+        public override async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, RequestContext context)
         {
             var edits = new ArrayBuilder<TextEdit>();
-            var document = SolutionProvider.GetDocument(request.TextDocument, clientName);
+            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document != null)
             {
                 var formattingService = document.Project.LanguageServices.GetRequiredService<IEditorFormattingService>();
-                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), context.CancellationToken).ConfigureAwait(false);
 
                 if (string.IsNullOrEmpty(request.Character))
                 {
@@ -47,14 +46,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 IList<TextChange>? textChanges;
                 if (SyntaxFacts.IsNewLine(request.Character[0]))
                 {
-                    textChanges = await GetFormattingChangesOnReturnAsync(formattingService, document, position, cancellationToken).ConfigureAwait(false);
+                    textChanges = await GetFormattingChangesOnReturnAsync(formattingService, document, position, context.CancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    textChanges = await GetFormattingChangesAsync(formattingService, document, request.Character[0], position, cancellationToken).ConfigureAwait(false);
+                    textChanges = await GetFormattingChangesAsync(formattingService, document, request.Character[0], position, context.CancellationToken).ConfigureAwait(false);
                 }
 
-                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
                 if (textChanges != null)
                 {
                     edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -23,8 +22,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<TextEdit[]> HandleRequestAsync(DocumentRangeFormattingParams request, ClientCapabilities clientCapabilities, string? clientName,
-            CancellationToken cancellationToken)
-            => GetTextEditsAsync(request.TextDocument, clientName, cancellationToken, range: request.Range);
+        public override Task<TextEdit[]> HandleRequestAsync(DocumentRangeFormattingParams request, RequestContext context)
+            => GetTextEditsAsync(request.TextDocument, context, range: request.Range);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<TextEdit[]> HandleRequestAsync(DocumentRangeFormattingParams request, RequestContext context)
-            => GetTextEditsAsync(request.TextDocument, context, range: request.Range);
+        public override Task<TextEdit[]> HandleRequestAsync(DocumentRangeFormattingParams request, RequestContext context, CancellationToken cancellationToken)
+            => GetTextEditsAsync(request.TextDocument, context, cancellationToken, range: request.Range);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -21,7 +22,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// Handles an LSP request.
         /// </summary>
         /// <param name="context">The LSP request context.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the request processing.</param>
         /// <returns>The LSP response.</returns>
-        Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context);
+        Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
@@ -4,9 +4,7 @@
 
 #nullable enable
 
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
@@ -22,11 +20,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <summary>
         /// Handles an LSP request.
         /// </summary>
-        /// <param name="request">the lsp request.</param>
-        /// <param name="clientCapabilities">the client capabilities for the request.</param>
-        /// <param name="clientName">the lsp client making the request.</param>
-        /// <param name="cancellationToken">a cancellation token.</param>
-        /// <returns>the LSP response.</returns>
-        Task<ResponseType> HandleRequestAsync(RequestType request, ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken);
+        /// <param name="context">The LSP request context.</param>
+        /// <returns>The LSP response.</returns>
+        Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 .ToImmutableArray();
         }
 
-        public Task<LSP.InitializeResult> HandleRequestAsync(LSP.InitializeParams request, RequestContext context)
+        public Task<LSP.InitializeResult> HandleRequestAsync(LSP.InitializeParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var triggerCharacters = _completionProviders.SelectMany(lz => GetTriggerCharacters(lz.Value)).Distinct().Select(c => c.ToString()).ToArray();
 

--- a/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
@@ -34,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 .ToImmutableArray();
         }
 
-        public Task<LSP.InitializeResult> HandleRequestAsync(LSP.InitializeParams request, LSP.ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
+        public Task<LSP.InitializeResult> HandleRequestAsync(LSP.InitializeParams request, RequestContext context)
         {
             var triggerCharacters = _completionProviders.SelectMany(lz => GetTriggerCharacters(lz.Value)).Distinct().Select(c => c.ToString()).ToArray();
 

--- a/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -26,15 +25,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<LSP.DocumentOnAutoInsertResponseItem[]> HandleRequestAsync(LSP.DocumentOnAutoInsertParams request, LSP.ClientCapabilities clientCapabilities, string? clientName,
-            CancellationToken cancellationToken)
-            => OnAutoInsertAsync(request, clientName, cancellationToken);
-
-        private async Task<LSP.DocumentOnAutoInsertResponseItem[]> OnAutoInsertAsync(LSP.DocumentOnAutoInsertParams autoInsertParams, string? clientName, CancellationToken cancellationToken)
+        public override async Task<LSP.DocumentOnAutoInsertResponseItem[]> HandleRequestAsync(LSP.DocumentOnAutoInsertParams autoInsertParams, RequestContext context)
         {
             using var _ = ArrayBuilder<LSP.DocumentOnAutoInsertResponseItem>.GetInstance(out var response);
 
-            var document = SolutionProvider.GetDocument(autoInsertParams.TextDocument, clientName);
+            var document = SolutionProvider.GetDocument(autoInsertParams.TextDocument, context.ClientName);
 
             if (document == null)
             {
@@ -49,16 +44,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return response.ToArray();
             }
 
-            var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxTree = await document.GetRequiredSyntaxTreeAsync(context.CancellationToken).ConfigureAwait(false);
+            var sourceText = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+            var options = await document.GetOptionsAsync(context.CancellationToken).ConfigureAwait(false);
 
             var linePosition = ProtocolConversions.PositionToLinePosition(autoInsertParams.Position);
             var position = sourceText.Lines.GetPosition(linePosition);
 
             var result = autoInsertParams.Character == "\n"
-                ? service.GetDocumentationCommentSnippetOnEnterTyped(syntaxTree, sourceText, position, options, cancellationToken)
-                : service.GetDocumentationCommentSnippetOnCharacterTyped(syntaxTree, sourceText, position, options, cancellationToken);
+                ? service.GetDocumentationCommentSnippetOnEnterTyped(syntaxTree, sourceText, position, options, context.CancellationToken)
+                : service.GetDocumentationCommentSnippetOnCharacterTyped(syntaxTree, sourceText, position, options, context.CancellationToken);
 
             if (result == null)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override Task<ActiveProjectContexts?> HandleRequestAsync(GetTextDocumentWithContextParams request, RequestContext context)
+        public override Task<ActiveProjectContexts?> HandleRequestAsync(GetTextDocumentWithContextParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var documents = SolutionProvider.GetDocuments(request.TextDocument.Uri, context.ClientName);
 

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Composition;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -30,7 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _metadataAsSourceFileService = metadataAsSourceFileService;
         }
 
-        public override async Task<LSP.VSReferenceItem[]> HandleRequestAsync(ReferenceParams referenceParams, RequestContext context)
+        public override async Task<LSP.VSReferenceItem[]> HandleRequestAsync(ReferenceParams referenceParams, RequestContext context, CancellationToken cancellationToken)
         {
             Debug.Assert(context.ClientCapabilities.HasVisualStudioLspCapability());
 
@@ -42,10 +43,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var findUsagesService = document.GetRequiredLanguageService<IFindUsagesLSPService>();
             var position = await document.GetPositionFromLinePositionAsync(
-                ProtocolConversions.PositionToLinePosition(referenceParams.Position), context.CancellationToken).ConfigureAwait(false);
+                ProtocolConversions.PositionToLinePosition(referenceParams.Position), cancellationToken).ConfigureAwait(false);
 
             var findUsagesContext = new FindUsagesLSPContext(
-                referenceParams.PartialResultToken, document, position, _metadataAsSourceFileService, context.CancellationToken);
+                referenceParams.PartialResultToken, document, position, _metadataAsSourceFileService, cancellationToken);
 
             // Finds the references for the symbol at the specific position in the document, reporting them via streaming to the LSP client.
             await findUsagesService.FindReferencesAsync(document, position, findUsagesContext).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<WorkspaceEdit?> HandleRequestAsync(RenameParams request, RequestContext context)
+        public override async Task<WorkspaceEdit?> HandleRequestAsync(RenameParams request, RequestContext context, CancellationToken cancellationToken)
         {
             WorkspaceEdit? workspaceEdit = null;
             var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
@@ -35,23 +36,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             {
                 var oldSolution = document.Project.Solution;
                 var renameService = document.Project.LanguageServices.GetRequiredService<IEditorInlineRenameService>();
-                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), context.CancellationToken).ConfigureAwait(false);
+                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
 
-                var renameInfo = await renameService.GetRenameInfoAsync(document, position, context.CancellationToken).ConfigureAwait(false);
+                var renameInfo = await renameService.GetRenameInfoAsync(document, position, cancellationToken).ConfigureAwait(false);
                 if (!renameInfo.CanRename)
                 {
                     return workspaceEdit;
                 }
 
-                var renameLocationSet = await renameInfo.FindRenameLocationsAsync(oldSolution.Workspace.Options, context.CancellationToken).ConfigureAwait(false);
-                var renameReplacementInfo = await renameLocationSet.GetReplacementsAsync(request.NewName, oldSolution.Workspace.Options, context.CancellationToken).ConfigureAwait(false);
+                var renameLocationSet = await renameInfo.FindRenameLocationsAsync(oldSolution.Workspace.Options, cancellationToken).ConfigureAwait(false);
+                var renameReplacementInfo = await renameLocationSet.GetReplacementsAsync(request.NewName, oldSolution.Workspace.Options, cancellationToken).ConfigureAwait(false);
 
                 var renamedSolution = renameReplacementInfo.NewSolution;
                 var solutionChanges = renamedSolution.GetChanges(oldSolution);
 
                 // Linked files can correspond to multiple roslyn documents each with changes.  Merge the changes in the linked files so that all linked documents have the same text.
                 // Then we can just take the text changes from the first document to avoid returning duplicate edits.
-                renamedSolution = await renamedSolution.WithMergedLinkedFileChangesAsync(oldSolution, solutionChanges, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+                renamedSolution = await renamedSolution.WithMergedLinkedFileChangesAsync(oldSolution, solutionChanges, cancellationToken: cancellationToken).ConfigureAwait(false);
                 solutionChanges = renamedSolution.GetChanges(oldSolution);
                 var changedDocuments = solutionChanges
                     .GetProjectChanges()
@@ -64,8 +65,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     var oldDoc = oldSolution.GetRequiredDocument(docId);
                     var newDoc = renamedSolution.GetRequiredDocument(docId);
 
-                    var textChanges = await newDoc.GetTextChangesAsync(oldDoc, context.CancellationToken).ConfigureAwait(false);
-                    var oldText = await oldDoc.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+                    var textChanges = await newDoc.GetTextChangesAsync(oldDoc, cancellationToken).ConfigureAwait(false);
+                    var oldText = await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(false);
                     var textDocumentEdit = new TextDocumentEdit
                     {
                         TextDocument = new VersionedTextDocumentIdentifier { Uri = newDoc.GetURI() },

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// <summary>
     /// Context for requests handled by <see cref="IRequestHandler"/>
     /// </summary>
-    internal struct RequestContext
+    internal readonly struct RequestContext
     {
         /// <summary>
         /// The client capabilities for the request.

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -24,16 +24,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// </summary>
         public string? ClientName { get; }
 
-        /// <summary>
-        /// A cancellation token
-        /// </summary>
-        public CancellationToken CancellationToken { get; }
-
-        public RequestContext(ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
+        public RequestContext(ClientCapabilities clientCapabilities, string? clientName)
         {
             ClientCapabilities = clientCapabilities;
             ClientName = clientName;
-            CancellationToken = cancellationToken;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+    /// <summary>
+    /// Context for requests handled by <see cref="IRequestHandler"/>
+    /// </summary>
+    internal struct RequestContext
+    {
+        /// <summary>
+        /// The client capabilities for the request.
+        /// </summary>
+        public ClientCapabilities ClientCapabilities { get; }
+
+        /// <summary>
+        /// The LSP client making the request
+        /// </summary>
+        public string? ClientName { get; }
+
+        /// <summary>
+        /// A cancellation token
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+
+        public RequestContext(ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
+        {
+            ClientCapabilities = clientCapabilities;
+            ClientName = clientName;
+            CancellationToken = cancellationToken;
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<object[]> HandleRequestAsync(DocumentSymbolParams request, RequestContext context)
+        public override async Task<object[]> HandleRequestAsync(DocumentSymbolParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
             if (document == null)
@@ -40,15 +40,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var symbols = ArrayBuilder<object>.GetInstance();
 
             var navBarService = document.Project.LanguageServices.GetRequiredService<INavigationBarItemService>();
-            var navBarItems = await navBarService.GetItemsAsync(document, context.CancellationToken).ConfigureAwait(false);
+            var navBarItems = await navBarService.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
             if (navBarItems.Count == 0)
             {
                 return symbols.ToArrayAndFree();
             }
 
-            var compilation = await document.Project.GetCompilationAsync(context.CancellationToken).ConfigureAwait(false);
-            var tree = await document.GetSyntaxTreeAsync(context.CancellationToken).ConfigureAwait(false);
-            var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // TODO - Return more than 2 levels of symbols.
             // https://github.com/dotnet/roslyn/projects/45#card-20033869
@@ -57,18 +57,18 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 foreach (var item in navBarItems)
                 {
                     // only top level ones
-                    symbols.Add(await GetDocumentSymbolAsync(item, compilation, tree, text, context.CancellationToken).ConfigureAwait(false));
+                    symbols.Add(await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false));
                 }
             }
             else
             {
                 foreach (var item in navBarItems)
                 {
-                    symbols.Add(GetSymbolInformation(item, compilation, tree, document, text, context.CancellationToken, containerName: null));
+                    symbols.Add(GetSymbolInformation(item, compilation, tree, document, text, cancellationToken, containerName: null));
 
                     foreach (var childItem in item.ChildItems)
                     {
-                        symbols.Add(GetSymbolInformation(childItem, compilation, tree, document, text, context.CancellationToken, item.Text));
+                        symbols.Add(GetSymbolInformation(childItem, compilation, tree, document, text, cancellationToken, item.Text));
                     }
                 }
             }

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -26,10 +26,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<SymbolInformation[]> HandleRequestAsync(WorkspaceSymbolParams request, RequestContext context)
+        public override async Task<SymbolInformation[]> HandleRequestAsync(WorkspaceSymbolParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var solution = SolutionProvider.GetCurrentSolutionForMainWorkspace();
-            var searchTasks = Task.WhenAll(solution.Projects.Select(project => SearchProjectAsync(project, request, context.CancellationToken)));
+            var searchTasks = Task.WhenAll(solution.Projects.Select(project => SearchProjectAsync(project, request, cancellationToken)));
             return (await searchTasks.ConfigureAwait(false)).SelectMany(s => s).ToArray();
 
             // local functions

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -26,11 +26,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        public override async Task<SymbolInformation[]> HandleRequestAsync(WorkspaceSymbolParams request, ClientCapabilities clientCapabilities,
-            string? clientName, CancellationToken cancellationToken)
+        public override async Task<SymbolInformation[]> HandleRequestAsync(WorkspaceSymbolParams request, RequestContext context)
         {
             var solution = SolutionProvider.GetCurrentSolutionForMainWorkspace();
-            var searchTasks = Task.WhenAll(solution.Projects.Select(project => SearchProjectAsync(project, request, cancellationToken)));
+            var searchTasks = Task.WhenAll(solution.Projects.Select(project => SearchProjectAsync(project, request, context.CancellationToken)));
             return (await searchTasks.ConfigureAwait(false)).SelectMany(s => s).ToArray();
 
             // local functions

--- a/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
@@ -28,6 +28,7 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
+using LSP = Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
@@ -62,7 +63,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // However, this works through liveshare on the LSP client, but not the LSP extension.
             // see https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1107682 for tracking.
             var request = ((JObject)input).ToObject<CompletionParams>(s_jsonSerializer);
-            return base.HandleRequestAsync(request, requestContext.GetClientCapabilities(), null, cancellationToken);
+            var context = new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken);
+            return base.HandleRequestAsync(request, context);
         }
     }
 
@@ -76,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<LanguageServer.Protocol.CompletionItem> HandleAsync(LanguageServer.Protocol.CompletionItem param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDocumentHighlightName)]
@@ -89,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<DocumentHighlight[]> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDocumentSymbolName)]
@@ -110,7 +112,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 clientCapabilities.TextDocument.DocumentSymbol.HierarchicalDocumentSymbolSupport = false;
             }
 
-            var response = await base.HandleRequestAsync(param, clientCapabilities, null, cancellationToken).ConfigureAwait(false);
+            var context = new LSP.RequestContext(clientCapabilities, null, cancellationToken);
+            var response = await base.HandleRequestAsync(param, context).ConfigureAwait(false);
 
             // Since hierarchicalSupport will never be true, it is safe to cast the response to SymbolInformation[]
             return response.Cast<SymbolInformation>().ToArray();
@@ -128,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<TextEdit[]> HandleAsync(DocumentFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
 
         protected override async Task<IList<TextChange>> GetFormattingChangesAsync(IEditorFormattingService formattingService, Document document, TextSpan? textSpan, CancellationToken cancellationToken)
         {
@@ -149,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<TextEdit[]> HandleAsync(DocumentRangeFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
 
         protected override async Task<IList<TextChange>> GetFormattingChangesAsync(IEditorFormattingService formattingService, Document document, TextSpan? textSpan, CancellationToken cancellationToken)
         {
@@ -170,7 +173,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<TextEdit[]> HandleAsync(DocumentOnTypeFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, requestContext?.ClientCapabilities?.ToObject<ClientCapabilities>(), null, cancellationToken);
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
 
         protected override async Task<IList<TextChange>?> GetFormattingChangesAsync(IEditorFormattingService formattingService, Document document, char typedChar, int position, CancellationToken cancellationToken)
         {
@@ -198,7 +201,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<LanguageServer.Protocol.Location[]> HandleAsync(TextDocumentPositionParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
 
         protected override async Task FindImplementationsAsync(IFindUsagesService findUsagesService, Document document, int position, SimpleFindUsagesContext context)
         {
@@ -220,7 +223,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public async Task<InitializeResult> HandleAsync(InitializeParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var initializeResult = await base.HandleRequestAsync(param, requestContext.GetClientCapabilities(), null, cancellationToken).ConfigureAwait(false);
+            var context = new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken);
+            var initializeResult = await base.HandleRequestAsync(param, context).ConfigureAwait(false);
             initializeResult.Capabilities.Experimental = new RoslynExperimentalCapabilities { SyntacticLspProvider = true };
             return initializeResult;
         }
@@ -237,7 +241,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<SignatureHelp> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentRenameName)]
@@ -250,7 +254,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<WorkspaceEdit?> HandleAsync(RenameParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.WorkspaceSymbolName)]
@@ -264,6 +268,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         [JsonRpcMethod(UseSingleObjectParameterDeserialization = true)]
         public Task<SymbolInformation[]> HandleAsync(WorkspaceSymbolParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, requestContext.GetClientCapabilities(), null, cancellationToken);
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
@@ -63,8 +63,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // However, this works through liveshare on the LSP client, but not the LSP extension.
             // see https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1107682 for tracking.
             var request = ((JObject)input).ToObject<CompletionParams>(s_jsonSerializer);
-            var context = new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken);
-            return base.HandleRequestAsync(request, context);
+            var context = new LSP.RequestContext(requestContext.GetClientCapabilities(), null);
+            return base.HandleRequestAsync(request, context, cancellationToken);
         }
     }
 
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<LanguageServer.Protocol.CompletionItem> HandleAsync(LanguageServer.Protocol.CompletionItem param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDocumentHighlightName)]
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<DocumentHighlight[]> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDocumentSymbolName)]
@@ -112,8 +112,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 clientCapabilities.TextDocument.DocumentSymbol.HierarchicalDocumentSymbolSupport = false;
             }
 
-            var context = new LSP.RequestContext(clientCapabilities, null, cancellationToken);
-            var response = await base.HandleRequestAsync(param, context).ConfigureAwait(false);
+            var context = new LSP.RequestContext(clientCapabilities, null);
+            var response = await base.HandleRequestAsync(param, context, cancellationToken).ConfigureAwait(false);
 
             // Since hierarchicalSupport will never be true, it is safe to cast the response to SymbolInformation[]
             return response.Cast<SymbolInformation>().ToArray();
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<TextEdit[]> HandleAsync(DocumentFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
 
         protected override async Task<IList<TextChange>> GetFormattingChangesAsync(IEditorFormattingService formattingService, Document document, TextSpan? textSpan, CancellationToken cancellationToken)
         {
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<TextEdit[]> HandleAsync(DocumentRangeFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
 
         protected override async Task<IList<TextChange>> GetFormattingChangesAsync(IEditorFormattingService formattingService, Document document, TextSpan? textSpan, CancellationToken cancellationToken)
         {
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<TextEdit[]> HandleAsync(DocumentOnTypeFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
 
         protected override async Task<IList<TextChange>?> GetFormattingChangesAsync(IEditorFormattingService formattingService, Document document, char typedChar, int position, CancellationToken cancellationToken)
         {
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             => _threadingContext = threadingContext;
 
         public Task<LanguageServer.Protocol.Location[]> HandleAsync(TextDocumentPositionParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
 
         protected override async Task FindImplementationsAsync(IFindUsagesService findUsagesService, Document document, int position, SimpleFindUsagesContext context)
         {
@@ -223,8 +223,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public async Task<InitializeResult> HandleAsync(InitializeParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var context = new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken);
-            var initializeResult = await base.HandleRequestAsync(param, context).ConfigureAwait(false);
+            var context = new LSP.RequestContext(requestContext.GetClientCapabilities(), null);
+            var initializeResult = await base.HandleRequestAsync(param, context, cancellationToken).ConfigureAwait(false);
             initializeResult.Capabilities.Experimental = new RoslynExperimentalCapabilities { SyntacticLspProvider = true };
             return initializeResult;
         }
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<SignatureHelp> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentRenameName)]
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
 
         public Task<WorkspaceEdit?> HandleAsync(RenameParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(param, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.WorkspaceSymbolName)]
@@ -268,6 +268,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         [JsonRpcMethod(UseSingleObjectParameterDeserialization = true)]
         public Task<SymbolInformation[]> HandleAsync(WorkspaceSymbolParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null, cancellationToken));
+            => base.HandleRequestAsync(request, new LSP.RequestContext(requestContext.GetClientCapabilities(), null), cancellationToken);
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Xaml;
@@ -30,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public override async Task<CompletionItem[]> HandleRequestAsync(CompletionParams request, RequestContext context)
+        public override async Task<CompletionItem[]> HandleRequestAsync(CompletionParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = SolutionProvider.GetTextDocument(request.TextDocument, context.ClientName);
             if (document == null)
@@ -39,8 +40,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
             }
 
             var completionService = document.Project.LanguageServices.GetRequiredService<IXamlCompletionService>();
-            var offset = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), context.CancellationToken).ConfigureAwait(false);
-            var completions = await completionService.GetCompletionsAsync(document, offset, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+            var offset = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+            var completions = await completionService.GetCompletionsAsync(document, offset, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (completions == null)
             {
                 return Array.Empty<CompletionItem>();

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
@@ -6,7 +6,6 @@ using System;
 using System.Composition;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Xaml;
@@ -31,17 +30,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public override async Task<CompletionItem[]> HandleRequestAsync(CompletionParams request, ClientCapabilities clientCapabilities, string clientName, CancellationToken cancellationToken)
+        public override async Task<CompletionItem[]> HandleRequestAsync(CompletionParams request, RequestContext context)
         {
-            var document = SolutionProvider.GetTextDocument(request.TextDocument, clientName);
+            var document = SolutionProvider.GetTextDocument(request.TextDocument, context.ClientName);
             if (document == null)
             {
                 return CreateErrorItem($"Cannot find document in solution!", request.TextDocument.Uri.ToString());
             }
 
             var completionService = document.Project.LanguageServices.GetRequiredService<IXamlCompletionService>();
-            var offset = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
-            var completions = await completionService.GetCompletionsAsync(document, offset, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var offset = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), context.CancellationToken).ConfigureAwait(false);
+            var completions = await completionService.GetCompletionsAsync(document, offset, cancellationToken: context.CancellationToken).ConfigureAwait(false);
             if (completions == null)
             {
                 return Array.Empty<CompletionItem>();

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Xaml;
@@ -34,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public override async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, RequestContext context)
+        public override async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, RequestContext context, CancellationToken cancellationToken)
         {
             if (!(completionItem.Data is CompletionResolveData data))
             {
@@ -48,15 +49,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 return completionItem;
             }
 
-            int offset = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), context.CancellationToken).ConfigureAwait(false);
+            int offset = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), cancellationToken).ConfigureAwait(false);
             var completionService = document.Project.LanguageServices.GetRequiredService<IXamlCompletionService>();
-            var symbol = await completionService.GetSymbolAsync(document, offset, completionItem.Label, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+            var symbol = await completionService.GetSymbolAsync(document, offset, completionItem.Label, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (symbol == null)
             {
                 return completionItem;
             }
 
-            var description = await symbol.GetDescriptionAsync(document, offset, context.CancellationToken).ConfigureAwait(false);
+            var description = await symbol.GetDescriptionAsync(document, offset, cancellationToken).ConfigureAwait(false);
 
             var vsCompletionItem = CloneVSCompletionItem(completionItem);
             vsCompletionItem.Description = new ClassifiedTextElement(description.Select(tp => new ClassifiedTextRun(tp.Tag.ToClassificationTypeName(), tp.Text)));

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -28,12 +27,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, ClientCapabilities clientCapabilities,
-            string? clientName, CancellationToken cancellationToken)
+        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context)
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
-            var document = SolutionProvider.GetTextDocument(request.TextDocument, clientName);
+            var document = SolutionProvider.GetTextDocument(request.TextDocument, context.ClientName);
             if (document == null)
             {
                 return foldingRanges.ToArrayAndFree();
@@ -45,13 +43,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var structureTags = await xamlStructureService.GetStructureTagsAsync(document, cancellationToken).ConfigureAwait(false);
+            var structureTags = await xamlStructureService.GetStructureTagsAsync(document, context.CancellationToken).ConfigureAwait(false);
             if (structureTags == null)
             {
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
 
             foreach (var structureTag in structureTags)
             {

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -27,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context)
+        public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
@@ -43,13 +44,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var structureTags = await xamlStructureService.GetStructureTagsAsync(document, context.CancellationToken).ConfigureAwait(false);
+            var structureTags = await xamlStructureService.GetStructureTagsAsync(document, cancellationToken).ConfigureAwait(false);
             if (structureTags == null)
             {
                 return foldingRanges.ToArrayAndFree();
             }
 
-            var text = await document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var structureTag in structureTags)
             {

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Initialize/InitializeHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Initialize/InitializeHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public Task<InitializeResult> HandleRequestAsync(InitializeParams request, RequestContext context)
+        public Task<InitializeResult> HandleRequestAsync(InitializeParams request, RequestContext context, CancellationToken cancellationToken)
         {
 
             return Task.FromResult(new InitializeResult

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Initialize/InitializeHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Initialize/InitializeHandler.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
-        public Task<InitializeResult> HandleRequestAsync(InitializeParams request, ClientCapabilities clientCapabilities, string? clientName, CancellationToken cancellationToken)
+        public Task<InitializeResult> HandleRequestAsync(InitializeParams request, RequestContext context)
         {
 
             return Task.FromResult(new InitializeResult


### PR DESCRIPTION
There are already 3 parameters for every LSP request (plus the generic request parameter), and in #46051 I'm planning on adding a couple of new ones, so separating things out to a context object first will make that change easier. I imagine the `RequestContext` will also be a good thing to base some extension methods on to further simplify the handlers in future.

I deliberately avoided doing any cleanup to make the review easier.

Merging this in to master so there is less chance of conflicts when things are merged to the feature branch.