### PR TITLE
Terminate the integration test process if cleanup fails

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
@@ -89,7 +89,7 @@ End Module
 ");
 
             VisualStudio.Editor.PlaceCaret("(", charsOffset: 1);
-            VisualStudio.Editor.SendKeys("x   as   integer", VirtualKey.Tab);
+            VisualStudio.Editor.SendKeys("x   As   integer", VirtualKey.Tab);
             VisualStudio.Editor.Verify.IsNotSaved();
             VisualStudio.Editor.SendKeys(new KeyPress(VirtualKey.S, ShiftState.Ctrl));
             var savedFileName = VisualStudio.Editor.Verify.IsSaved();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 using ProjName = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils.Project;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -92,8 +92,16 @@ End Module
             VisualStudio.Editor.SendKeys("x   as   integer", VirtualKey.Tab);
             VisualStudio.Editor.Verify.IsNotSaved();
             VisualStudio.Editor.SendKeys(new KeyPress(VirtualKey.S, ShiftState.Ctrl));
-            VisualStudio.Editor.Verify.IsSaved();
-            VisualStudio.Editor.Verify.TextContains(@"Sub Main(x As Integer)");
+            var savedFileName = VisualStudio.Editor.Verify.IsSaved();
+            try
+            {
+                VisualStudio.Editor.Verify.TextContains(@"Sub Main(x As Integer)");
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException($"Unexpected failure after saving document '{savedFileName}'", e);
+            }
+
             VisualStudio.ExecuteCommand(WellKnownCommandNames.Edit_Undo);
             VisualStudio.Editor.Verify.TextContains(@"Sub Main(x   As   Integer)");
             VisualStudio.Editor.Verify.CaretPosition(45);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -145,9 +145,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             Contract.ThrowIfTrue(GetDTE().ActiveDocument.ProjectItem.Saved);
         }
 
-        public void VerifySaved()
+        public string VerifySaved()
         {
-            Contract.ThrowIfFalse(GetDTE().ActiveDocument.ProjectItem.Saved);
+            var activeDocument = GetDTE().ActiveDocument;
+            Contract.ThrowIfFalse(activeDocument.ProjectItem.Saved);
+            return activeDocument.FullName;
         }
 
         public string GetActiveBufferName()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -133,6 +133,18 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             GetWaitingService().WaitForAllAsyncOperations(timeout, featureNames);
         }
 
+        public void WaitForAllAsyncOperationsOrFail(TimeSpan timeout, params string[] featureNames)
+        {
+            try
+            {
+                WaitForAllAsyncOperations(timeout, featureNames);
+            }
+            catch (Exception e)
+            {
+                Environment.FailFast("Terminating test process due to unrecoverable timeout.", e);
+            }
+        }
+
         private static void WaitForProjectSystem(TimeSpan timeout)
         {
             var operationProgressStatus = InvokeOnUIThread(_ => GetGlobalService<SVsOperationProgress, IVsOperationProgressStatusService>());

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.Verifier.cs
@@ -26,9 +26,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 _textViewWindow._editorInProc.VerifyNotSaved();
             }
 
-            public void IsSaved()
+            public string IsSaved()
             {
-                _textViewWindow._editorInProc.VerifySaved();
+                return _textViewWindow._editorInProc.VerifySaved();
             }
 
             public void CurrentLineText(

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -48,6 +48,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void WaitForAllAsyncOperations(TimeSpan timeout, params string[] featureNames)
             => _inProc.WaitForAllAsyncOperations(timeout, featureNames);
 
+        public void WaitForAllAsyncOperationsOrFail(TimeSpan timeout, params string[] featureNames)
+            => _inProc.WaitForAllAsyncOperationsOrFail(timeout, featureNames);
+
         public void CleanUpWorkspace()
             => _inProc.CleanUpWorkspace();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             Workspace.CleanUpWaitingService();
             Workspace.CleanUpWorkspace();
             SolutionExplorer.CleanUpOpenSolution();
-            Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout);
+            Workspace.WaitForAllAsyncOperationsOrFail(Helper.HangMitigatingTimeout);
 
             // Close any windows leftover from previous (failed) tests
             InteractiveWindow.CloseInteractiveWindow();


### PR DESCRIPTION
* Terminate the test process if state cleanup times out (it would never complete from this state, so better to fail quickly with logs)
* Collect additional diagnostics about `CommitOnSave` failures
* Fix non-deterministic undo behavior in `CommitOnSave` (fixes the flakiness)