### PR TITLE
Improve handling of OOM during EnC analysis

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -10696,8 +10696,8 @@ class C
             });
 
             var expectedDiagnostic = outOfMemory ?
-                Diagnostic(RudeEditKind.MemberBodyTooBig, "public static void G()", "method") :
-                Diagnostic(RudeEditKind.MemberBodyInternalError, "public static void G()", "method");
+                Diagnostic(RudeEditKind.MemberBodyTooBig, "public static void G()", FeaturesResources.method) :
+                Diagnostic(RudeEditKind.MemberBodyInternalError, "public static void G()", FeaturesResources.method);
 
             validator.VerifyRudeDiagnostics(edits, active, new[] { expectedDiagnostic });
         }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Roslyn.Test.Utilities;
@@ -10641,6 +10643,63 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Theory, CombinatorialData]
+        public void MemberBodyInternalError(bool outOfMemory)
+        {
+            var src1 = @"
+class C
+{
+    public static void F()
+    {
+        <AS:1>G();</AS:1>
+    }
+
+    public static void G()
+    {
+        <AS:0>H(1);</AS:0>
+    }
+
+    public static void H(int x)
+    {
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    public static void F()
+    {
+        <AS:1>G();</AS:1>
+    }
+
+    public static void G()
+    {
+        <AS:0>H(2);</AS:0>
+    }
+
+    public static void H(int x)
+    {
+    }
+}
+";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+            var validator = CSharpEditAndContinueTestHelpers.CreateInstance(node =>
+            {
+                if (node.Parent is MethodDeclarationSyntax methodDecl && methodDecl.Identifier.Text == "G")
+                {
+                    throw outOfMemory ? new OutOfMemoryException() : new NullReferenceException("NullRef!");
+                }
+            });
+
+            var expectedDiagnostic = outOfMemory ?
+                Diagnostic(RudeEditKind.MemberBodyTooBig, "public static void G()", "method") :
+                Diagnostic(RudeEditKind.MemberBodyInternalError, "public static void G()", "method");
+
+            validator.VerifyRudeDiagnostics(edits, active, new[] { expectedDiagnostic });
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.EditAndContinue;
-using Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.EditAndContinue;
@@ -15,22 +13,24 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
     internal sealed class CSharpEditAndContinueTestHelpers : EditAndContinueTestHelpers
     {
-        private readonly CSharpEditAndContinueAnalyzer _analyzer = new CSharpEditAndContinueAnalyzer(new TestActiveStatementSpanTracker());
-
         private readonly ImmutableArray<MetadataReference> _fxReferences;
+        private readonly CSharpEditAndContinueAnalyzer _analyzer;
 
-        internal static CSharpEditAndContinueTestHelpers CreateInstance()
-            => new CSharpEditAndContinueTestHelpers(TargetFramework.Mscorlib46Extended);
+        public CSharpEditAndContinueTestHelpers(TargetFramework targetFramework, Action<SyntaxNode> faultInjector = null)
+        {
+            _fxReferences = TargetFrameworkUtil.GetReferences(targetFramework);
+            _analyzer = new CSharpEditAndContinueAnalyzer(new TestActiveStatementSpanTracker(), faultInjector);
+        }
 
-        internal static CSharpEditAndContinueTestHelpers CreateInstance40()
-            => new CSharpEditAndContinueTestHelpers(TargetFramework.Mscorlib40AndSystemCore);
+        internal static CSharpEditAndContinueTestHelpers CreateInstance(Action<SyntaxNode> faultInjector = null)
+            => new CSharpEditAndContinueTestHelpers(TargetFramework.Mscorlib46Extended, faultInjector);
 
-        public CSharpEditAndContinueTestHelpers(TargetFramework targetFramework)
-            => _fxReferences = TargetFrameworkUtil.GetReferences(targetFramework);
+        internal static CSharpEditAndContinueTestHelpers CreateInstance40(Action<SyntaxNode> faultInjector = null)
+            => new CSharpEditAndContinueTestHelpers(TargetFramework.Mscorlib40AndSystemCore, faultInjector);
 
         public override AbstractEditAndContinueAnalyzer Analyzer => _analyzer;
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
     {
         internal static CSharpEditAndContinueAnalyzer CreateAnalyzer()
         {
-            return new CSharpEditAndContinueAnalyzer(new TestActiveStatementSpanTracker());
+            return new CSharpEditAndContinueAnalyzer(new TestActiveStatementSpanTracker(), testFaultInjector: null);
         }
 
         internal enum MethodKind

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueDiagnosticDescriptorsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueDiagnosticDescriptorsTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Equal(new LocalizableResourceString(nameof(FeaturesResources.Updating_an_active_statement_will_prevent_the_debug_session_from_continuing),
                 FeaturesResources.ResourceManager, typeof(FeaturesResources)), d.MessageFormat);
 
-            Assert.Equal("ENC0082", EditAndContinueDiagnosticDescriptors.GetDescriptor(RudeEditKind.ComplexQueryExpression).Id);
+            Assert.Equal("ENC0087", EditAndContinueDiagnosticDescriptors.GetDescriptor(RudeEditKind.ComplexQueryExpression).Id);
 
             d = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile);
             Assert.Equal("ENC1001", d.Id);

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
@@ -63,7 +65,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 RudeEditKind.ChangingStateMachineShape,
                 RudeEditKind.InternalError,
                 RudeEditKind.MemberBodyInternalError,
-                RudeEditKind.SourceFileTooBig,
             };
 
             var arg3 = new HashSet<RudeEditKind>()
@@ -72,44 +73,49 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 RudeEditKind.DeleteLambdaWithMultiScopeCapture,
             };
 
