### PR TITLE
Added some padding to the left of the text - Inline Parameter Name Hints

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
@@ -39,7 +39,10 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                 FontSize = format.FontRenderingEmSize - (0.25 * format.FontRenderingEmSize),
                 FontStyle = FontStyles.Normal,
                 Foreground = format.ForegroundBrush,
-                Padding = new Thickness(1, 0, 0, 0),
+
+                // Adds a little bit of padding to the left of the text relative to the border
+                // to make the text seem more balanced in the border
+                Padding = new Thickness(left: 1, top: 0, right: 0, bottom: 0),
                 Text = text + ":",
                 VerticalAlignment = VerticalAlignment.Center,
             };
@@ -54,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                 CornerRadius = new CornerRadius(2),
                 Height = lineHeight - (0.25 * lineHeight),
                 HorizontalAlignment = HorizontalAlignment.Center,
-                Margin = new Thickness(0, -0.20 * lineHeight, 5, 0),
+                Margin = new Thickness(left: 0, top: -0.20 * lineHeight, right: 5, bottom: 0),
                 Padding = new Thickness(1),
                 VerticalAlignment = VerticalAlignment.Center,
             };

--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                 FontSize = format.FontRenderingEmSize - (0.25 * format.FontRenderingEmSize),
                 FontStyle = FontStyles.Normal,
                 Foreground = format.ForegroundBrush,
-                Padding = new Thickness(0),
+                Padding = new Thickness(1, 0, 0, 0),
                 Text = text + ":",
                 VerticalAlignment = VerticalAlignment.Center,
             };


### PR DESCRIPTION
Hello,

As per the request of the UX Board, I have added some small amount of padding between the TextBlock and the Border to make the text feel less cramped.

Before:
![image](https://user-images.githubusercontent.com/40616383/90052762-9d01a000-dca7-11ea-9411-c0fc18704f8f.png)

After:
![image](https://user-images.githubusercontent.com/40616383/90053006-e94ce000-dca7-11ea-87be-a4dffdd525f8.png)
