### PR TITLE
Remove prototypes and fix a small bug

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -233,6 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Error(diagnostics, ErrorCode.ERR_TypelessNewIllegalTargetType, syntax, type);
                     goto case TypeKind.Error;
                 case TypeKind.Pointer:
+                case TypeKind.FunctionPointer:
                     Error(diagnostics, ErrorCode.ERR_UnsafeTypeInObjectCreation, syntax, type);
                     goto case TypeKind.Error;
                 case TypeKind.Error:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1885,14 +1885,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UseDefViolationOut = 8886,
         WRN_UseDefViolation = 8887,
 
+        ERR_CannotSpecifyManagedWithUnmanagedSpecifiers = 8888,
+        ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv = 8889,
+        ERR_TypeNotFound = 8890,
+        ERR_TypeMustBePublic = 8801,
+
         #endregion diagnostics introduced for C# 9.0
-
-        // PROTOTYPE(func-ptr): Pack before merge
-
-        ERR_CannotSpecifyManagedWithUnmanagedSpecifiers = 9500,
-        ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv = 9501,
-        ERR_TypeNotFound = 9502,
-        ERR_TypeMustBePublic = 9503,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1888,7 +1888,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CannotSpecifyManagedWithUnmanagedSpecifiers = 8888,
         ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv = 8889,
         ERR_TypeNotFound = 8890,
-        ERR_TypeMustBePublic = 8801,
+        ERR_TypeMustBePublic = 8891,
 
         #endregion diagnostics introduced for C# 9.0
 

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -427,7 +427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get => GetSpecialTypeMember(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__DefaultImplementationsOfInterfaces) is object;
         }
 
-        // PROTOTYPE(func-ptr): Remove when we have a runtime that supports this to test with
+        // https://github.com/dotnet/roslyn/issues/46676: Remove when we have a runtime that supports this to test with
         private bool _overrideRuntimeSupportUnmanagedSignatureCallingConvention;
         internal void SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention()
             => _overrideRuntimeSupportUnmanagedSignatureCallingConvention = true;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -620,7 +620,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         NullableDirectiveTrivia = 9055,
 
         FunctionPointerType = 9056,
-        // PROTOTYPE(func-ptr): Go through the things that use SyntaxKind.Parameter and adjust as necessary
         FunctionPointerParameter = 9057,
         FunctionPointerParameterList = 9058,
         FunctionPointerCallingConvention = 9059,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -7549,10 +7549,10 @@ class C
 }");
 
             comp.VerifyDiagnostics(
-                // (7,19): error CS9501: The target runtime doesn't support extensible or runtime-environment default calling conventions.
+                // (7,19): error CS8889: The target runtime doesn't support extensible or runtime-environment default calling conventions.
                 //         delegate* unmanaged<void> ptr1;
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv, "unmanaged").WithLocation(7, 19),
-                // (8,19): error CS9501: The target runtime doesn't support extensible or runtime-environment default calling conventions.
+                // (8,19): error CS8889: The target runtime doesn't support extensible or runtime-environment default calling conventions.
                 //         delegate* unmanaged[Stdcall, Thiscall]<void> ptr2;
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv, "unmanaged").WithLocation(8, 19)
             );
@@ -7608,7 +7608,7 @@ unsafe class C
 ";
             var allInCoreLib = CreateEmptyCompilation(source1 + source2, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll);
             allInCoreLib.VerifyDiagnostics(
-                // (23,29): error CS9503: Type 'CallConvTest' must be public to be used as a calling convention.
+                // (23,29): error CS8891: Type 'CallConvTest' must be public to be used as a calling convention.
                 //         delegate* unmanaged[Test]<void> ptr = null;
                 Diagnostic(ErrorCode.ERR_TypeMustBePublic, "Test").WithArguments("System.Runtime.CompilerServices.CallConvTest").WithLocation(23, 29)
             );
@@ -7628,7 +7628,7 @@ unsafe class C
 
             var comp1 = CreateEmptyCompilation(source2, references: new[] { coreLib.EmitToImageReference() }, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll);
             comp1.VerifyDiagnostics(
-                // (7,29): error CS9503: Type 'CallConvTest' must be public to be used as a calling convention.
+                // (7,29): error CS8891: Type 'CallConvTest' must be public to be used as a calling convention.
                 //         delegate* unmanaged[Test]<void> ptr = null;
                 Diagnostic(ErrorCode.ERR_TypeMustBePublic, "Test").WithArguments("System.Runtime.CompilerServices.CallConvTest").WithLocation(7, 29)
             );
@@ -7677,7 +7677,7 @@ unsafe class C
 ";
             var allInCoreLib = CreateEmptyCompilation(source1 + source2, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll);
             allInCoreLib.VerifyDiagnostics(
-                // (23,29): error CS9502: Type 'CallConvTest' is not defined.
+                // (23,29): error CS8890: Type 'CallConvTest' is not defined.
                 //         delegate* unmanaged[Test]<void> ptr = null;
                 Diagnostic(ErrorCode.ERR_TypeNotFound, "Test").WithArguments("CallConvTest").WithLocation(23, 29)
             );