-            foreach (RudeEditKind value in Enum.GetValues(typeof(RudeEditKind)))
+            var allKinds = Enum.GetValues(typeof(RudeEditKind)).Cast<RudeEditKind>();
+
+            foreach (var kind in allKinds)
             {
-                if (value == RudeEditKind.None)
+                if (kind == RudeEditKind.None)
                 {
                     continue;
                 }
 
-                if (arg0.Contains(value))
+                if (arg0.Contains(kind))
                 {
-                    var re = new RudeEditDiagnostic(value, TextSpan.FromBounds(1, 2));
+                    var re = new RudeEditDiagnostic(kind, TextSpan.FromBounds(1, 2));
                     var d = re.ToDiagnostic(tree);
-                    Assert.False(d.GetMessage().Contains("{"), value.ToString());
+                    Assert.False(d.GetMessage().Contains("{"), kind.ToString());
                 }
-                else if (arg2.Contains(value))
+                else if (arg2.Contains(kind))
                 {
-                    var re = new RudeEditDiagnostic(value, TextSpan.FromBounds(1, 2), syntaxNode, new[] { "<1>", "<2>" });
+                    var re = new RudeEditDiagnostic(kind, TextSpan.FromBounds(1, 2), syntaxNode, new[] { "<1>", "<2>" });
                     var d = re.ToDiagnostic(tree);
-                    Assert.True(d.GetMessage().Contains("<1>"), value.ToString());
-                    Assert.True(d.GetMessage().Contains("<2>"), value.ToString());
-                    Assert.False(d.GetMessage().Contains("{"), value.ToString());
+                    Assert.True(d.GetMessage().Contains("<1>"), kind.ToString());
+                    Assert.True(d.GetMessage().Contains("<2>"), kind.ToString());
+                    Assert.False(d.GetMessage().Contains("{"), kind.ToString());
                 }
-                else if (arg3.Contains(value))
+                else if (arg3.Contains(kind))
                 {
-                    var re = new RudeEditDiagnostic(value, TextSpan.FromBounds(1, 2), syntaxNode, new[] { "<1>", "<2>", "<3>" });
+                    var re = new RudeEditDiagnostic(kind, TextSpan.FromBounds(1, 2), syntaxNode, new[] { "<1>", "<2>", "<3>" });
                     var d = re.ToDiagnostic(tree);
-                    Assert.True(d.GetMessage().Contains("<1>"), value.ToString());
-                    Assert.True(d.GetMessage().Contains("<2>"), value.ToString());
-                    Assert.True(d.GetMessage().Contains("<3>"), value.ToString());
-                    Assert.False(d.GetMessage().Contains("{"), value.ToString());
+                    Assert.True(d.GetMessage().Contains("<1>"), kind.ToString());
+                    Assert.True(d.GetMessage().Contains("<2>"), kind.ToString());
+                    Assert.True(d.GetMessage().Contains("<3>"), kind.ToString());
+                    Assert.False(d.GetMessage().Contains("{"), kind.ToString());
                 }
                 else
                 {
-                    var re = new RudeEditDiagnostic(value, TextSpan.FromBounds(1, 2), syntaxNode, new[] { "<1>" });
+                    var re = new RudeEditDiagnostic(kind, TextSpan.FromBounds(1, 2), syntaxNode, new[] { "<1>" });
                     var d = re.ToDiagnostic(tree);
-                    Assert.True(d.GetMessage().Contains("<1>"), value.ToString());
-                    Assert.False(d.GetMessage().Contains("{"), value.ToString());
+                    Assert.True(d.GetMessage().Contains("<1>"), kind.ToString());
+                    Assert.False(d.GetMessage().Contains("{"), kind.ToString());
                 }
             }
+
+            // check that all values are unique:
+            AssertEx.Equal(allKinds, allKinds.Distinct());
         }
     }
 }

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -62,6 +62,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 RudeEditKind.RenamingCapturedVariable,
                 RudeEditKind.ChangingStateMachineShape,
                 RudeEditKind.InternalError,
+                RudeEditKind.MemberBodyInternalError,
+                RudeEditKind.SourceFileTooBig,
             };
 
             var arg3 = new HashSet<RudeEditKind>()

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -38,13 +38,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
             {
-                return new CSharpEditAndContinueAnalyzer(languageServices.WorkspaceServices.GetRequiredService<IActiveStatementSpanTrackerFactory>().GetOrCreateActiveStatementSpanTracker());
+                var activeStatementSpanTracker = languageServices.WorkspaceServices.GetRequiredService<IActiveStatementSpanTrackerFactory>().GetOrCreateActiveStatementSpanTracker();
+                return new CSharpEditAndContinueAnalyzer(activeStatementSpanTracker, testFaultInjector: null);
             }
         }
 
         // Public for testing purposes
