### PR TITLE
Harden DiagnosticResultSerializer diagnostic reader part

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -219,7 +219,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // This data should always be correct as we're never persisting the data between sessions.
             Contract.ThrowIfNull(reader);
 
-            return DiagnosticResultSerializer.ReadDiagnosticAnalysisResults(reader, analyzerMap, documentAnalysisScope, project, version, cancellationToken);
+            if (!DiagnosticResultSerializer.TryReadDiagnosticAnalysisResults(reader, analyzerMap,
+                    documentAnalysisScope, project, version, cancellationToken, out var result))
+            {
+                return DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;
+            }
+
+            return result.Value;
         }
     }
 }


### PR DESCRIPTION
**Strongly recommended to review with whitespace diffs disabled: https://github.com/dotnet/roslyn/pull/46597/files?diff=unified&w=1**

Closes #46544

Current implementation of read logic in DiagnosticResultSerializer was partially graceful - handled version mismatches + exceptions from deserializing individual document diagnostics. However, it attempted to continue deserializing data after any such mismatch/exception, and none of this code was guarded against further exceptions. This PR does the following changes:

1. Completely harden the deserializing logic against any exceptions or version mismatches. We now log NFW for exceptions and prevent VS crash.
2. Do not attempt to continue deserializing data when there is a failure to read any specific part of the serialized data. We immediately bail out from deserializing and return empty diagnostic result. This prevents cascaded exceptions/NFWs.