### PR TITLE
Exclude Main method from "Add null check" refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
 }");
         }
 
-
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
         public async Task TestCharMainNoArguments()
         {
@@ -77,7 +76,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
     public static int Main([||]string[] args) => 0;
 }");
         }
-
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
         public async Task TestCharMainWithStringArrayArgument()
@@ -110,7 +108,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
     public static int Main([||]string args) => 0;
 }");
         }
-
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
         public async Task TestCharMainWithStringArgument()

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -28,6 +28,102 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestVoidMainNoArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static void Main([||]) => Console.WriteLine(""Hello world"");
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestIntMainNoArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static int Main([||]) => 0;
+}");
+        }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestCharMainNoArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static char Main([||]) => '0';
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestVoidMainWithStringArrayArgument()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static void Main([||]string[] args) => Console.WriteLine(""Hello world"");
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestIntMainWithStringArrayArgument()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static int Main([||]string[] args) => 0;
+}");
+        }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestCharMainWithStringArrayArgument()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static char Main([||]string[] args) => '0';
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestVoidMainWithStringArgument()
+        {
+            // TODO: This is incorrect behavior. Update the test after fixing https://github.com/dotnet/roslyn/issues/46869
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static void Main([||]string args) => Console.WriteLine(""Hello world"");
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestIntMainWithStringArgument()
+        {
+            // TODO: This is incorrect behavior. Update the test after fixing https://github.com/dotnet/roslyn/issues/46869
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static int Main([||]string args) => 0;
+}");
+        }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestCharMainWithStringArgument()
+        {
+            // TODO: This is incorrect behavior. Update the test after fixing https://github.com/dotnet/roslyn/issues/46869
+            await TestMissingInRegularAndScriptAsync(
+@"public static class Program
+{
+    public static char Main([||]string args) => '0';
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
         public async Task TestSimpleReferenceType()
         {
             await TestInRegularAndScript1Async(

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -119,14 +119,14 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             return result.ToImmutable();
         }
 
-            private bool IsEntryPoint(IMethodSymbol methodSymbol, INamedTypeSymbol taskType, INamedTypeSymbol genericTaskType)
-                => (methodSymbol.Name == WellKnownMemberNames.EntryPointMethodName || methodSymbol.Name == "<Main>$") &&  // https://github.com/dotnet/roslyn/issues/45110 Switch to using WellKnownMemberNames.TopLevelStatementsEntryPointMethodName
-                                                                                                                          // once src\CodeStyle\Core\Analyzers\Microsoft.CodeAnalysis.CodeStyle.csproj is able to use the latest version of the type.
-                   methodSymbol.IsStatic &&
-                   (methodSymbol.ReturnsVoid ||
-                    methodSymbol.ReturnType.SpecialType == SpecialType.System_Int32 ||
-                    methodSymbol.ReturnType.OriginalDefinition.Equals(taskType) ||
-                    methodSymbol.ReturnType.OriginalDefinition.Equals(genericTaskType));
+        private static bool IsEntryPoint(IMethodSymbol methodSymbol, INamedTypeSymbol taskType, INamedTypeSymbol genericTaskType)
+            => (methodSymbol.Name == WellKnownMemberNames.EntryPointMethodName || methodSymbol.Name == "<Main>$") &&  // https://github.com/dotnet/roslyn/issues/45110 Switch to using WellKnownMemberNames.TopLevelStatementsEntryPointMethodName
+                                                                                                                      // once src\CodeStyle\Core\Analyzers\Microsoft.CodeAnalysis.CodeStyle.csproj is able to use the latest version of the type.
+               methodSymbol.IsStatic &&
+               (methodSymbol.ReturnsVoid ||
+                methodSymbol.ReturnType.SpecialType == SpecialType.System_Int32 ||
+                methodSymbol.ReturnType.OriginalDefinition.Equals(taskType) ||
+                methodSymbol.ReturnType.OriginalDefinition.Equals(genericTaskType));
 
         private async Task<Document> UpdateDocumentForRefactoringAsync(
             Document document,


### PR DESCRIPTION
This implementation has the same issue stated in https://github.com/dotnet/roslyn/issues/46869.

Fixes https://github.com/dotnet/roslyn/issues/46827