### PR TITLE
Exclude unexercised assembly from optprof config

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -384,7 +384,7 @@
           "filteredTestCases": [
             {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Threading.Tasks.Extensions.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
+              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },
             {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/Microsoft.CodeAnalysis.CSharp.dll",


### PR DESCRIPTION
DDRIT_RPS_ManagedLangs_Typing has been failing for a while because of this

```
No profile was generated for module 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Current\Bin\Roslyn\System.Threading.Tasks.Extensions.dll', which usually means that the scenario did not exercise the module
```

@dotnet/roslyn-infrastructure 