### PR TITLE
Enable partial NGEN for Microsoft.CodeAnalysis.Remote.Workspaces

### DIFF
--- a/src/Workspaces/Remote/Core/Microsoft.CodeAnalysis.Remote.Workspaces.csproj
+++ b/src/Workspaces/Remote/Core/Microsoft.CodeAnalysis.Remote.Workspaces.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.Remote</RootNamespace>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplyNgenOptimization Condition="'$(TargetFramework)' == 'net472'">partial</ApplyNgenOptimization>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
This assembly is now loaded to devenv process and needs to be partially NGEN'd to avoid image size regression.