### PR TITLE
Pass document and solution to request handlers

### DIFF
--- a/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
@@ -52,7 +52,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var handler = (IRequestHandler<RequestType, ResponseType>?)handlerEntry.Value;
             Contract.ThrowIfNull(handler, string.Format("Request handler not found for method {0}", methodName));
 
-            return _queue.ExecuteAsync(mutatesSolutionState, handler, request, clientCapabilities, clientName, cancellationToken);
+            LSP.TextDocumentIdentifier? documentIdentifier = null;
+
+            return _queue.ExecuteAsync(mutatesSolutionState, documentIdentifier, handler, request, clientCapabilities, clientName, cancellationToken);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
@@ -52,9 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var handler = (IRequestHandler<RequestType, ResponseType>?)handlerEntry.Value;
             Contract.ThrowIfNull(handler, string.Format("Request handler not found for method {0}", methodName));
 
-            LSP.TextDocumentIdentifier? documentIdentifier = null;
-
-            return _queue.ExecuteAsync(mutatesSolutionState, documentIdentifier, handler, request, clientCapabilities, clientName, cancellationToken);
+            return _queue.ExecuteAsync(mutatesSolutionState, handler, request, clientCapabilities, clientName, cancellationToken);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -65,13 +65,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return (null, solution);
         }
 
-        public static RequestContext CreateRequestContext(this ILspSolutionProvider provider, TextDocumentIdentifier textDocument, ClientCapabilities clientCapabilities, string? clientName = null)
-        {
-            var (document, solution) = GetDocumentAndSolution(provider, textDocument, clientName);
-
-            return new RequestContext(document, solution, null, clientCapabilities, clientName);
-        }
-
         public static ImmutableArray<Document> GetDocuments(this ILspSolutionProvider solutionProvider, Uri uri, string? clientName)
         {
             return GetDocuments<Document>(solutionProvider, uri, (s, u, c) => s.GetDocuments(u), clientName);

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -87,9 +87,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static LSP.TextDocumentIdentifier DocumentToTextDocumentIdentifier(Document document)
             => new LSP.TextDocumentIdentifier() { Uri = document.GetURI() };
 
-        internal static LSP.TextDocumentIdentifier? TextDocumentItemToTextDocumentIdentifier(LSP.TextDocumentItem textDocument)
-            => new LSP.TextDocumentIdentifier() { Uri = textDocument.Uri };
-
         public static LinePosition PositionToLinePosition(LSP.Position position)
             => new LinePosition(position.Line, position.Character);
 

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -87,6 +87,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static LSP.TextDocumentIdentifier DocumentToTextDocumentIdentifier(Document document)
             => new LSP.TextDocumentIdentifier() { Uri = document.GetURI() };
 
+        internal static LSP.TextDocumentIdentifier? TextDocumentItemToTextDocumentIdentifier(LSP.TextDocumentItem textDocument)
+            => new LSP.TextDocumentIdentifier() { Uri = textDocument.Uri };
+
         public static LinePosition PositionToLinePosition(LSP.Position position)
             => new LinePosition(position.Line, position.Character);
 

--- a/src/Features/LanguageServer/Protocol/Handler/AbstractRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/AbstractRequestHandler.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
@@ -18,6 +19,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             SolutionProvider = solutionProvider;
         }
 
