### PR TITLE
Move null check above where the variable is used

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -1814,7 +1814,6 @@ class A
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
-
         [WorkItem(46423, "https://github.com/dotnet/roslyn/issues/46423")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DoNotCrashWhenTypeCantBeDetermined()

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -1814,6 +1814,36 @@ class A
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
+
+        [WorkItem(46423, "https://github.com/dotnet/roslyn/issues/46423")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DoNotCrashWhenTypeCantBeDetermined()
+        {
+            var source =
+@"
+class Other
+{
+    public short GetScopeIdForTelemetry(FixAllScope scope)
+        => (short)(scope switch
+        {
+            FixAllScope.Document => 1,
+            FixAllScope.Project => 2,
+            FixAllScope.Solution => 3,
+            _ => 4,
+        });
+
+    public enum FixAllScope
+    {
+        Document,
+        Project,
+        Solution,
+        Other
+    }
+}";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
         [WorkItem(545777, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545777")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DoNotRemoveImportantTrailingTrivia()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -339,14 +339,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             // The type in `(Type)...` or `... as Type`
             var castType = semanticModel.GetTypeInfo(castNode, cancellationToken).Type;
 
+            // If we don't understand the type, we must keep it.
+            if (castType == null)
+                return true;
+
             // The type in `(...)expr` or `expr as ...`
             var castedExpressionType = semanticModel.GetTypeInfo(castedExpressionNode, cancellationToken).Type;
 
             var conversion = semanticModel.ClassifyConversion(castNode.SpanStart, castedExpressionNode, castType, isExplicitInSource: true);
-
-            // If we don't understand the type, we must keep it.
-            if (castType == null)
-                return true;
 
             // If we've got an error for some reason, then we don't want to touch this at all.
             if (castType.IsErrorType())


### PR DESCRIPTION
Fixes #46423

ClassifyConversion validates the parameter is not null.