-        public CSharpEditAndContinueAnalyzer(IActiveStatementSpanTracker activeStatementSpanTracker)
-            : base(activeStatementSpanTracker)
+        public CSharpEditAndContinueAnalyzer(IActiveStatementSpanTracker activeStatementSpanTracker, Action<SyntaxNode>? testFaultInjector = null)
+            : base(activeStatementSpanTracker, testFaultInjector)
         {
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -30,9 +30,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         private readonly IActiveStatementSpanTracker _activeStatementSpanTracker;
 
-        protected AbstractEditAndContinueAnalyzer(IActiveStatementSpanTracker activeStatementSpanTracker)
+        // used by tests to validate correct handlign of unexpected exceptions
+        private readonly Action<SyntaxNode>? _testFaultInjector;
+
+        protected AbstractEditAndContinueAnalyzer(IActiveStatementSpanTracker activeStatementSpanTracker, Action<SyntaxNode>? testFaultInjector)
         {
             _activeStatementSpanTracker = activeStatementSpanTracker;
+            _testFaultInjector = testFaultInjector;
         }
 
         internal abstract bool ExperimentalFeaturesEnabled(SyntaxTree tree);
@@ -417,6 +421,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var newRoot = await newTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
                 var newText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
+                _testFaultInjector?.Invoke(newRoot);
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // TODO: newTree.HasErrors?
@@ -589,29 +594,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     lineEdits.AsImmutable(),
                     hasSemanticErrors: false);
             }
-            catch (Exception e) when (ReportFatalErrorAnalyzeDocumentAsync(baseActiveStatements, e))
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
                 // The same behavior as if there was a syntax error - we are unable to analyze the document. 
-                return DocumentAnalysisResults.SyntaxErrors(ImmutableArray.Create(
-                    new RudeEditDiagnostic(RudeEditKind.InternalError, span: default, arguments: new[] { document.FilePath, e.ToString() })));
+                // We expect OOM to be thrown durign the analysis if the number of top-level entities is too large.
+                // In such case we report a rude edit for the document. If the host is actually running out of memory,
+                // it might throw another OOM here or later on.
+                var diagnostic = (e is OutOfMemoryException) ?
+                    new RudeEditDiagnostic(RudeEditKind.SourceFileTooBig, span: default, arguments: new[] { document.FilePath }) :
+                    new RudeEditDiagnostic(RudeEditKind.InternalError, span: default, arguments: new[] { document.FilePath, e.ToString() });
+
+                return DocumentAnalysisResults.SyntaxErrors(ImmutableArray.Create(diagnostic));
             }
-        }
-
-#pragma warning disable IDE0052 // Remove unread private members
-        // Active statements spans are usually unavailable in crash dumps due to a bug in the debugger (DevDiv #150901), 
-        // so we stash them here in plain array (can't use immutable, see the bug) just before we report NFW.
-        private static ActiveStatement[]? s_fatalErrorBaseActiveStatements;
-#pragma warning restore IDE0052 // Remove unread private members
-
-        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "'AnalyzeDocumentAsync' is the name of the method where an error occurred.")]
-        private static bool ReportFatalErrorAnalyzeDocumentAsync(ImmutableArray<ActiveStatement> baseActiveStatements, Exception e)
-        {
-            if (!(e is OperationCanceledException))
-            {
-                s_fatalErrorBaseActiveStatements = baseActiveStatements.ToArray();
-            }
-
-            return FatalError.ReportWithoutCrashUnlessCanceled(e);
         }
 
         internal static Dictionary<SyntaxNode, EditKind> BuildEditMap(EditScript<SyntaxNode> editScript)
@@ -987,179 +981,208 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return;
             }
 
-            // Populated with active lambdas and matched lambdas. 
-            // Unmatched non-active lambdas are not included.
-            // { old-lambda-body -> info }
-            Dictionary<SyntaxNode, LambdaInfo>? lazyActiveOrMatchedLambdas = null;
-
-            // finds leaf nodes that correspond to the old active statements:
-            Debug.Assert(end > start || !hasActiveStatement && end == start);
-            var activeNodes = new ActiveNode[end - start];
-            for (var i = 0; i < activeNodes.Length; i++)
+            try
             {
-                var ordinal = start + i;
-                var oldStatementSpan = oldText.Lines.GetTextSpanSafe(oldActiveStatements[ordinal].Span);
+                _testFaultInjector?.Invoke(newBody);
 
-                var oldStatementSyntax = FindStatement(oldBody, oldStatementSpan, out var statementPart);
-                Contract.ThrowIfNull(oldStatementSyntax);
+                // Populated with active lambdas and matched lambdas. 
+                // Unmatched non-active lambdas are not included.
+                // { old-lambda-body -> info }
+                Dictionary<SyntaxNode, LambdaInfo>? lazyActiveOrMatchedLambdas = null;
 
-                var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldStatementSyntax);
-                if (oldEnclosingLambdaBody != null)
+                // finds leaf nodes that correspond to the old active statements:
+                Debug.Assert(end > start || !hasActiveStatement && end == start);
+                var activeNodes = new ActiveNode[end - start];
+                for (var i = 0; i < activeNodes.Length; i++)
                 {
-                    lazyActiveOrMatchedLambdas ??= new Dictionary<SyntaxNode, LambdaInfo>();
+                    var ordinal = start + i;
+                    var oldStatementSpan = oldText.Lines.GetTextSpanSafe(oldActiveStatements[ordinal].Span);
 
-                    if (!lazyActiveOrMatchedLambdas.TryGetValue(oldEnclosingLambdaBody, out var lambda))
+                    var oldStatementSyntax = FindStatement(oldBody, oldStatementSpan, out var statementPart);
+                    Contract.ThrowIfNull(oldStatementSyntax);
+
+                    var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldStatementSyntax);
+                    if (oldEnclosingLambdaBody != null)
                     {
-                        lambda = new LambdaInfo(new List<int>());
-                        lazyActiveOrMatchedLambdas.Add(oldEnclosingLambdaBody, lambda);
+                        lazyActiveOrMatchedLambdas ??= new Dictionary<SyntaxNode, LambdaInfo>();
+
+                        if (!lazyActiveOrMatchedLambdas.TryGetValue(oldEnclosingLambdaBody, out var lambda))
+                        {
+                            lambda = new LambdaInfo(new List<int>());
+                            lazyActiveOrMatchedLambdas.Add(oldEnclosingLambdaBody, lambda);
+                        }
+
+                        lambda.ActiveNodeIndices!.Add(i);
                     }
 
