### PR TITLE
Expose ParseOptions on generator context

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -15,6 +15,7 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFil
 Microsoft.CodeAnalysis.IMethodSymbol.CallingConvention.get -> System.Reflection.Metadata.SignatureCallingConvention
 Microsoft.CodeAnalysis.IMethodSymbol.CallingConventionTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>
 Microsoft.CodeAnalysis.SourceGeneratorContext.AddSource(string hintName, string source) -> void
+Microsoft.CodeAnalysis.SourceGeneratorContext.ParseOptions.get -> Microsoft.CodeAnalysis.ParseOptions
 Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.UseExplicitManagedCallingConventionSpecifier = 512 -> Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.Diagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.GeneratedTrees.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SyntaxTree>

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(generatorState.Info.Initialized);
 
                 // we create a new context for each run of the generator. We'll never re-use existing state, only replace anything we have 
-                var context = new SourceGeneratorContext(compilation, state.AdditionalTexts.NullToEmpty(), state.OptionsProvider, generatorState.SyntaxReceiver);
+                var context = new SourceGeneratorContext(compilation, state.ParseOptions, state.AdditionalTexts.NullToEmpty(), state.OptionsProvider, generatorState.SyntaxReceiver);
                 try
                 {
                     generator.Execute(context);

--- a/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SourceGeneratorContext.cs
@@ -21,9 +21,10 @@ namespace Microsoft.CodeAnalysis
 
         private readonly AdditionalSourcesCollection _additionalSources;
 
-        internal SourceGeneratorContext(Compilation compilation, ImmutableArray<AdditionalText> additionalTexts, AnalyzerConfigOptionsProvider optionsProvider, ISyntaxReceiver? syntaxReceiver, CancellationToken cancellationToken = default)
+        internal SourceGeneratorContext(Compilation compilation, ParseOptions parseOptions, ImmutableArray<AdditionalText> additionalTexts, AnalyzerConfigOptionsProvider optionsProvider, ISyntaxReceiver? syntaxReceiver, CancellationToken cancellationToken = default)
         {
             Compilation = compilation;
+            ParseOptions = parseOptions;
             AdditionalFiles = additionalTexts;
             AnalyzerConfigOptions = optionsProvider;
             SyntaxReceiver = syntaxReceiver;
@@ -41,6 +42,11 @@ namespace Microsoft.CodeAnalysis
         /// this compilation will contain errors.
         /// </remarks>
         public Compilation Compilation { get; }
+
+        /// <summary>
+        /// Get the <see cref="ParseOptions"/> that will be used to parse any added sources.
+        /// </summary>
+        public ParseOptions ParseOptions { get; }
 
         /// <summary>
         /// A set of additional non-code text files that can be used by generators.


### PR DESCRIPTION
Small PR that exposes the parse options that will be used to the consuming generator