### PR TITLE
Check if $insertionDir exists before getting children.

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -330,12 +330,14 @@ function SetVisualStudioBootstrapperBuildArgs() {
   $vsMajorVersion = $branchData.vsMajorVersion
   $vsChannel = "int.$vsBranchSimpleName"
 
-  Write-Host "##vso[task.setvariable variable=VisualStudio.MajorVersion;]$vsMajorVersion"        
+  Write-Host "##vso[task.setvariable variable=VisualStudio.MajorVersion;]$vsMajorVersion"
   Write-Host "##vso[task.setvariable variable=VisualStudio.ChannelName;]$vsChannel"
 
   $insertionDir = Join-Path $VSSetupDir "Insertion"
-  $manifestList = [string]::Join(',', (Get-ChildItem "$insertionDir\*.vsman"))
-  Write-Host "##vso[task.setvariable variable=VisualStudio.SetupManifestList;]$manifestList"
+  if (Test-Path $insertionDir) {
+    $manifestList = [string]::Join(',', (Get-ChildItem "$insertionDir\*.vsman"))
+    Write-Host "##vso[task.setvariable variable=VisualStudio.SetupManifestList;]$manifestList"
+  }
 }
 
 # Core function for running our unit / integration tests tests


### PR DESCRIPTION
There's a combination of flags to build.ps1 that doesn't do the VSSetup related stuff, so the insertion dir doesn't exist. This is used in CI that indexes Roslyn source code. Otherwise it fails the build.