### PR TITLE
Add temporary support for colorization in LSP hover

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SyntacticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SyntacticQuickInfoSourceTests.cs
@@ -276,7 +276,6 @@ if (true)
         protected override async Task AssertContentIsAsync(
             TestWorkspace workspace,
             Document document,
-            ITextSnapshot snapshot,
             int position,
             string expectedContent,
             string expectedDocumentationComment = null)
@@ -289,7 +288,7 @@ if (true)
             var trackingSpan = new Mock<ITrackingSpan>(MockBehavior.Strict);
             var threadingContext = workspace.ExportProvider.GetExportedValue<IThreadingContext>();
             var streamingPresenter = workspace.ExportProvider.GetExport<IStreamingFindUsagesPresenter>();
-            var quickInfoItem = await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan.Object, info, snapshot, document, threadingContext, streamingPresenter, CancellationToken.None);
+            var quickInfoItem = await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan.Object, info, document, threadingContext, streamingPresenter, CancellationToken.None);
             var containerElement = quickInfoItem.Item as ContainerElement;
 
             var textElements = containerElement.Elements.OfType<ClassifiedTextElement>();
@@ -327,7 +326,6 @@ if (true)
             var testDocument = workspace.Documents.Single();
             var position = testDocument.CursorPosition.Value;
             var document = workspace.CurrentSolution.Projects.First().Documents.First();
