### PR TITLE
Initialize OOP telemetry session lazily after in-proc one is initialized

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -51,23 +51,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _lazyClient = new AsyncLazy<RemoteHostClient>(CreateHostClientAsync, cacheResult: true);
         }
 
-        private async Task<RemoteHostClient> CreateHostClientAsync(CancellationToken cancellationToken)
-        {
-            var client = await ServiceHubRemoteHostClient.CreateAsync(_services, cancellationToken).ConfigureAwait(false);
-
-            var telemetrySessionSettings = _services.GetService<IWorkspaceTelemetryService>()?.SerializeCurrentSessionSettings();
-
-            // initialize the remote service
-            await client.RunRemoteAsync(
-                WellKnownServiceHubService.RemoteHost,
-                nameof(IRemoteHostService.InitializeTelemetrySession),
-                solution: null,
-                new object?[] { client.ClientId, telemetrySessionSettings },
-                callbackTarget: null,
-                cancellationToken).ConfigureAwait(false);
-
-            return client;
-        }
+        private Task<RemoteHostClient> CreateHostClientAsync(CancellationToken cancellationToken)
+            => ServiceHubRemoteHostClient.CreateAsync(_services, cancellationToken);
 
         public Task<RemoteHostClient?> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)
             => _lazyClient.GetValueAsync(cancellationToken).AsNullable();

--- a/src/VisualStudio/Core/Def/Telemetry/AbstractWorkspaceTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AbstractWorkspaceTelemetryService.cs
@@ -31,6 +31,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             WatsonReporter.RegisterTelemetrySesssion(telemetrySession);
 
             CurrentSession = telemetrySession;
+
+            TelemetrySessionInitialized();
+        }
+
+        protected virtual void TelemetrySessionInitialized()
+        {
         }
 
         public bool HasActiveSession

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioWorkspaceTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioWorkspaceTelemetryService.cs
@@ -6,23 +6,31 @@
 
 using System;
 using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 {
     [ExportWorkspaceService(typeof(IWorkspaceTelemetryService)), Shared]
     internal sealed class VisualStudioWorkspaceTelemetryService : AbstractWorkspaceTelemetryService
     {
+        private readonly VisualStudioWorkspace _workspace;
         private readonly IGlobalOptionService _optionsService;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioWorkspaceTelemetryService(IGlobalOptionService optionsService)
+        public VisualStudioWorkspaceTelemetryService(
+            VisualStudioWorkspace workspace,
+            IGlobalOptionService optionsService)
         {
+            _workspace = workspace;
             _optionsService = optionsService;
         }
 
@@ -32,5 +40,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                 new EtwLogger(_optionsService),
                 new VSTelemetryLogger(telemetrySession),
                 Logger.GetLogger());
+
+        protected override void TelemetrySessionInitialized()
+        {
+            _ = Task.Run(async () =>
+            {
+                var client = await RemoteHostClient.TryGetClientAsync(_workspace, CancellationToken.None).ConfigureAwait(false);
+                if (client == null)
+                {
+                    return;
+                }
+
+                var settings = SerializeCurrentSessionSettings();
+                Contract.ThrowIfNull(settings);
+
+                // initialize session in the remote service
+                await client.RunRemoteAsync(
+                    WellKnownServiceHubService.RemoteHost,
+                    nameof(IRemoteHostService.InitializeTelemetrySession),
+                    solution: null,
+                    new object?[] { client.ClientId, settings },
+                    callbackTarget: null,
+                    CancellationToken.None).ConfigureAwait(false);
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/46895