### PR TITLE
Add IVT to MonoDevelop.Ide to VSMac can hook up the remote workspace

### DIFF
--- a/src/Workspaces/Remote/Core/Microsoft.CodeAnalysis.Remote.Workspaces.csproj
+++ b/src/Workspaces/Remote/Core/Microsoft.CodeAnalysis.Remote.Workspaces.csproj
@@ -55,5 +55,15 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Completion.Tests" Key="$(IntelliCodeKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35081" />
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp" Partner="Pythia" Key="$(IntelliCodeKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp.Extraction" Partner="Pythia" Key="$(IntelliCodeKey)" />
+    
+    <!-- BEGIN MONODEVELOP
+    These MonoDevelop dependencies don't ship with Visual Studio, so can't break our
+    binary insertions and are exempted from the ExternalAccess adapter assembly policies.
+    -->
+    <InternalsVisibleTo Include="MonoDevelop.Ide" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
+    <InternalsVisibleTo Include="MonoDevelop.Refactoring" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
+    <InternalsVisibleTo Include="MonoDevelop.Ide.Tests" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
+    <InternalsVisibleTo Include="MonoDevelop.Refactoring.Tests" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
+    <!-- END MONODEVELOP -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently, there is no way to either integrate/enable the remote workspace in VSMac due to VisualStudioWorkspaceServiceHubConnector and VisualStudioRemoteHostClientProvider being provided only in the VS layer, and cannot be source copied because the types used are internal in this assembly.