### PR TITLE
Revert "don't run CI on changes that do not change code"

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -8,17 +8,11 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-  branches:
-    include:
-    - master
-    - master-vs-deps
-    - release/*
-    - features/*
-    - demos/*
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
+- master
+- master-vs-deps
+- release/*
+- features/*
+- demos/*
 
 jobs:
 - job: VS_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,17 +8,11 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-  branches:
-    include:
-    - master
-    - master-vs-deps
-    - release/*
-    - features/*
-    - demos/*
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
+- master
+- master-vs-deps
+- release/*
+- features/*
+- demos/*
 
 jobs:
 - job: Windows_Desktop_Unit_Tests


### PR DESCRIPTION
Reverts dotnet/roslyn#46504

GitHub does not support this configuration. Disabling the build for a pull request has a side effect of never having the tests for the pull request pass. This prevents merging pull requests falling into the exclusion category.