### PR TITLE
Apply limited code cleanup when creating new files

### DIFF
--- a/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
@@ -54,7 +54,19 @@ namespace Microsoft.CodeAnalysis.FileHeaders
         private async Task<Document> GetTransformedDocumentAsync(Document document, CancellationToken cancellationToken)
             => document.WithSyntaxRoot(await GetTransformedSyntaxRootAsync(document, cancellationToken).ConfigureAwait(false));
 
-        private async Task<SyntaxNode> GetTransformedSyntaxRootAsync(Document document, CancellationToken cancellationToken)
+        private Task<SyntaxNode> GetTransformedSyntaxRootAsync(Document document, CancellationToken cancellationToken)
+        {
+#if CODE_STYLE
+            var newLineText = Environment.NewLine;
+#else
+            var newLineText = document.Project.Solution.Options.GetOption(FormattingOptions.NewLine, document.Project.Language);
+#endif
+            var newLineTrivia = EndOfLine(newLineText);
+
+            return GetTransformedSyntaxRootAsync(SyntaxFacts, FileHeaderHelper, newLineTrivia, document, cancellationToken);
+        }
+
+        internal static async Task<SyntaxNode> GetTransformedSyntaxRootAsync(ISyntaxFacts syntaxFacts, AbstractFileHeaderHelper fileHeaderHelper, SyntaxTrivia newLineTrivia, Document document, CancellationToken cancellationToken)
         {
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
@@ -68,21 +80,21 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 
             var expectedFileHeader = fileHeaderTemplate.Replace("{fileName}", Path.GetFileName(document.FilePath));
 
-            var fileHeader = FileHeaderHelper.ParseFileHeader(root);
+            var fileHeader = fileHeaderHelper.ParseFileHeader(root);
             SyntaxNode newSyntaxRoot;
             if (fileHeader.IsMissing)
             {
-                newSyntaxRoot = AddHeader(document, root, expectedFileHeader);
+                newSyntaxRoot = AddHeader(syntaxFacts, fileHeaderHelper, newLineTrivia, root, expectedFileHeader);
             }
             else
             {
-                newSyntaxRoot = ReplaceHeader(document, root, expectedFileHeader);
+                newSyntaxRoot = ReplaceHeader(syntaxFacts, fileHeaderHelper, newLineTrivia, root, expectedFileHeader);
             }
 
             return newSyntaxRoot;
         }
 
