### PR TITLE
Introduce warning for multiple entry points (sync + async)

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -30,3 +30,4 @@ The table below describes all of the warnings controlled by warning levels `5` o
 | CS8885 | 5 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
 | CS8886 | 5 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
 | CS8887 | 5 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8892 | 5 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6134,6 +6134,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TypeMustBePublic" xml:space="preserve">
     <value>Type '{0}' must be public to be used as a calling convention.</value>
   </data>
+  <data name="WRN_SyncAndAsyncEntryPoints" xml:space="preserve">
+    <value>Program has more than one entry point defined.</value>
+  </data>
   <data name="ERR_InternalError" xml:space="preserve">
     <value>Internal error in the C# compiler.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6135,7 +6135,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Type '{0}' must be public to be used as a calling convention.</value>
   </data>
   <data name="WRN_SyncAndAsyncEntryPoints" xml:space="preserve">
-    <value>Program has more than one entry point defined.</value>
+    <value>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</value>
   </data>
   <data name="ERR_InternalError" xml:space="preserve">
     <value>Internal error in the C# compiler.</value>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1735,7 +1735,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),
-                         symbols: ImmutableArray.Create(viableEntryPoints.First(), taskEntryPoints.First()),
+                         symbols: ImmutableArray.Create(viableEntryPoints.First(), taskEntryPoints.First().Candidate),
                          additionalLocations: ImmutableArray.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Candidate.Locations.First()));
 
                     diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1736,7 +1736,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),
                          symbols: ImmutableArray<Symbol>.Create(viableEntryPoints.First(), taskEntryPoints.First()),
-                         additionalLocations: ImmutableArray<Location>.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Locations.First());
+                         additionalLocations: ImmutableArray<Location>.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Locations.First()));
 
                     diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1735,7 +1735,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),
-                         symbols: ImmutableArray.Create(viableEntryPoints.First(), taskEntryPoints.First().Candidate),
+                         symbols: ImmutableArray.Create((Symbol)viableEntryPoints.First(), (Symbol)taskEntryPoints.First().Candidate),
                          additionalLocations: ImmutableArray.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Candidate.Locations.First()));
 
                     diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1735,7 +1735,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),
-                         symbols: ImmutableArray.Create((Symbol)viableEntryPoints.First(), (Symbol)taskEntryPoints.First().Candidate),
+                         symbols: ImmutableArray.Create<Symbol>(viableEntryPoints.First(), taskEntryPoints.First().Candidate),
                          additionalLocations: ImmutableArray.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Candidate.Locations.First()));
 
                     diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1732,18 +1732,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0 && viableEntryPoints.Count == 1)
                 {
-                    var taskCandidates = taskEntryPoints.Select(s => (Symbol)s.Candidate).ToImmutableArray();
-                    var taskLocations = taskCandidates.Select(s => s.Locations.First()).ToImmutableArray();
+                    var taskCandidates = taskEntryPoints.SelectAsArray(s => (Symbol)s.Candidate);
+                    var taskLocations = taskCandidates.SelectAsArray(s => s.Locations[0]);
 
                     foreach (var (_, Candidate, _) in taskEntryPoints)
                     {
                         // Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.
                         var info = new CSDiagnosticInfo(
                              ErrorCode.WRN_SyncAndAsyncEntryPoints,
-                             args: new object[] { Candidate, viableEntryPoints.First() },
+                             args: new object[] { Candidate, viableEntryPoints[0] },
                              symbols: taskCandidates,
                              additionalLocations: taskLocations);
-                        diagnostics.Add(new CSDiagnostic(info, Candidate.Locations.First()));
+                        diagnostics.Add(new CSDiagnostic(info, Candidate.Locations[0]));
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1730,10 +1730,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0)
+                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count == 1 && viableEntryPoints.Count == 1)
                 {
                     // TODO: I think I should first concat both taskEntryPoints and viableEntryPoints first.
-                    viableEntryPoints.Sort(LexicalOrderSymbolComparer.Instance);
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1730,20 +1730,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0 && viableEntryPoints.Count == 1)
+                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0)
                 {
                     var taskCandidates = taskEntryPoints.SelectAsArray(s => (Symbol)s.Candidate);
                     var taskLocations = taskCandidates.SelectAsArray(s => s.Locations[0]);
 
-                    foreach (var (_, Candidate, _) in taskEntryPoints)
+                    foreach (var candidate in taskCandidates)
                     {
                         // Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.
                         var info = new CSDiagnosticInfo(
                              ErrorCode.WRN_SyncAndAsyncEntryPoints,
-                             args: new object[] { Candidate, viableEntryPoints[0] },
+                             args: new object[] { candidate, viableEntryPoints[0] },
                              symbols: taskCandidates,
                              additionalLocations: taskLocations);
-                        diagnostics.Add(new CSDiagnostic(info, Candidate.Locations[0]));
+                        diagnostics.Add(new CSDiagnostic(info, candidate.Locations[0]));
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1735,8 +1735,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),
-                         symbols: ImmutableArray<Symbol>.Create(viableEntryPoints.First(), taskEntryPoints.First()),
-                         additionalLocations: ImmutableArray<Location>.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Locations.First()));
+                         symbols: ImmutableArray.Create(viableEntryPoints.First(), taskEntryPoints.First()),
+                         additionalLocations: ImmutableArray.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Candidate.Locations.First()));
 
                     diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1738,7 +1738,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                          symbols: ImmutableArray.Create<Symbol>(viableEntryPoints.First(), taskEntryPoints.First().Candidate),
                          additionalLocations: ImmutableArray.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Candidate.Locations.First()));
 
