### PR TITLE
Add missing dependent target to InteractiveHost32 publish target

### DIFF
--- a/src/Interactive/HostProcess/InteractiveHost32.csproj
+++ b/src/Interactive/HostProcess/InteractiveHost32.csproj
@@ -24,7 +24,7 @@
 
     Use BuiltProjectOutputGroup as the dependend target to ensure the targets has all dependencies that BuiltProjectOutputGroupOutput would have.
   -->
-  <Target Name="PublishProjectOutputGroup" DependsOnTargets="BuiltProjectOutputGroup" Returns="@(_PublishProjectOutputGroup)">
+  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Build;BuiltProjectOutputGroup" Returns="@(_PublishProjectOutputGroup)">
     <ItemGroup>
       <_PublishProjectOutputGroup Include="$(TargetPath)">
         <TargetPath>$(TargetFileName)</TargetPath>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/46906