### PR TITLE
Fix crash when typing in an indexer.

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2494,12 +2494,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return WithAccessorList(declaration, newList);
         }
 
-        private static AccessorListSyntax GetAccessorList(SyntaxNode declaration)
-            => declaration.Kind() switch
+        internal static AccessorListSyntax GetAccessorList(SyntaxNode declaration)
+            => declaration switch
             {
-                SyntaxKind.PropertyDeclaration => ((PropertyDeclarationSyntax)declaration).AccessorList,
-                SyntaxKind.IndexerDeclaration => ((IndexerDeclarationSyntax)declaration).AccessorList,
-                SyntaxKind.EventDeclaration => ((EventDeclarationSyntax)declaration).AccessorList,
+                PropertyDeclarationSyntax property => property.AccessorList,
+                IndexerDeclarationSyntax indexer => indexer.AccessorList,
+                EventDeclarationSyntax @event => @event.AccessorList,
                 _ => null,
             };
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2495,13 +2495,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         internal static AccessorListSyntax GetAccessorList(SyntaxNode declaration)
-            => declaration switch
-            {
-                PropertyDeclarationSyntax property => property.AccessorList,
-                IndexerDeclarationSyntax indexer => indexer.AccessorList,
-                EventDeclarationSyntax @event => @event.AccessorList,
-                _ => null,
-            };
+            => (declaration as BasePropertyDeclarationSyntax)?.AccessorList;
 
         private static bool CanHaveAccessors(SyntaxNode declaration)
             => declaration.Kind() switch
@@ -2513,11 +2507,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             };
 
         private static SyntaxNode WithAccessorList(SyntaxNode declaration, AccessorListSyntax accessorList)
-            => declaration.Kind() switch
+            => declaration switch
             {
-                SyntaxKind.PropertyDeclaration => ((PropertyDeclarationSyntax)declaration).WithAccessorList(accessorList),
-                SyntaxKind.IndexerDeclaration => ((PropertyDeclarationSyntax)declaration).WithAccessorList(accessorList),
-                SyntaxKind.EventDeclaration => ((EventDeclarationSyntax)declaration).WithAccessorList(accessorList),
+                BasePropertyDeclarationSyntax baseProperty => baseProperty.WithAccessorList(accessorList),
                 _ => declaration,
             };
 

--- a/src/Workspaces/CSharp/Portable/SemanticModelReuse/CSharpSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/SemanticModelReuse/CSharpSemanticModelReuseLanguageService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SemanticModelReuse
         }
 
         protected override SyntaxList<AccessorDeclarationSyntax> GetAccessors(BasePropertyDeclarationSyntax baseProperty)