-                    diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));
+                    foreach (var (_, Candidate, _) in taskEntryPoints)
+                    {
+                        // Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.
+                        diagnostic.Add(new CSDiagnostic(info, Candidate.Locations.First(), Candidate, viableEntryPoints.First()));
+                    }
                 }
 
                 foreach (var (_, _, SpecificDiagnostics) in taskEntryPoints)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1730,7 +1730,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count == 1 && viableEntryPoints.Count == 1)
+                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0 && viableEntryPoints.Count == 1)
                 {
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1741,7 +1741,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     foreach (var (_, Candidate, _) in taskEntryPoints)
                     {
                         // Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.
-                        diagnostic.Add(new CSDiagnostic(info, Candidate.Locations.First(), Candidate, viableEntryPoints.First()));
+                        diagnostics.Add(new CSDiagnostic(info, Candidate.Locations.First(), Candidate, viableEntryPoints.First()));
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1732,12 +1732,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count == 1 && viableEntryPoints.Count == 1)
                 {
-                    // TODO: I think I should first concat both taskEntryPoints and viableEntryPoints first.
                     var info = new CSDiagnosticInfo(
                          ErrorCode.WRN_SyncAndAsyncEntryPoints,
                          args: Array.Empty<object>(),
-                         symbols: viableEntryPoints.OfType<Symbol>().AsImmutable(),
-                         additionalLocations: viableEntryPoints.Select(m => m.Locations.First()).OfType<Location>().AsImmutable());
+                         symbols: ImmutableArray<Symbol>.Create(viableEntryPoints.First(), taskEntryPoints.First()),
+                         additionalLocations: ImmutableArray<Location>.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Locations.First());
 
                     diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1730,6 +1730,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
+                else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0)
+                {
+                    // TODO: I think I should first concat both taskEntryPoints and viableEntryPoints first.
+                    viableEntryPoints.Sort(LexicalOrderSymbolComparer.Instance);
+                    var info = new CSDiagnosticInfo(
+                         ErrorCode.WRN_SyncAndAsyncEntryPoints,
+                         args: Array.Empty<object>(),
+                         symbols: viableEntryPoints.OfType<Symbol>().AsImmutable(),
+                         additionalLocations: viableEntryPoints.Select(m => m.Locations.First()).OfType<Location>().AsImmutable());
+
+                    diagnostics.Add(new CSDiagnostic(info, viableEntryPoints.First().Locations.First()));
+                }
 
                 foreach (var (_, _, SpecificDiagnostics) in taskEntryPoints)
                 {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1732,16 +1732,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (LanguageVersion >= MessageID.IDS_FeatureAsyncMain.RequiredVersion() && taskEntryPoints.Count > 0 && viableEntryPoints.Count == 1)
                 {
-                    var info = new CSDiagnosticInfo(
-                         ErrorCode.WRN_SyncAndAsyncEntryPoints,
-                         args: Array.Empty<object>(),
-                         symbols: ImmutableArray.Create<Symbol>(viableEntryPoints.First(), taskEntryPoints.First().Candidate),
-                         additionalLocations: ImmutableArray.Create(viableEntryPoints.First().Locations.First(), taskEntryPoints.First().Candidate.Locations.First()));
+                    var taskCandidates = taskEntryPoints.Select(s => (Symbol)s.Candidate).ToImmutableArray();
+                    var taskLocations = taskCandidates.Select(s => s.Locations.First()).ToImmutableArray();
 
                     foreach (var (_, Candidate, _) in taskEntryPoints)
                     {
                         // Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.
-                        diagnostics.Add(new CSDiagnostic(info, Candidate.Locations.First(), Candidate, viableEntryPoints.First()));
+                        var info = new CSDiagnosticInfo(
+                             ErrorCode.WRN_SyncAndAsyncEntryPoints,
+                             args: new object[] { Candidate, viableEntryPoints.First() },
+                             symbols: taskCandidates,
+                             additionalLocations: taskLocations);
+                        diagnostics.Add(new CSDiagnostic(info, Candidate.Locations.First()));
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
@@ -57,6 +57,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.CSharp
                     case (int)ErrorCode.WRN_MainCantBeGeneric:
                     case (int)ErrorCode.ERR_NoMainInClass:
                     case (int)ErrorCode.ERR_MainClassNotFound:
+                    case (int)ErrorCode.WRN_SyncAndAsyncEntryPoints:
                         // no entry point related errors are live
                         continue;
                     case (int)ErrorCode.ERR_BadDelegateConstructor:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1890,6 +1890,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TypeNotFound = 8890,
         ERR_TypeMustBePublic = 8891,
 
+        WRN_SyncAndAsyncEntryPoints = 8892,
+
         #endregion diagnostics introduced for C# 9.0
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -228,6 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_UseDefViolationThis:
                 case ErrorCode.WRN_UseDefViolationOut:
                 case ErrorCode.WRN_UseDefViolation:
+                case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                     // Warning level 5 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 5 (C# 9) and that can be reported for pre-existing code.
                     return 5;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -257,7 +257,7 @@
                 case ErrorCode.WRN_UseDefViolationThis:
                 case ErrorCode.WRN_UseDefViolationOut:
                 case ErrorCode.WRN_UseDefViolation:
-                case ErrorCode.WRN_SyncAndAsyncEntryPoints
+                case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -257,6 +257,7 @@
                 case ErrorCode.WRN_UseDefViolationThis:
                 case ErrorCode.WRN_UseDefViolationOut:
                 case ErrorCode.WRN_UseDefViolation:
+                case ErrorCode.WRN_SyncAndAsyncEntryPoints
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -877,6 +877,11 @@
         <target state="new">Type '{0}' must be public to be used as a calling convention.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_SyncAndAsyncEntryPoints">
+        <source>Program has more than one entry point defined.</source>
+        <target state="new">Program has more than one entry point defined.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_TypeNotFound">
         <source>Type '{0}' is not defined.</source>
         <target state="new">Type '{0}' is not defined.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_SyncAndAsyncEntryPoints">
-        <source>Program has more than one entry point defined.</source>
-        <target state="new">Program has more than one entry point defined.</target>
+        <source>Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</source>
+        <target state="new">Method '{0}' will not be used as an entry point because a synchronous entry point '{1}' was found.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TypeNotFound">

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -206,8 +206,8 @@ public class D
             var compilation = CompileConsoleApp(source);
 
             compilation.VerifyDiagnostics(
-                // (6,28): error CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.
-                Diagnostic(ErrorCode.ERR_MultipleEntryPoints, "Main"));
+                // (7,28): warning CS8892: Program has more than one entry point defined.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -203,8 +203,8 @@ public class D
             var compilation = CompileConsoleApp(source);
 
             compilation.VerifyDiagnostics(
-                // (6,28): warning CS8892: Program has more than one entry point defined.
-                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
+                // (7,22): error CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.
+                Diagnostic(ErrorCode.ERR_MultipleEntryPoints, "Main"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -133,7 +133,6 @@ public class D
                 Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
         }
 
-
         [Fact]
         public void ERR_MultipleEntryPointsCSharp70_SyncAndAsync()
         {
@@ -180,6 +179,30 @@ public class D
             compilation.VerifyDiagnostics(
                 // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
                 Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"),
+                // (6,28): warning CS8892: Program has more than one entry point defined.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
+        }
+
+        [Fact]
+        public void ERR_MultipleEntryPointsCSharpLatest_TwoSyncAndOneAsync()
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+public class C
+{
+  public static async Task Main() { await Task.Delay(1); }
+  public static void Main(string[] a) { System.Console.WriteLine(2); }
+}
+
+public class D
+{
+  public static void Main() { System.Console.WriteLine(3); }
+}
+";
+            var compilation = CompileConsoleApp(source);
+
+            compilation.VerifyDiagnostics(
                 // (6,28): warning CS8892: Program has more than one entry point defined.
                 Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -118,18 +118,11 @@ public class C
   public static async Task Main() { await Task.Delay(1); }
   public static void Main(string[] a) { System.Console.WriteLine(2); }
 }
-
-public class D
-{
-  public static string Main() { System.Console.WriteLine(3); return null; }
-}
 ";
             var compilation = CompileConsoleApp(source, parseOptions: TestOptions.Regular7_1);
 
             compilation.VerifyDiagnostics(
-                // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
-                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"),
-                // (6,28): warning CS8892: Program has more than one entry point defined.
+                // (7,28): warning CS8892: Program has more than one entry point defined.
                 Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
         }
 
@@ -144,17 +137,10 @@ public class C
   public static async Task Main() { await Task.Delay(1); }
   public static void Main(string[] a) { System.Console.WriteLine(2); }
 }
-
-public class D
-{
-  public static string Main() { System.Console.WriteLine(3); return null; }
-}
 ";
             var compilation = CompileConsoleApp(source, parseOptions: TestOptions.Regular7);
 
-            compilation.VerifyDiagnostics(
-                // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
-                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"));
+            compilation.VerifyDiagnostics();
         }
 
         [Fact]
@@ -168,18 +154,11 @@ public class C
   public static async Task Main() { await Task.Delay(1); }
   public static void Main(string[] a) { System.Console.WriteLine(2); }
 }
-
-public class D
-{
-  public static string Main() { System.Console.WriteLine(3); return null; }
-}
 ";
             var compilation = CompileConsoleApp(source);
 
             compilation.VerifyDiagnostics(
-                // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
-                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"),
-                // (6,28): warning CS8892: Program has more than one entry point defined.
+                // (7,28): warning CS8892: Program has more than one entry point defined.
                 Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
         }
 
@@ -204,6 +183,30 @@ public class D
 
             compilation.VerifyDiagnostics(
                 // (7,22): error CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.
+                Diagnostic(ErrorCode.ERR_MultipleEntryPoints, "Main"));
+        }
+
+        [Fact]
+        public void ERR_MultipleEntryPointsCSharpLatest_TwoAsyncAndOneSync()
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+public class C
+{
+  public static async Task Main() { await Task.Delay(1); }
+  public static void Main(string[] a) { System.Console.WriteLine(2); }
+}
+
+public class D
+{
+  public static async Task Main() { await Task.Delay(1); }
+}
+";
+            var compilation = CompileConsoleApp(source);
+
+            compilation.VerifyDiagnostics(
+                // (6,28): error CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.
                 Diagnostic(ErrorCode.ERR_MultipleEntryPoints, "Main"));
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -108,7 +108,7 @@ public class D
         }
 
         [Fact]
-        public void ERR_MultipleEntryPoints_SyncAndAsync()
+        public void ERR_MultipleEntryPointsCSharp71_SyncAndAsync()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -129,7 +129,58 @@ public class D
             compilation.VerifyDiagnostics(
                 // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
                 Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"),
-                // (4,28): warning CS8892: Program has more than one entry point defined.
+                // (6,28): warning CS8892: Program has more than one entry point defined.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
+        }
+
+
+        [Fact]
+        public void ERR_MultipleEntryPointsCSharp70_SyncAndAsync()
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+public class C
+{
+  public static async Task Main() { await Task.Delay(1); }
+  public static void Main(string[] a) { System.Console.WriteLine(2); }
+}
+
+public class D
+{
+  public static string Main() { System.Console.WriteLine(3); return null; }
+}
+";
+            var compilation = CompileConsoleApp(source, parseOptions: TestOptions.Regular7);
+
+            compilation.VerifyDiagnostics(
+                // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
+                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"));
+        }
+
+        [Fact]
+        public void ERR_MultipleEntryPointsCSharpLatest_SyncAndAsync()
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+public class C
+{
+  public static async Task Main() { await Task.Delay(1); }
+  public static void Main(string[] a) { System.Console.WriteLine(2); }
+}
+
+public class D
+{
+  public static string Main() { System.Console.WriteLine(3); return null; }
+}
+";
+            var compilation = CompileConsoleApp(source);
+
+            compilation.VerifyDiagnostics(
+                // (12,24): warning CS0028: 'D.Main()' has the wrong signature to be an entry point
+                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("D.Main()"),
+                // (6,28): warning CS8892: Program has more than one entry point defined.
                 Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -108,7 +108,7 @@ public class D
         }
 
         [Fact]
-        public void ERR_MultipleEntryPointsCSharp71_SyncAndAsync()
+        public void WRN_SyncAndAsyncEntryPoints_CSharp71()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -122,12 +122,12 @@ public class C
             var compilation = CompileConsoleApp(source, parseOptions: TestOptions.Regular7_1);
 
             compilation.VerifyDiagnostics(
-                // (7,28): warning CS8892: Program has more than one entry point defined.
-                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
+                // (6,28): warning CS8892: Method 'C.Main()' will not be used as an entry point because a synchronous entry point 'C.Main(string[])' was found.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("C.Main()", "C.Main(string[])").WithLocation(6, 28));
         }
 
         [Fact]
-        public void ERR_MultipleEntryPointsCSharp70_SyncAndAsync()
+        public void SyncAndAsyncEntryPointsBeforeAsyncMainFeature_NoDiagnostics()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -144,7 +144,7 @@ public class C
         }
 
         [Fact]
