### PR TITLE
Add a cache for AnalyzerConfigSets

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/CachingAnalyzerConfigSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/CachingAnalyzerConfigSet.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class CachingAnalyzerConfigSet
+    {
+        private readonly ConcurrentDictionary<string, AnalyzerConfigOptionsResult> _sourcePathToResult = new ConcurrentDictionary<string, AnalyzerConfigOptionsResult>();
+        private readonly Func<string, AnalyzerConfigOptionsResult> _computeFunction;
+        private readonly AnalyzerConfigSet _underlyingSet;
+
+        public CachingAnalyzerConfigSet(AnalyzerConfigSet underlyingSet)
+        {
+            _underlyingSet = underlyingSet;
+            _computeFunction = _underlyingSet.GetOptionsForSourcePath;
+        }
+
+        public AnalyzerConfigOptionsResult GetOptionsForSourcePath(string sourcePath)
+        {
+            return _sourcePathToResult.GetOrAdd(sourcePath, _computeFunction);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -55,7 +56,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The <see cref="AnalyzerConfigSet"/> to be used for analyzer options for specific trees.
         /// </summary>
-        private readonly ValueSource<AnalyzerConfigSet> _lazyAnalyzerConfigSet;
+        private readonly ValueSource<CachingAnalyzerConfigSet> _lazyAnalyzerConfigSet;
 
         private AnalyzerOptions? _lazyAnalyzerOptions;
 
@@ -70,7 +71,7 @@ namespace Microsoft.CodeAnalysis
             ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState> analyzerConfigDocumentStates,
             AsyncLazy<VersionStamp> lazyLatestDocumentVersion,
             AsyncLazy<VersionStamp> lazyLatestDocumentTopLevelChangeVersion,
-            ValueSource<AnalyzerConfigSet> lazyAnalyzerConfigSet)
+            ValueSource<CachingAnalyzerConfigSet> lazyAnalyzerConfigSet)
         {
             _solutionServices = solutionServices;
             _languageServices = languageServices;
@@ -321,6 +322,7 @@ namespace Microsoft.CodeAnalysis
                 // TODO: correctly find the file path, since it looks like we give this the document's .Name under the covers if we don't have one
                 return new WorkspaceAnalyzerConfigOptions(_projectState._lazyAnalyzerConfigSet.GetValue(CancellationToken.None).GetOptionsForSourcePath(textFile.Path));
             }