-            => baseProperty.AccessorList.Accessors;
+            => baseProperty.AccessorList!.Accessors;
 
         public override SyntaxNode? TryGetContainingMethodBodyForSpeculation(SyntaxNode node)
         {

--- a/src/Workspaces/CSharp/Portable/SemanticModelReuse/CSharpSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/SemanticModelReuse/CSharpSemanticModelReuseLanguageService.cs
@@ -8,20 +8,21 @@ using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.SemanticModelReuse;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.SemanticModelReuse
 {
     [ExportLanguageService(typeof(ISemanticModelReuseLanguageService), LanguageNames.CSharp), Shared]
     internal class CSharpSemanticModelReuseLanguageService : AbstractSemanticModelReuseLanguageService<
+        MemberDeclarationSyntax,
         BaseMethodDeclarationSyntax,
-        AccessorDeclarationSyntax,
-        PropertyDeclarationSyntax,
-        EventDeclarationSyntax>
+        AccessorDeclarationSyntax>
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -31,11 +32,15 @@ namespace Microsoft.CodeAnalysis.CSharp.SemanticModelReuse
 
         protected override ISyntaxFacts SyntaxFacts => CSharpSyntaxFacts.Instance;
 
-        protected override SyntaxList<AccessorDeclarationSyntax> GetAccessors(EventDeclarationSyntax @event)
-            => @event.AccessorList?.Accessors ?? default;
+        protected override MemberDeclarationSyntax GetAccessorContainerDeclaration(AccessorDeclarationSyntax currentAccessor)
+        {
+            Contract.ThrowIfFalse(currentAccessor.Parent is AccessorListSyntax);
+            Contract.ThrowIfFalse(currentAccessor.Parent.Parent is MemberDeclarationSyntax);
+            return (MemberDeclarationSyntax)currentAccessor.Parent.Parent;
+        }
 
-        protected override SyntaxList<AccessorDeclarationSyntax> GetAccessors(PropertyDeclarationSyntax property)
-            => property.AccessorList?.Accessors ?? default;
+        protected override SyntaxList<AccessorDeclarationSyntax> GetAccessors(MemberDeclarationSyntax member)
+            => CSharpSyntaxGenerator.GetAccessorList(member).Accessors;
 
         public override SyntaxNode? TryGetContainingMethodBodyForSpeculation(SyntaxNode node)
         {

--- a/src/Workspaces/CSharp/Portable/SemanticModelReuse/CSharpSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/SemanticModelReuse/CSharpSemanticModelReuseLanguageService.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SemanticModelReuse
     internal class CSharpSemanticModelReuseLanguageService : AbstractSemanticModelReuseLanguageService<
         MemberDeclarationSyntax,
         BaseMethodDeclarationSyntax,
+        BasePropertyDeclarationSyntax,
         AccessorDeclarationSyntax>
     {
         [ImportingConstructor]
@@ -32,15 +33,15 @@ namespace Microsoft.CodeAnalysis.CSharp.SemanticModelReuse
 
         protected override ISyntaxFacts SyntaxFacts => CSharpSyntaxFacts.Instance;
 
-        protected override MemberDeclarationSyntax GetAccessorContainerDeclaration(AccessorDeclarationSyntax currentAccessor)
+        protected override BasePropertyDeclarationSyntax GetBasePropertyDeclaration(AccessorDeclarationSyntax accessor)
         {
-            Contract.ThrowIfFalse(currentAccessor.Parent is AccessorListSyntax);
-            Contract.ThrowIfFalse(currentAccessor.Parent.Parent is MemberDeclarationSyntax);
-            return (MemberDeclarationSyntax)currentAccessor.Parent.Parent;
+            Contract.ThrowIfFalse(accessor.Parent is AccessorListSyntax);
+            Contract.ThrowIfFalse(accessor.Parent.Parent is BasePropertyDeclarationSyntax);
+            return (BasePropertyDeclarationSyntax)accessor.Parent.Parent;
         }
 
-        protected override SyntaxList<AccessorDeclarationSyntax> GetAccessors(MemberDeclarationSyntax member)
-            => CSharpSyntaxGenerator.GetAccessorList(member).Accessors;
+        protected override SyntaxList<AccessorDeclarationSyntax> GetAccessors(BasePropertyDeclarationSyntax baseProperty)
+            => baseProperty.AccessorList.Accessors;
 
         public override SyntaxNode? TryGetContainingMethodBodyForSpeculation(SyntaxNode node)
         {

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -15,9 +15,11 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
     internal abstract class AbstractSemanticModelReuseLanguageService<
         TMemberDeclarationSyntax,
         TBaseMethodDeclarationSyntax,
+        TBasePropertyDeclarationSyntax,
         TAccessorDeclarationSyntax> : ISemanticModelReuseLanguageService
         where TMemberDeclarationSyntax : SyntaxNode
         where TBaseMethodDeclarationSyntax : TMemberDeclarationSyntax
+        where TBasePropertyDeclarationSyntax : TMemberDeclarationSyntax
         where TAccessorDeclarationSyntax : SyntaxNode
     {
         protected abstract ISyntaxFacts SyntaxFacts { get; }
@@ -25,8 +27,8 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
         public abstract SyntaxNode? TryGetContainingMethodBodyForSpeculation(SyntaxNode node);
 
         protected abstract Task<SemanticModel?> TryGetSpeculativeSemanticModelWorkerAsync(SemanticModel previousSemanticModel, SyntaxNode currentBodyNode, CancellationToken cancellationToken);
-        protected abstract SyntaxList<TAccessorDeclarationSyntax> GetAccessors(TMemberDeclarationSyntax member);
-        protected abstract TMemberDeclarationSyntax GetAccessorContainerDeclaration(TAccessorDeclarationSyntax currentAccessor);
+        protected abstract SyntaxList<TAccessorDeclarationSyntax> GetAccessors(TBasePropertyDeclarationSyntax baseProperty);
+        protected abstract TBasePropertyDeclarationSyntax GetBasePropertyDeclaration(TAccessorDeclarationSyntax accessor);
 
         public Task<SemanticModel?> TryGetSpeculativeSemanticModelAsync(SemanticModel previousSemanticModel, SyntaxNode currentBodyNode, CancellationToken cancellationToken)
         {
@@ -45,10 +47,10 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
                 // in the case of an accessor, have to find the previous accessor in the previous prop/event corresponding
                 // to the current prop/event.
 
-                var currentContainer = GetAccessorContainerDeclaration(currentAccessor);
+                var currentContainer = GetBasePropertyDeclaration(currentAccessor);
                 var previousContainer = GetPreviousBodyNode(previousRoot, currentRoot, currentContainer);
 
-                if (previousContainer is not TMemberDeclarationSyntax previousMember)
+                if (previousContainer is not TBasePropertyDeclarationSyntax previousMember)
                 {
                     Debug.Fail("Previous container didn't map back to a normal accessor container.");
                     return null;

--- a/src/Workspaces/CoreTest/SemanticModelReuse/SemanticModelReuseTests.cs
+++ b/src/Workspaces/CoreTest/SemanticModelReuse/SemanticModelReuseTests.cs
@@ -135,8 +135,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.SemanticModelReuse
             Assert.True(model3.IsSpeculativeSemanticModel);
         }
 
-        [Fact]
-        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_CSharp()
+        [Fact, WorkItem(1167540, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1167540")]
+        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_Property_CSharp()
         {
             var source = "class C { int M { get { return 0; } } }";
             var document1 = CreateDocument(source, LanguageNames.CSharp);
@@ -152,6 +152,52 @@ namespace Microsoft.CodeAnalysis.UnitTests.SemanticModelReuse
             Assert.True(model2.IsSpeculativeSemanticModel);
 
             var document3 = document1.WithText(SourceText.From("class C { int M { get { return 2; } } }"));
+
+            // This should be able to get a speculative model using the original model we primed the cache with.
+            var model3 = await document3.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.True(model3.IsSpeculativeSemanticModel);
+        }
+
+        [Fact, WorkItem(1167540, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1167540")]
+        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_Event_CSharp()
+        {
+            var source = "class C { event System.Action E { add { return 0; } } }";
+            var document1 = CreateDocument(source, LanguageNames.CSharp);
+
+            // First call will prime the cache to point at the real semantic model.
+            var model1 = await document1.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.False(model1.IsSpeculativeSemanticModel);
+
+            var document2 = document1.WithText(SourceText.From("class C { event System.Action E { add { return 1; } } }"));
+
+            // This should be able to get a speculative model using the original model we primed the cache with.
+            var model2 = await document2.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.True(model2.IsSpeculativeSemanticModel);
+
+            var document3 = document1.WithText(SourceText.From("class C { event System.Action E { add { return 2; } } }"));
+
+            // This should be able to get a speculative model using the original model we primed the cache with.
+            var model3 = await document3.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.True(model3.IsSpeculativeSemanticModel);
+        }
+
+        [Fact, WorkItem(1167540, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1167540")]
+        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_Indexer_CSharp()
+        {
+            var source = "class C { int this[int i] { get { return 0; } } }";
+            var document1 = CreateDocument(source, LanguageNames.CSharp);
+
+            // First call will prime the cache to point at the real semantic model.
+            var model1 = await document1.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.False(model1.IsSpeculativeSemanticModel);
+
+            var document2 = document1.WithText(SourceText.From("class C { int this[int i] { get { return 1; } } }"));
+
+            // This should be able to get a speculative model using the original model we primed the cache with.
+            var model2 = await document2.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.True(model2.IsSpeculativeSemanticModel);
+
+            var document3 = document1.WithText(SourceText.From("class C { int this[int i] { get { return 2; } } }"));
 
             // This should be able to get a speculative model using the original model we primed the cache with.
             var model3 = await document3.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
@@ -321,7 +367,7 @@ end class"));
         }
 
         [Fact]
-        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_VisualBasic()
+        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_Property_VisualBasic()
         {
             var source = @"
 class C
@@ -357,6 +403,50 @@ class C
             return 2
         end get
     end property
+end class"));
+
+            // This should be able to get a speculative model using the original model we primed the cache with.
+            var model3 = await document3.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.True(model3.IsSpeculativeSemanticModel);
+        }
+
+        [Fact]
+        public async Task MultipleBodyEditsShouldProduceFreshModel_Accessor_Event_VisualBasic()
+        {
+            var source = @"
+class C
+    public custom event E as System.Action
+        addhandler(value as System.Action)
+            return 0
+        end addhandler
+    end event
+end class";
+            var document1 = CreateDocument(source, LanguageNames.VisualBasic);
+
+            // First call will prime the cache to point at the real semantic model.
+            var model1 = await document1.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.False(model1.IsSpeculativeSemanticModel);
+
+            var document2 = document1.WithText(SourceText.From(@"
+class C
+    public custom event E as System.Action
+        addhandler(value as System.Action)
+            return 1
+        end addhandler
+    end event
+end class"));
+
+            // This should be able to get a speculative model using the original model we primed the cache with.
+            var model2 = await document2.ReuseExistingSpeculativeModelAsync(source.IndexOf("return"), CancellationToken.None);
+            Assert.True(model2.IsSpeculativeSemanticModel);
+
+            var document3 = document1.WithText(SourceText.From(@"
+class C
+    public custom event E as System.Action
+        addhandler(value as System.Action)
+            return 2
+        end addhandler
+    end event
 end class"));
 
             // This should be able to get a speculative model using the original model we primed the cache with.

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -3061,7 +3061,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             End If
         End Function
 
-        Private Shared Function GetAccessorList(declaration As SyntaxNode) As SyntaxList(Of AccessorBlockSyntax)
+        Friend Shared Function GetAccessorList(declaration As SyntaxNode) As SyntaxList(Of AccessorBlockSyntax)
             Select Case declaration.Kind
                 Case SyntaxKind.PropertyBlock
                     Return DirectCast(declaration, PropertyBlockSyntax).Accessors

--- a/src/Workspaces/VisualBasic/Portable/SemanticModelReuse/VisualBasicSemanticModelReuseLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/SemanticModelReuse/VisualBasicSemanticModelReuseLanguageService.vb
@@ -17,6 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SemanticModelReuse
         Inherits AbstractSemanticModelReuseLanguageService(Of
             DeclarationStatementSyntax,
             MethodBlockBaseSyntax,
+            DeclarationStatementSyntax,
             AccessorBlockSyntax)
 
         <ImportingConstructor>
@@ -26,8 +27,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SemanticModelReuse
 
         Protected Overrides ReadOnly Property SyntaxFacts As ISyntaxFacts = VisualBasicSyntaxFacts.Instance
 
-        Protected Overrides Function GetAccessorContainerDeclaration(currentAccessor As AccessorBlockSyntax) As DeclarationStatementSyntax
-            Dim container = currentAccessor.Parent
+        Protected Overrides Function GetBasePropertyDeclaration(accessor As AccessorBlockSyntax) As DeclarationStatementSyntax
+            Dim container = accessor.Parent
             Contract.ThrowIfFalse(TypeOf container Is PropertyBlockSyntax OrElse
                                   TypeOf container Is EventBlockSyntax)
             Return DirectCast(container, DeclarationStatementSyntax)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1167540

We have a cache that attempts to reuse semantic models if edits are made entirely within a method-block or accessor-block.  The code that dealt with accessors only handled properties/events, forgetting that indexers are a different syntactic form entirely.  

