### PR TITLE
Fix couple of issues related to SerializableOptionSet which were leading to checkum validation asserts

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -278,7 +278,8 @@ class Test { }");
 
             solution = WithChangedOptionsFromRemoteWorkspace(solution);
 
-            Assert.NotEqual(
+            // No serializable remote options affect options checksum, so the checksums should match.
+            Assert.Equal(
                 await solution.State.GetChecksumAsync(CancellationToken.None),
                 await RemoteWorkspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None));
 

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -212,8 +212,8 @@ namespace Microsoft.CodeAnalysis.Options
         {
             var serializableOptionKeys = GetRegisteredSerializableOptions(languages);
             var serializableOptionValues = GetSerializableOptionValues(serializableOptionKeys, languages);
-            var changedOptionsKeys = _changedOptionKeys.Where(key => serializableOptionKeys.Contains(key.Option)).ToImmutableHashSet();
-            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues, changedOptionsKeys);
+            var changedOptionsKeysSerializable = _changedOptionKeys.Where(key => serializableOptionKeys.Contains(key.Option)).ToImmutableHashSet();
+            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues, changedOptionsKeysSerializable);
         }
 
         private ImmutableDictionary<OptionKey, object?> GetSerializableOptionValues(ImmutableHashSet<IOption> optionKeys, ImmutableHashSet<string> languages)

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -8,12 +8,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options.Providers;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -210,10 +212,13 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         public SerializableOptionSet GetSerializableOptionsSnapshot(ImmutableHashSet<string> languages, IOptionService optionService)
         {
-            var serializableOptionKeys = GetRegisteredSerializableOptions(languages);
-            var serializableOptionValues = GetSerializableOptionValues(serializableOptionKeys, languages);
-            var changedOptionsKeysSerializable = _changedOptionKeys.Where(key => serializableOptionKeys.Contains(key.Option)).ToImmutableHashSet();
-            return new SerializableOptionSet(languages, optionService, serializableOptionKeys, serializableOptionValues, changedOptionsKeysSerializable);
+            Debug.Assert(languages.All(RemoteSupportedLanguages.IsSupported));
+            var serializableOptions = GetRegisteredSerializableOptions(languages);
+            var serializableOptionValues = GetSerializableOptionValues(serializableOptions, languages);
+            var changedOptionsKeysSerializable = _changedOptionKeys
+                .Where(key => serializableOptions.Contains(key.Option) && (!key.Option.IsPerLanguage || languages.Contains(key.Language!)))
+                .ToImmutableHashSet();
+            return new SerializableOptionSet(languages, optionService, serializableOptions, serializableOptionValues, changedOptionsKeysSerializable);
         }
 
         private ImmutableDictionary<OptionKey, object?> GetSerializableOptionValues(ImmutableHashSet<IOption> optionKeys, ImmutableHashSet<string> languages)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -8,8 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
-using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -89,8 +89,19 @@ namespace Microsoft.CodeAnalysis
                 PublicContract.ToBoxedImmutableArrayWithDistinctNonNullItems(analyzerReferences, nameof(analyzerReferences)));
         }
 
