### PR TITLE
Use AzDo-aware warning messages in build.ps1

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -280,7 +280,7 @@ function GetIbcSourceBranchName() {
 
     $branchData = GetBranchPublishData $officialSourceBranchName
     if ($branchData -eq $null) {
-      Write-Host "##vso[task.logissue type=warning]Branch $officialSourceBranchName is not listed in PublishData.json. Using IBC data from '$fallback'."
+      Write-LogIssue -Type "warning" -Message "Branch $officialSourceBranchName is not listed in PublishData.json. Using IBC data from '$fallback'."
       Write-Host "Override by setting IbcDrop build variable." -ForegroundColor Yellow
       return $fallback
     }
@@ -322,7 +322,7 @@ function SetVisualStudioBootstrapperBuildArgs() {
   $branchData = GetBranchPublishData $branchName
 
   if ($branchData -eq $null) {
-    Write-Host "##vso[task.logissue type=warning]Branch $officialSourceBranchName is not listed in PublishData.json. Using VS bootstrapper for branch '$fallbackBranch'. "
+    Write-LogIssue -Type warning -Message "Branch $officialSourceBranchName is not listed in PublishData.json. Using VS bootstrapper for branch '$fallbackBranch'. "
     $branchData = GetBranchPublishData $fallbackBranch
   }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -280,7 +280,7 @@ function GetIbcSourceBranchName() {
 
     $branchData = GetBranchPublishData $officialSourceBranchName
     if ($branchData -eq $null) {
-      Write-Host "Warning: Branch $officialSourceBranchName is not listed in PublishData.json. Using IBC data from '$fallback'." -ForegroundColor Yellow
+      Write-Host "##vso[task.logissue type=warning]Branch $officialSourceBranchName is not listed in PublishData.json. Using IBC data from '$fallback'."
       Write-Host "Override by setting IbcDrop build variable." -ForegroundColor Yellow
       return $fallback
     }
@@ -322,7 +322,7 @@ function SetVisualStudioBootstrapperBuildArgs() {
   $branchData = GetBranchPublishData $branchName
 
   if ($branchData -eq $null) {
-    Write-Host "Warning: Branch $officialSourceBranchName is not listed in PublishData.json. Using VS bootstrapper for branch '$fallbackBranch'. " -ForegroundColor Yellow
+    Write-Host "##vso[task.logissue type=warning]Branch $officialSourceBranchName is not listed in PublishData.json. Using VS bootstrapper for branch '$fallbackBranch'. "
     $branchData = GetBranchPublishData $fallbackBranch
   }
 


### PR DESCRIPTION
This will make the warning show up more clearly in the AzDo log. (I can try to run an official build on this branch and link/screenshot the relevant part of the log.)