+        public virtual TextDocumentIdentifier? GetTextDocumentIdentifier(RequestType request) => null;
         public abstract Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -49,12 +49,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _codeRefactoringService = codeRefactoringService;
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(VSCodeAction request)
+            => ((JToken)request.Data).ToObject<CodeActionResolveData>().TextDocument;
+
         public override async Task<LSP.VSCodeAction> HandleRequestAsync(LSP.VSCodeAction codeAction, RequestContext context, CancellationToken cancellationToken)
         {
-            var data = ((JToken)codeAction.Data).ToObject<CodeActionResolveData>();
-            var document = SolutionProvider.GetDocument(data.TextDocument, context.ClientName);
+            var document = context.Document;
             Contract.ThrowIfNull(document);
 
+            var data = ((JToken)codeAction.Data).ToObject<CodeActionResolveData>();
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 document,
                 _codeFixService,

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -48,9 +48,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _codeRefactoringService = codeRefactoringService;
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(CodeActionParams request) => request.TextDocument;
+
         public override async Task<LSP.VSCodeAction[]> HandleRequestAsync(LSP.CodeActionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return Array.Empty<VSCodeAction>();

--- a/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Commands/ExecuteWorkspaceCommandHandler.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -38,6 +39,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             return requestHandlerDictionary.ToImmutable();
         }
+
+        public virtual TextDocumentIdentifier? GetTextDocumentIdentifier(ExecuteCommandParams request) => null;
 
         /// <summary>
         /// Handles an <see cref="LSP.Methods.WorkspaceExecuteCommand"/>

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -32,9 +32,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.CompletionParams request) => request.TextDocument;
+
         public override async Task<LSP.CompletionItem[]> HandleRequestAsync(LSP.CompletionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return Array.Empty<LSP.CompletionItem>();

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -19,18 +19,20 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    internal abstract class AbstractGoToDefinitionHandler<RequestType, ResponseType> : AbstractRequestHandler<RequestType, ResponseType>
+    internal abstract class AbstractGoToDefinitionHandler : AbstractRequestHandler<LSP.TextDocumentPositionParams, LSP.Location[]>
     {
         private readonly IMetadataAsSourceFileService _metadataAsSourceFileService;
 
         public AbstractGoToDefinitionHandler(IMetadataAsSourceFileService metadataAsSourceFileService, ILspSolutionProvider solutionProvider) : base(solutionProvider)
             => _metadataAsSourceFileService = metadataAsSourceFileService;
 
+        public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.TextDocumentPositionParams request) => request.TextDocument;
+
         protected async Task<LSP.Location[]> GetDefinitionAsync(LSP.TextDocumentPositionParams request, bool typeOnly, RequestContext context, CancellationToken cancellationToken)
         {
             var locations = ArrayBuilder<LSP.Location>.GetInstance();
 
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return locations.ToArrayAndFree();

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
     [Shared]
     [ExportLspMethod(LSP.Methods.TextDocumentDefinitionName)]
-    internal class GoToDefinitionHandler : AbstractGoToDefinitionHandler<LSP.TextDocumentPositionParams, LSP.Location[]>
+    internal class GoToDefinitionHandler : AbstractGoToDefinitionHandler
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
     [Shared]
     [ExportLspMethod(LSP.Methods.TextDocumentTypeDefinitionName)]
-    internal class GoToTypeDefinitionHandler : AbstractGoToDefinitionHandler<LSP.TextDocumentPositionParams, LSP.Location[]>
+    internal class GoToTypeDefinitionHandler : AbstractGoToDefinitionHandler
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -25,11 +25,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(FoldingRangeParams request) => request.TextDocument;
+
         public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return foldingRanges.ToArrayAndFree();

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         protected async Task<LSP.TextEdit[]> GetTextEditsAsync(LSP.TextDocumentIdentifier documentIdentifier, RequestContext context, CancellationToken cancellationToken, LSP.Range? range = null)
         {
             var edits = new ArrayBuilder<LSP.TextEdit>();
-            var document = SolutionProvider.GetDocument(documentIdentifier, context.ClientName);
+            var document = context.Document;
 
             if (document != null)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
-        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(LSP.TextDocumentIdentifier documentIdentifier, RequestContext context, CancellationToken cancellationToken, LSP.Range? range = null)
+        protected async Task<LSP.TextEdit[]> GetTextEditsAsync(RequestContext context, CancellationToken cancellationToken, LSP.Range? range = null)
         {
             var edits = new ArrayBuilder<LSP.TextEdit>();
             var document = context.Document;

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -26,6 +26,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.DocumentFormattingParams request) => request.TextDocument;
 
         public override Task<LSP.TextEdit[]> HandleRequestAsync(LSP.DocumentFormattingParams request, RequestContext context, CancellationToken cancellationToken)
-            => GetTextEditsAsync(request.TextDocument, context, cancellationToken);
+            => GetTextEditsAsync(context, cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.DocumentFormattingParams request) => request.TextDocument;
+
         public override Task<LSP.TextEdit[]> HandleRequestAsync(LSP.DocumentFormattingParams request, RequestContext context, CancellationToken cancellationToken)
             => GetTextEditsAsync(request.TextDocument, context, cancellationToken);
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -29,10 +29,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(DocumentOnTypeFormattingParams request) => request.TextDocument;
+
         public override async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var edits = new ArrayBuilder<TextEdit>();
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document != null)
             {
                 var formattingService = document.Project.LanguageServices.GetRequiredService<IEditorFormattingService>();

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -26,6 +26,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public override TextDocumentIdentifier? GetTextDocumentIdentifier(DocumentRangeFormattingParams request) => request.TextDocument;
 
         public override Task<TextEdit[]> HandleRequestAsync(DocumentRangeFormattingParams request, RequestContext context, CancellationToken cancellationToken)
-            => GetTextEditsAsync(request.TextDocument, context, cancellationToken, range: request.Range);
+            => GetTextEditsAsync(context, cancellationToken, range: request.Range);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(DocumentRangeFormattingParams request) => request.TextDocument;
+
         public override Task<TextEdit[]> HandleRequestAsync(DocumentRangeFormattingParams request, RequestContext context, CancellationToken cancellationToken)
             => GetTextEditsAsync(request.TextDocument, context, cancellationToken, range: request.Range);
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
@@ -26,9 +26,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(TextDocumentPositionParams request) => request.TextDocument;
+
         public override async Task<DocumentHighlight[]> HandleRequestAsync(TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return Array.Empty<DocumentHighlight>();

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -26,9 +26,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(TextDocumentPositionParams request) => request.TextDocument;
+
         public override async Task<Hover?> HandleRequestAsync(TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return null;

--- a/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         TextDocumentIdentifier? GetTextDocumentIdentifier(RequestType request);
 
         /// <summary>
-        /// Handles an LSP request.
+        /// Handles an LSP request in the context of the supplied document and/or solutuion.
         /// </summary>
-        /// <param name="context">The LSP request context.</param>
+        /// <param name="context">The LSP request context, which should have been filled in with document information from <see cref="GetTextDocumentIdentifier(RequestType)"/> if applicable.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the request processing.</param>
         /// <returns>The LSP response.</returns>
         Task<ResponseType> HandleRequestAsync(RequestType request, RequestContext context, CancellationToken cancellationToken);

--- a/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IRequestHandler.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
@@ -18,6 +19,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
     internal interface IRequestHandler<RequestType, ResponseType> : IRequestHandler
     {
+        /// <summary>
+        /// Gets the TestDocumentIdentifier from the request, if the request provides one.
+        /// </summary>
+        TextDocumentIdentifier? GetTextDocumentIdentifier(RequestType request);
+
         /// <summary>
         /// Handles an LSP request.
         /// </summary>

--- a/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 .ToImmutableArray();
         }
 
+        public TextDocumentIdentifier? GetTextDocumentIdentifier(InitializeParams request) => null;
+
         public Task<LSP.InitializeResult> HandleRequestAsync(LSP.InitializeParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var triggerCharacters = _completionProviders.SelectMany(lz => GetTriggerCharacters(lz.Value)).Distinct().Select(c => c.ToString()).ToArray();

--- a/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
@@ -26,11 +26,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.DocumentOnAutoInsertParams request) => request.TextDocument;
+
         public override async Task<LSP.DocumentOnAutoInsertResponseItem[]> HandleRequestAsync(LSP.DocumentOnAutoInsertParams autoInsertParams, RequestContext context, CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<LSP.DocumentOnAutoInsertResponseItem>.GetInstance(out var response);
 
-            var document = SolutionProvider.GetDocument(autoInsertParams.TextDocument, context.ClientName);
+            var document = context.Document;
 
             if (document == null)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -31,11 +31,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _metadataAsSourceFileService = metadataAsSourceFileService;
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(ReferenceParams request) => request.TextDocument;
+
         public override async Task<LSP.VSReferenceItem[]> HandleRequestAsync(ReferenceParams referenceParams, RequestContext context, CancellationToken cancellationToken)
         {
             Debug.Assert(context.ClientCapabilities.HasVisualStudioLspCapability());
 
-            var document = SolutionProvider.GetDocument(referenceParams.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return Array.Empty<LSP.VSReferenceItem>();

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
@@ -25,11 +25,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.TextDocumentPositionParams request) => request.TextDocument;
+
         public override async Task<LSP.Location[]> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var locations = ArrayBuilder<LSP.Location>.GetInstance();
 
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return locations.ToArrayAndFree();

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -28,10 +28,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(RenameParams request) => request.TextDocument;
+
         public override async Task<WorkspaceEdit?> HandleRequestAsync(RenameParams request, RequestContext context, CancellationToken cancellationToken)
         {
             WorkspaceEdit? workspaceEdit = null;
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document != null)
             {
                 var oldSolution = document.Project.Solution;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -37,12 +37,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// </summary>
         public string? ClientName { get; }
 
-        public RequestContext(ClientCapabilities clientCapabilities, string? clientName)
-            : this(null, null, null, clientCapabilities, clientName)
-        {
-        }
-
-        internal RequestContext(Document? document, Solution? solution, Action<Solution>? solutionUpdater, ClientCapabilities clientCapabilities, string? clientName)
+        public RequestContext(Document? document, Solution? solution, Action<Solution>? solutionUpdater, ClientCapabilities clientCapabilities, string? clientName)
         {
             Document = document;
             Solution = solution;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -19,13 +19,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly Action<Solution>? _solutionUpdater;
 
         /// <summary>
-        /// The document that the request is for, if applicable
+        /// The document that the request is for, if applicable. This comes from the <see cref="TextDocumentIdentifier"/> returned from the handler itself via a call to <see cref="IRequestHandler{RequestType, ResponseType}.GetTextDocumentIdentifier(RequestType)"/>.
         /// </summary>
         public Document? Document { get; }
+
         /// <summary>
-        /// The solution state that the request should operate on
+        /// The solution state that the request should operate on.
         /// </summary>
-        public Solution? Solution { get; }
+        public Solution Solution { get; }
 
         /// <summary>
         /// The client capabilities for the request.
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// </summary>
         public string? ClientName { get; }
 
-        public RequestContext(Document? document, Solution? solution, Action<Solution>? solutionUpdater, ClientCapabilities clientCapabilities, string? clientName)
+        public RequestContext(Document? document, Solution solution, Action<Solution>? solutionUpdater, ClientCapabilities clientCapabilities, string? clientName)
         {
             Document = document;
             Solution = solution;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -19,6 +19,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly Action<Solution>? _solutionUpdater;
 
         /// <summary>
+        /// The document that the request is for, if applicable
+        /// </summary>
+        public Document? Document { get; }
+        /// <summary>
         /// The solution state that the request should operate on
         /// </summary>
         public Solution? Solution { get; }
@@ -34,12 +38,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public string? ClientName { get; }
 
         public RequestContext(ClientCapabilities clientCapabilities, string? clientName)
-            : this(null, null, clientCapabilities, clientName)
+            : this(null, null, null, clientCapabilities, clientName)
         {
         }
 
-        internal RequestContext(Solution? solution, Action<Solution>? solutionUpdater, ClientCapabilities clientCapabilities, string? clientName)
+        internal RequestContext(Document? document, Solution? solution, Action<Solution>? solutionUpdater, ClientCapabilities clientCapabilities, string? clientName)
         {
+            Document = document;
             Solution = solution;
             _solutionUpdater = solutionUpdater;
             ClientCapabilities = clientCapabilities;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
@@ -23,13 +23,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             public readonly bool MutatesSolutionState;
             public readonly string? ClientName;
             public readonly ClientCapabilities ClientCapabilities;
+            public readonly TextDocumentIdentifier? TextDocument;
             public readonly CancellationToken CancellationToken;
 
-            public QueueItem(bool mutatesSolutionState, ClientCapabilities clientCapabilities, string? clientName, Func<RequestContext, CancellationToken, Task<bool>> callback, CancellationToken cancellationToken)
+            public QueueItem(bool mutatesSolutionState, ClientCapabilities clientCapabilities, string? clientName, TextDocumentIdentifier? textDocument, Func<RequestContext, CancellationToken, Task<bool>> callback, CancellationToken cancellationToken)
             {
                 MutatesSolutionState = mutatesSolutionState;
                 ClientCapabilities = clientCapabilities;
                 ClientName = clientName;
+                TextDocument = textDocument;
                 CallbackAsync = callback;
                 CancellationToken = cancellationToken;
             }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
@@ -26,13 +26,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             public readonly TextDocumentIdentifier? TextDocument;
             public readonly CancellationToken CancellationToken;
 
-            public QueueItem(bool mutatesSolutionState, ClientCapabilities clientCapabilities, string? clientName, TextDocumentIdentifier? textDocument, Func<RequestContext, CancellationToken, Task<bool>> callback, CancellationToken cancellationToken)
+            public QueueItem(bool mutatesSolutionState, ClientCapabilities clientCapabilities, string? clientName, TextDocumentIdentifier? textDocument, Func<RequestContext, CancellationToken, Task<bool>> callbackAsync, CancellationToken cancellationToken)
             {
                 MutatesSolutionState = mutatesSolutionState;
                 ClientCapabilities = clientCapabilities;
                 ClientName = clientName;
                 TextDocument = textDocument;
-                CallbackAsync = callback;
+                CallbackAsync = callbackAsync;
                 CancellationToken = cancellationToken;
             }
         }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 solution = MergeChanges(solution, _lastMutatedSolution);
 
                 Solution? mutatedSolution = null;
-                var context = new RequestContext(solution, s => mutatedSolution = s, work.ClientCapabilities, work.ClientName);
+                var context = new RequestContext(document, solution, s => mutatedSolution = s, work.ClientCapabilities, work.ClientName);
 
                 if (work.MutatesSolutionState)
                 {

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <returns>A task that can be awaited to observe the results of the handing of this request.</returns>
         public Task<TResponseType> ExecuteAsync<TRequestType, TResponseType>(
             bool mutatesSolutionState,
+            TextDocumentIdentifier? documentIdentifier
             IRequestHandler<TRequestType, TResponseType> handler,
             TRequestType request,
             ClientCapabilities clientCapabilities,
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // Create a task completion source that will represent the processing of this request to the caller
             var completion = new TaskCompletionSource<TResponseType>();
 
-            var item = new QueueItem(mutatesSolutionState, clientCapabilities, clientName,
+            var item = new QueueItem(mutatesSolutionState, clientCapabilities, clientName, documentIdentifier,
                 callback: async (context, cancellationToken) =>
                 {
                     // Check if cancellation was requested while this was waiting in the queue

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <returns>A task that can be awaited to observe the results of the handing of this request.</returns>
         public Task<TResponseType> ExecuteAsync<TRequestType, TResponseType>(
             bool mutatesSolutionState,
-            TextDocumentIdentifier? documentIdentifier
             IRequestHandler<TRequestType, TResponseType> handler,
             TRequestType request,
             ClientCapabilities clientCapabilities,
@@ -57,7 +56,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // Create a task completion source that will represent the processing of this request to the caller
             var completion = new TaskCompletionSource<TResponseType>();
 
-            var item = new QueueItem(mutatesSolutionState, clientCapabilities, clientName, documentIdentifier,
+            var textDocument = handler.GetTextDocumentIdentifier(request);
+            var item = new QueueItem(mutatesSolutionState, clientCapabilities, clientName, textDocument,
                 callback: async (context, cancellationToken) =>
                 {
                     // Check if cancellation was requested while this was waiting in the queue

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -111,9 +111,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
                 // The "current" solution can be updated by non-LSP actions, so we need it, but we also need
                 // to merge in the changes from any mutations that have been applied to open documents
-                var solution = GetCurrentSolution();
-                var (document, solution) = GetWorkspaceState(work.TextDocument, work.ClientName);
-
+                var (document, solution) = _solutionProvider.GetDocumentAndSolution(work.TextDocument, work.ClientName);
                 solution = MergeChanges(solution, _lastMutatedSolution);
 
                 Solution? mutatedSolution = null;
@@ -144,24 +142,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // TODO: Merge in changes to the solution that have been received from didChange LSP methods
             // https://github.com/dotnet/roslyn/issues/45427
             return mutatedSolution ?? solution;
-        }
-
-        private (Document?, Solution) GetWorkspaceState(TextDocumentIdentifier? textDocument, string? clientName)
-        {
-            Document? document = null;
-            Solution? solution = null;
-            if (textDocument != null)
-            {
-                document = _solutionProvider.GetDocument(textDocument, clientName);
-                solution = document?.Project.Solution;
-            }
-
-            if (solution == null)
-            {
-                solution = _solutionProvider.GetCurrentSolutionForMainWorkspace();
-            }
-
-            return (document, solution);
         }
 
         public void Dispose()

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var textDocument = handler.GetTextDocumentIdentifier(request);
             var item = new QueueItem(mutatesSolutionState, clientCapabilities, clientName, textDocument,
-                callback: async (context, cancellationToken) =>
+                callbackAsync: async (context, cancellationToken) =>
                 {
                     // Check if cancellation was requested while this was waiting in the queue
                     if (cancellationToken.IsCancellationRequested)
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // The "current" solution can be updated by non-LSP actions, so we need it, but we also need
                 // to merge in the changes from any mutations that have been applied to open documents
                 var (document, solution) = _solutionProvider.GetDocumentAndSolution(work.TextDocument, work.ClientName);
-                solution = MergeChanges(solution, _lastMutatedSolution);
+                solution = MergeChanges(solution, lastMutatedSolution);
 
                 Solution? mutatedSolution = null;
                 var context = new RequestContext(document, solution, s => mutatedSolution = s, work.ClientCapabilities, work.ClientName);

--- a/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -31,9 +31,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             : base(solutionProvider)
             => _allProviders = allProviders;
 
+        public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.TextDocumentPositionParams request) => request.TextDocument;
+
         public override async Task<LSP.SignatureHelp> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return new LSP.SignatureHelp();

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -29,9 +29,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier GetTextDocumentIdentifier(DocumentSymbolParams request) => request.TextDocument;
+
         public override async Task<object[]> HandleRequestAsync(DocumentSymbolParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return Array.Empty<SymbolInformation>();

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
         public override async Task<SymbolInformation[]> HandleRequestAsync(WorkspaceSymbolParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var solution = SolutionProvider.GetCurrentSolutionForMainWorkspace();
+            var solution = context.Solution;
             var searchTasks = Task.WhenAll(solution.Projects.Select(project => SearchProjectAsync(project, request, cancellationToken)));
             return (await searchTasks.ConfigureAwait(false)).SelectMany(s => s).ToArray();
 

--- a/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
@@ -63,8 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // However, this works through liveshare on the LSP client, but not the LSP extension.
             // see https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1107682 for tracking.
             var request = ((JObject)input).ToObject<CompletionParams>(s_jsonSerializer);
-            var textDocument = GetTextDocumentIdentifier(request);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(request, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
     }
@@ -80,8 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<LanguageServer.Protocol.CompletionItem> HandleAsync(LanguageServer.Protocol.CompletionItem param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(param);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(param, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(param, context, cancellationToken);
         }
     }
@@ -97,8 +95,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<DocumentHighlight[]> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(param);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(param, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(param, context, cancellationToken);
         }
     }
@@ -121,8 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 clientCapabilities.TextDocument.DocumentSymbol.HierarchicalDocumentSymbolSupport = false;
             }
 
-            var textDocument = GetTextDocumentIdentifier(param);
-            var context = SolutionProvider.CreateRequestContext(textDocument, clientCapabilities);
+            var context = this.CreateRequestContext(param, SolutionProvider, clientCapabilities);
             var response = await base.HandleRequestAsync(param, context, cancellationToken).ConfigureAwait(false);
 
             // Since hierarchicalSupport will never be true, it is safe to cast the response to SymbolInformation[]
@@ -142,8 +138,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<TextEdit[]> HandleAsync(DocumentFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(request);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(request, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
 
@@ -167,8 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<TextEdit[]> HandleAsync(DocumentRangeFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(request);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(request, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
 
@@ -192,8 +186,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<TextEdit[]> HandleAsync(DocumentOnTypeFormattingParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(request);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(request, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
 
@@ -224,8 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<LanguageServer.Protocol.Location[]> HandleAsync(TextDocumentPositionParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(request);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(request, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
 
@@ -252,7 +244,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public async Task<InitializeResult> HandleAsync(InitializeParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var context = _solutionProvider.CreateRequestContext(null, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(param, _solutionProvider, requestContext.GetClientCapabilities());
             var initializeResult = await base.HandleRequestAsync(param, context, cancellationToken).ConfigureAwait(false);
             initializeResult.Capabilities.Experimental = new RoslynExperimentalCapabilities { SyntacticLspProvider = true };
             return initializeResult;
@@ -271,8 +263,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<SignatureHelp> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(param);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(param, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(param, context, cancellationToken);
         }
     }
@@ -288,8 +279,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public Task<WorkspaceEdit?> HandleAsync(RenameParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var textDocument = GetTextDocumentIdentifier(param);
-            var context = SolutionProvider.CreateRequestContext(textDocument, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(param, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(param, context, cancellationToken);
         }
     }
@@ -306,7 +296,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         [JsonRpcMethod(UseSingleObjectParameterDeserialization = true)]
         public Task<SymbolInformation[]> HandleAsync(WorkspaceSymbolParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var context = SolutionProvider.CreateRequestContext(null, requestContext.GetClientCapabilities());
+            var context = this.CreateRequestContext(request, SolutionProvider, requestContext.GetClientCapabilities());
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
     }
@@ -316,8 +306,10 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     /// </summary>
     internal static class Extensions
     {
-        public static LSP.RequestContext CreateRequestContext(this ILspSolutionProvider provider, TextDocumentIdentifier textDocument, ClientCapabilities clientCapabilities, string? clientName = null)
+        public static LSP.RequestContext CreateRequestContext<TRequest, TResponse>(this IRequestHandler<TRequest, TResponse> requestHandler, TRequest request, ILspSolutionProvider provider, ClientCapabilities clientCapabilities, string? clientName = null)
         {
+            var textDocument = requestHandler.GetTextDocumentIdentifier(request);
+
             var (document, solution) = provider.GetDocumentAndSolution(textDocument, clientName);
 
             return new LSP.RequestContext(document, solution, null, clientCapabilities, clientName);

--- a/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
@@ -310,4 +310,17 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             return base.HandleRequestAsync(request, context, cancellationToken);
         }
     }
+
+    /// <summary>
+    /// Helper methods only used by the above, that can be deleted along with the above
+    /// </summary>
+    internal static class Extensions
+    {
+        public static LSP.RequestContext CreateRequestContext(this ILspSolutionProvider provider, TextDocumentIdentifier textDocument, ClientCapabilities clientCapabilities, string? clientName = null)
+        {
+            var (document, solution) = provider.GetDocumentAndSolution(textDocument, clientName);
+
+            return new LSP.RequestContext(document, solution, null, clientCapabilities, clientName);
+        }
+    }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
@@ -31,9 +31,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier GetTextDocumentIdentifier(CompletionParams request) => request.TextDocument;
+
         public override async Task<CompletionItem[]> HandleRequestAsync(CompletionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetTextDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return CreateErrorItem($"Cannot find document in solution!", request.TextDocument.Uri.ToString());

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
             }
 
             var documentId = DocumentId.CreateFromSerialized(ProjectId.CreateFromSerialized(data.ProjectGuid), data.DocumentGuid);
-            var document = SolutionProvider.GetCurrentSolutionForMainWorkspace().GetAdditionalDocument(documentId);
+            var document = context.Solution.GetAdditionalDocument(documentId);
             if (document == null)
             {
                 return completionItem;

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -28,11 +28,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(FoldingRangeParams request) => request.TextDocument;
+
         public override async Task<FoldingRange[]> HandleRequestAsync(FoldingRangeParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var foldingRanges = ArrayBuilder<FoldingRange>.GetInstance();
 
-            var document = SolutionProvider.GetTextDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return foldingRanges.ToArrayAndFree();

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Hover/HoverHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Hover/HoverHandler.cs
@@ -33,9 +33,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(TextDocumentPositionParams request) => request.TextDocument;
+
         public override async Task<Hover?> HandleRequestAsync(TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var document = SolutionProvider.GetTextDocument(request.TextDocument, context.ClientName);
+            var document = context.Document;
             if (document == null)
             {
                 return null;

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Initialize/InitializeHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Initialize/InitializeHandler.cs
@@ -25,6 +25,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         {
         }
 
+        public TextDocumentIdentifier? GetTextDocumentIdentifier(InitializeParams request) => null;
+
         public Task<InitializeResult> HandleRequestAsync(InitializeParams request, RequestContext context, CancellationToken cancellationToken)
         {
 


### PR DESCRIPTION
Part of #46051

In order for us to effectively block mutations, and also allow non-mutating requests to go through, we need the RequestExecutionQueue to be in charge of telling the handlers what solution and/or document they operate on, rather than them get it direct from the solution provider. Unfortunately only the request handlers know how to get the Uri of the document they retrieve, so first the queue has to ask them.