### PR TITLE
Stop specifying Rich Nav's version of dotnet

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -20,12 +20,6 @@ jobs:
   steps:
     - script: eng/cibuild.cmd -configuration Debug -prepareMachine
       displayName: Build
-      
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
-      inputs:
-        packageType: sdk
-        version: 2.1.503
 
     - task: RichCodeNavIndexer@0
       displayName: RichCodeNav Upload
@@ -34,3 +28,5 @@ jobs:
         environment: production
         richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
       continueOnError: true
+      env:
+        DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet


### PR DESCRIPTION
Rich Code Navigation builds have been failing because we weren't respecting Roslyn's install location of the DotNet SDK. With this change, we both respect that location, and no longer need to install our own SDK in a separate task.