### PR TITLE
Update description of Microsoft.Net.Compilers.Toolset

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -15,7 +15,7 @@
 
       The supported mechanism for providing new compilers in a build enviroment is updating to the newer .NET SDK or Visual Studio Build Tools SKU.
 
-      This package requires either MSBuild 16.3 and .NET Framework 4.7.2+ or .NET Core 3.1.
+      This package requires either MSBuild 16.3 and .NET Framework 4.7.2+ or .NET Core 3.1+.
 
       $(RoslynPackageDescriptionDetails)
     </PackageDescription>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -15,7 +15,7 @@
 
       The supported mechanism for providing new compilers in a build enviroment is updating to the newer .NET SDK or Visual Studio Build Tools SKU.
 
-      This package requires either MSBuild 16.3 and .NET Desktop 4.7.2+ or .NET Core 2.1+
+      This package requires either MSBuild 16.3 and .NET Framework 4.7.2+ or .NET Core 3.1.
 
       $(RoslynPackageDescriptionDetails)
     </PackageDescription>


### PR DESCRIPTION
This package has `<TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>`, which means it currently requires .Net Core 3.1.

Also, as has been noted by https://github.com/dotnet/roslyn/pull/39272#discussion_r334669353, the description should talk about ".NET Framework", since ".NET Desktop" doesn't really mean anything.