### PR TITLE
Fix inconsistent language version parsing

### DIFF
--- a/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
+++ b/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
@@ -156,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     result = LanguageVersion.VisualBasic15_3
                 Case "15.5"
                     result = LanguageVersion.VisualBasic15_5
-                Case "16"
+                Case "16", "16.0"
                     result = LanguageVersion.VisualBasic16
                 Case "default"
                     result = LanguageVersion.Default

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2091,6 +2091,7 @@ End Module").Path
             InlineData("15.3", True, LanguageVersion.VisualBasic15_3),
             InlineData("15.5", True, LanguageVersion.VisualBasic15_5),
             InlineData("16", True, LanguageVersion.VisualBasic16),
+            InlineData("16.0", True, LanguageVersion.VisualBasic16),
             InlineData("DEFAULT", True, LanguageVersion.Default),
             InlineData("default", True, LanguageVersion.Default),
             InlineData("LATEST", True, LanguageVersion.Latest),


### PR DESCRIPTION
While reading through [this doc](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/langversion):

> Any of the whole numbers may also be specified using .0 as the minor version, for example, 11.0.

I found that 16.0 didn't work, this should fix that.