### PR TITLE
 Stop emitting ModuleInitializerAttribute as a custom attribute since it has no runtime meaning

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -735,6 +735,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             IsTargetAttribute(target, AttributeDescription.DllImportAttribute) ||
                             IsTargetAttribute(target, AttributeDescription.PreserveSigAttribute) ||
                             IsTargetAttribute(target, AttributeDescription.DynamicSecurityMethodAttribute) ||
+                            IsTargetAttribute(target, AttributeDescription.ModuleInitializerAttribute) ||
                             IsSecurityAttribute(target.DeclaringCompilation))
                         {
                             return false;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ModuleInitializers/ModuleInitializersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ModuleInitializers/ModuleInitializersTests.cs
@@ -61,6 +61,31 @@ namespace System.Runtime.CompilerServices { class ModuleInitializerAttribute : S
         }
 
         [Fact]
+        public void CustomAttributeIsNotEmitted()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+
+class C
+{
+    [ModuleInitializer]
+    internal static void M() { }
+}
+
+namespace System.Runtime.CompilerServices { class ModuleInitializerAttribute : System.Attribute { } }
+";
+            CompileAndVerify(
+                source,
+                parseOptions: s_parseOptions,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
+                symbolValidator: module =>
+                {
+                    var moduleInitializerMethod = module.ContainingAssembly.GetTypeByMetadataName("C").GetMember("M");
+                    Assert.Empty(moduleInitializerMethod.GetAttributes());
+                });
+        }
+
+        [Fact]
         public void ModuleTypeStaticConstructorIsNotEmittedWhenNoMethodIsMarkedWithModuleInitializerAttribute()
         {
             string source = @"


### PR DESCRIPTION
The presence of ModuleInitializerAttribute as a custom attribute in the metadata doesn't make sense for the same reason that MethodImplAttribute/SerializerAttribute/IndexerNameAttribute wouldn't make sense in the metadata. They do nothing as custom attributes at runtime. ModuleInitializerAttribute should probably be added to the [C# reserved attributes page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/general). (I can think of a few others, too.)

Checking for a ModuleInitializerAttribute custom attribute in metadata isn't even a canonical way to answer the question, "Is this method called by the module initializer?" That would depend on the compiler and version used to create the metadata. Therefore, adding it to the custom attributes table is only misleading.

@RikkiGibson 