-                    lambda.ActiveNodeIndices!.Add(i);
-                }
+                    SyntaxNode? trackedNode = null;
+                    // Tracking spans corresponding to the active statements from the tracking service.
+                    // We seed the method body matching algorithm with tracking spans (unless they were deleted)
+                    // to get precise matching.
+                    var isTracked = _activeStatementSpanTracker.TryGetSpan(new ActiveStatementId(documentId, ordinal), newText, out var trackedSpan);
 
-                SyntaxNode? trackedNode = null;
-                // Tracking spans corresponding to the active statements from the tracking service.
-                // We seed the method body matching algorithm with tracking spans (unless they were deleted)
-                // to get precise matching.
-                var isTracked = _activeStatementSpanTracker.TryGetSpan(new ActiveStatementId(documentId, ordinal), newText, out var trackedSpan);
-
-                if (isTracked)
-                {
-                    // The tracking span might have been deleted or moved outside of the member span.
-                    // It is not an error to move the statement - we just ignore it.
-                    if (trackedSpan.Length != 0 && edit.NewNode.Span.Contains(trackedSpan))
+                    if (isTracked)
                     {
-                        var newStatementSyntax = FindStatement(newBody, trackedSpan, out var part);
-                        Contract.ThrowIfNull(newStatementSyntax);
-
-                        var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody, newStatementSyntax);
-
-                        // The tracking span might have been moved outside of the lambda span.
+                        // The tracking span might have been deleted or moved outside of the member span.
                         // It is not an error to move the statement - we just ignore it.
-                        if (oldEnclosingLambdaBody == newEnclosingLambdaBody &&
-                            StatementLabelEquals(oldStatementSyntax, newStatementSyntax))
+                        if (trackedSpan.Length != 0 && edit.NewNode.Span.Contains(trackedSpan))
                         {
-                            trackedNode = newStatementSyntax;
+                            var newStatementSyntax = FindStatement(newBody, trackedSpan, out var part);
+                            Contract.ThrowIfNull(newStatementSyntax);
+
+                            var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody, newStatementSyntax);
+
+                            // The tracking span might have been moved outside of the lambda span.
+                            // It is not an error to move the statement - we just ignore it.
+                            if (oldEnclosingLambdaBody == newEnclosingLambdaBody &&
+                                StatementLabelEquals(oldStatementSyntax, newStatementSyntax))
+                            {
+                                trackedNode = newStatementSyntax;
+                            }
                         }
                     }
+
+                    activeNodes[i] = new ActiveNode(oldStatementSyntax, oldEnclosingLambdaBody, statementPart, isTracked ? trackedSpan : (TextSpan?)null, trackedNode);
                 }
 
-                activeNodes[i] = new ActiveNode(oldStatementSyntax, oldEnclosingLambdaBody, statementPart, isTracked ? trackedSpan : (TextSpan?)null, trackedNode);
-            }
+                var bodyMatch = ComputeBodyMatch(oldBody, newBody, activeNodes.Where(n => n.EnclosingLambdaBody == null).ToArray(), diagnostics, out var oldHasStateMachineSuspensionPoint, out var newHasStateMachineSuspensionPoint);
+                var map = ComputeMap(bodyMatch, activeNodes, ref lazyActiveOrMatchedLambdas, diagnostics);
 
-            var bodyMatch = ComputeBodyMatch(oldBody, newBody, activeNodes.Where(n => n.EnclosingLambdaBody == null).ToArray(), diagnostics, out var oldHasStateMachineSuspensionPoint, out var newHasStateMachineSuspensionPoint);
-            var map = ComputeMap(bodyMatch, activeNodes, ref lazyActiveOrMatchedLambdas, diagnostics);
+                // Save the body match for local variable mapping.
+                // We'll use it to tell the compiler what local variables to preserve in an active method.
+                // An edited async/iterator method is considered active.
+                updatedMembers.Add(new UpdatedMemberInfo(editOrdinal, oldBody, newBody, map, lazyActiveOrMatchedLambdas, hasActiveStatement, oldHasStateMachineSuspensionPoint, newHasStateMachineSuspensionPoint));
 
