### PR TITLE
No PROTOTYPE markers allowed in compiler in certain branches

### DIFF
--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -33,6 +33,19 @@ try {
   . (Join-Path $PSScriptRoot "build-utils.ps1")
   Push-Location $RepoRoot
 
+  # Verify no PROTOTYPE marker left in master
+  if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "master")
+  {
+    Write-Host "Checking no PROTOTYPE markers in compiler source"
+    Get-ChildItem -Path src/Compilers/*.cs,src/Compilers/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch -OutVariable prototypes | Out-Null
+    if ($prototypes)
+    {
+      Write-Host "Found PROTOTYPE markers in compiler source:"
+      Write-Host $prototypes
+      throw "PROTOTYPE markers disallowed in compiler source"
+    }
+  }
+
   Write-Host "Building Roslyn"
   Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"}
 

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -37,7 +37,7 @@ try {
   if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "master")
   {
     Write-Host "Checking no PROTOTYPE markers in compiler source"
-    Get-ChildItem -Path src/Compilers/*.cs,src/Compilers/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch -OutVariable prototypes | Out-Null
+    $prototypes = Get-ChildItem -Path src/Compilers/*.cs,src/Compilers/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
     if ($prototypes)
     {
       Write-Host "Found PROTOTYPE markers in compiler source:"

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -34,12 +34,10 @@ try {
   Push-Location $RepoRoot
 
   # Verify no PROTOTYPE marker left in master
-  if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "master")
-  {
+  if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "master") {
     Write-Host "Checking no PROTOTYPE markers in compiler source"
-    $prototypes = Get-ChildItem -Path src/Compilers/*.cs,src/Compilers/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
-    if ($prototypes)
-    {
+    $prototypes = Get-ChildItem -Path src/Compilers/*.cs, src/Compilers/*.vb,src/Compilers/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
+    if ($prototypes) {
       Write-Host "Found PROTOTYPE markers in compiler source:"
       Write-Host $prototypes
       throw "PROTOTYPE markers disallowed in compiler source"

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1047,7 +1047,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 // error CS1715: 'Derived.M': type must be 'object' to match overridden member 'Base.M'
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.Type);
-                                // https://github.com/dotnet/roslyn/issues/46745 when overriddenMemberType.Type is an inheritable reference type and the covariant return
+                                // https://github.com/dotnet/roslyn/issues/44207 when overriddenMemberType.Type is an inheritable reference type and the covariant return
                                 // feature is enabled, and the platform supports it, and there is no setter, we can say it has to be 'object' **or a derived type**.
                                 // That would probably be a new error code.
                             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1047,7 +1047,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 // error CS1715: 'Derived.M': type must be 'object' to match overridden member 'Base.M'
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.Type);
-                                // PROTOTYPE(covariant-returns): when overriddenMemberType.Type is an inheritable reference type and the covariant return
+                                // https://github.com/dotnet/roslyn/issues/46745 when overriddenMemberType.Type is an inheritable reference type and the covariant return
                                 // feature is enabled, and the platform supports it, and there is no setter, we can say it has to be 'object' **or a derived type**.
                                 // That would probably be a new error code.
                             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -2083,6 +2083,7 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: '(c?.GetP
 
         }
 
+        // PROTOTYPE
         [Fact]
         public void UnusedFunctionPointerAsResultOfQuestionDot()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -2083,7 +2083,6 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: '(c?.GetP
 
         }
 
-        // PROTOTYPE
         [Fact]
         public void UnusedFunctionPointerAsResultOfQuestionDot()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/32170