### PR TITLE
Add IVT access for razor temporarily

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
@@ -60,5 +60,7 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp.Extraction" Partner="Pythia" Key="$(IntelliCodeKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor.ServiceHub" />
+    <!-- TODO - This IVT should be removed - https://github.com/dotnet/roslyn/issues/46940 -->
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Key="$(RazorKey)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes servicehub activation issue -
```
08/18/2020 15:11:57 Pacific Standard Time : Error : Error creating Microsoft.CodeAnalysis.Remote.Razor.RazorLanguageService instance of CLR service module 'razorLanguageService64': System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. HResult='-2146232828' 
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.ServiceHub.HostStub.ServiceManager.<CreateAndConfigureServiceAsync>d__50.MoveNext()
===InnerException===
System.MethodAccessException: Attempt by method 'Microsoft.CodeAnalysis.Remote.Razor.RazorServiceBase..ctor(System.IO.Stream, System.IServiceProvider)' to access method 'Microsoft.CodeAnalysis.Remote.ServiceBase.StartService()' failed. HResult='-2146233072' 
   at Microsoft.CodeAnalysis.Remote.Razor.RazorServiceBase..ctor(Stream stream, IServiceProvider serviceProvider)
```