-            // Save the body match for local variable mapping.
-            // We'll use it to tell the compiler what local variables to preserve in an active method.
-            // An edited async/iterator method is considered active.
-            updatedMembers.Add(new UpdatedMemberInfo(editOrdinal, oldBody, newBody, map, lazyActiveOrMatchedLambdas, hasActiveStatement, oldHasStateMachineSuspensionPoint, newHasStateMachineSuspensionPoint));
-
-            for (var i = 0; i < activeNodes.Length; i++)
-            {
-                var ordinal = start + i;
-                var hasMatching = false;
-                var isNonLeaf = oldActiveStatements[ordinal].IsNonLeaf;
-                var isPartiallyExecuted = (oldActiveStatements[ordinal].Flags & ActiveStatementFlags.PartiallyExecuted) != 0;
-                var statementPart = activeNodes[i].StatementPart;
-                var oldStatementSyntax = activeNodes[i].OldNode;
-                var oldEnclosingLambdaBody = activeNodes[i].EnclosingLambdaBody;
-
-                newExceptionRegions[ordinal] = ImmutableArray.Create<LinePositionSpan>();
-
-                TextSpan newSpan;
-                SyntaxNode? newStatementSyntax;
-                Match<SyntaxNode>? match;
-
-                if (oldEnclosingLambdaBody == null)
+                for (var i = 0; i < activeNodes.Length; i++)
                 {
-                    match = bodyMatch;
+                    var ordinal = start + i;
+                    var hasMatching = false;
+                    var isNonLeaf = oldActiveStatements[ordinal].IsNonLeaf;
+                    var isPartiallyExecuted = (oldActiveStatements[ordinal].Flags & ActiveStatementFlags.PartiallyExecuted) != 0;
+                    var statementPart = activeNodes[i].StatementPart;
+                    var oldStatementSyntax = activeNodes[i].OldNode;
+                    var oldEnclosingLambdaBody = activeNodes[i].EnclosingLambdaBody;
 
-                    hasMatching = TryMatchActiveStatement(oldStatementSyntax, statementPart, oldBody, newBody, out newStatementSyntax) ||
-                                  match.TryGetNewNode(oldStatementSyntax, out newStatementSyntax);
-                }
-                else
-                {
-                    RoslynDebug.Assert(lazyActiveOrMatchedLambdas != null);
+                    newExceptionRegions[ordinal] = ImmutableArray.Create<LinePositionSpan>();
 
-                    var oldLambdaInfo = lazyActiveOrMatchedLambdas[oldEnclosingLambdaBody];
-                    var newEnclosingLambdaBody = oldLambdaInfo.NewBody;
-                    match = oldLambdaInfo.Match;
+                    TextSpan newSpan;
+                    SyntaxNode? newStatementSyntax;
+                    Match<SyntaxNode>? match;
 
-                    if (match != null)
+                    if (oldEnclosingLambdaBody == null)
                     {
-                        RoslynDebug.Assert(newEnclosingLambdaBody != null); // matching lambda has body
+                        match = bodyMatch;
 
-                        hasMatching = TryMatchActiveStatement(oldStatementSyntax, statementPart, oldEnclosingLambdaBody, newEnclosingLambdaBody, out newStatementSyntax) ||
+                        hasMatching = TryMatchActiveStatement(oldStatementSyntax, statementPart, oldBody, newBody, out newStatementSyntax) ||
                                       match.TryGetNewNode(oldStatementSyntax, out newStatementSyntax);
                     }
                     else
                     {
-                        // Lambda match is null if lambdas can't be matched, 
-                        // in such case we won't have active statement matched either.
-                        hasMatching = false;
-                        newStatementSyntax = null;
+                        RoslynDebug.Assert(lazyActiveOrMatchedLambdas != null);
+
+                        var oldLambdaInfo = lazyActiveOrMatchedLambdas[oldEnclosingLambdaBody];
+                        var newEnclosingLambdaBody = oldLambdaInfo.NewBody;
+                        match = oldLambdaInfo.Match;
+
+                        if (match != null)
+                        {
+                            RoslynDebug.Assert(newEnclosingLambdaBody != null); // matching lambda has body
+
+                            hasMatching = TryMatchActiveStatement(oldStatementSyntax, statementPart, oldEnclosingLambdaBody, newEnclosingLambdaBody, out newStatementSyntax) ||
+                                          match.TryGetNewNode(oldStatementSyntax, out newStatementSyntax);
+                        }
+                        else
+                        {
+                            // Lambda match is null if lambdas can't be matched, 
+                            // in such case we won't have active statement matched either.
+                            hasMatching = false;
+                            newStatementSyntax = null;
+                        }
                     }
-                }
 
-                if (hasMatching)
-                {
-                    RoslynDebug.Assert(newStatementSyntax != null);
-                    RoslynDebug.Assert(match != null);
-
-                    // The matching node doesn't produce sequence points.
-                    // E.g. "const" keyword is inserted into a local variable declaration with an initializer.
-                    newSpan = FindClosestActiveSpan(newStatementSyntax, statementPart);
-
-                    if ((isNonLeaf || isPartiallyExecuted) && !AreEquivalentActiveStatements(oldStatementSyntax, newStatementSyntax, statementPart))
+                    if (hasMatching)
                     {
-                        // rude edit: non-leaf active statement changed
-                        diagnostics.Add(new RudeEditDiagnostic(isNonLeaf ? RudeEditKind.ActiveStatementUpdate : RudeEditKind.PartiallyExecutedActiveStatementUpdate, newSpan));
+                        RoslynDebug.Assert(newStatementSyntax != null);
+                        RoslynDebug.Assert(match != null);
+
+                        // The matching node doesn't produce sequence points.
+                        // E.g. "const" keyword is inserted into a local variable declaration with an initializer.
+                        newSpan = FindClosestActiveSpan(newStatementSyntax, statementPart);
+
+                        if ((isNonLeaf || isPartiallyExecuted) && !AreEquivalentActiveStatements(oldStatementSyntax, newStatementSyntax, statementPart))
+                        {
+                            // rude edit: non-leaf active statement changed
+                            diagnostics.Add(new RudeEditDiagnostic(isNonLeaf ? RudeEditKind.ActiveStatementUpdate : RudeEditKind.PartiallyExecutedActiveStatementUpdate, newSpan));
+                        }
+
+                        // other statements around active statement:
+                        ReportOtherRudeEditsAroundActiveStatement(diagnostics, match, oldStatementSyntax, newStatementSyntax, isNonLeaf);
                     }
-
-                    // other statements around active statement:
-                    ReportOtherRudeEditsAroundActiveStatement(diagnostics, match, oldStatementSyntax, newStatementSyntax, isNonLeaf);
-                }
-                else if (match == null)
-                {
-                    RoslynDebug.Assert(oldEnclosingLambdaBody != null);
-                    RoslynDebug.Assert(lazyActiveOrMatchedLambdas != null);
-
-                    newSpan = GetDeletedNodeDiagnosticSpan(oldEnclosingLambdaBody, bodyMatch, lazyActiveOrMatchedLambdas);
-
-                    // Lambda containing the active statement can't be found in the new source.
-                    var oldLambda = GetLambda(oldEnclosingLambdaBody);
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ActiveStatementLambdaRemoved, newSpan, oldLambda,
-                        new[] { GetDisplayName(oldLambda) }));
-                }
-                else
-                {
-                    newSpan = GetDeletedNodeActiveSpan(match.Matches, oldStatementSyntax);
-
-                    if (isNonLeaf || isPartiallyExecuted)
+                    else if (match == null)
                     {
-                        // rude edit: internal active statement deleted
-                        diagnostics.Add(
-                            new RudeEditDiagnostic(isNonLeaf ? RudeEditKind.DeleteActiveStatement : RudeEditKind.PartiallyExecutedActiveStatementDelete,
-                            GetDeletedNodeDiagnosticSpan(match.Matches, oldStatementSyntax)));
+                        RoslynDebug.Assert(oldEnclosingLambdaBody != null);
+                        RoslynDebug.Assert(lazyActiveOrMatchedLambdas != null);
+
+                        newSpan = GetDeletedNodeDiagnosticSpan(oldEnclosingLambdaBody, bodyMatch, lazyActiveOrMatchedLambdas);
+
+                        // Lambda containing the active statement can't be found in the new source.
+                        var oldLambda = GetLambda(oldEnclosingLambdaBody);
+                        diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ActiveStatementLambdaRemoved, newSpan, oldLambda,
+                            new[] { GetDisplayName(oldLambda) }));
+                    }
+                    else
+                    {
+                        newSpan = GetDeletedNodeActiveSpan(match.Matches, oldStatementSyntax);
+
+                        if (isNonLeaf || isPartiallyExecuted)
+                        {
+                            // rude edit: internal active statement deleted
+                            diagnostics.Add(
+                                new RudeEditDiagnostic(isNonLeaf ? RudeEditKind.DeleteActiveStatement : RudeEditKind.PartiallyExecutedActiveStatementDelete,
+                                GetDeletedNodeDiagnosticSpan(match.Matches, oldStatementSyntax)));
+                        }
+                    }
+
+                    // exception handling around the statement:
+                    CalculateExceptionRegionsAroundActiveStatement(
+                        bodyMatch,
+                        oldStatementSyntax,
+                        newStatementSyntax,
+                        newSpan,
+                        ordinal,
+                        newText,
+                        isNonLeaf,
+                        newExceptionRegions,
+                        diagnostics);
+
+                    Debug.Assert(newActiveStatements[ordinal] == null && newSpan != default);
+
+                    newActiveStatements[ordinal] = oldActiveStatements[ordinal].WithSpan(newText.Lines.GetLinePositionSpan(newSpan));
+                }
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // Set the new spans of active statements overlapping the method body to match the old spans.
+                // Even though these might be now outside of the method body it's ok since we report a rude edit and don't allow to continue.
+
+                if (hasActiveStatement)
+                {
+                    for (var i = start; i < end; i++)
+                    {
+                        Debug.Assert(newActiveStatements[i] == null);
+                        newActiveStatements[i] = oldActiveStatements[i];
+                        newExceptionRegions[i] = ImmutableArray.Create<LinePositionSpan>();
                     }
                 }
 
