### PR TITLE
Remove outdated comments related to PortableShim

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/EmbeddedTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EmbeddedTextTests.cs
@@ -58,8 +58,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<IOException>(() => EmbeddedText.FromStream("path", new HugeStream()));
             Assert.Throws<EndOfStreamException>(() => EmbeddedText.FromStream("path", new TruncatingStream(10)));
             Assert.Throws<EndOfStreamException>(() => EmbeddedText.FromStream("path", new TruncatingStream(1000)));
-
-            // Should be Assert.Throws<IOException>, but impeded by https://github.com/dotnet/roslyn/issues/12926
             Assert.Throws<IOException>(() => EmbeddedText.FromStream("path", new ReadFailsStream()));
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -485,8 +485,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     Type? type;
                     try
                     {
-                        // TODO: Once we move to CoreCLR we should just call GetType(typeName, throwOnError: true, ignoreCase: false) directly.
-                        // For now we fall back to reflection shim in order to report good error message (type load exception).
                         type = analyzerAssembly.GetType(typeName, throwOnError: true, ignoreCase: false);
                     }
                     catch (Exception e)


### PR DESCRIPTION
AFAICT, `PortableShim` was removed in https://github.com/dotnet/roslyn/pull/12546, but some confusing and outdated comments referencing it were left behind. This PR fixes that.

cc: @agocke 