### PR TITLE
msbuild workspace global property defaults can be overridden

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             }
 
             globalProperties = globalProperties ?? ImmutableDictionary<string, string>.Empty;
-            var allProperties = s_defaultGlobalProperties.AddRange(globalProperties);
+            var allProperties = s_defaultGlobalProperties.RemoveRange(globalProperties.Keys).AddRange(globalProperties);
             _batchBuildProjectCollection = new MSB.Evaluation.ProjectCollection(allProperties);
             _batchBuildLogger = new MSBuildDiagnosticLogger()
             {

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -421,11 +421,11 @@ class C1
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(33047, "https://github.com/dotnet/roslyn/issues/33047")]
-        public async Task TestOpenProject_CSharp_GlobalPropertyDesignTimeBuildDefault()
+        public async Task TestOpenProject_CSharp_GlobalPropertyShouldUnsetParentConfigurationAndPlatformDefault()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles()
-                .WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.DesignTimeBuild)
-                .WithFile(@"CSharpProject\DesignTimeBuildConditional.cs", Resources.SourceFiles.CSharp.CSharpClass));
+                .WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.ShouldUnsetParentConfigurationAndPlatform)
+                .WithFile(@"CSharpProject\ShouldUnsetParentConfigurationAndPlatformConditional.cs", Resources.SourceFiles.CSharp.CSharpClass));
 
             var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
@@ -434,27 +434,27 @@ class C1
                 var project = await workspace.OpenProjectAsync(projectFilePath);
                 var document = project.Documents.First();
                 var tree = await document.GetSyntaxTreeAsync();
-                var expectedFileName = GetSolutionFileName(@"CSharpProject\DesignTimeBuildConditional.cs");
+                var expectedFileName = GetSolutionFileName(@"CSharpProject\CSharpClass.cs");
                 Assert.Equal(expectedFileName, tree.FilePath);
             }
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(33047, "https://github.com/dotnet/roslyn/issues/33047")]
-        public async Task TestOpenProject_CSharp_GlobalPropertyDesignTimeBuildFalse()
+        public async Task TestOpenProject_CSharp_GlobalPropertyShouldUnsetParentConfigurationAndPlatformTrue()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles()
-                .WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.DesignTimeBuild)
-                .WithFile(@"CSharpProject\DesignTimeBuildConditional.cs", Resources.SourceFiles.CSharp.CSharpClass));
+                .WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.ShouldUnsetParentConfigurationAndPlatform)
+                .WithFile(@"CSharpProject\ShouldUnsetParentConfigurationAndPlatformConditional.cs", Resources.SourceFiles.CSharp.CSharpClass));
 
             var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