-                // exception handling around the statement:
-                CalculateExceptionRegionsAroundActiveStatement(
-                    bodyMatch,
-                    oldStatementSyntax,
-                    newStatementSyntax,
-                    newSpan,
-                    ordinal,
-                    newText,
-                    isNonLeaf,
-                    newExceptionRegions,
-                    diagnostics);
-
-                Debug.Assert(newActiveStatements[ordinal] == null && newSpan != default);
-
-                newActiveStatements[ordinal] = oldActiveStatements[ordinal].WithSpan(newText.Lines.GetLinePositionSpan(newSpan));
+                // We expect OOM to be thrown durign the analysis if the number of statements is too large.
+                // In such case we report a rude edit for the document. If the host is actually running out of memory,
+                // it might throw another OOM here or later on.
+                diagnostics.Add(new RudeEditDiagnostic(
+                    (e is OutOfMemoryException) ? RudeEditKind.MemberBodyTooBig : RudeEditKind.MemberBodyInternalError,
+                    GetBodyDiagnosticSpan(newBody, EditKind.Update),
+                    newBody,
+                    arguments: new[] { GetBodyDisplayName(newBody) }));
             }
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -597,7 +597,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
                 // The same behavior as if there was a syntax error - we are unable to analyze the document. 
-                // We expect OOM to be thrown durign the analysis if the number of top-level entities is too large.
+                // We expect OOM to be thrown during the analysis if the number of top-level entities is too large.
                 // In such case we report a rude edit for the document. If the host is actually running out of memory,
                 // it might throw another OOM here or later on.
                 var diagnostic = (e is OutOfMemoryException) ?
@@ -1175,7 +1175,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     }
                 }
 
