### PR TITLE
Fix convert-to-switch handling of comments at the end of blocks

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -691,6 +691,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
         {
             case string s when s.Length > 5 && s.Length < 10:
                 M(o: 0);
+
                 break;
             case int i:
                 M(o: 0);
@@ -832,7 +833,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
                 {
                     break;
                 }
-
                 break;
             case 2:
                 break;

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -2593,5 +2593,60 @@ enum ET1
 
             await test.RunAsync();
         }
+
+        [WorkItem(46863, "https://github.com/dotnet/roslyn/issues/46863")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task CommentsAtTheEndOfBlocksShouldBePlacedBeforeBreakStatements()
+        {
+            var source = @"
+class C
+{
+    void M(int p)
+    {
+        [||]if (p == 1)
+        {
+            DoA();
+            // Comment about why A doesn't need something here
+        }
+        else if (p == 2)
+        {
+            DoB();
+            // Comment about why B doesn't need something here
+        }
+    }
+
+    void DoA() { }
+    void DoB() { }
+}";
+
+            var fixedSource = @"
+class C
+{
+    void M(int p)
+    {
+        switch (p)
+        {
+            case 1:
+                DoA();
+                // Comment about why A doesn't need something here
+                break;
+            case 2:
+                DoB();
+                // Comment about why B doesn't need something here
+                break;
+        }
+    }
+
+    void DoA() { }
+    void DoB() { }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                CodeActionValidationMode = CodeActionValidationMode.None,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
                 closeParenToken: ifStatement.CloseParenToken.WithPrependedLeadingTrivia(ElasticMarker),
                 openBraceToken: block?.OpenBraceToken ?? Token(SyntaxKind.OpenBraceToken),
                 sections: List(sectionList.Cast<SwitchSectionSyntax>()),
-                closeBraceToken: block?.CloseBraceToken.WithLeadingTrivia(SyntaxTriviaList.Empty) ?? Token(SyntaxKind.CloseBraceToken));
+                closeBraceToken: block?.CloseBraceToken.WithoutLeadingTrivia() ?? Token(SyntaxKind.CloseBraceToken));
         }
 
         private static WhenClauseSyntax? AsWhenClause(AnalyzedSwitchLabel label)

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
                 closeParenToken: ifStatement.CloseParenToken.WithPrependedLeadingTrivia(ElasticMarker),
                 openBraceToken: block?.OpenBraceToken ?? Token(SyntaxKind.OpenBraceToken),
                 sections: List(sectionList.Cast<SwitchSectionSyntax>()),
-                closeBraceToken: block?.CloseBraceToken ?? Token(SyntaxKind.CloseBraceToken));
+                closeBraceToken: block?.CloseBraceToken.WithLeadingTrivia(SyntaxTriviaList.Empty) ?? Token(SyntaxKind.CloseBraceToken));
         }
 
         private static WhenClauseSyntax? AsWhenClause(AnalyzedSwitchLabel label)
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
                     statements.AddRange(block.Statements);
                     if (requiresBreak)
                     {
-                        statements.Add(BreakStatement());
+                        statements.Add(BreakStatement().WithLeadingTrivia(block.CloseBraceToken.LeadingTrivia));
                     }
                 }
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
@@ -825,6 +825,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return node.WithLeadingTrivia(leadingTrivia).WithTrailingTrivia(trailingTrivia);
         }
 
+        /// <summary>
+        /// Creates a new token with the leading trivia removed.
+        /// </summary>
+        public static SyntaxToken WithoutLeadingTrivia(this SyntaxToken token)
+        {
+            return token.WithLeadingTrivia(default(SyntaxTriviaList));
+        }
+
         // Copy of the same function in SyntaxNode.cs
         public static SyntaxNode? GetParent(this SyntaxNode node, bool ascendOutOfTrivia)
         {


### PR DESCRIPTION
Fixes #46863

~~The last commit is a WIP that I either would like input on or would be happy to drop, leaving VB as-is. The problem with the commit is that the test fails due to the formatter not indenting one of the comments. The formatter for C# is not behaving this way. What approach would you take?~~

```diff
 Class C
     Sub M(p As Integer)
         Select p
             Case 1
                 DoA()
-                ' Comment about why A doesn't need something here
+            ' Comment about why A doesn't need something here
             Case 2
                 DoB()
                 ' Comment about why B doesn't need something here
         End Select
     End Sub
 
     Sub DoA()
     End Sub
     Sub DoB()
     End Sub
 End Class
```

/cc @CyrusNajmabadi 