### PR TITLE
Change the word in comments

### DIFF
--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     _cancellationSource.Cancel();
                 }
 
-                // Connecting the named pipe client would hang if the process exits before the connection is established,
+                // Connecting the named pipe client would block if the process exits before the connection is established,
                 // as the client waits for the server to become available. We signal the cancellation token to abort.
                 newProcess.Exited += ProcessExitedBeforeEstablishingConnection;
 

--- a/src/Interactive/HostProcess/InteractiveHostEntryPoint.cs
+++ b/src/Interactive/HostProcess/InteractiveHostEntryPoint.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             /// <summary>
             /// The system does not display the critical-error-handler message box. Instead, the system sends the error to the calling process.
             /// Best practice is that all applications call the process-wide SetErrorMode function with a parameter of SEM_FAILCRITICALERRORS at startup. 
-            /// This is to prevent error mode dialogs from hanging the application.
+            /// This is to prevent error mode dialogs from blocking the application.
             /// </summary>
             SEM_NOGPFAULTERRORBOX = 0x0002,
 

--- a/src/Interactive/HostTest/InteractiveHostDesktopTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostDesktopTests.cs
@@ -70,7 +70,7 @@ System.Console.Error.WriteLine(""error-\u7890!"");
         [Fact]
         public async Task StackOverflow()
         {
-            // Windows Server 2008 (OS v6.0), Vista (OS v6.0) and XP (OS v5.1) ignores SetErrorMode and shows crash dialog, which would hang the test:
+            // Windows Server 2008 (OS v6.0), Vista (OS v6.0) and XP (OS v5.1) ignores SetErrorMode and shows crash dialog, which would block the test:
             if (Environment.OSVersion.Version < new Version(6, 1, 0, 0))
             {
                 return;


### PR DESCRIPTION
PoliCheck doesn't like 'hang' & 'hanging' in the code so we have 3 bugs related to it.
[bug1](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1172380/)
[bug2](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1172381/)
[bug3](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1172382/)

Change them to 'block'