### PR TITLE
Fix comment

### DIFF
--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         /// <summary>
         /// Displays the version number in the format expected on the command-line (/langver flag).
-        /// For instance, "6", "7", "7.1", "latest".
+        /// For instance, "6", "7.0", "7.1", "latest".
         /// </summary>
         public static string ToDisplayString(this LanguageVersion version)
         {


### PR DESCRIPTION
The code returns "6" for C# 6, and "7.0" for C# 7. The old comment implied that this function returns "7", while it returns "7.0".