### PR TITLE
Check async modifier in DeclarationModifiers

### DIFF
--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -1701,7 +1701,7 @@ namespace PushUpTest
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
-        public async Task Pull()
+        public async Task TestPullAsyncMethod()
         {
             var testText = @"
 using System.Threading.Tasks;

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -1700,7 +1700,7 @@ namespace PushUpTest
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task Pull()
         {
             var testText = @"

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -1233,7 +1233,7 @@ namespace Destination
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestPullMethodUpToVBClassViaQuickAction()
         {
-            // Moving member from C# to Visual Basic is not supported currently since the FindMostRelevantDeclarationAsync method in 
+            // Moving member from C# to Visual Basic is not supported currently since the FindMostRelevantDeclarationAsync method in
             // AbstractCodeGenerationService will return null.
             var input = @"
 <Workspace>
@@ -1698,6 +1698,39 @@ namespace PushUpTest
     }
 }";
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
+        }
+
+        [Fact]
+        public async Task Pull()
+        {
+            var testText = @"
+using System.Threading.Tasks;
+
+internal interface IPullUp { }
+
+internal class PullUp : IPullUp
+{
+    internal async Task PullU[||]pAsync()
+    {
+        await Task.Delay(1000);
+    }
+}";
+            var expectedText = @"
+using System.Threading.Tasks;
+
+internal interface IPullUp
+{
+    Task PullUpAsync();
+}
+
+internal class PullUp : IPullUp
+{
+    public async Task PullUpAsync()
+    {
+        await Task.Delay(1000);
+    }
+}";
+            await TestWithPullMemberDialogAsync(testText, expectedText);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]

--- a/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
+++ b/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
             // Currently support to pull field, method, event, property and indexer up,
             // constructor, operator and finalizer are excluded.
             var (document, _, cancellationToken) = context;
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var selectedMemberNode = await GetSelectedNodeAsync(context).ConfigureAwait(false);
             if (selectedMemberNode == null)

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -3463,6 +3463,19 @@ class C
 }");
         }
 
+        [Fact]
+        public void TestAsyncMethodModifier()
+        {
+            TestModifiersAsync(DeclarationModifiers.Async,
+                @"
+using System.Threading.Tasks;
+class C
+{
+    [|public async Task DoAsync() { await Task.CompletedTask; }|]
+}
+");
+        }
+
         [Fact, WorkItem(1084965, " https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1084965")]
         public void TestPropertyModifiers1()
         {

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -75,9 +75,9 @@ namespace Microsoft.CodeAnalysis.Editing
                     isVirtual: symbol.IsVirtual,
                     isOverride: symbol.IsOverride,
                     isSealed: symbol.IsSealed,
-                    isConst: field != null && field.IsConst,
+                    isConst: field?.IsConst == true,
                     isUnsafe: symbol.RequiresUnsafeModifier(),
-                    isVolatile: field != null && field.IsVolatile,
+                    isVolatile: field?.IsVolatile == true,
                     isExtern: symbol.IsExtern,
                     isAsync: method?.IsAsync == true);
             }

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.Editing
             {
                 var field = symbol as IFieldSymbol;
                 var property = symbol as IPropertySymbol;
+                var method = symbol as IMethodSymbol;
 
                 return new DeclarationModifiers(
                     isStatic: symbol.IsStatic,
@@ -77,7 +78,8 @@ namespace Microsoft.CodeAnalysis.Editing
                     isConst: field != null && field.IsConst,
                     isUnsafe: symbol.RequiresUnsafeModifier(),
                     isVolatile: field != null && field.IsVolatile,
-                    isExtern: symbol.IsExtern);
+                    isExtern: symbol.IsExtern,
+                    isAsync: method?.IsAsync == true);
             }
 
             // Only named types, members of named types, and local functions have modifiers.

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -198,7 +198,7 @@ End Class
             VerifySyntax(Of AttributeListSyntax)(Generator.Attribute(GetAttributeData("
 Imports System
 Public Class MyAttribute
-  Inherits Attribute 
+  Inherits Attribute
   Public Property Value As Integer
 End Class
 ", "<MyAttribute(Value := 123)>")), "<Global.MyAttribute(Value:=123)>")
@@ -1747,7 +1747,7 @@ End Property")
     End Set
 End Property")
 
-            ' convert private method to public 
+            ' convert private method to public
             Dim pim = Generator.AsPrivateInterfaceImplementation(
                     Generator.MethodDeclaration("m", returnType:=Generator.IdentifierName("t")),
                     Generator.IdentifierName("i"))
@@ -2202,10 +2202,10 @@ Class C
   Custom Event MyEvent As MyDelegate
       AddHandler(ByVal value As MyDelegate)
       End AddHandler
- 
+
       RemoveHandler(ByVal value As MyDelegate)
       End RemoveHandler
- 
+
       RaiseEvent(ByVal message As String)
       End RaiseEvent
   End Event
@@ -3434,7 +3434,7 @@ Public Class C
     Public Shared Z, Y, Z As Integer
 End Class")
 
-            ' Removing 
+            ' Removing
             VerifySyntax(Of ClassBlockSyntax)(
                 Generator.RemoveNode(declC, declX),
 "' Comment


### PR DESCRIPTION
Isssue: #43198 
DeclarationModifiers From(ISymbol symbol) is not checking the async modifier from a symbol. So when a method is changed to public, the async modifier is lost.

Add the check in the method and two unit tests