### PR TITLE
Adjust log line splitting for shared compiler

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
-        private static readonly string[] s_separators = { Environment.NewLine };
+        private static readonly string[] s_separators = { "\r\n", "\r", "\n" };
 
         internal override void LogMessages(string output, MessageImportance messageImportance)
         {

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -169,6 +169,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
+        // Same separators as those used by Process.OutputDataReceived to maintain consistency between csc and VBCSCompiler
         private static readonly string[] s_separators = { "\r\n", "\r", "\n" };
 
         internal override void LogMessages(string output, MessageImportance messageImportance)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/42172.

When the `Csc` task does not use shared compilation, output of `csc` is [processed by MSBuild using `Process.OutputDataReceived`](https://github.com/dotnet/msbuild/blob/e8c17c128ed847d4acd278b42a02df9621bd1652/src/Utilities/ToolTask.cs#L698), [which considers line separators to be `\r`, `\n` and `\r\n`](https://github.com/dotnet/runtime/blob/a778b7e09722c45891ab66f0cd38785d3156c839/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs#L142-L144). This means that when the output of `csc` is `C.cs(8,26): warning CS0618: 'Class1' is obsolete: '\n'`, MSBuild sees this as two lines (the second one containing just `'`).

When the `Csc` task uses shared compilation, the output of `VBCSCompiler` is instead processed by `Csc.LogMessages`, which currently only considers `Environment.NewLine` as a line separator. This means that the same output as above is seen by MSBuild as a single line on Windows.

When the output above is processed as a single line, it seems MSBuild does not consider it to be warning. (Though I haven't really looked into why that happens.)

This PR makes the two paths consistent, by changing separators in `Csc.LogMessages` to `\r`, `\n` and `\r\n`.

I haven't figured out a good way to test `Csc.LogMessages`. Let me know if there is one.

The following interaction demonstrates that this change actually fixes https://github.com/dotnet/roslyn/issues/42172 (3.8.0-before is a version without the fix, 3.8.0-after with the fix):

```
> dotnet add package Microsoft.Net.Compilers.Toolset -v 3.8.0-before
> dotnet build -p:UseSharedCompilation=true -t:Rebuild
Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored C:\code\tmp\corelib\corelib.csproj (in 197 ms).
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  corelib -> C:\code\tmp\corelib\bin\Debug\netstandard2.0\corelib.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.11
> dotnet build -p:UseSharedCompilation=false -t:Rebuild
Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
C.cs(8,26): warning CS0618: 'Class1' is obsolete: ' [C:\code\tmp\corelib\corelib.csproj]
  corelib -> C:\code\tmp\corelib\bin\Debug\netstandard2.0\corelib.dll

Build succeeded.

C.cs(8,26): warning CS0618: 'Class1' is obsolete: ' [C:\code\tmp\corelib\corelib.csproj]
    1 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.37
> dotnet add package Microsoft.Net.Compilers.Toolset -v 3.8.0-after 
> dotnet build -p:UseSharedCompilation=true -t:Rebuild
Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
C.cs(8,26): warning CS0618: 'Class1' is obsolete: ' [C:\code\tmp\corelib\corelib.csproj]
  corelib -> C:\code\tmp\corelib\bin\Debug\netstandard2.0\corelib.dll

Build succeeded.

C.cs(8,26): warning CS0618: 'Class1' is obsolete: ' [C:\code\tmp\corelib\corelib.csproj]
    1 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.56
> dotnet build -p:UseSharedCompilation=false -t:Rebuild
Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
C.cs(8,26): warning CS0618: 'Class1' is obsolete: ' [C:\code\tmp\corelib\corelib.csproj]
  corelib -> C:\code\tmp\corelib\bin\Debug\netstandard2.0\corelib.dll

Build succeeded.

C.cs(8,26): warning CS0618: 'Class1' is obsolete: ' [C:\code\tmp\corelib\corelib.csproj]
    1 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.33
```