### PR TITLE
Handle exception during teardown

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnectionHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnectionHost.cs
@@ -94,7 +94,26 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             Debug.Assert(_queue is object);
             Debug.Assert(_listenTasks is object);
 
-            _cancellationTokenSource.Cancel();
+            try
+            {
+                // Even though the Tasks created to run the compilation servers can never throw, 
+                // the CancellationToken from this source ends up getting passeed throughout the 
+                // named pipe infrastructure. Parts of that infrastructure hook into 
+                // CancellationToken.Register and those will throw during a Cancel operation. 
+                //
+                // Most notably of these is IOCancellationHelper.Cancel. This has a race where it
+                // will try to cancel IO on a disposed SafeHandle. That causes an ObjectDisposedException
+                // to propagate out from the Cancel method here.
+                //
+                // There is no good way to guard against this hence we just have to accept it as a
+                // possible outcome.
+                _cancellationTokenSource.Cancel();
+            }
+            catch (Exception ex)
+            {
+                CompilerServerLogger.LogException(ex, $"Cancelling server listens threw an exception");
+            }
+
             try
             {
                 Task.WaitAll(_listenTasks);


### PR DESCRIPTION
The `CancellationTokenSource.Cancel` method can throw and that needs to
be accounted for. This exception is not coming from our code but rather
it's coming from the framework code. It is attempting to access a
disposed handle when cancellation IO operations and that results in an
unhandled exception.

This can't really be prevented on our part. We just need to handle it.

closes #46724