### PR TITLE
Changed the colors for light/blue theme - Inline Parameter Name Hints

### DIFF
--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2017.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2017.xml
@@ -64,7 +64,7 @@
             <Color Name="label name">
             </Color>
             <Color Name="inline parameter name hints">
-                <Foreground Type="CT_RAW" Source="FF808080" />
+                <Foreground Type="CT_RAW" Source="FF686868" />
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
             </Color>
             <Color Name="xml doc comment - attribute name">
@@ -219,7 +219,7 @@
             <Color Name="label name">
             </Color>
             <Color Name="inline parameter name hints">
-                <Foreground Type="CT_RAW" Source="FF808080" />
+                <Foreground Type="CT_RAW" Source="FF686868" />
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
             </Color>
             <Color Name="xml doc comment - attribute name">

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2019.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2019.xml
@@ -70,7 +70,7 @@
             <Color Name="label name">
             </Color>
             <Color Name="inline parameter name hints">
-                <Foreground Type="CT_RAW" Source="FF808080" />
+                <Foreground Type="CT_RAW" Source="FF686868" />
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
             </Color>
             <Color Name="xml doc comment - attribute name">
@@ -231,7 +231,7 @@
             <Color Name="label name">
             </Color>
             <Color Name="inline parameter name hints">
-                <Foreground Type="CT_RAW" Source="FF808080" />
+                <Foreground Type="CT_RAW" Source="FF686868" />
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
             </Color>
             <Color Name="xml doc comment - attribute name">


### PR DESCRIPTION
Hello,

Per the advice from the UX Design board I have changed the default colors for light and blue theme.

Before:
![image](https://user-images.githubusercontent.com/40616383/89457221-05460400-d733-11ea-90cb-eb044d4bf03f.png)
Color Ratio: 3.21

After:
![image](https://user-images.githubusercontent.com/40616383/89456555-0fb3ce00-d732-11ea-8594-5254354ef679.png)
Color Ratio: 4.53