### PR TITLE
Added interpolated strings to list of possible literals - Inline Parameter Name Hints

### DIFF
--- a/src/EditorFeatures/Test2/InlineParameterNameHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineParameterNameHints/CSharpInlineParameterNameHintsTests.vb
@@ -336,5 +336,29 @@ class A
 
             Await VerifyParamHints(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineParameterNameHints)>
+        Public Async Function TestInterpolatedString() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class A
+{
+    string testMethod(string x)
+    {
+        return x;
+    }
+    void Main() 
+    {
+        testMethod({|x:$""|});
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineParameterNameHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineParameterNameHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -330,5 +330,27 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineParameterNameHints
 
             Await VerifyParamHints(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineParameterNameHints)>
+        Public Async Function TestInterpolatedString() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+                        Class Foo
+                            Sub Main(args As String())
+                                TestMethod({|x:$""|})
+                            End Sub
+
+                            Sub TestMethod(x As String)
+
+                            End Sub
+                        End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
@@ -81,6 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
                 // We want to adorn literals no matter what
                 return true;
             }
+            if (arg is InterpolatedStringExpressionSyntax)
+            {
+                // We want to adorn all types of strings
+                return true;
+            }
             if (arg is ObjectCreationExpressionSyntax)
             {
                 // We want to adorn object invocations that exist as arguments because they are not declared anywhere

--- a/src/Features/VisualBasic/Portable/InlineParameterNameHints/VisualBasicInlineParameterNameHintsService.vb
+++ b/src/Features/VisualBasic/Portable/InlineParameterNameHints/VisualBasicInlineParameterNameHintsService.vb
@@ -43,6 +43,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineParameterNameHints
                 Return True
             End If
 
+            If TypeOf arg Is InterpolatedStringExpressionSyntax Then
+                ' We want to adorn all types of strings
+                Return True
+            End If
+
             If TypeOf arg Is ObjectCreationExpressionSyntax Then
                 ' We want to adorn object invocations that exist as arguments because they are Not declared anywhere
                 ' else in the file


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/46611

Added ```InterpolatedStringExpressionSyntax``` as one of the types of arguments to adorn and added tests for each language.