### PR TITLE
Handle conditional binding without ancestor conditional access

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8455,7 +8455,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression GetReceiverForConditionalBinding(ExpressionSyntax binding, DiagnosticBag diagnostics)
         {
             var conditionalAccessNode = SyntaxFactory.FindConditionalAccessNodeForBinding(binding);
-            Debug.Assert(conditionalAccessNode != null);
+            if (conditionalAccessNode == null)
+            {
+                return BadExpression(binding);
+            }
 
             BoundExpression receiver = this.ConditionalReceiverExpression;
             if (receiver?.Syntax != GetConditionalReceiverSyntax(conditionalAccessNode))

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2235,10 +2235,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // In a well formed tree, the corresponding access node should be one of the ancestors
             // and its "?" token should precede the binding syntax.
-            while (currentNode != null)
+            while (true)
             {
                 currentNode = currentNode.Parent;
-                Debug.Assert(currentNode != null, "binding should be enclosed in a conditional access");
+
+                if (currentNode == null)
+                {
+                    return null;
+                }
 
                 if (currentNode.Kind() == SyntaxKind.ConditionalAccessExpression)
                 {
@@ -2249,8 +2253,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
-
-            return null;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -6003,5 +6003,29 @@ class B<T, U, U>
             symbol = model.GetDeclaredSymbol(typeParameters[typeParameters.Length - 2]);
             Assert.True(symbol.IsReferenceType);
         }
+
+        [Fact]
+        [WorkItem(25262, "https://github.com/dotnet/roslyn/issues/25262")]
+        public void IncompleteInvocationSpeculativeSymbolInfo()
+        {
+            var source = @"
+class Foo
+{
+    void Bar(string s)
+    {
+        s?.ToString();
+    }
+}";
+
+            var comp = CreateCompilation(source);
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            var newInvocation = invocation.WithoutTrivia();
+
+            var symbolInfo = model.GetSpeculativeSymbolInfo(invocation.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression);
+            Assert.True(symbolInfo.IsEmpty);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/25262.

I *think* this should also fix the issue reported by @mavasani and @sharwell in https://github.com/dotnet/roslyn/issues/25262#issuecomment-566755712, though I don't how to reproduce it with `GetSymbolInfo` (instead of `GetSpeculativeSymbolInfo`).