-        private SyntaxNode ReplaceHeader(Document document, SyntaxNode root, string expectedFileHeader)
+        private static SyntaxNode ReplaceHeader(ISyntaxFacts syntaxFacts, AbstractFileHeaderHelper fileHeaderHelper, SyntaxTrivia newLineTrivia, SyntaxNode root, string expectedFileHeader)
         {
             // Skip single line comments, whitespace, and end of line trivia until a blank line is encountered.
             var triviaList = root.GetLeadingTrivia();
@@ -108,7 +120,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             for (var i = 0; i < triviaList.Count; i++)
             {
                 var triviaLine = triviaList[i];
-                if (triviaLine.RawKind == SyntaxKinds.SingleLineCommentTrivia)
+                if (triviaLine.RawKind == syntaxFacts.SyntaxKinds.SingleLineCommentTrivia)
                 {
                     if (possibleLeadingSpaces != string.Empty)
                     {
@@ -120,7 +132,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
                     removalList.Add(i);
                     onBlankLine = false;
                 }
-                else if (triviaLine.RawKind == SyntaxKinds.WhitespaceTrivia)
+                else if (triviaLine.RawKind == syntaxFacts.SyntaxKinds.WhitespaceTrivia)
                 {
                     if (leadingSpaces == string.Empty)
                     {
@@ -129,7 +141,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 
                     removalList.Add(i);
                 }
-                else if (triviaLine.RawKind == SyntaxKinds.EndOfLineTrivia)
+                else if (triviaLine.RawKind == syntaxFacts.SyntaxKinds.EndOfLineTrivia)
                 {
                     possibleLeadingSpaces = string.Empty;
                     removalList.Add(i);
@@ -155,14 +167,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
                 triviaList = triviaList.RemoveAt(removalList[i]);
             }
 
-#if CODE_STYLE
-            var newLineText = Environment.NewLine;
-#else
-            var newLineText = document.Project.Solution.Options.GetOption(FormattingOptions.NewLine, root.Language);
-#endif
-            var newLineTrivia = EndOfLine(newLineText);
-
-            var newHeaderTrivia = CreateNewHeader(leadingSpaces + FileHeaderHelper.CommentPrefix, expectedFileHeader, newLineText);
+            var newHeaderTrivia = CreateNewHeader(syntaxFacts, leadingSpaces + fileHeaderHelper.CommentPrefix, expectedFileHeader, newLineTrivia.ToFullString());
 
             // Add a blank line and any remaining preserved trivia after the header.
             newHeaderTrivia = newHeaderTrivia.Add(newLineTrivia).Add(newLineTrivia).AddRange(triviaList);
@@ -171,26 +176,20 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             return root.WithLeadingTrivia(newHeaderTrivia);
         }
 
-        private SyntaxNode AddHeader(Document document, SyntaxNode root, string expectedFileHeader)
+        private static SyntaxNode AddHeader(ISyntaxFacts syntaxFacts, AbstractFileHeaderHelper fileHeaderHelper, SyntaxTrivia newLineTrivia, SyntaxNode root, string expectedFileHeader)
         {
-#if CODE_STYLE
-            var newLineText = Environment.NewLine;
-#else
-            var newLineText = document.Project.Solution.Options.GetOption(FormattingOptions.NewLine, root.Language);
-#endif
-            var newLineTrivia = EndOfLine(newLineText);
-            var newTrivia = CreateNewHeader(FileHeaderHelper.CommentPrefix, expectedFileHeader, newLineText).Add(newLineTrivia).Add(newLineTrivia);
+            var newTrivia = CreateNewHeader(syntaxFacts, fileHeaderHelper.CommentPrefix, expectedFileHeader, newLineTrivia.ToFullString()).Add(newLineTrivia).Add(newLineTrivia);
 
             // Skip blank lines already at the beginning of the document, since we add our own
             var leadingTrivia = root.GetLeadingTrivia();
             var skipCount = 0;
             for (var i = 0; i < leadingTrivia.Count; i++)
             {
-                if (leadingTrivia[i].RawKind == SyntaxKinds.EndOfLineTrivia)
+                if (leadingTrivia[i].RawKind == syntaxFacts.SyntaxKinds.EndOfLineTrivia)
                 {
                     skipCount = i + 1;
                 }
-                else if (leadingTrivia[i].RawKind != SyntaxKinds.WhitespaceTrivia)
+                else if (leadingTrivia[i].RawKind != syntaxFacts.SyntaxKinds.WhitespaceTrivia)
                 {
                     break;
                 }
@@ -201,11 +200,11 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             return root.WithLeadingTrivia(newTrivia);
         }
 
-        private SyntaxTriviaList CreateNewHeader(string prefixWithLeadingSpaces, string expectedFileHeader, string newLineText)
+        private static SyntaxTriviaList CreateNewHeader(ISyntaxFacts syntaxFacts, string prefixWithLeadingSpaces, string expectedFileHeader, string newLineText)
         {
             var copyrightText = GetCopyrightText(prefixWithLeadingSpaces, expectedFileHeader, newLineText);
             var newHeader = copyrightText;
-            return SyntaxFacts.ParseLeadingTrivia(newHeader);
+            return syntaxFacts.ParseLeadingTrivia(newHeader);
         }
 
         private static string GetCopyrightText(string prefixWithLeadingSpaces, string copyrightText, string newLineText)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -6,7 +6,11 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.FileHeaders;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.FileHeaders;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation;
 
@@ -23,5 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         protected override string ContentTypeName => ContentTypeNames.CSharpContentType;
         protected override string LanguageName => LanguageNames.CSharp;
+        protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
+        protected override AbstractFileHeaderHelper FileHeaderHelper => CSharpFileHeaderHelper.Instance;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -5,9 +5,12 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.FileHeaders;
+using Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.FileHeaders;
@@ -29,5 +32,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         protected override string LanguageName => LanguageNames.CSharp;
         protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
         protected override AbstractFileHeaderHelper FileHeaderHelper => CSharpFileHeaderHelper.Instance;
+
+        protected override async Task<Document> OrganizeUsingsCreatedFromTemplateAsync(Document document, CancellationToken cancellationToken)
+        {
+            var organizedDocument = await base.OrganizeUsingsCreatedFromTemplateAsync(document, cancellationToken).ConfigureAwait(false);
+            return await MisplacedUsingDirectivesCodeFixProvider.TransformDocumentIfRequiredAsync(organizedDocument, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -315,6 +315,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 rootToFormat = documentWithFileHeader;
             }
 
+            // Sort using directives
+            addedDocument = ThreadHelper.JoinableTaskFactory.Run(() => Formatter.OrganizeImportsAsync(addedDocument, cancellationToken));
+            rootToFormat = addedDocument.GetSyntaxRootSynchronously(cancellationToken);
+
             // Format document
             var unformattedText = addedDocument.GetTextSynchronously(cancellationToken);
             var formattedRoot = Formatter.Format(rootToFormat, workspace, documentOptions, cancellationToken);

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Editing;
@@ -257,6 +258,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         int IVsEditorFactoryNotify.NotifyItemRenamed(IVsHierarchy pHier, uint itemid, string pszMkDocumentOld, string pszMkDocumentNew)
             => VSConstants.S_OK;
 
+        protected virtual Task<Document> OrganizeUsingsCreatedFromTemplateAsync(Document document, CancellationToken cancellationToken)
+            => Formatter.OrganizeImportsAsync(document, cancellationToken);
+
         private void FormatDocumentCreatedFromTemplate(IVsHierarchy hierarchy, uint itemid, string filePath, CancellationToken cancellationToken)
         {
             // A file has been created on disk which the user added from the "Add Item" dialog. We need
@@ -315,8 +319,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 rootToFormat = documentWithFileHeader;
             }
 
-            // Sort using directives
-            addedDocument = ThreadHelper.JoinableTaskFactory.Run(() => Formatter.OrganizeImportsAsync(addedDocument, cancellationToken));
+            // Organize using directives
+            addedDocument = ThreadHelper.JoinableTaskFactory.Run(() => OrganizeUsingsCreatedFromTemplateAsync(addedDocument, cancellationToken));
             rootToFormat = addedDocument.GetSyntaxRootSynchronously(cancellationToken);
 
             // Format document

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
@@ -4,7 +4,11 @@
 
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.CodeAnalysis.FileHeaders
+Imports Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
+Imports Microsoft.CodeAnalysis.VisualBasic.FileHeaders
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
 
@@ -26,6 +30,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.VisualBasic
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property SyntaxGenerator As SyntaxGenerator
+            Get
+                Return VisualBasicSyntaxGenerator.Instance
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property FileHeaderHelper As AbstractFileHeaderHelper
+            Get
+                Return VisualBasicFileHeaderHelper.Instance
             End Get
         End Property
     End Class


### PR DESCRIPTION
Apply limited code cleanup when creating new files from templates:

* Add file header if necessary
* Sort using directives and separate groups if necessary
* Place using directives inside/outside namespace if necessary

Closes #21227
Closes #36214