### PR TITLE
VS master -> main

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -277,7 +277,7 @@ function GetIbcSourceBranchName() {
   }
 
   function calculate {
-    $fallback = "master"
+    $fallback = "main"
 
     $branchData = GetBranchPublishData $officialSourceBranchName
     if ($branchData -eq $null) {


### PR DESCRIPTION
VS has renamed their default branch to main. Thus any references in our scripts to the VS master branch should be updated.

/cc @genlu @dotnet/roslyn-infrastructure 