### PR TITLE
Fix failure to apply timeout in WaitForAllAsyncOperations

### DIFF
--- a/src/Test/Diagnostics/TestingOnly_WaitingService.cs
+++ b/src/Test/Diagnostics/TestingOnly_WaitingService.cs
@@ -56,18 +56,9 @@ namespace Roslyn.Hosting.Diagnostics.Waiters
             GC.KeepAlive(featureWaiter);
         }
 
-        public void WaitForAllAsyncOperations(params string[] featureNames)
-        {
-            WaitForAllAsyncOperations(TimeSpan.FromMilliseconds(-1), featureNames);
-        }
-
         public void WaitForAllAsyncOperations(TimeSpan timeout, params string[] featureNames)
         {
-            var task = _provider.WaitAllAsync(
-                featureNames,
-#pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-                eventProcessingAction: () => Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.ApplicationIdle));
-#pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
+            var task = _provider.WaitAllAsync(featureNames, timeout: timeout);
 
             if (timeout == TimeSpan.FromMilliseconds(-1))
             {


### PR DESCRIPTION
A hang was observed in this code for an integration test run.