### PR TITLE
Clean up ref assemblies in solution explorer

### DIFF
--- a/src/Test/Utilities/Portable/Generate.ps1
+++ b/src/Test/Utilities/Portable/Generate.ps1
@@ -31,9 +31,11 @@ function Add-TargetFramework($name, $packagePath, $list)
       $logicalName = "$($name).$($dll)";
     }
 
+    $link = "Resources\ReferenceAssemblies\$name\$dll"
     $script:targetsContent += @"
         <EmbeddedResource Include="$packagePath\$dllPath">
           <LogicalName>$logicalName</LogicalName>
+          <Link>$link</Link>
         </EmbeddedResource>
 
 "@

--- a/src/Test/Utilities/Portable/Generated.targets
+++ b/src/Test/Utilities/Portable/Generated.targets
@@ -2,201 +2,267 @@
     <ItemGroup>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net20)\build\.NETFramework\v2.0\mscorlib.dll">
           <LogicalName>net20.mscorlib.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net20\mscorlib.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net20)\build\.NETFramework\v2.0\System.dll">
           <LogicalName>net20.System.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net20\System.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net20)\build\.NETFramework\v2.0\Microsoft.VisualBasic.dll">
           <LogicalName>net20.Microsoft.VisualBasic.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net20\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(Pkgjnm2_ReferenceAssemblies_net35)\build\.NETFramework\v3.5\System.Core.dll">
           <LogicalName>net35.System.Core.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net35\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\mscorlib.dll">
           <LogicalName>net40.mscorlib.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\mscorlib.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.dll">
           <LogicalName>net40.System.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\System.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Core.dll">
           <LogicalName>net40.System.Core.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Data.dll">
           <LogicalName>net40.System.Data.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\System.Data.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Xml.dll">
           <LogicalName>net40.System.Xml.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\System.Xml.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Xml.Linq.dll">
           <LogicalName>net40.System.Xml.Linq.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\Microsoft.VisualBasic.dll">
           <LogicalName>net40.Microsoft.VisualBasic.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\Microsoft.CSharp.dll">
           <LogicalName>net40.Microsoft.CSharp.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net40\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\mscorlib.dll">
           <LogicalName>net451.mscorlib.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\mscorlib.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.dll">
           <LogicalName>net451.System.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Configuration.dll">
           <LogicalName>net451.System.Configuration.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Configuration.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Core.dll">
           <LogicalName>net451.System.Core.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Data.dll">
           <LogicalName>net451.System.Data.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Data.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Drawing.dll">
           <LogicalName>net451.System.Drawing.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Drawing.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.EnterpriseServices.dll">
           <LogicalName>net451.System.EnterpriseServices.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.EnterpriseServices.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Runtime.Serialization.dll">
           <LogicalName>net451.System.Runtime.Serialization.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Windows.Forms.dll">
           <LogicalName>net451.System.Windows.Forms.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Windows.Forms.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Web.Services.dll">
           <LogicalName>net451.System.Web.Services.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Web.Services.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Xml.dll">
           <LogicalName>net451.System.Xml.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Xml.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\System.Xml.Linq.dll">
           <LogicalName>net451.System.Xml.Linq.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Microsoft.CSharp.dll">
           <LogicalName>net451.Microsoft.CSharp.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Microsoft.VisualBasic.dll">
           <LogicalName>net451.Microsoft.VisualBasic.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Facades\System.ObjectModel.dll">
           <LogicalName>net451.System.ObjectModel.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.ObjectModel.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Facades\System.Runtime.dll">
           <LogicalName>net451.System.Runtime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Runtime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Facades\System.Runtime.InteropServices.WindowsRuntime.dll">
           <LogicalName>net451.System.Runtime.InteropServices.WindowsRuntime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Facades\System.Threading.dll">
           <LogicalName>net451.System.Threading.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Threading.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net451)\build\.NETFramework\v4.5.1\Facades\System.Threading.Tasks.dll">
           <LogicalName>net451.System.Threading.Tasks.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net451\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\mscorlib.dll">
           <LogicalName>net461.mscorlib.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\mscorlib.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\System.dll">
           <LogicalName>net461.System.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\System.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\System.Core.dll">
           <LogicalName>net461.System.Core.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\Facades\System.Runtime.dll">
           <LogicalName>net461.System.Runtime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\System.Runtime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\Facades\System.Threading.Tasks.dll">
           <LogicalName>net461.System.Threading.Tasks.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\Microsoft.CSharp.dll">
           <LogicalName>net461.Microsoft.CSharp.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.dll">
           <LogicalName>net461.Microsoft.VisualBasic.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\net461\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\mscorlib.dll">
           <LogicalName>netcoreapp31.mscorlib.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\mscorlib.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.dll">
           <LogicalName>netcoreapp31.System.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Core.dll">
           <LogicalName>netcoreapp31.System.Core.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Collections.dll">
           <LogicalName>netcoreapp31.System.Collections.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Collections.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Console.dll">
           <LogicalName>netcoreapp31.System.Console.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Console.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Linq.dll">
           <LogicalName>netcoreapp31.System.Linq.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Linq.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Linq.Expressions.dll">
           <LogicalName>netcoreapp31.System.Linq.Expressions.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Runtime.dll">
           <LogicalName>netcoreapp31.System.Runtime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Runtime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Runtime.InteropServices.dll">
           <LogicalName>netcoreapp31.System.Runtime.InteropServices.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Runtime.InteropServices.WindowsRuntime.dll">
           <LogicalName>netcoreapp31.System.Runtime.InteropServices.WindowsRuntime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Threading.Tasks.dll">
           <LogicalName>netcoreapp31.System.Threading.Tasks.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\netstandard.dll">
           <LogicalName>netcoreapp31.netstandard.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\netstandard.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\Microsoft.CSharp.dll">
           <LogicalName>netcoreapp31.Microsoft.CSharp.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\Microsoft.VisualBasic.dll">
           <LogicalName>netcoreapp31.Microsoft.VisualBasic.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netcoreapp31\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll">
           <LogicalName>netstandard20.mscorlib.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\mscorlib.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.dll">
           <LogicalName>netstandard20.System.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\System.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Core.dll">
           <LogicalName>netstandard20.System.Core.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Dynamic.Runtime.dll">
           <LogicalName>netstandard20.System.Dynamic.Runtime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.dll">
           <LogicalName>netstandard20.System.Linq.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\System.Linq.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Expressions.dll">
           <LogicalName>netstandard20.System.Linq.Expressions.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.dll">
           <LogicalName>netstandard20.System.Runtime.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\System.Runtime.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll">
           <LogicalName>netstandard20.netstandard.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\netstandard20\netstandard.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\$(MicrosoftCSharpVersion)\ref\netstandard1.0\Microsoft.CSharp.dll">
           <LogicalName>netstandard10.microsoftcsharp.Microsoft.CSharp.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\microsoftcsharp\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\$(MicrosoftCSharpVersion)\lib\netstandard1.3\Microsoft.CSharp.dll">
           <LogicalName>netstandard13lib.microsoftcsharp.Microsoft.CSharp.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\microsoftcsharp\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\$(MicrosoftVisualBasicVersion)\ref\netstandard1.1\Microsoft.VisualBasic.dll">
           <LogicalName>netstandard11.microsoftvisualbasic.Microsoft.VisualBasic.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\microsoftvisualbasic\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgSystem_Threading_Tasks_Extensions)\\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll">
           <LogicalName>portablelib.systemthreadingtasksextensions.System.Threading.Tasks.Extensions.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\systemthreadingtasksextensions\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgSystem_Threading_Tasks_Extensions)\\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll">
           <LogicalName>netstandard20lib.systemthreadingtasksextensions.System.Threading.Tasks.Extensions.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\systemthreadingtasksextensions\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NET_Build_Extensions)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\net461\lib\netstandard.dll">
           <LogicalName>netstandardtonet461.buildextensions.netstandard.dll</LogicalName>
+          <Link>Resources\ReferenceAssemblies\buildextensions\netstandard.dll</Link>
         </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This moves the ref assembly resources display in solution explorer to be
hierarchical based on the target framework that they came from. Prior to
this all of the assemblies were just dumped into the root of the project