-            var snapshot = testDocument.GetTextBuffer().CurrentSnapshot;
 
             if (string.IsNullOrEmpty(expectedContent))
             {
@@ -335,7 +333,7 @@ if (true)
             }
             else
             {
-                await AssertContentIsAsync(workspace, document, snapshot, position, expectedContent, expectedDocumentationComment);
+                await AssertContentIsAsync(workspace, document, position, expectedContent, expectedDocumentationComment);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -33,8 +35,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             ImmutableArray<TaggedText> taggedTexts,
             ref int index,
             Document document,
-            IThreadingContext threadingContext,
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
+            IThreadingContext? threadingContext,
+            Lazy<IStreamingFindUsagesPresenter>? streamingPresenter)
         {
             // This method produces a sequence of zero or more paragraphs
             var paragraphs = new List<object>();
@@ -127,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                 {
                     // This is tagged text getting added to the current line we are building.
                     var style = GetClassifiedTextRunStyle(part.Style);
-                    if (part.NavigationTarget is object)
+                    if (part.NavigationTarget is object && streamingPresenter != null && threadingContext != null)
                     {
                         if (Uri.TryCreate(part.NavigationTarget, UriKind.Absolute, out var absoluteUri))
                         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.QuickInfo;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 
@@ -25,9 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal static class IntellisenseQuickInfoBuilder
     {
-        internal static async Task<IntellisenseQuickInfoItem> BuildItemAsync(ITrackingSpan trackingSpan,
-            CodeAnalysisQuickInfoItem quickInfoItem,
-            ITextSnapshot snapshot,
+        private static async Task<ContainerElement> BuildInteractiveContentAsync(CodeAnalysisQuickInfoItem quickInfoItem,
             Document document,
             IThreadingContext threadingContext,
             Lazy<IStreamingFindUsagesPresenter> streamingPresenter,
@@ -114,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 var tabSize = document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.TabSize, document.Project.Language);
                 var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 var spans = IndentationHelper.GetSpansWithAlignedIndentation(text, classifiedSpanList.ToImmutableArray(), tabSize);
-                var textRuns = spans.Select(s => new ClassifiedTextRun(s.ClassificationType, snapshot.GetText(s.TextSpan.ToSpan()), ClassifiedTextRunStyle.UseClassificationFont));
+                var textRuns = spans.Select(s => new ClassifiedTextRun(s.ClassificationType, text.GetSubText(s.TextSpan).ToString(), ClassifiedTextRunStyle.UseClassificationFont));
 
                 if (textRuns.Any())
                 {
@@ -122,11 +119,34 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 }
             }
 
-            var content = new ContainerElement(
+            return new ContainerElement(
                                 ContainerElementStyle.Stacked | ContainerElementStyle.VerticalPadding,
                                 elements);
+        }
+
+        internal static async Task<IntellisenseQuickInfoItem> BuildItemAsync(ITrackingSpan trackingSpan,
+            CodeAnalysisQuickInfoItem quickInfoItem,
+            Document document,
+            IThreadingContext threadingContext,
+            Lazy<IStreamingFindUsagesPresenter> streamingPresenter,
+            CancellationToken cancellationToken)
+        {
+            var content = await BuildInteractiveContentAsync(quickInfoItem, document, threadingContext, streamingPresenter, cancellationToken).ConfigureAwait(false);
 
             return new IntellisenseQuickInfoItem(trackingSpan, content);
+        }
+
+        /// <summary>
+        /// Builds the classified hover content without navigation actions and requiring
+        /// an instance of <see cref="IStreamingFindUsagesPresenter"/>
+        /// TODO - This can be removed once LSP supports colorization in markupcontent
+        /// https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
+        /// </summary>
+        internal static Task<ContainerElement> BuildContentWithoutNavigationActionsAsync(CodeAnalysisQuickInfoItem quickInfoItem,
+            Document document,
+            CancellationToken cancellationToken)
+        {
+            return BuildInteractiveContentAsync(quickInfoItem, document, threadingContext: null, streamingPresenter: null, cancellationToken);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
@@ -124,7 +124,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                                 elements);
         }
 
-        internal static async Task<IntellisenseQuickInfoItem> BuildItemAsync(ITrackingSpan trackingSpan,
+        internal static async Task<IntellisenseQuickInfoItem> BuildItemAsync(
+            ITrackingSpan trackingSpan,
             CodeAnalysisQuickInfoItem quickInfoItem,
             Document document,
             IThreadingContext threadingContext,
@@ -142,7 +143,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
         /// TODO - This can be removed once LSP supports colorization in markupcontent
         /// https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
         /// </summary>
-        internal static Task<ContainerElement> BuildContentWithoutNavigationActionsAsync(CodeAnalysisQuickInfoItem quickInfoItem,
+        internal static Task<ContainerElement> BuildContentWithoutNavigationActionsAsync(
+            CodeAnalysisQuickInfoItem quickInfoItem,
             Document document,
             CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/QuickInfoSourceProvider.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/QuickInfoSourceProvider.QuickInfoSource.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                         {
                             var textVersion = snapshot.Version;
                             var trackingSpan = textVersion.CreateTrackingSpan(item.Span.ToSpan(), SpanTrackingMode.EdgeInclusive);
-                            return await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan, item, snapshot, document, _threadingContext, _streamingPresenter, cancellationToken).ConfigureAwait(false);
+                            return await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan, item, document, _threadingContext, _streamingPresenter, cancellationToken).ConfigureAwait(false);
                         }
 
                         return null;

--- a/src/EditorFeatures/Test2/IntelliSense/AbstractIntellisenseQuickInfoBuilderTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/AbstractIntellisenseQuickInfoBuilderTests.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
                 Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)()
                 Dim streamingPresenter = workspace.ExportProvider.GetExport(Of IStreamingFindUsagesPresenter)()
-                Return Await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan.Object, quickInfoItem, cursorBuffer.CurrentSnapshot, document, threadingContext, streamingPresenter, CancellationToken.None)
+                Return Await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan.Object, quickInfoItem, document, threadingContext, streamingPresenter, CancellationToken.None)
             End Using
         End Function
 
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
                 Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)()
                 Dim streamingPresenter = workspace.ExportProvider.GetExport(Of IStreamingFindUsagesPresenter)()
-                Return Await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan.Object, codeAnalysisQuickInfoItem, cursorBuffer.CurrentSnapshot, document, threadingContext, streamingPresenter, CancellationToken.None)
+                Return Await IntellisenseQuickInfoBuilder.BuildItemAsync(trackingSpan.Object, codeAnalysisQuickInfoItem, document, threadingContext, streamingPresenter, CancellationToken.None)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/TestUtilities/QuickInfo/AbstractQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/TestUtilities/QuickInfo/AbstractQuickInfoSourceTests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
         protected abstract Task AssertContentIsAsync(
             TestWorkspace workspace,
             Document document,
-            ITextSnapshot snapshot,
             int position,
             string expectedContent,
             string expectedDocumentationComment = null);

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -44,21 +45,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            return new Hover
+
+            // TODO - Switch to markup content once it supports classifications.
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
+            return new VSHover
             {
                 Range = ProtocolConversions.TextSpanToRange(info.Span, text),
-                Contents = new MarkupContent
-                {
-                    Kind = MarkupKind.Markdown,
-                    Value = GetMarkdownString(info)
-                }
+                Contents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(string.Empty),
+                RawContent = await IntellisenseQuickInfoBuilder.BuildContentWithoutNavigationActionsAsync(info, document, cancellationToken).ConfigureAwait(false)
             };
-
-            // local functions
-            // TODO - This should return correctly formatted markdown from quick info.
-            // https://github.com/dotnet/roslyn/issues/43387
-            static string GetMarkdownString(QuickInfoItem info)
-                => string.Join("\r\n", info.Sections.Select(section => section.Text).Where(text => !string.IsNullOrEmpty(text)));
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             {
                 Range = ProtocolConversions.TextSpanToRange(info.Span, text),
                 Contents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(string.Empty),
+                // Build the classified text without navigation actions - they are not serializable.
                 RawContent = await IntellisenseQuickInfoBuilder.BuildContentWithoutNavigationActionsAsync(info, document, cancellationToken).ConfigureAwait(false)
             };
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -5,6 +5,8 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.VisualStudio.Text.Adornments;
 using Roslyn.Test.Utilities;
 using Xunit;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -31,10 +33,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var expectedLocation = locations["caret"].Single();
 
-            var expected = CreateHover(expectedLocation, $"string A.Method(int i)\r\n A great method\r\n\r\n{FeaturesResources.Returns_colon}\r\n  a string");
-
             var results = await RunGetHoverAsync(workspace.CurrentSolution, expectedLocation).ConfigureAwait(false);