+
             private sealed class WorkspaceAnalyzerConfigOptions : AnalyzerConfigOptions
             {
                 private readonly ImmutableDictionary<string, string> _backing;
@@ -334,9 +336,9 @@ namespace Microsoft.CodeAnalysis
 
         private sealed class WorkspaceSyntaxTreeOptionsProvider : SyntaxTreeOptionsProvider
         {
-            private readonly ValueSource<AnalyzerConfigSet> _lazyAnalyzerConfigSet;
+            private readonly ValueSource<CachingAnalyzerConfigSet> _lazyAnalyzerConfigSet;
 
-            public WorkspaceSyntaxTreeOptionsProvider(ValueSource<AnalyzerConfigSet> lazyAnalyzerConfigSet)
+            public WorkspaceSyntaxTreeOptionsProvider(ValueSource<CachingAnalyzerConfigSet> lazyAnalyzerConfigSet)
                 => _lazyAnalyzerConfigSet = lazyAnalyzerConfigSet;
 
             public override bool? IsGenerated(SyntaxTree tree)
@@ -362,9 +364,9 @@ namespace Microsoft.CodeAnalysis
             public override int GetHashCode() => _lazyAnalyzerConfigSet.GetHashCode();
         }
 
-        private static ValueSource<AnalyzerConfigSet> ComputeAnalyzerConfigSetValueSource(IEnumerable<AnalyzerConfigDocumentState> analyzerConfigDocumentStates)
+        private static ValueSource<CachingAnalyzerConfigSet> ComputeAnalyzerConfigSetValueSource(IEnumerable<AnalyzerConfigDocumentState> analyzerConfigDocumentStates)
         {
-            return new AsyncLazy<AnalyzerConfigSet>(
+            return new AsyncLazy<CachingAnalyzerConfigSet>(
                 asynchronousComputeFunction: async cancellationToken =>
                 {
                     var tasks = analyzerConfigDocumentStates.Select(a => a.GetAnalyzerConfigAsync(cancellationToken));
@@ -372,12 +374,12 @@ namespace Microsoft.CodeAnalysis
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    return AnalyzerConfigSet.Create(analyzerConfigs);
+                    return new CachingAnalyzerConfigSet(AnalyzerConfigSet.Create(analyzerConfigs));
                 },
                 synchronousComputeFunction: cancellationToken =>
                 {
                     var analyzerConfigs = analyzerConfigDocumentStates.SelectAsArray(a => a.GetAnalyzerConfig(cancellationToken));
-                    return AnalyzerConfigSet.Create(analyzerConfigs);
+                    return new CachingAnalyzerConfigSet(AnalyzerConfigSet.Create(analyzerConfigs));
                 },
                 cacheResult: true);
         }
@@ -522,7 +524,7 @@ namespace Microsoft.CodeAnalysis
             ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState>? analyzerConfigDocumentStates = null,
             AsyncLazy<VersionStamp>? latestDocumentVersion = null,
             AsyncLazy<VersionStamp>? latestDocumentTopLevelChangeVersion = null,
-            ValueSource<AnalyzerConfigSet>? analyzerConfigSet = null)
+            ValueSource<CachingAnalyzerConfigSet>? analyzerConfigSet = null)
         {
             return new ProjectState(
                 projectInfo ?? _projectInfo,
@@ -695,6 +697,7 @@ namespace Microsoft.CodeAnalysis
                 projectInfo = projectInfo
                     .WithCompilationOptions(CompilationOptions.WithSyntaxTreeOptionsProvider(newProvider));
             }
+
             return this.With(
                 projectInfo: projectInfo,
                 analyzerConfigDocumentStates: newAnalyzerConfigDocumentStates,
@@ -703,10 +706,13 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveDocuments(ImmutableArray<DocumentId> documentIds)
         {
+            // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
+            // for removed documents.
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
                 documentIds: _documentIds.RemoveRange(documentIds),
-                documentStates: _documentStates.RemoveRange(documentIds));
+                documentStates: _documentStates.RemoveRange(documentIds),
+                analyzerConfigSet: ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates.Values));
         }
 
         public ProjectState RemoveAdditionalDocuments(ImmutableArray<DocumentId> documentIds)
@@ -726,10 +732,13 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveAllDocuments()
         {
+            // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
+            // for removed documents.
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()).WithDocuments(SpecializedCollections.EmptyEnumerable<DocumentInfo>()),
                 documentIds: ImmutableList<DocumentId>.Empty,
-                documentStates: ImmutableSortedDictionary.Create<DocumentId, DocumentState>(DocumentIdComparer.Instance));
+                documentStates: ImmutableSortedDictionary.Create<DocumentId, DocumentState>(DocumentIdComparer.Instance),
+                analyzerConfigSet: ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates.Values));
         }
 
         public ProjectState UpdateDocument(DocumentState newDocument, bool textChanged, bool recalculateDependentVersions)


### PR DESCRIPTION
The change to move .editorconfig off of syntax trees meant that we were recomputing a bunch of information again and again, since previously the cached syntax trees implicitly acted as a cache of this data. This adds a quick cache back to avoid some extra overhead.


<details>
<summary>Ask Mode</summary>

**Who is impacted by this bug?**
Anybody who tries using a solution with an .editorconfig that is big enough to have scale issues. (Roslyn is notably impacted.)

**Bugs Fixed**
We don't have a tracking bug -- we just wrote the PR as soon as we were aware of the issue.

**What is the customer scenario and impact of the bug?**
If you have solutions with .editorconfigs, a bunch of features will slow down. For example, making a change in Roslyn and waiting for squiggles to show for that change is slowed down from a few seconds to almost a minute.

**What is the workaround?**
None.

**How was the bug found?**
Dogfooding.

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
Insufficient testing of https://github.com/dotnet/roslyn/pull/44331. The original change was a performance fix for one scenario, but this regressed the perf for a different change. RPS doesn't have any scenarios where we test a solution with an .editorconfig, so the path that regressed is never tested. We are working on making such a test solution long term.

**Testing**
Manually verified by two different developers. Long term, an automated test is being worked on to catch this.

</details>