### PR TITLE
Removes jitteriness - Inline Parameter Name Hints

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
@@ -21,19 +21,15 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
     internal class InlineParameterNameHintsTag : IntraTextAdornmentTag
     {
         public const string TagId = "inline parameter name hints";
+
         /// <summary>
         /// Creates the UIElement on call
         /// Uses PositionAffinity.Predecessor because we want the tag to be associated with the preceding character
         /// </summary>
         /// <param name="text">The name of the parameter associated with the argument</param>
         public InlineParameterNameHintsTag(string text, IWpfTextView textView, TextFormattingRunProperties format)
-            : base(CreateElement(text, textView, format), removalCallback: AdornmentCallbackFunction, PositionAffinity.Predecessor)
+            : base(CreateElement(text, textView, format), removalCallback: null, PositionAffinity.Predecessor)
         {
-        }
-
-        private static void AdornmentCallbackFunction(object tag, UIElement element)
-        {
-            //
         }
 
         private static UIElement CreateElement(string text, IWpfTextView textView, TextFormattingRunProperties format)
@@ -63,12 +59,14 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                 HorizontalAlignment = HorizontalAlignment.Center,
                 Margin = new Thickness(0, -0.20 * textView.LineHeight, 5, 0),
                 Padding = new Thickness(1),
+
+                // Need to set SnapsToDevicePixels and UseLayoutRounding to avoid unnecessary reformatting
                 SnapsToDevicePixels = textView.VisualElement.SnapsToDevicePixels,
                 UseLayoutRounding = textView.VisualElement.UseLayoutRounding,
                 VerticalAlignment = VerticalAlignment.Center
             };
 
-            // Need to set these properties to avoid unecessary reformatting because some dependancy properties
+            // Need to set these properties to avoid unnecessary reformatting because some dependancy properties
             // affect layout
             TextOptions.SetTextFormattingMode(border, TextOptions.GetTextFormattingMode(textView.VisualElement));
             TextOptions.SetTextHintingMode(border, TextOptions.GetTextHintingMode(textView.VisualElement));

--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -18,18 +21,22 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
     internal class InlineParameterNameHintsTag : IntraTextAdornmentTag
     {
         public const string TagId = "inline parameter name hints";
-
         /// <summary>
         /// Creates the UIElement on call
         /// Uses PositionAffinity.Predecessor because we want the tag to be associated with the preceding character
         /// </summary>
         /// <param name="text">The name of the parameter associated with the argument</param>
-        public InlineParameterNameHintsTag(string text, double lineHeight, TextFormattingRunProperties format)
-            : base(CreateElement(text, lineHeight, format), removalCallback: null, PositionAffinity.Predecessor)
+        public InlineParameterNameHintsTag(string text, IWpfTextView textView, TextFormattingRunProperties format)
+            : base(CreateElement(text, textView, format), removalCallback: AdornmentCallbackFunction, PositionAffinity.Predecessor)
         {
         }
 
-        private static UIElement CreateElement(string text, double lineHeight, TextFormattingRunProperties format)
+        private static void AdornmentCallbackFunction(object tag, UIElement element)
+        {
+            //
+        }
+
+        private static UIElement CreateElement(string text, IWpfTextView textView, TextFormattingRunProperties format)
         {
             // Constructs the hint block which gets assigned parameter name and fontstyles according to the options
             // page. Calculates a font size 1/4 smaller than the font size of the rest of the editor
@@ -52,12 +59,20 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                 Background = format.BackgroundBrush,
                 Child = block,
                 CornerRadius = new CornerRadius(2),
-                Height = lineHeight - (0.25 * lineHeight),
+                Height = textView.LineHeight - (0.25 * textView.LineHeight),
                 HorizontalAlignment = HorizontalAlignment.Center,
-                Margin = new Thickness(0, -0.20 * lineHeight, 5, 0),
+                Margin = new Thickness(0, -0.20 * textView.LineHeight, 5, 0),
                 Padding = new Thickness(1),
-                VerticalAlignment = VerticalAlignment.Center,
+                SnapsToDevicePixels = textView.VisualElement.SnapsToDevicePixels,
+                UseLayoutRounding = textView.VisualElement.UseLayoutRounding,
+                VerticalAlignment = VerticalAlignment.Center
             };
+
+            // Need to set these properties to avoid unecessary reformatting because some dependancy properties
+            // affect layout
+            TextOptions.SetTextFormattingMode(border, TextOptions.GetTextFormattingMode(textView.VisualElement));
+            TextOptions.SetTextHintingMode(border, TextOptions.GetTextHintingMode(textView.VisualElement));
+            TextOptions.SetTextRenderingMode(border, TextOptions.GetTextRenderingMode(textView.VisualElement));
 
             border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
             return border;

--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTagger.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
     {
         private readonly ITagAggregator<InlineParameterNameHintDataTag> _tagAggregator;
         private readonly ITextBuffer _buffer;
-        private readonly ITextView _textView;
+        private readonly IWpfTextView _textView;
 
         /// <summary>
         /// stores the parameter hint tags in a global location 
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
 
         public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 
-        public InlineParameterNameHintsTagger(InlineParameterNameHintsTaggerProvider taggerProvider, ITextView textView, ITextBuffer buffer, ITagAggregator<InlineParameterNameHintDataTag> tagAggregator)
+        public InlineParameterNameHintsTagger(InlineParameterNameHintsTaggerProvider taggerProvider, IWpfTextView textView, ITextBuffer buffer, ITagAggregator<InlineParameterNameHintDataTag> tagAggregator)
         {
             _cache = new List<ITagSpan<IntraTextAdornmentTag>>();
             _threadAffinitizedObject = new ForegroundThreadAffinitizedObject(taggerProvider.ThreadingContext);
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                     if (dataTagSpans.Count == 1)
                     {
                         var dataTagSpan = dataTagSpans[0];
-                        _cache.Add(new TagSpan<IntraTextAdornmentTag>(new SnapshotSpan(dataTagSpan.Start, 0), new InlineParameterNameHintsTag(textTag.ParameterName, _textView.LineHeight, Format)));
+                        _cache.Add(new TagSpan<IntraTextAdornmentTag>(new SnapshotSpan(dataTagSpan.Start, 0), new InlineParameterNameHintsTag(textTag.ParameterName, _textView, Format)));
                     }
                 }
             }

--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTaggerProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
             }
 
             var tagAggregator = _viewTagAggregatorFactoryService.CreateTagAggregator<InlineParameterNameHintDataTag>(textView);
-            return new InlineParameterNameHintsTagger(this, textView, buffer, tagAggregator) as ITagger<T>;
+            return new InlineParameterNameHintsTagger(this, (IWpfTextView)textView, buffer, tagAggregator) as ITagger<T>;
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/46610

Hello,

Jason and I found that the DesiredSize property on the Border was getting changed by a small amount when changing the editor. We found this comment:
```
// Note: Some adornments may change size when added to the view's visual tree due to inherited
// dependency properties that affect layout. Such options can include SnapsToDevicePixels,
// UseLayoutRounding, TextRenderingMode, TextHintingMode, and TextFormattingMode. Making sure
// that these properties on the adornment match the view's values before calling Measure here
// can help avoid the size change and the resulting unnecessary re-format.
```

on the IntraTextAdornmentTagger.cs which basically states that certain properties need to be set for the UI element in order for them to not get resized. So we made sure to set those properties using the view's values before calling Measure. This required a shift from using a TextView to a WpfTextView, which was just casted in the InlineParameterNameHintsTagger.cs