### PR TITLE
Wait for Nuget restores to be complete before considering the solution fully loaded.

### DIFF
--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -142,6 +142,7 @@
       <_Dependency Remove="Nerdbank.Streams"/>
       <_Dependency Remove="Newtonsoft.Json"/>
       <_Dependency Remove="NuGet.VisualStudio"/>
+      <_Dependency Remove="NuGet.SolutionRestoreManager.Interop"/>
       <_Dependency Remove="stdole"/>
       <_Dependency Remove="StreamJsonRpc"/>
       <_Dependency Remove="System.IO.Pipelines"/>

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -169,6 +169,7 @@
     <PackageReference Include="VSLangProj140" Version="$(VSLangProj140Version)" />
     <PackageReference Include="VsWebsite.Interop" Version="$(VsWebsiteInteropVersion)" />
     <PackageReference Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
+    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="$(NuGetSolutionRestoreManagerInteropVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
 


### PR DESCRIPTION
This affects NavigateTo and Lightbulbs, both of which wait for 'fully loaded' before providing results.  For both of these we def want to wait for restores as prior to a restoration we can't really provide good results since we don't know the full meaning of hte code, and because it's likely that doing this work while the restore is happening will just cause contention.