### PR TITLE
Fix nint ConstOutOfRange test on non-en-US culture

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -5014,6 +5014,8 @@ class Program
         [Fact]
         public void ConstantConversions_03()
         {
+            using var _ = new EnsureInvariantCulture();
+
             constantConversions("sbyte", "nint", "-1", null, "-1", "-1", null, "-1", "-1");
             constantConversions("sbyte", "nint", "sbyte.MinValue", null, "-128", "-128", null, "-128", "-128");
             constantConversions("sbyte", "nint", "sbyte.MaxValue", null, "127", "127", null, "127", "127");


### PR DESCRIPTION
On my machine (where the default culture is cs-CZ), the test `NativeIntegerTests.ConstantConversions_03` fails with (notice the difference in decimal separator):

```
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NativeIntegerTests.ConstantConversions_03 [FAIL]
  
  Expected:
                  Diagnostic(ErrorCode.WRN_ConstOutOfRangeChecked, "(nint)x").WithArguments("-2.147494E+09", "nint")
  Actual:
                  // (10,25): warning CS8778: Constant value '-2,147494E+09' may overflow 'nint' at runtime (use 'unchecked' syntax to override)
                  //             y = checked((nint)x);
                  Diagnostic(ErrorCode.WRN_ConstOutOfRangeChecked, "(nint)x").WithArguments("-2,147494E+09", "nint").WithLocation(10, 25)
  Diff:
  ++>                 Diagnostic(ErrorCode.WRN_ConstOutOfRangeChecked, "(nint)x").WithArguments("-2,147494E+09", "nint").WithLocation(10, 25)
  -->                 Diagnostic(ErrorCode.WRN_ConstOutOfRangeChecked, "(nint)x").WithArguments("-2.147494E+09", "nint")
  Expected: True
  Actual:   False
  Stack Trace:
    C:\code\roslyn\src\Test\Utilities\Portable\Diagnostics\DiagnosticExtensions.cs(86,0): at Microsoft.CodeAnalysis.DiagnosticExtensions.Verify(IEnumerable`1 actual, DiagnosticDescription[] expected, Boolean errorCodeOnly)
    C:\code\roslyn\src\Test\Utilities\Portable\Diagnostics\DiagnosticExtensions.cs(101,0): at Microsoft.CodeAnalysis.DiagnosticExtensions.VerifyDiagnostics[TCompilation](TCompilation c, DiagnosticDescription[] expected)
    C:\code\roslyn\src\Compilers\CSharp\Test\Semantic\Semantics\NativeIntegerTests.cs(5125,0): at Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NativeIntegerTests.<ConstantConversions_03>g__constantConversion|90_4(String sourceType, String destinationType, String sourceValue, Boolean useChecked, DiagnosticDescription expectedError, String expectedOutput)
    C:\code\roslyn\src\Compilers\CSharp\Test\Semantic\Semantics\NativeIntegerTests.cs(5099,0): at Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NativeIntegerTests.<ConstantConversions_03>g__constantConversions|90_3(String sourceType, String destinationType, String sourceValue, DiagnosticDescription checkedError, String checked32, String checked64, DiagnosticDescription uncheckedError, String unchecked32, String unchecked64)
    C:\code\roslyn\src\Compilers\CSharp\Test\Semantic\Semantics\NativeIntegerTests.cs(5069,0): at Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NativeIntegerTests.ConstantConversions_03()
```

Forcing the culture to invariant for the duration of this test fixes it for me.

cc: @cston (who added the test in https://github.com/dotnet/roslyn/pull/45581)