@@ -7697,7 +7697,7 @@ unsafe class C
 
             var comp1 = CreateEmptyCompilation(source2, references: new[] { coreLib.EmitToImageReference() }, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll);
             comp1.VerifyDiagnostics(
-                // (7,29): error CS9502: Type 'CallConvTest' is not defined.
+                // (7,29): error CS8890: Type 'CallConvTest' is not defined.
                 //         delegate* unmanaged[Test]<void> ptr = null;
                 Diagnostic(ErrorCode.ERR_TypeNotFound, "Test").WithArguments("CallConvTest").WithLocation(7, 29)
             );
@@ -7765,7 +7765,7 @@ unsafe class C
             var comp1 = CreateCompilationWithFunctionPointers(source1 + source2);
             comp1.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
             comp1.VerifyDiagnostics(
-                // (12,29): error CS9502: Type 'CallConvTest' is not defined.
+                // (12,29): error CS8890: Type 'CallConvTest' is not defined.
                 //         delegate* unmanaged[Test]<void> ptr;
                 Diagnostic(ErrorCode.ERR_TypeNotFound, "Test").WithArguments("CallConvTest").WithLocation(12, 29)
             );
@@ -7784,7 +7784,7 @@ unsafe class C
             var comp2 = CreateCompilationWithFunctionPointers(source2, new[] { reference.EmitToImageReference() });
             comp2.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
             comp2.VerifyDiagnostics(
-                // (7,29): error CS9502: Type 'CallConvTest' is not defined.
+                // (7,29): error CS8890: Type 'CallConvTest' is not defined.
                 //         delegate* unmanaged[Test]<void> ptr;
                 Diagnostic(ErrorCode.ERR_TypeNotFound, "Test").WithArguments("CallConvTest").WithLocation(7, 29)
             );

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -6313,8 +6313,8 @@ unsafe class Derived2 : Base
     public override delegate* unmanaged[Stdcall, Stdcall, Thiscall]<ref string> M4() => throw null;
 }
 ";
-            // PROTOTYPE(func-ptr): When we have a p8 runtime, verify output on these, that the correct overload
-            // is called.
+            // https://github.com/dotnet/roslyn/issues/46676: When we have a p8 runtime, verify output
+            // on these, that the correct overload is called.
 
             var allSourceComp = CreateCompilationWithFunctionPointers(source1 + source2);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -294,22 +294,22 @@ class C
 }");
 
             comp.VerifyDiagnostics(
-                // (4,47): error CS9501: The target runtime doesn't support extensible or runtime-environment default calling conventions.
+                // (4,47): error CS8889: The target runtime doesn't support extensible or runtime-environment default calling conventions.
                 //     public unsafe void M1(delegate* unmanaged[invalid]<void> p) {}
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv, "invalid").WithLocation(4, 47),
-                // (4,47): error CS9502: Type 'CallConvinvalid' is not defined.
+                // (4,47): error CS8890: Type 'CallConvinvalid' is not defined.
                 //     public unsafe void M1(delegate* unmanaged[invalid]<void> p) {}
                 Diagnostic(ErrorCode.ERR_TypeNotFound, "invalid").WithArguments("CallConvinvalid").WithLocation(4, 47),
-                // (5,37): error CS9501: The target runtime doesn't support extensible or runtime-environment default calling conventions.
+                // (5,37): error CS8889: The target runtime doesn't support extensible or runtime-environment default calling conventions.
                 //     public unsafe void M2(delegate* unmanaged[invalid, Stdcall]<void> p) {}
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv, "unmanaged").WithLocation(5, 37),
-                // (5,47): error CS9502: Type 'CallConvinvalid' is not defined.
+                // (5,47): error CS8890: Type 'CallConvinvalid' is not defined.
                 //     public unsafe void M2(delegate* unmanaged[invalid, Stdcall]<void> p) {}
                 Diagnostic(ErrorCode.ERR_TypeNotFound, "invalid").WithArguments("CallConvinvalid").WithLocation(5, 47),
                 // (6,47): error CS1001: Identifier expected
                 //     public unsafe void M3(delegate* unmanaged[]<void> p) {}
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "]").WithLocation(6, 47),
-                // (6,47): error CS9501: The target runtime doesn't support extensible or runtime-environment default calling conventions.
+                // (6,47): error CS8889: The target runtime doesn't support extensible or runtime-environment default calling conventions.
                 //     public unsafe void M3(delegate* unmanaged[]<void> p) {}
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportUnmanagedDefaultCallConv, "").WithLocation(6, 47)
             );

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FunctionPointerTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
         public void ManagedWithUnmanagedSpecifiers()
         {
             UsingStatement("delegate* managed[Cdecl]<void> ptr;", options: TestOptions.RegularPreview,
-                // (1,18): error CS9500: 'managed' calling convention cannot be combined with unmanaged calling convention specifiers.
+                // (1,18): error CS8888: 'managed' calling convention cannot be combined with unmanaged calling convention specifiers.
                 // delegate* managed[Cdecl]<void> ptr;
                 Diagnostic(ErrorCode.ERR_CannotSpecifyManagedWithUnmanagedSpecifiers, "[Cdecl]").WithLocation(1, 18)
             );


### PR DESCRIPTION
Removes prototype comments from the branch and fixes a small bug with target-typed new interation. Fixes https://github.com/dotnet/roslyn/issues/46688.