-        internal ImmutableHashSet<string> GetProjectLanguages()
-            => Projects.Select(p => p.Language).ToImmutableHashSet();
+        internal ImmutableHashSet<string> GetRemoteSupportedProjectLanguages()
+        {
+            var builder = ImmutableHashSet.CreateBuilder<string>();
+            foreach (var project in Projects)
+            {
+                if (RemoteSupportedLanguages.IsSupported(project.Language))
+                {
+                    builder.Add(project.Language);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
 
         internal SolutionInfo WithTelemetryId(Guid telemetryId)
             => new SolutionInfo(Attributes.With(telemetryId: telemetryId), Projects, AnalyzerReferences);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Logging;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -213,7 +214,7 @@ namespace Microsoft.CodeAnalysis
             solutionAttributes ??= _solutionAttributes;
             projectIds ??= ProjectIds;
             idToProjectStateMap ??= _projectIdToProjectStateMap;
-            options ??= Options.WithLanguages(GetProjectLanguages(idToProjectStateMap));
+            options ??= Options.WithLanguages(GetRemoteSupportedProjectLanguages(idToProjectStateMap));
             analyzerReferences ??= AnalyzerReferences;
             projectIdToTrackerMap ??= _projectIdToTrackerMap;
             filePathToDocumentIdsMap ??= _filePathToDocumentIdsMap;
@@ -1934,10 +1935,21 @@ namespace Microsoft.CodeAnalysis
         internal bool ContainsTransitiveReference(ProjectId fromProjectId, ProjectId toProjectId)
             => _dependencyGraph.GetProjectsThatThisProjectTransitivelyDependsOn(fromProjectId).Contains(toProjectId);
 
-        internal ImmutableHashSet<string> GetProjectLanguages()
-            => GetProjectLanguages(ProjectStates);
+        internal ImmutableHashSet<string> GetRemoteSupportedProjectLanguages()
+            => GetRemoteSupportedProjectLanguages(ProjectStates);
 
-        private static ImmutableHashSet<string> GetProjectLanguages(ImmutableDictionary<ProjectId, ProjectState> projectStates)
-            => projectStates.Select(p => p.Value.Language).ToImmutableHashSet();
+        private static ImmutableHashSet<string> GetRemoteSupportedProjectLanguages(ImmutableDictionary<ProjectId, ProjectState> projectStates)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<string>();
+            foreach (var projectState in projectStates)
+            {
+                if (RemoteSupportedLanguages.IsSupported(projectState.Value.Language))
+                {
+                    builder.Add(projectState.Value.Language);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis
 
             var emptyOptions = new SerializableOptionSet(languages: ImmutableHashSet<string>.Empty, _optionService,
                 serializableOptions: ImmutableHashSet<IOption>.Empty, values: ImmutableDictionary<OptionKey, object?>.Empty,
-                changedOptionKeys: ImmutableHashSet<OptionKey>.Empty);
+                changedOptionKeysSerializable: ImmutableHashSet<OptionKey>.Empty);
 
             _latestSolution = CreateSolution(info, emptyOptions, analyzerReferences: SpecializedCollections.EmptyReadOnlyList<AnalyzerReference>());
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected internal Solution CreateSolution(SolutionInfo solutionInfo)
         {
-            var options = _optionService.GetSerializableOptionsSnapshot(solutionInfo.GetProjectLanguages());
+            var options = _optionService.GetSerializableOptionsSnapshot(solutionInfo.GetRemoteSupportedProjectLanguages());
             return CreateSolution(solutionInfo, options, solutionInfo.AnalyzerReferences);
         }
 
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis
 
         internal void UpdateCurrentSolutionOnOptionsChanged()
         {
-            var newOptions = _optionService.GetSerializableOptionsSnapshot(this.CurrentSolution.State.GetProjectLanguages());
+            var newOptions = _optionService.GetSerializableOptionsSnapshot(this.CurrentSolution.State.GetRemoteSupportedProjectLanguages());
             this.SetCurrentSolution(this.CurrentSolution.WithOptions(newOptions));
         }
 

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task MetadataReference_RoundTrip_Test()
         {
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var reference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
 
             var serializer = workspace.Services.GetService<ISerializerService>();
@@ -358,13 +358,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task OptionSet_Serialization()
         {
-            await VerifyOptionSetsAsync(_ => { }).ConfigureAwait(false);
+            using var workspace = new AdhocWorkspace()
+                .CurrentSolution.AddProject("Project1", "Project.dll", LanguageNames.CSharp)
+                .Solution.AddProject("Project2", "Project2.dll", LanguageNames.VisualBasic)
+                .Solution.Workspace;
+            await VerifyOptionSetsAsync(workspace, _ => { }).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task OptionSet_Serialization_CustomValue()
         {
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
 
             var newQualifyFieldAccessValue = new CodeStyleOption2<bool>(false, NotificationOption2.Error);
             var newQualifyMethodAccessValue = new CodeStyleOption2<bool>(true, NotificationOption2.Warning);
@@ -400,7 +404,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task Missing_Metadata_Serialization_Test()
         {
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var serializer = workspace.Services.GetService<ISerializerService>();
 
             var reference = new MissingMetadataReference();
@@ -414,7 +418,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task Missing_Analyzer_Serialization_Test()
         {
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var serializer = workspace.Services.GetService<ISerializerService>();
 
             var reference = new AnalyzerFileReference(Path.Combine(TempRoot.Root, "missing_reference"), new MissingAnalyzerLoader());
@@ -428,7 +432,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task Missing_Analyzer_Serialization_Desktop_Test()
         {
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var serializer = workspace.Services.GetService<ISerializerService>();
 
             var reference = new AnalyzerFileReference(Path.Combine(TempRoot.Root, "missing_reference"), new MissingAnalyzerLoader());
@@ -443,7 +447,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public async Task RoundTrip_Analyzer_Serialization_Test()
         {
             using var tempRoot = new TempRoot();
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var serializer = workspace.Services.GetService<ISerializerService>();
 
             // actually shadow copy content
@@ -464,7 +468,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var tempRoot = new TempRoot();
 
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var serializer = workspace.Services.GetService<ISerializerService>();
 
             // actually shadow copy content
@@ -639,7 +643,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestEncodingSerialization()
         {
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var serializer = workspace.Services.GetService<ISerializerService>();
 
             // test with right serializable encoding
@@ -706,15 +710,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
                 Assert.Equal(original, recovered);
             }
-        }
-
-        private static Task VerifyOptionSetsAsync(Action<OptionSet> verifyOptionValues)
-        {
-            var workspace = new AdhocWorkspace()
-                .CurrentSolution.AddProject("Project1", "Project.dll", LanguageNames.CSharp)
-                .Solution.AddProject("Project2", "Project2.dll", LanguageNames.VisualBasic)
-                .Solution.Workspace;
-            return VerifyOptionSetsAsync(workspace, verifyOptionValues);
         }
 
         private static async Task VerifyOptionSetsAsync(Workspace workspace, Action<OptionSet> verifyOptionValues)

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -5,7 +5,9 @@
 #nullable enable
 
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor.Implementation.TodoComments;
@@ -15,6 +17,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
@@ -211,23 +214,54 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
                 var currentOptionValue = optionSet.GetOption(option, LanguageNames.CSharp);
                 var newOptionValue = !currentOptionValue;
-                var newOptionSet = optionSet.WithChangedOption(optionKey, newOptionValue);
+                var newOptionSet = (SerializableOptionSet)optionSet.WithChangedOption(optionKey, newOptionValue);
 
                 optionService.SetOptions(newOptionSet);
                 var isOptionSet = (bool?)optionService.GetOptions().GetOption(optionKey);
                 Assert.Equal(newOptionValue, isOptionSet);
 
+                // Verify the serializable option snapshot obtained option service has the changed option only if the option key is serializable.
                 var languages = ImmutableHashSet.Create(LanguageNames.CSharp);
                 var serializableOptionSet = optionService.GetSerializableOptionsSnapshot(languages);
-                var changedOptions = serializableOptionSet.GetChangedOptions();
-                if (isSerializable)
+                VerifyChangedOptionsCore(serializableOptionSet, optionKey, expectedChangedOption: isSerializable);
+
+                // Serialize/deserialize the option set to test round tripping.
+                serializableOptionSet = (SerializableOptionSet)serializableOptionSet.WithChangedOption(optionKey, newOptionValue);
+                using var memoryStream = new MemoryStream();
+                using var writer = new ObjectWriter(memoryStream, leaveOpen: true);
+                serializableOptionSet.Serialize(writer, CancellationToken.None);
+
+                memoryStream.Position = 0;
+                var originalChecksum = Checksum.Create(memoryStream);
+
+                memoryStream.Position = 0;
+                using var reader = ObjectReader.TryGetReader(memoryStream);
+                serializableOptionSet = SerializableOptionSet.Deserialize(reader, optionService, CancellationToken.None);
+
+                // Verify the option set obtained from round trip has the changed option only if the option key is serializable.
+                VerifyChangedOptionsCore(serializableOptionSet, optionKey, expectedChangedOption: isSerializable);
+
+                using var newMemoryStream = new MemoryStream();
+                using var newWriter = new ObjectWriter(newMemoryStream, leaveOpen: true);
+                serializableOptionSet.Serialize(newWriter, CancellationToken.None);
+                newMemoryStream.Position = 0;
+                var newChecksum = Checksum.Create(newMemoryStream);
+
+                Assert.Equal(originalChecksum, newChecksum);
+                return;
+
+                static void VerifyChangedOptionsCore(SerializableOptionSet serializableOptionSet, OptionKey optionKey, bool expectedChangedOption)
                 {
-                    var changedOptionKey = Assert.Single(changedOptions);
-                    Assert.Equal(optionKey, changedOptionKey);
-                }
-                else
-                {
-                    Assert.Empty(changedOptions);
+                    var changedOptions = serializableOptionSet.GetChangedOptions();
+                    if (expectedChangedOption)
+                    {
+                        var changedOptionKey = Assert.Single(changedOptions);
+                        Assert.Equal(optionKey, changedOptionKey);
+                    }
+                    else
+                    {
+                        Assert.Empty(changedOptions);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Strongly recommended to review commit by commit**

[First commit](https://github.com/dotnet/roslyn/commit/0feca6ce9b4fb0199ea745e063a8cb96ef5c711e) fixes the options checksum validation assert in servicehub dumps found in https://dev.azure.com/dnceng/public/_build/results?buildId=753622&view=artifacts&type=publishedArtifacts. The test added in that commit fails prior to the product changes in the commit.

[Second commit](https://github.com/dotnet/roslyn/commit/c471139857d924ae96468816ca4ab5b865ed180a) fixes #44791. The test added in the commit fails with the same assert as repro provided in #24408 prior to the product changes in the commit. Verified that the repro in #24408 also succeeds without asserts after this commit