-        public void ERR_MultipleEntryPointsCSharpLatest_SyncAndAsync()
+        public void WRN_SyncAndAsyncEntryPointsCSharpLatest_SyncAndAsync()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -158,8 +158,8 @@ public class C
             var compilation = CompileConsoleApp(source);
 
             compilation.VerifyDiagnostics(
-                // (7,28): warning CS8892: Program has more than one entry point defined.
-                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
+                // (6,28): warning CS8892: Method 'C.Main()' will not be used as an entry point because a synchronous entry point 'C.Main(string[])' was found.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("C.Main()", "C.Main(string[])").WithLocation(6, 28));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
     {
         private CSharpCompilation CompileConsoleApp(string source, CSharpParseOptions parseOptions = null)
         {
-            return CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: parseOptions);
+            return CreateCompilation(source, options: TestOptions.ReleaseExe.WithWarningLevel(5), parseOptions: parseOptions);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -108,6 +108,7 @@ public class D
         }
 
         [Fact]
+        [WorkItem(46831, "https://github.com/dotnet/roslyn/issues/46831")]
         public void WRN_SyncAndAsyncEntryPoints_CSharp71()
         {
             string source = @"
@@ -144,6 +145,7 @@ public class C
         }
 
         [Fact]
+        [WorkItem(46831, "https://github.com/dotnet/roslyn/issues/46831")]
         public void WRN_SyncAndAsyncEntryPointsCSharpLatest_SyncAndAsync()
         {
             string source = @"
@@ -163,7 +165,8 @@ public class C
         }
 
         [Fact]
-        public void ERR_MultipleEntryPointsCSharpLatest_TwoSyncAndOneAsync()
+        [WorkItem(46831, "https://github.com/dotnet/roslyn/issues/46831")]
+        public void ERR_And_WRN_MultipleEntryPointsCSharpLatest_TwoSyncAndOneAsync()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -183,10 +186,13 @@ public class D
 
             compilation.VerifyDiagnostics(
                 // (7,22): error CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.
-                Diagnostic(ErrorCode.ERR_MultipleEntryPoints, "Main"));
+                Diagnostic(ErrorCode.ERR_MultipleEntryPoints, "Main"),
+                // (6,28): warning CS8892: Method 'C.Main()' will not be used as an entry point because a synchronous entry point 'C.Main(string[])' was found.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("C.Main()", "C.Main(string[])").WithLocation(6, 28));
         }
 
         [Fact]
