### PR TITLE
Improve sorting of navigate-to matches when doing dotted patterns

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
         protected override TestWorkspace CreateWorkspace(string content, ExportProvider exportProvider)
             => TestWorkspace.CreateCSharp(content, exportProvider: exportProvider);
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task NoItemsForEmptyFile(TestHost testHost)
         {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindClass(TestHost testHost)
         {
@@ -55,7 +55,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindVerbatimClass(TestHost testHost)
         {
@@ -73,7 +73,7 @@ testHost, @"class @static
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindNestedClass(TestHost testHost)
         {
@@ -93,7 +93,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindMemberInANestedClass(TestHost testHost)
         {
@@ -116,7 +116,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindGenericClassWithConstraints(TestHost testHost)
         {
@@ -132,7 +132,7 @@ class Goo<T> where T : IEnumerable
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindGenericMethodWithConstraints(TestHost testHost)
         {
@@ -151,7 +151,7 @@ class Goo<U>
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindPartialClass(TestHost testHost)
         {
@@ -175,7 +175,7 @@ partial class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindTypesInMetadata(TestHost testHost)
         {
@@ -189,7 +189,7 @@ Class Program { FileStyleUriParser f; }", async w =>
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindClassInNamespace(TestHost testHost)
         {
@@ -206,7 +206,7 @@ testHost, @"namespace Bar
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindStruct(TestHost testHost)
         {
@@ -220,7 +220,7 @@ testHost, @"struct Bar
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindEnum(TestHost testHost)
         {
@@ -237,7 +237,7 @@ testHost, @"enum Colors
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindEnumMember(TestHost testHost)
         {
@@ -254,7 +254,7 @@ testHost, @"enum Colors
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindField1(TestHost testHost)
         {
@@ -269,7 +269,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindField2(TestHost testHost)
         {
@@ -284,7 +284,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindField3(TestHost testHost)
         {
@@ -298,7 +298,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindVerbatimField(TestHost testHost)
         {
@@ -317,7 +317,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindPtrField1(TestHost testHost)
         {
@@ -331,7 +331,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindPtrField2(TestHost testHost)
         {
@@ -346,7 +346,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindConstField(TestHost testHost)
         {
@@ -361,7 +361,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindIndexer(TestHost testHost)
         {
@@ -373,7 +373,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindEvent(TestHost testHost)
         {
@@ -385,7 +385,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindAutoProperty(TestHost testHost)
         {
@@ -400,7 +400,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindMethod(TestHost testHost)
         {
@@ -415,7 +415,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindVerbatimMethod(TestHost testHost)
         {
@@ -434,7 +434,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindParameterizedMethod(TestHost testHost)
         {
@@ -451,7 +451,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindConstructor(TestHost testHost)
         {
@@ -468,7 +468,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindParameterizedConstructor(TestHost testHost)
         {
@@ -485,7 +485,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindStaticConstructor(TestHost testHost)
         {
@@ -502,7 +502,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindPartialMethods(TestHost testHost)
         {
@@ -517,7 +517,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindPartialMethodDefinitionOnly(TestHost testHost)
         {
@@ -532,7 +532,7 @@ testHost, @"partial class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindPartialMethodImplementationOnly(TestHost testHost)
         {
@@ -549,7 +549,7 @@ testHost, @"partial class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindOverriddenMembers(TestHost testHost)
         {
@@ -579,7 +579,7 @@ testHost, @"partial class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindInterface(TestHost testHost)
         {
@@ -593,7 +593,7 @@ testHost, @"public interface IGoo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindDelegateInNamespace(TestHost testHost)
         {
@@ -608,7 +608,7 @@ testHost, @"namespace Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindLambdaExpression(TestHost testHost)
         {
@@ -625,7 +625,7 @@ class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindArray(TestHost testHost)
         {
@@ -640,7 +640,7 @@ testHost, @"class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindClassAndMethodWithSameName(TestHost testHost)
         {
@@ -666,7 +666,7 @@ class Test
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindMethodNestedInGenericTypes(TestHost testHost)
         {
@@ -689,7 +689,7 @@ testHost, @"class A<T>
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task OrderingOfConstructorsAndTypes(TestHost testHost)
         {
@@ -726,7 +726,7 @@ class C2
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task NavigateToMethodWithNullableParameter(TestHost testHost)
         {
@@ -743,7 +743,7 @@ testHost, @"class C
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task StartStopSanity(TestHost testHost)
         {
@@ -766,7 +766,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DescriptionItems(TestHost testHost)
         {
@@ -789,7 +789,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest1(TestHost testHost)
         {
@@ -809,7 +809,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest2(TestHost testHost)
         {
@@ -826,7 +826,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest3(TestHost testHost)
         {
@@ -843,7 +843,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest4(TestHost testHost)
         {
@@ -855,7 +855,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest5(TestHost testHost)
         {
@@ -867,7 +867,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest6(TestHost testHost)
         {
@@ -886,7 +886,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TermSplittingTest7(TestHost testHost)
         {
@@ -898,7 +898,7 @@ testHost, @"public class Goo
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task TestIndexer1(TestHost testHost)
         {
@@ -929,7 +929,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DottedPattern1(TestHost testHost)
         {
@@ -947,7 +947,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DottedPattern2(TestHost testHost)
         {
@@ -964,7 +964,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DottedPattern3(TestHost testHost)
         {
@@ -982,7 +982,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DottedPattern4(TestHost testHost)
         {
@@ -1000,7 +1000,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DottedPattern5(TestHost testHost)
         {
@@ -1018,7 +1018,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task DottedPattern6(TestHost testHost)
         {
@@ -1035,7 +1035,7 @@ class D
             });
         }
 
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         [WorkItem(7855, "https://github.com/dotnet/Roslyn/issues/7855")]
         public async Task DottedPattern7(TestHost testHost)
@@ -1054,7 +1054,7 @@ class D
             });
         }
 
-        [WpfTheory, WorkItem(46267, "https://github.com/dotnet/roslyn/issues/46267")]
+        [Theory, WorkItem(46267, "https://github.com/dotnet/roslyn/issues/46267")]
         [CombinatorialData]
         public async Task DottedPatternMatchKind(TestHost testHost)
         {
@@ -1119,7 +1119,7 @@ class D
         }
 
         [WorkItem(11474, "https://github.com/dotnet/roslyn/pull/11474")]
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task FindFuzzy1(TestHost testHost)
         {
@@ -1137,7 +1137,7 @@ testHost, @"class C
         }
 
         [WorkItem(18843, "https://github.com/dotnet/roslyn/issues/18843")]
-        [WpfTheory]
+        [Theory]
         [CombinatorialData]
         public async Task Test__arglist(TestHost testHost)
         {

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -876,8 +876,8 @@ testHost, @"public class Goo
             {
                 var expecteditems = new List<NavigateToItem>
                 {
-                    new NavigateToItem("get_key_word", NavigateToItemKind.Field, "csharp", null, null,s_emptyPrefixPatternMatch, null),
-                    new NavigateToItem("GetKeyWord", NavigateToItemKind.Field, "csharp", null, null, s_emptyPrefixPatternMatch_NotCaseSensitive, null)
+                    new NavigateToItem("get_key_word", NavigateToItemKind.Field, "csharp", null, null,s_emptySubstringPatternMatch, null),
+                    new NavigateToItem("GetKeyWord", NavigateToItemKind.Field, "csharp", null, null, s_emptySubstringPatternMatch_NotCaseSensitive, null)
                 };
 
                 var items = await _aggregator.GetItemsAsync("get word");
@@ -1049,6 +1049,25 @@ class D
                 };
 
                 var items = await _aggregator.GetItemsAsync("Baz.Q");
+
+                VerifyNavigateToResultItems(expecteditems, items);
+            });
+        }
+
+        [WpfTheory, WorkItem(46267, "https://github.com/dotnet/roslyn/issues/46267")]
+        [CombinatorialData]
+        public async Task DottedPatternMatchKind(TestHost testHost)
+        {
+            var source = "namespace System { class Console { void Write(string s) { } void WriteLine(string s) { } } }";
+            await TestAsync(testHost, source, async w =>
+            {
+                var expecteditems = new List<NavigateToItem>
+                {
+                    new NavigateToItem("Write", NavigateToItemKind.Method, "csharp", null, null, s_emptyExactPatternMatch, null),
+                    new NavigateToItem("WriteLine", NavigateToItemKind.Method, "csharp", null, null, s_emptyPrefixPatternMatch, null)
+                };
+
+                var items = await _aggregator.GetItemsAsync("Console.Write");
 
                 VerifyNavigateToResultItems(expecteditems, items);
             });

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
             Return TestWorkspace.CreateVisualBasic(content, exportProvider:=exportProvider)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestNoItemsForEmptyFile(testHost As TestHost) As Task
             Await TestAsync(testHost, "", Async Function(w)
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
                                           End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindClass(testHost As TestHost) As Task
             Await TestAsync(testHost,
@@ -41,7 +41,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindVerbatimClass(testHost As TestHost) As Task
             Await TestAsync(testHost,
@@ -55,7 +55,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindNestedClass(testHost As TestHost) As Task
             Await TestAsync(testHost,
@@ -70,7 +70,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindMemberInANestedClass(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Alpha
@@ -87,7 +87,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindGenericConstrainedClass(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo(Of M As IComparable)
@@ -97,7 +97,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindGenericConstrainedMethod(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo(Of M As IComparable)
@@ -109,7 +109,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindPartialClass(testHost As TestHost) As Task
             Await TestAsync(testHost, "Partial Public Class Goo
@@ -131,7 +131,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindClassInNamespace(testHost As TestHost) As Task
             Await TestAsync(testHost, "Namespace Bar
@@ -143,7 +143,7 @@ End Namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindStruct(testHost As TestHost) As Task
             Await TestAsync(testHost, "Structure Bar
@@ -153,7 +153,7 @@ End Structure", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindEnum(testHost As TestHost) As Task
             Await TestAsync(testHost, "Enum Colors
@@ -166,7 +166,7 @@ End Enum", Async Function(w)
            End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindEnumMember(testHost As TestHost) As Task
             Await TestAsync(testHost, "Enum Colors
@@ -179,7 +179,7 @@ End Enum", Async Function(w)
            End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindField1(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -190,7 +190,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindField2(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -201,7 +201,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindField3(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -211,7 +211,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindVerbatimField(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -225,7 +225,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindConstField(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -236,7 +236,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindIndexer(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -255,7 +255,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         <WorkItem(780993, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/780993")>
         Public Async Function TestFindEvent(testHost As TestHost) As Task
@@ -267,7 +267,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindNormalProperty(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -283,7 +283,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindAutoImplementedProperty(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -294,7 +294,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindMethod(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -306,7 +306,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindVerbatimMethod(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -321,7 +321,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindParameterizedMethod(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -333,7 +333,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindConstructor(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -345,7 +345,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindStaticConstructor(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -357,7 +357,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindDestructor(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -376,7 +376,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindPartialMethods(testHost As TestHost) As Task
             Await TestAsync(testHost, "Partial Class Goo
@@ -401,7 +401,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindPartialMethodDefinitionOnly(testHost As TestHost) As Task
             Await TestAsync(testHost, "Partial Class Goo
@@ -413,7 +413,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindPartialMethodImplementationOnly(testHost As TestHost) As Task
             Await TestAsync(testHost, "Partial Class Goo
@@ -425,7 +425,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindOverriddenMethods(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class BaseGoo
@@ -450,7 +450,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDottedPattern1(testHost As TestHost) As Task
             Await TestAsync(testHost, "namespace Goo
@@ -472,7 +472,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDottedPattern2(testHost As TestHost) As Task
             Await TestAsync(testHost, "namespace Goo
@@ -493,7 +493,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDottedPattern3(testHost As TestHost) As Task
             Await TestAsync(testHost, "namespace Goo
@@ -515,7 +515,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDottedPattern4(testHost As TestHost) As Task
             Await TestAsync(testHost, "namespace Goo
@@ -537,7 +537,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDottedPattern5(testHost As TestHost) As Task
             Await TestAsync(testHost, "namespace Goo
@@ -559,7 +559,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDottedPattern6(testHost As TestHost) As Task
             Await TestAsync(testHost, "namespace Goo
@@ -578,7 +578,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         <WorkItem(7855, "https://github.com/dotnet/Roslyn/issues/7855")>
         Public Async Function TestDottedPattern7(testHost As TestHost) As Task
@@ -601,7 +601,7 @@ end namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindInterface(testHost As TestHost) As Task
             Await TestAsync(testHost, "Public Interface IGoo
@@ -611,7 +611,7 @@ End Interface", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindDelegateInNamespace(testHost As TestHost) As Task
             Await TestAsync(testHost, "Namespace Goo
@@ -622,7 +622,7 @@ End Namespace", Async Function(w)
                 End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindLambdaExpression(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -633,7 +633,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindModule(testHost As TestHost) As Task
             Await TestAsync(testHost, "Module ModuleTest
@@ -643,7 +643,7 @@ End Module", Async Function(w)
              End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindLineContinuationMethod(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -655,7 +655,7 @@ End Sub", Async Function(w)
           End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindArray(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -666,7 +666,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindClassAndMethodWithSameName(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class Goo
@@ -688,7 +688,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindMethodNestedInGenericTypes(testHost As TestHost) As Task
             Await TestAsync(testHost, "Class A(Of T)
@@ -705,7 +705,7 @@ End Class", Async Function(w)
         End Function
 
         <WorkItem(1111131, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1111131")>
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindClassInNamespaceWithGlobalPrefix(testHost As TestHost) As Task
             Await TestAsync(testHost, "Namespace Global.MyNS
@@ -718,7 +718,7 @@ End Namespace", Async Function(w)
         End Function
 
         <WorkItem(1121267, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1121267")>
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestFindClassInGlobalNamespace(testHost As TestHost) As Task
             Await TestAsync(testHost, "Namespace Global
@@ -731,7 +731,7 @@ End Namespace", Async Function(w)
         End Function
 
         <WorkItem(1834, "https://github.com/dotnet/roslyn/issues/1834")>
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestConstructorNotParentedByTypeBlock(testHost As TestHost) As Task
             Await TestAsync(testHost, "Module Program
@@ -744,7 +744,7 @@ End Sub", Async Function(w)
           End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestStartStopSanity(testHost As TestHost) As Task
             ' Verify that multiple calls to start/stop don't blow up
@@ -763,7 +763,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDescriptionItems(testHost As TestHost) As Task
             Await TestAsync(testHost, "
@@ -786,7 +786,7 @@ End Class", Async Function(w)
             End Function)
         End Function
 
-        <WpfTheory>
+        <Theory>
         <CombinatorialData>
         Public Async Function TestDescriptionItemsFilePath(testHost As TestHost) As Task
             Using workspace = CreateWorkspace(

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -21,6 +21,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal abstract partial class AbstractNavigateToSearchService
     {
+        private static ImmutableArray<(PatternMatchKind roslynKind, NavigateToMatchKind vsKind)> s_kindPairs =
+            ImmutableArray.Create(
+                (PatternMatchKind.Exact, NavigateToMatchKind.Exact),
+                (PatternMatchKind.Prefix, NavigateToMatchKind.Prefix),
+                (PatternMatchKind.Substring, NavigateToMatchKind.Substring),
+                (PatternMatchKind.CamelCaseExact, NavigateToMatchKind.CamelCaseExact),
+                (PatternMatchKind.CamelCasePrefix, NavigateToMatchKind.CamelCasePrefix),
+                (PatternMatchKind.CamelCaseNonContiguousPrefix, NavigateToMatchKind.CamelCaseNonContiguousPrefix),
+                (PatternMatchKind.CamelCaseSubstring, NavigateToMatchKind.CamelCaseSubstring),
+                (PatternMatchKind.CamelCaseNonContiguousSubstring, NavigateToMatchKind.CamelCaseNonContiguousSubstring),
+                (PatternMatchKind.Fuzzy, NavigateToMatchKind.Fuzzy));
+
         public static Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInCurrentProcessAsync(
             Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
@@ -187,44 +199,19 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
         private static NavigateToMatchKind GetNavigateToMatchKind(ArrayBuilder<PatternMatch> nameMatches)
         {
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.Exact))
-            {
-                return NavigateToMatchKind.Exact;
-            }
+            // work backwards through the match kinds.  That way our result is as bad as our worst match part.  For
+            // example, say the user searches for `Console.Write` and we find `Console.Write` (exact, exact), and
+            // `Console.WriteLine` (exact, prefix).  We don't want the latter hit to be considered an `exact` match, and
+            // thus as good as `Console.Write`.
 
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.Prefix))
+            for (var i = s_kindPairs.Length - 1; i >= 0; i--)
             {
-                return NavigateToMatchKind.Prefix;
-            }
-
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.Substring))
-            {
-                return NavigateToMatchKind.Substring;
-            }
-
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.CamelCaseExact))
-            {
-                return NavigateToMatchKind.CamelCaseExact;
-            }
-
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.CamelCasePrefix))
-            {
-                return NavigateToMatchKind.CamelCasePrefix;
-            }
-
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.CamelCaseNonContiguousPrefix))
-            {
-                return NavigateToMatchKind.CamelCaseNonContiguousPrefix;
-            }
-
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.CamelCaseSubstring))
-            {
-                return NavigateToMatchKind.CamelCaseSubstring;
-            }
-
-            if (nameMatches.Any(r => r.Kind == PatternMatchKind.CamelCaseNonContiguousSubstring))
-            {
-                return NavigateToMatchKind.CamelCaseNonContiguousSubstring;
+                var (roslynKind, vsKind) = s_kindPairs[i];
+                foreach (var match in nameMatches)
+                {
+                    if (match.Kind == roslynKind)
+                        return vsKind;
+                }
             }
 
             return NavigateToMatchKind.Regular;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/46267

Review both commits.  The second is just test cleanup.

--

For example, say the user seraches for "Console.Write", our previous system woudl rank `Console.Write` and `Console.WriteLine` equally good, as both of them were an `exact` match on `Console`.

The new ranking system now flips to one where instead of stating that the result is `exact` if one item is exact, it's only `exact` if *all* portoins are exact.

Note: in an ideal world we could make very fine grained weights here to pass to VS.  i.e. if the user had `Foo.Bar.Baz.Quux` that would be a better match against `Foo.Bar.Baz.Quux1` vs `Foo1.Bar1.Baz1.Quux1`.  However, the VS API is limited here, and all we can do is say "this was an exact/prefix/substring" match overall.  There's no way to say that it was `exact/exact/exact/prefix` vs `prefix/prefix/prefix/prefix`, and weight the former one better for having more 'exact' matches.

The new approach balances out that we are always losing information passing data on to VS, but that in that loss, we should not *elevate* matches to be at the same level as things that are strictly better.