### PR TITLE
Fix failures to use VBCSCompiler.exe for Roslyn builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     </MajorVersion>
     <MinorVersion>
     </MinorVersion>
-    <MicrosoftNetCompilersToolsetVersion>3.8.0-1.20361.1</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.8.0-2.20408.4</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -173,6 +173,23 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Work around missing code fix references causing VBCSCompiler.exe to reject compilations.
+    https://github.com/dotnet/roslyn/issues/46684
+  -->
+  <Target Name="ExcludeCodeFixes"
+          BeforeTargets="CoreCompile"
+          Condition="'$(UseRoslynAnalyzers)' != 'false' AND '$(BuildingProject)' == 'true'">
+    <!--
+      Disable analyzers that only provide code fixes.
+    -->
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes'
+                  OR '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers.CodeFixes'"/>
+    </ItemGroup>
+  </Target>
+
   <!-- 
     This target is used to copy referenced projects to a sub-directory vs. the direct output 
     directory of the build. Useful when the referenced project is an EXE and the referencing 


### PR DESCRIPTION
* Update to Microsoft.Net.Compilers.Toolset 3.8.0-2.20408.4, which brings in #46510.
* Exclude problematic code fix assemblies from command line builds. These assemblies do not provide analyzers, so they are expected to silently be excluded from the build. However, in two cases the dependencies of the code fix assembly were triggering the analyzer inconsistency check in VBCSCompiler, which resulted in disabling the compiler server for impacted builds.

Rebuild time locally:

* Before change: 5:40 minutes
* After change: 2:03 minutes