+        [WorkItem(46831, "https://github.com/dotnet/roslyn/issues/46831")]
         public void WRN_SyncAndAsyncEntryPointsCSharpLatest_TwoAsyncAndOneSync()
         {
             string source = @"
@@ -236,6 +242,7 @@ public class D
         }
 
         [Fact]
+        [WorkItem(46831, "https://github.com/dotnet/roslyn/issues/46831")]
         public void WRN_SyncAndAsyncEntryPoints_WithTypeDefined()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -251,7 +251,7 @@ public class C
             var compilation = CompileConsoleApp(source, mainTypeName: "C");
             compilation.VerifyDiagnostics(
                 // (8,28): warning CS8892: Method 'C.Main()' will not be used as an entry point because a synchronous entry point 'C.Main(string[])' was found.
-                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("C.Main()", "C.Main(string[])").WithLocation(8, 28)); 
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("C.Main()", "C.Main(string[])").WithLocation(8, 28));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -206,8 +206,10 @@ public class D
             var compilation = CompileConsoleApp(source);
 
             compilation.VerifyDiagnostics(
-                // (7,28): warning CS8892: Program has more than one entry point defined.
-                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main"));
+                // (6,28): warning CS8892: Method 'C.Main()' will not be used as an entry point because a synchronous entry point 'C.Main(string[])' was found.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("C.Main()", "C.Main(string[])").WithLocation(6, 28),
+                // (12,28): warning CS8892: Method 'D.Main()' will not be used as an entry point because a synchronous entry point 'C.Main(string[])' was found.
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("D.Main()", "C.Main(string[])").WithLocation(12, 28));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -398,6 +398,7 @@ class X
                     ErrorCode.WRN_UseDefViolationThis,
                     ErrorCode.WRN_UseDefViolationOut,
                     ErrorCode.WRN_UseDefViolation,
+                    ErrorCode.WRN_SyncAndAsyncEntryPoints,
                 };
 
                 Assert.Contains(error, nullableUnrelatedWarnings);

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -343,6 +343,7 @@ class X
                         case ErrorCode.WRN_UseDefViolationThis:
                         case ErrorCode.WRN_UseDefViolationOut:
                         case ErrorCode.WRN_UseDefViolation:
+                        case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 5 and C# 9.
                             Assert.Equal(5, ErrorFacts.GetWarningLevel(errorCode));
                             break;


### PR DESCRIPTION
Fixes #46831

## Summary

- If one sync entry point found and one async entry point found => warning on async (new behavior)
- If multiple sync entry points found => error on sync entry point (the same behavior as before), in addition to warnings on async entry points, if any (new behavior)
- If multiple async entry points found but no sync entry points => error (the same behavior as before)
- If multiple async entry points found and **one** synchronous entry point => warning (new behavior)