-            AssertJsonEquals(expected, results);
+
+            VerifyContent(results, $"string A.Method(int i)|A great method|{FeaturesResources.Returns_colon}|  |a string");
         }
 
         [Fact]
@@ -55,10 +56,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
 }";
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var expectedLocation = locations["caret"].Single();
-            var expected = CreateHover(expectedLocation, $"string A.Method(int i)\r\n A great method\r\n\r\n{FeaturesResources.Exceptions_colon}\r\n  System.NullReferenceException");
 
             var results = await RunGetHoverAsync(workspace.CurrentSolution, expectedLocation).ConfigureAwait(false);
-            AssertJsonEquals(expected, results);
+            VerifyContent(results, $"string A.Method(int i)|A great method|{FeaturesResources.Exceptions_colon}|  System.NullReferenceException");
         }
 
         [Fact]
@@ -79,10 +79,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
 }";
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var expectedLocation = locations["caret"].Single();
-            var expected = CreateHover(expectedLocation, "string A.Method(int i)\r\n A great method\r\n\r\nRemarks are cool too.");
 
             var results = await RunGetHoverAsync(workspace.CurrentSolution, expectedLocation).ConfigureAwait(false);
-            AssertJsonEquals(expected, results);
+            VerifyContent(results, "string A.Method(int i)|A great method|Remarks are cool too.");
         }
 
         [Fact]
@@ -108,10 +107,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
 }";
             using var workspace = CreateTestWorkspace(markup, out var locations);
             var expectedLocation = locations["caret"].Single();
-            var expected = CreateHover(expectedLocation, "string A.Method(int i)\r\n A great method\r\n\r\n• Item 1.\r\n• Item 2.");
 
             var results = await RunGetHoverAsync(workspace.CurrentSolution, expectedLocation).ConfigureAwait(false);
-            AssertJsonEquals(expected, results);
+            VerifyContent(results, "string A.Method(int i)|A great method|• |Item 1.|• |Item 2.");
         }
 
         [Fact]
@@ -187,24 +185,37 @@ $@"<Workspace>
                 var result = await RunGetHoverAsync(workspace.CurrentSolution, location, project.Id);
 
                 var expectedConstant = project.Name == "Net472" ? "Target in net472" : "Target in netcoreapp3.1";
-                var expectedHover = CreateHover(location, $"({FeaturesResources.constant}) string WithConstant.Target = \"{expectedConstant}\"");
-                AssertJsonEquals(expectedHover, result);
+                VerifyContent(result, $"({FeaturesResources.constant}) string WithConstant.Target = \"{expectedConstant}\"");
             }
         }
 
-        private static async Task<LSP.Hover> RunGetHoverAsync(Solution solution, LSP.Location caret, ProjectId projectContext = null)
-            => await GetLanguageServer(solution).ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Hover>(LSP.Methods.TextDocumentHoverName,
+        private static async Task<LSP.VSHover> RunGetHoverAsync(Solution solution, LSP.Location caret, ProjectId projectContext = null)
+            => (LSP.VSHover)await GetLanguageServer(solution).ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Hover>(LSP.Methods.TextDocumentHoverName,
                 CreateTextDocumentPositionParams(caret, projectContext), new LSP.ClientCapabilities(), null, CancellationToken.None);
 
-        private static LSP.Hover CreateHover(LSP.Location location, string text)
-            => new LSP.Hover()
+        private void VerifyContent(LSP.VSHover result, string expectedContent)
+        {
+            var containerElement = (ContainerElement)result.RawContent;
+            using var _ = ArrayBuilder<ClassifiedTextElement>.GetInstance(out var classifiedTextElements);
+            GetClassifiedTextElements(containerElement, classifiedTextElements);
+            Assert.False(classifiedTextElements.SelectMany(classifiedTextElements => classifiedTextElements.Runs).Any(run => run.NavigationAction != null));
+            var content = string.Join("|", classifiedTextElements.Select(cte => string.Join(string.Empty, cte.Runs.Select(ctr => ctr.Text))));
+            Assert.Equal(expectedContent, content);
+        }
+
+        private void GetClassifiedTextElements(ContainerElement container, ArrayBuilder<ClassifiedTextElement> classifiedTextElements)
+        {
+            foreach (var element in container.Elements)
             {
-                Contents = new LSP.MarkupContent()
+                if (element is ClassifiedTextElement classifiedTextElement)
                 {
-                    Kind = LSP.MarkupKind.Markdown,
-                    Value = text
-                },
-                Range = location.Range
-            };
+                    classifiedTextElements.Add(classifiedTextElement);
+                }
+                else if (element is ContainerElement containerElement)
+                {
+                    GetClassifiedTextElements(containerElement, classifiedTextElements);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds support for VS specific colorization in hover by passing the classified text through.

https://github.com/dotnet/aspnetcore-tooling/pull/2322 must be merged first to avoid breaking razor hover.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1121394