-            using (var workspace = CreateMSBuildWorkspace(("DesignTimeBuild", bool.FalseString)))
+            using (var workspace = CreateMSBuildWorkspace(("ShouldUnsetParentConfigurationAndPlatform", bool.TrueString)))
             {
                 var project = await workspace.OpenProjectAsync(projectFilePath);
                 var document = project.Documents.First();
                 var tree = await document.GetSyntaxTreeAsync();
-                var expectedFileName = GetSolutionFileName(@"CSharpProject\CSharpClass.cs");
+                var expectedFileName = GetSolutionFileName(@"CSharpProject\ShouldUnsetParentConfigurationAndPlatformConditional.cs");
                 Assert.Equal(expectedFileName, tree.FilePath);
             }
         }

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -420,6 +420,46 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [WorkItem(33047, "https://github.com/dotnet/roslyn/issues/33047")]
+        public async Task TestOpenProject_CSharp_GlobalPropertyDesignTimeBuildDefault()
+        {
+            CreateFiles(GetSimpleCSharpSolutionFiles()
+                .WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.DesignTimeBuild)
+                .WithFile(@"CSharpProject\DesignTimeBuildConditional.cs", Resources.SourceFiles.CSharp.CSharpClass));
+
+            var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+
+            using (var workspace = CreateMSBuildWorkspace())
+            {
+                var project = await workspace.OpenProjectAsync(projectFilePath);
+                var document = project.Documents.First();
+                var tree = await document.GetSyntaxTreeAsync();
+                var expectedFileName = GetSolutionFileName(@"CSharpProject\DesignTimeBuildConditional.cs");
+                Assert.Equal(expectedFileName, tree.FilePath);
+            }
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [WorkItem(33047, "https://github.com/dotnet/roslyn/issues/33047")]
+        public async Task TestOpenProject_CSharp_GlobalPropertyDesignTimeBuildFalse()
+        {
+            CreateFiles(GetSimpleCSharpSolutionFiles()
+                .WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.DesignTimeBuild)
+                .WithFile(@"CSharpProject\DesignTimeBuildConditional.cs", Resources.SourceFiles.CSharp.CSharpClass));
+
+            var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+
+            using (var workspace = CreateMSBuildWorkspace(("DesignTimeBuild", bool.FalseString)))
+            {
+                var project = await workspace.OpenProjectAsync(projectFilePath);
+                var document = project.Documents.First();
+                var tree = await document.GetSyntaxTreeAsync();
+                var expectedFileName = GetSolutionFileName(@"CSharpProject\CSharpClass.cs");
+                Assert.Equal(expectedFileName, tree.FilePath);
+            }
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(739043, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/739043")]
         public async Task TestOpenProject_CSharp_WithoutPrefer32BitAndConsoleApplication()
         {

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DesignTimeBuild.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DesignTimeBuild.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{686DD036-86AA-443E-8A10-DDB43266A8C4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSharpProject</RootNamespace>
+    <AssemblyName>CSharpProject</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Condition="$(DesignTimeBuild)" Include="DesignTimeBuildConditional.cs" />
+    <Compile Include="CSharpClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ShouldUnsetParentConfigurationAndPlatform.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ShouldUnsetParentConfigurationAndPlatform.csproj
@@ -39,7 +39,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Condition="$(DesignTimeBuild)" Include="DesignTimeBuildConditional.cs" />
+    <Compile Condition="$(ShouldUnsetParentConfigurationAndPlatform)" Include="ShouldUnsetParentConfigurationAndPlatformConditional.cs" />
     <Compile Include="CSharpClass.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -116,6 +116,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string CircularProjectReferences_CircularCSharpProject1 => GetText("CircularProjectReferences.CircularCSharpProject1.csproj");
                 public static string CircularProjectReferences_CircularCSharpProject2 => GetText("CircularProjectReferences.CircularCSharpProject2.csproj");
                 public static string CSharpProject => GetText("ProjectFiles.CSharp.CSharpProject.csproj");
+                public static string DesignTimeBuild => GetText("ProjectFiles.CSharp.DesignTimeBuild.csproj");
                 public static string DuplicateFile => GetText("ProjectFiles.CSharp.DuplicateFile.csproj");
                 public static string DuplicateReferences => GetText("ProjectFiles.CSharp.DuplicateReferences.csproj");
                 public static string DuplicatedGuidLibrary1 => GetText("ProjectFiles.CSharp.DuplicatedGuidLibrary1.csproj");

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -116,7 +116,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string CircularProjectReferences_CircularCSharpProject1 => GetText("CircularProjectReferences.CircularCSharpProject1.csproj");
                 public static string CircularProjectReferences_CircularCSharpProject2 => GetText("CircularProjectReferences.CircularCSharpProject2.csproj");
                 public static string CSharpProject => GetText("ProjectFiles.CSharp.CSharpProject.csproj");
-                public static string DesignTimeBuild => GetText("ProjectFiles.CSharp.DesignTimeBuild.csproj");
                 public static string DuplicateFile => GetText("ProjectFiles.CSharp.DuplicateFile.csproj");
                 public static string DuplicateReferences => GetText("ProjectFiles.CSharp.DuplicateReferences.csproj");
                 public static string DuplicatedGuidLibrary1 => GetText("ProjectFiles.CSharp.DuplicatedGuidLibrary1.csproj");
@@ -150,6 +149,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string ProjectLoadErrorOnMissingDebugType => GetText("ProjectFiles.CSharp.ProjectLoadErrorOnMissingDebugType.csproj");
                 public static string ProjectReference => GetText("ProjectFiles.CSharp.ProjectReference.csproj");
                 public static string ReferencesPortableProject => GetText("ProjectFiles.CSharp.ReferencesPortableProject.csproj");
+                public static string ShouldUnsetParentConfigurationAndPlatform => GetText("ProjectFiles.CSharp.ShouldUnsetParentConfigurationAndPlatform.csproj");
                 public static string Wildcards => GetText("ProjectFiles.CSharp.Wildcards.csproj");
                 public static string WithoutCSharpTargetsImported => GetText("ProjectFiles.CSharp.WithoutCSharpTargetsImported.csproj");
                 public static string WithDiscoverEditorConfigFiles => GetText("ProjectFiles.CSharp.WithDiscoverEditorConfigFiles.csproj");


### PR DESCRIPTION
fixes #33047