### PR TITLE
Pass CodeGenerationOptions into CodeGenerationService

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -211,6 +211,29 @@ class MyClass
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task ExtractInterfaceAction_ExtractableMembers_IncludesPublicProperty_WithGetAndSet()
+        {
+            var markup = @"
+class MyClass$$
+{
+    public int Prop { get; set; }
+}";
+
+            var expectedMarkup = @"
+interface IMyClass
+{
+    int Prop { get; set; }
+}
+
+class MyClass : IMyClass
+{
+    public int Prop { get; set; }
+}";
+
+            await TestExtractInterfaceCodeActionCSharpAsync(markup, expectedMarkup);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
         public async Task ExtractInterface_ExtractableMembers_IncludesPublicProperty_WithGetAndPrivateSet()
         {
             var markup = @"

--- a/src/EditorFeatures/TestUtilities/ExtractInterface/AbstractExtractInterfaceTests.cs
+++ b/src/EditorFeatures/TestUtilities/ExtractInterface/AbstractExtractInterfaceTests.cs
@@ -35,6 +35,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
                 expectedInterfaceCode);
         }
 
+        public static async Task TestExtractInterfaceCodeActionCSharpAsync(
+            string markup,
+            string expectedMarkup)
+        {
+            await TestExtractInterfaceCodeActionAsync(
+                markup,
+                LanguageNames.CSharp,
+                expectedMarkup);
+        }
+
         public static async Task TestExtractInterfaceCommandVisualBasicAsync(
             string markup,
             bool expectedSuccess,
@@ -57,6 +67,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
                 expectedUpdatedOriginalDocumentCode,
                 expectedInterfaceCode,
                 new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace: rootNamespace));
+        }
+
+        public static async Task TestExtractInterfaceCodeActionVisualBasicAsync(
+            string markup,
+            string expectedMarkup)
+        {
+            await TestExtractInterfaceCodeActionAsync(
+                markup,
+                LanguageNames.VisualBasic,
+                expectedMarkup);
         }
 
         private static async Task TestExtractInterfaceCommandAsync(
@@ -120,6 +140,21 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
                 {
                     Assert.False(result.Succeeded);
                 }
+            }
+        }
+
+        private static async Task TestExtractInterfaceCodeActionAsync(
+            string markup,
+            string languageName,
+            string expectedMarkup,
+            CompilationOptions compilationOptions = null)
+        {
+            using (var testState = ExtractInterfaceTestState.Create(markup, languageName, compilationOptions))
+            {
+                var updatedSolution = await testState.ExtractViaCodeAction();
+                var updatedDocument = updatedSolution.GetDocument(testState.ExtractFromDocument.Id);
+                var updatedCode = (await updatedDocument.GetTextAsync()).ToString();
+                Assert.Equal(expectedMarkup, updatedCode);
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/ExtractInterface/ExtractInterfaceTestState.cs
+++ b/src/EditorFeatures/TestUtilities/ExtractInterface/ExtractInterfaceTestState.cs
@@ -11,7 +11,9 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractInterface;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
 {
@@ -80,6 +82,31 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
                     this.ErrorSeverity = severity;
                 },
                 CancellationToken.None);
+        }
+
+        public async Task<Solution> ExtractViaCodeAction()
+        {
+            var actions = await ExtractInterfaceService.GetExtractInterfaceCodeActionAsync(
+                ExtractFromDocument,
+                new TextSpan(_testDocument.CursorPosition.Value, 1),
+                CancellationToken.None);
+            var action = actions.Single();
+
+            var options = (ExtractInterfaceOptionsResult)action.GetOptions(CancellationToken.None);
+            var changedOptions = new ExtractInterfaceOptionsResult(
+                options.IsCancelled,
+                options.IncludedMembers,
+                options.InterfaceName,
+                options.FileName,
+                ExtractInterfaceOptionsResult.ExtractLocation.SameFile);
+
+            var operations = await action.GetOperationsAsync(changedOptions, CancellationToken.None);
+            foreach (var operation in operations)
+            {
+                operation.Apply(Workspace, CancellationToken.None);
+            }
+
+            return Workspace.CurrentSolution;
         }
 
         public void Dispose()

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -28,8 +28,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             var typeDeclaration = originalRoot.GetAnnotatedNodes(symbolMapping.TypeNodeAnnotation).Single();
             var editor = new SyntaxEditor(originalRoot, symbolMapping.AnnotatedSolution.Workspace);
 
