### PR TITLE
Array indexing of array size 1 removed - Inline Parameter Name Hints

### DIFF
--- a/src/EditorFeatures/Test2/InlineParameterNameHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineParameterNameHints/CSharpInlineParameterNameHintsTests.vb
@@ -360,5 +360,69 @@ class A
 
             Await VerifyParamHints(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineParameterNameHints)>
+        Public Async Function TestSingleBracketedList() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class Program
+{
+    static void Main(string[] args)
+    {
+        var twoParameterIndexer = new OneParameterIndexer();
+        var x = twoParameterIndexer[1];
+    }
+}
+class OneParameterIndexer
+{
+    public int this[int param1]
+    {
+        get
+        {
+            return 42;
+        }
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineParameterNameHints)>
+        Public Async Function TestDoubleBracketedList() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class Program
+{
+    static void Main(string[] args)
+    {
+        var twoParameterIndexer = new TwoParameterIndexer();
+        var x = twoParameterIndexer[{|param1:1|}, {|param2:2|}];
+    }
+}
+class TwoParameterIndexer
+{
+    public int this[int param1, int param2]
+    {
+        get
+        {
+            return 42;
+        }
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input)
+        End Function
+
+
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
@@ -76,6 +76,16 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
         /// <returns>true when the adornment should be added</returns>
         private static bool IsExpressionWithNoName(ExpressionSyntax arg)
         {
+            if (arg.Parent.Parent is BracketedArgumentListSyntax bracketList)
+            {
+                // Do not need to add hints for array accesses if the length is 1
+                if (bracketList.Arguments.Count == 1)
+                {
+                    return false;
+                }
+
+                return true;
+            }
             if (arg is LiteralExpressionSyntax)
             {
                 // We want to adorn literals no matter what
@@ -104,16 +114,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
                 // Recurse until we find a literal
                 // If so, then we should add the adornment
                 return IsExpressionWithNoName(negation.Operand);
-            }
-            if (arg.Parent is BracketedArgumentListSyntax bracketList)
-            {
-                // Do not need to add hints for array accesses if the length is 1
-                if (bracketList.Arguments.Count == 1)
-                {
-                    return false;
-                }
-
-                return true;
             }
 
             return false;

--- a/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
@@ -105,6 +105,11 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
                 // If so, then we should add the adornment
                 return IsExpressionWithNoName(negation.Operand);
             }
+            if (arg.Parent is BracketedArgumentListSyntax)
+            {
+                // Do not need to add hints for array accesses
+                return false;
+            }
 
             return false;
         }

--- a/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineParameterNameHints/CSharpInlineParameterNameHintsService.cs
@@ -105,10 +105,15 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
                 // If so, then we should add the adornment
                 return IsExpressionWithNoName(negation.Operand);
             }
-            if (arg.Parent is BracketedArgumentListSyntax)
+            if (arg.Parent is BracketedArgumentListSyntax bracketList)
             {
-                // Do not need to add hints for array accesses
-                return false;
+                // Do not need to add hints for array accesses if the length is 1
+                if (bracketList.Arguments.Count == 1)
+                {
+                    return false;
+                }
+
+                return true;
             }
 
             return false;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/46614

Removed the possibility of hints showing up if the argument list for an array is only of size 1. 
Added two tests as well. Needs to be added for VB (did not have time)