### PR TITLE
Ensure the Compilation's options are changed on .editorconfig changes

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1428,7 +1428,8 @@ namespace Microsoft.CodeAnalysis
             // This method shouldn't have been called if the document has not changed.
             Debug.Assert(oldProject != newProject);
 
-            return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ReplaceAllSyntaxTreesAction(newProject));
+            return ForkProject(newProject,
+                newProject.CompilationOptions != null ? new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions) : null);
         }
 
         /// <summary>

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2917,6 +2917,7 @@ public class C : A {
 
             var project = solution.GetProject(projectId);
             var provider = project.CompilationOptions.SyntaxTreeOptionsProvider;
+            Assert.Equal(provider, (await project.GetCompilationAsync()).Options.SyntaxTreeOptionsProvider);
             Assert.True(provider.TryGetDiagnosticValue(syntaxTreeBeforeEditorConfigChange, "CA1234", out var severity));
             Assert.Equal(ReportDiagnostic.Error, severity);
 
@@ -2929,6 +2930,7 @@ public class C : A {
 
             project = solution.GetProject(projectId);
             provider = project.CompilationOptions.SyntaxTreeOptionsProvider;
+            Assert.Equal(provider, (await project.GetCompilationAsync()).Options.SyntaxTreeOptionsProvider);
             Assert.True(provider.TryGetDiagnosticValue(syntaxTreeBeforeEditorConfigChange, "CA6789", out severity));
             Assert.Equal(ReportDiagnostic.Error, severity);
 


### PR DESCRIPTION
We were correctly producing a new CompilationOptions but failed to update an existing Compilation if one had been computed first.

<details>
<summary>Ask Mode</summary>

**Who is impacted by this bug?**
Anybody who tries to edit an .editorconfig's diagnostic severity and expects the change to be reflected.

**Bugs Fixed**
Fixes https://github.com/dotnet/roslyn/issues/46784

**What is the customer scenario and impact of the bug?**
Make any change to an .editorconfig that has diagnostic severity changes, and the change won't be reflected in the error list or anywhere else.

**What is the workaround?**
Restart Visual Studio.

**How was the bug found?**
Dogfooding and ad-hoc testing.

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
Insufficient testing of https://github.com/dotnet/roslyn/pull/44331. We were testing enough other impacts of the change we missed this case to start with. The original changed updated a unit test which correctly checked that the Workspace was producing a new set of options when an .editorconfig changed, but it missed a check that the options were passed to a new Compilation, which was not actually happening.

**Testing**
Manually verified, and a unit test catching the underlying mistake is updated. An integration test is also on it's way into the branch as well for an end-to-end with a code fix.

</details>