+            var options = new CodeGenerationOptions(
+                generateMethodBodies: true,
+                options: await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false));
             var codeGenService = document.GetRequiredLanguageService<ICodeGenerationService>();
-            var newTypeNode = codeGenService.CreateNamedTypeDeclaration(newType, cancellationToken: cancellationToken)
+            var newTypeNode = codeGenService.CreateNamedTypeDeclaration(newType, options: options, cancellationToken: cancellationToken)
                 .WithAdditionalAnnotations(SimplificationHelpers.SimplifyModuleNameAnnotation);
 
             var typeAnnotation = new SyntaxAnnotation();


### PR DESCRIPTION
Fixes NRE
```
        System.NullReferenceException: Object reference not set to an instance of an object
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.UseExpressionBodyIfDesired (Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax declaration, Microsoft.CodeAnalysis.ParseOptions parseOptions) [0x0000e] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.GenerateAccessorDeclaration (Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.IMethodSymbol accessor, Microsoft.CodeAnalysis.CSharp.SyntaxKind kind, System.Boolean hasBody, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, Microsoft.CodeAnalysis.ParseOptions parseOptions) [0x00043] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.GenerateAccessorDeclaration (Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.IMethodSymbol accessor, Microsoft.CodeAnalysis.CSharp.SyntaxKind kind, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationDestination destination, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, Microsoft.CodeAnalysis.ParseOptions parseOptions) [0x00018] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.GenerateAccessorList (Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationDestination destination, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, Microsoft.CodeAnalysis.ParseOptions parseOptions) [0x0002e] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.GeneratePropertyDeclaration (Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationDestination destination, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, Microsoft.CodeAnalysis.ParseOptions parseOptions) [0x0002a] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.GeneratePropertyOrIndexer (Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationDestination destination, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, Microsoft.CodeAnalysis.ParseOptions parseOptions) [0x00015] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.PropertyGenerator.AddPropertyTo (Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax destination, Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Collections.Generic.IList`1[T] availableIndices) [0x00023] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationService.AddProperty[TDeclarationNode] (TDeclarationNode destination, Microsoft.CodeAnalysis.IPropertySymbol property, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Collections.Generic.IList`1[T] availableIndices) [0x000e5] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CodeGeneration.AbstractCodeGenerationService.UpdateDestination[TDeclarationNode] (System.Collections.Generic.IList`1[T] availableIndices, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, TDeclarationNode currentDestination, Microsoft.CodeAnalysis.ISymbol member, System.Threading.CancellationToken cancellationToken) [0x00064] in <b39a4f1ac33a4fc6b7dc5ae677ccb661>:0 
          at Microsoft.CodeAnalysis.CodeGeneration.AbstractCodeGenerationService.AddMembersToAppropiateLocationInDestination[TDeclarationSyntax] (TDeclarationSyntax destination, System.Collections.Generic.IEnumerable`1[T] members, System.Collections.Generic.IList`1[T] availableIndices, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Threading.CancellationToken cancellationToken) [0x00019] in <b39a4f1ac33a4fc6b7dc5ae677ccb661>:0 
          at Microsoft.CodeAnalysis.CodeGeneration.AbstractCodeGenerationService.AddMembers[TDeclarationNode] (TDeclarationNode destination, System.Collections.Generic.IEnumerable`1[T] members, System.Collections.Generic.IList`1[T] availableIndices, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Threading.CancellationToken cancellationToken) [0x00053] in <b39a4f1ac33a4fc6b7dc5ae677ccb661>:0 
          at Microsoft.CodeAnalysis.CodeGeneration.AbstractCodeGenerationService.AddMembers[TDeclarationNode] (TDeclarationNode destination, System.Collections.Generic.IEnumerable`1[T] members, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Threading.CancellationToken cancellationToken) [0x0000c] in <b39a4f1ac33a4fc6b7dc5ae677ccb661>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.NamedTypeGenerator.GenerateNamedTypeDeclaration (Microsoft.CodeAnalysis.CodeGeneration.ICodeGenerationService service, Microsoft.CodeAnalysis.INamedTypeSymbol namedType, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationDestination destination, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Threading.CancellationToken cancellationToken) [0x000fb] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationService.CreateNamedTypeDeclaration (Microsoft.CodeAnalysis.INamedTypeSymbol namedType, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationDestination destination, Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions options, System.Threading.CancellationToken cancellationToken) [0x00000] in <0b4b810de0eb484da1af1202e064b20e>:0 
          at Microsoft.CodeAnalysis.ExtractInterface.AbstractExtractInterfaceService.ExtractInterfaceToSameFileAsync (Microsoft.CodeAnalysis.Solution solution, Microsoft.CodeAnalysis.ExtractInterface.ExtractInterfaceTypeAnalysisResult refactoringResult, Microsoft.CodeAnalysis.INamedTypeSymbol extractedInterfaceSymbol, Microsoft.CodeAnalysis.ExtractInterface.ExtractInterfaceOptionsResult extractInterfaceOptions, System.Threading.CancellationToken cancellationToken) [0x00235] in <2a820dfb35594d529c9279dfca8dfe38>:0 
          at Microsoft.CodeAnalysis.ExtractInterface.AbstractExtractInterfaceService.ExtractInterfaceFromAnalyzedTypeAsync (Microsoft.CodeAnalysis.ExtractInterface.ExtractInterfaceTypeAnalysisResult refactoringResult, Microsoft.CodeAnalysis.ExtractInterface.ExtractInterfaceOptionsResult extractInterfaceOptions, System.Threading.CancellationToken cancellationToken) [0x001fe] in <2a820dfb35594d529c9279dfca8dfe38>:0 
          at Microsoft.CodeAnalysis.ExtractInterface.ExtractInterfaceCodeAction.ComputeOperationsAsync (System.Object options, System.Threading.CancellationToken cancellationToken) [0x000ac] in <2a820dfb35594d529c9279dfca8dfe38>:0 
          at Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.GetOperationsAsync (System.Object options, System.Threading.CancellationToken cancellationToken) [0x00098] in <b39a4f1ac33a4fc6b7dc5ae677ccb661>:0 
          at Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.GetOperationsCoreAsync (Microsoft.CodeAnalysis.Shared.Utilities.IProgressTracker progressTracker, System.Threading.CancellationToken cancellationToken) [0x00083] in <b39a4f1ac33a4fc6b7dc5ae677ccb661>:0 
          at OmniSharp.Roslyn.CSharp.Services.Refactoring.V2.RunCodeActionService.Handle (OmniSharp.Models.V2.CodeActions.RunCodeActionRequest request) [0x001ad] in <65ffd1ba481041bd910cf3979d802028>:0 
```

First noticed as a failing test in an OmniSharp-Roslyn PR where I was inserting a new build of Roslyn - see https://github.com/OmniSharp/omnisharp-roslyn/pull/1897#issuecomment-675475420.

I was able to reproduce in VS2019 16.8 P2. Debugging shows that the CodeGenerationOptions used for generating the extracted interface did not have an OptionSet.

```diff
        private static AccessorDeclarationSyntax UseExpressionBodyIfDesired(
            CodeGenerationOptions options, AccessorDeclarationSyntax declaration, ParseOptions parseOptions)
        {
            if (declaration.ExpressionBody == null)
            {
!                var expressionBodyPreference = options.Options.GetOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors).Value;
                if (declaration.Body.TryConvertToArrowExpressionBody(
                        declaration.Kind(), parseOptions, expressionBodyPreference,
                        out var expressionBody, out var semicolonToken))
```