-                // We expect OOM to be thrown durign the analysis if the number of statements is too large.
+                // We expect OOM to be thrown during the analysis if the number of statements is too large.
                 // In such case we report a rude edit for the document. If the host is actually running out of memory,
                 // it might throw another OOM here or later on.
                 diagnostics.Add(new RudeEditDiagnostic(

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -138,6 +138,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.ChangingFromAsynchronousToSynchronous, nameof(FeaturesResources.Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.ChangingStateMachineShape, nameof(FeaturesResources.Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine));
             AddRudeEdit(RudeEditKind.ComplexQueryExpression, nameof(FeaturesResources.Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing));
+            AddRudeEdit(RudeEditKind.MemberBodyInternalError, nameof(FeaturesResources.Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error));
+            AddRudeEdit(RudeEditKind.MemberBodyTooBig, nameof(FeaturesResources.Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements));
+            AddRudeEdit(RudeEditKind.SourceFileTooBig, nameof(FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big));
 
             // VB specific
             AddRudeEdit(RudeEditKind.HandlesClauseUpdate, nameof(FeaturesResources.Updating_the_Handles_clause_of_0_will_prevent_the_debug_session_from_continuing));

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -108,7 +108,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ChangingFromAsynchronousToSynchronous = 85,
         ChangingStateMachineShape = 86,
 
-        // Chagned from 0x103 in 16.1
-        ComplexQueryExpression = 82,
+        // Chagned from 0x103 in 16.1 and from 82 to 87 in 16.8
+        ComplexQueryExpression = 87,
+
+        MemberBodyInternalError = 88,
+        SourceFileTooBig = 89,
+        MemberBodyTooBig = 90,
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1199,7 +1199,16 @@ This version used in: {2}</value>
     <value>Adding a method with an explicit interface specifier will prevent the debug session from continuing.</value>
   </data>
   <data name="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error" xml:space="preserve">
-    <value>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</value>
+    <value>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</value>
+  </data>
+  <data name="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big" xml:space="preserve">
+    <value>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</value>
+  </data>
+  <data name="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error" xml:space="preserve">
+    <value>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</value>
+  </data>
+  <data name="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements" xml:space="preserve">
+    <value>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</value>
   </data>
   <data name="Change_namespace_to_0" xml:space="preserve">
     <value>Change namespace to '{0}'</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -590,6 +590,21 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Pokud se změní {0} obsahující výraz switch, relace ladění nebude moct pokračovat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Přesunout obsah do oboru názvů...</target>
@@ -611,8 +626,8 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Po změně zdrojového souboru {0} nebude moct ladicí relace pokračovat z důvodu interní chyby: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Po změně zdrojového souboru {0} nebude moct ladicí relace pokračovat z důvodu interní chyby: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -590,6 +590,21 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Nach dem Ändern von "{0}" mit Schalterausdruck kann die Debugsitzung nicht mehr fortgesetzt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Inhalt in Namespace verschieben...</target>
@@ -611,8 +626,8 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Durch das Ändern der Quelldatei "{0}" wird verhindert, dass die Debugsitzung aufgrund eines internen Fehlers fortgesetzt wird: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Durch das Ändern der Quelldatei "{0}" wird verhindert, dass die Debugsitzung aufgrund eines internen Fehlers fortgesetzt wird: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -590,6 +590,21 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Si se modifica "{0}", que contiene una expresión switch, la sesión de depuración no podrá continuar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Mover contenido al espacio de nombres...</target>
@@ -611,8 +626,8 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Modificar fuente archivo {0} evitará que la sesión de depuración continua debido a un error interno: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Modificar fuente archivo {0} evitará que la sesión de depuración continua debido a un error interno: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -627,7 +627,7 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
         <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
-        <target state="needs-review-translation">Modificar fuente archivo {0} evitará que la sesión de depuración continua debido a un error interno: {1}.</target>
+        <target state="needs-review-translation">Modificar fuente archivo {0} evitará que la sesión de depuración continua debido a un error interno: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -590,6 +590,21 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">La modification de '{0}', qui contient une expression de switch, va empêcher la session de débogage de se poursuivre.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Déplacer le contenu vers un espace de noms...</target>
@@ -611,8 +626,8 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Le fait de modifier le fichier source {0} empêche la session de débogage de se poursuivre en raison de l’erreur interne : {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Le fait de modifier le fichier source {0} empêche la session de débogage de se poursuivre en raison de l’erreur interne : {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -590,6 +590,21 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Se si modifica '{0}' che contiene un'espressione switch, la sessione di debug non potrà continuare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Sposta contenuto nello spazio dei nomi...</target>
@@ -611,8 +626,8 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Se si modifica il file di origine {0}, la sessione di debug non potrà continuare a causa di errore interno: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Se si modifica il file di origine {0}, la sessione di debug non potrà continuare a causa di errore interno: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -590,6 +590,21 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">switch 式を含む '{0}' を変更すると、デバッグ セッションは続行されません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">名前空間へのコンテンツの移動...</target>
@@ -611,8 +626,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">ソース ファイル {0} を変更すると、デバッグ セッションが内部エラーのため続行できなくなります: {1}。</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">ソース ファイル {0} を変更すると、デバッグ セッションが内部エラーのため続行できなくなります: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -590,6 +590,21 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">switch 식을 포함하는 '{0}'을(를) 수정하면 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">네임스페이스로 콘텐츠 이동...</target>
@@ -611,8 +626,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">소스 파일 {0}을(를) 수정하면 다음 내부 오류로 인해 디버그 세션을 계속 진행할 수 없습니다. {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">소스 파일 {0}을(를) 수정하면 다음 내부 오류로 인해 디버그 세션을 계속 진행할 수 없습니다. {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -590,6 +590,21 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Zmodyfikowanie elementu „{0}”, który zawiera wyrażenie switch, uniemożliwi kontynuowanie sesji debugowania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Przenieś zawartość do przestrzeni nazw...</target>
@@ -611,8 +626,8 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Zmodyfikowanie pliku źródłowego {0} uniemożliwi kontynuowanie sesji debugowania ze względu na błąd wewnętrzny: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Zmodyfikowanie pliku źródłowego {0} uniemożliwi kontynuowanie sesji debugowania ze względu na błąd wewnętrzny: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -590,6 +590,21 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">A modificação de '{0}' contendo uma expressão de switch impedirá a continuação da sessão de depuração.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Mover conteúdo para o namespace...</target>
@@ -611,8 +626,8 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Modificar fonte arquivo {0} impedirá a sessão de depuração de continuar devido a erro interno: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Modificar fonte arquivo {0} impedirá a sessão de depuração de continuar devido a erro interno: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -590,6 +590,21 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Изменение "{0}", которое содержит выражение switch, сделает продолжение сеанса отладки невозможным.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">Переместить содержимое в пространство имен...</target>
@@ -611,8 +626,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">Изменение исходного файла {0} помешает сеанса отладки продолжения из-за внутренней ошибки: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">Изменение исходного файла {0} помешает сеанса отладки продолжения из-за внутренней ошибки: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -590,6 +590,21 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">Switch ifadesi içeren '{0}' öğesinin değiştirilmesi hata ayıklama oturumunun devam etmesini engeller.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">İçerikleri ad alanına taşı...</target>
@@ -611,8 +626,8 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">{0} kaynak dosyasının değiştirilmesi şu iç hata nedeniyle hata ayıklama oturumunun devam etmesini engeller: {1}.</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">{0} kaynak dosyasının değiştirilmesi şu iç hata nedeniyle hata ayıklama oturumunun devam etmesini engeller: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -590,6 +590,21 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">修改包含 switch 表达式的“{0}”将阻止调试会话继续执行。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">将内容移动到命名空间...</target>
@@ -611,8 +626,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">修改源文件 {0} 将防止调试会话因内部错误 {1} 而继续进行。</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">修改源文件 {0} 将防止调试会话因内部错误 {1} 而继续进行。</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -590,6 +590,21 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">修改包含參數運算式的 '{0}' 會讓偵錯工作階段無法繼續。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing because the body has too many statements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
+        <source>Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="new">Modifying the body of '{0}' will prevent the debug session from continuing due to internal error: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big">
+        <source>Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</source>
+        <target state="new">Modifying source file '{0}' will prevent the debug session from continuing because the file is too big.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="translated">將內容移到命名空間...</target>
@@ -611,8 +626,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error">
-        <source>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</source>
-        <target state="translated">修改原始檔案 {0} 將防止調試會話由於內部錯誤而繼續進行: {1}。</target>
+        <source>Modifying source file '{0}' will prevent the debug session from continuing due to internal error: {1}</source>
+        <target state="needs-review-translation">修改原始檔案 {0} 將防止調試會話由於內部錯誤而繼續進行: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="Nested_quantifier_0">

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -27,13 +27,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
             Public Function CreateLanguageService(languageServices As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-                Return New VisualBasicEditAndContinueAnalyzer(languageServices.WorkspaceServices.GetRequiredService(Of IActiveStatementSpanTrackerFactory)().GetOrCreateActiveStatementSpanTracker())
+                Dim activeStatementSpanTracker = languageServices.WorkspaceServices.GetRequiredService(Of IActiveStatementSpanTrackerFactory)().GetOrCreateActiveStatementSpanTracker()
+                Return New VisualBasicEditAndContinueAnalyzer(activeStatementSpanTracker, testFaultInjector:=Nothing)
             End Function
         End Class
 
         ' Public for testing purposes
-        Public Sub New(activeStatementSpanTracker As IActiveStatementSpanTracker)
-            MyBase.New(activeStatementSpanTracker)
+        Public Sub New(activeStatementSpanTracker As IActiveStatementSpanTracker, testFaultInjector As Action(Of SyntaxNode))
+            MyBase.New(activeStatementSpanTracker, testFaultInjector)
         End Sub
 
 #Region "Syntax Analysis"

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         End Class
 
         ' Public for testing purposes
-        Public Sub New(activeStatementSpanTracker As IActiveStatementSpanTracker, testFaultInjector As Action(Of SyntaxNode))
+        Public Sub New(activeStatementSpanTracker As IActiveStatementSpanTracker, Optional testFaultInjector As Action(Of SyntaxNode) = Nothing)
             MyBase.New(activeStatementSpanTracker, testFaultInjector)
         End Sub
 


### PR DESCRIPTION
Currently we may crash VS due to combination of two factors:

1) Tree diffing algorithm is O(N^2) in memory and may allocate huge arrays when the user edits methods that have 1000s of statements.
2) EnC wraps all logic in NFW and recovers from unexpected exceptions. For OOM NFW reporting however triggered fail fast crashing VS, even when VS was actually not running out of memory.

This change recovers from exceptions (including OOM) in the analyzer on method level in addition to top-level. If we fail to analyze a method for any reason we report a rude edit and continue analyzing other code. This allows us to report better targeted messages, such as "method 'foo' is too big". 

[2] is addressed by removing fail fast on OOM, unless OOM is thrown during reporting NFW, in which case the process is truly out of memory.