### PR TITLE
Add props file to CodeStyle package to disable built-in code style an…

### DIFF
--- a/src/CodeStyle/CSharp/CodeFixes/Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.csproj
+++ b/src/CodeStyle/CSharp/CodeFixes/Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.csproj
@@ -22,16 +22,17 @@
 
   <Target Name="_GetFilesToPackage">
     <ItemGroup>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.Fixes.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CSharp.CodeStyle.resources.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.resources.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.resources.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.Fixes.resources.dll"/>
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.Fixes.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CSharp.CodeStyle.resources.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.resources.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.resources.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.Fixes.resources.dll" TargetDir="analyzers/dotnet/cs" />
+      <_File Include="$(MSBuildProjectDirectory)\build\**\*.*" TargetDir="build" />
 
-      <TfmSpecificPackageFile Include="@(_File)" PackagePath="analyzers/dotnet/cs/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>
   </Target>
   <ItemGroup>
@@ -52,6 +53,9 @@
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="build\Microsoft.CodeAnalysis.CSharp.CodeStyle.props" />
   </ItemGroup>
   <Import Project="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Workspace\CSharp\CSharpWorkspaceExtensions.projitems" Label="Shared" />
   <Import Project="..\..\..\Analyzers\CSharp\CodeFixes\CSharpCodeFixes.projitems" Label="Shared" />

--- a/src/CodeStyle/CSharp/CodeFixes/build/Microsoft.CodeAnalysis.CSharp.CodeStyle.props
+++ b/src/CodeStyle/CSharp/CodeFixes/build/Microsoft.CodeAnalysis.CSharp.CodeStyle.props
@@ -8,6 +8,6 @@
     NOTE: Keep this file in sync with 'Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props'
   -->
   <PropertyGroup>
-    <EnableCodeStyleAnalyzers>false</EnableCodeStyleAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 </Project>

--- a/src/CodeStyle/CSharp/CodeFixes/build/Microsoft.CodeAnalysis.CSharp.CodeStyle.props
+++ b/src/CodeStyle/CSharp/CodeFixes/build/Microsoft.CodeAnalysis.CSharp.CodeStyle.props
@@ -8,6 +8,6 @@
     NOTE: Keep this file in sync with 'Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props'
   -->
   <PropertyGroup>
-    <EnableStyleAnalyzers>false</EnableStyleAnalyzers>
+    <EnableCodeStyleAnalyzers>false</EnableCodeStyleAnalyzers>
   </PropertyGroup>
 </Project>

--- a/src/CodeStyle/CSharp/CodeFixes/build/Microsoft.CodeAnalysis.CSharp.CodeStyle.props
+++ b/src/CodeStyle/CSharp/CodeFixes/build/Microsoft.CodeAnalysis.CSharp.CodeStyle.props
@@ -1,0 +1,13 @@
+﻿<Project>
+  <!-- 
+    PropertyGroup to disable built-in CodeStyle analyzers from .NET SDK that have the identical IDE rules to those implemented in this package.
+    This props file should only be present in the analyzer NuGet package, it should **not** be inserted into the .NET SDK.
+    In future, if we need to insert a CodeStyle props file into the .NET SDK, we should move out the below property group into a separate props file
+    which is not inserted into the .NET SDK.
+
+    NOTE: Keep this file in sync with 'Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props'
+  -->
+  <PropertyGroup>
+    <EnableStyleAnalyzers>false</EnableStyleAnalyzers>
+  </PropertyGroup>
+</Project>

--- a/src/CodeStyle/VisualBasic/CodeFixes/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.vbproj
+++ b/src/CodeStyle/VisualBasic/CodeFixes/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.vbproj
@@ -22,16 +22,17 @@
 
   <Target Name="_GetFilesToPackage">
     <ItemGroup>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.Fixes.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.resources.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.resources.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.resources.dll"/>
-      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.Fixes.resources.dll"/>
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.CodeStyle.Fixes.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.resources.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.resources.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.resources.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CodeStyle.Fixes\$(Configuration)\$(TargetFramework)\**\Microsoft.CodeAnalysis.CodeStyle.Fixes.resources.dll" TargetDir="analyzers/dotnet/vb" />
+      <_File Include="$(MSBuildProjectDirectory)\build\**\*.*" TargetDir="build" />
 
-      <TfmSpecificPackageFile Include="@(_File)" PackagePath="analyzers/dotnet/vb/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>
   </Target>
   <ItemGroup Label="Project References">
@@ -49,6 +50,9 @@
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="build\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props" />
   </ItemGroup>
   <Import Project="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems" Label="Shared" />
   <Import Project="..\..\..\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems" Label="Shared" />

--- a/src/CodeStyle/VisualBasic/CodeFixes/build/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props
+++ b/src/CodeStyle/VisualBasic/CodeFixes/build/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props
@@ -8,6 +8,6 @@
     NOTE: Keep this file in sync with 'Microsoft.CodeAnalysis.CSharp.CodeStyle.props'
   -->
   <PropertyGroup>
-    <EnableStyleAnalyzers>false</EnableStyleAnalyzers>
+    <EnableCodeStyleAnalyzers>false</EnableCodeStyleAnalyzers>
   </PropertyGroup>
 </Project>

--- a/src/CodeStyle/VisualBasic/CodeFixes/build/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props
+++ b/src/CodeStyle/VisualBasic/CodeFixes/build/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props
@@ -1,0 +1,13 @@
+﻿<Project>
+  <!-- 
+    PropertyGroup to disable built-in CodeStyle analyzers from .NET SDK that have the identical IDE rules to those implemented in this package.
+    This props file should only be present in the analyzer NuGet package, it should **not** be inserted into the .NET SDK.
+    In future, if we need to insert a CodeStyle props file into the .NET SDK, we should move out the below property group into a separate props file
+    which is not inserted into the .NET SDK.
+
+    NOTE: Keep this file in sync with 'Microsoft.CodeAnalysis.CSharp.CodeStyle.props'
+  -->
+  <PropertyGroup>
+    <EnableStyleAnalyzers>false</EnableStyleAnalyzers>
+  </PropertyGroup>
+</Project>

--- a/src/CodeStyle/VisualBasic/CodeFixes/build/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props
+++ b/src/CodeStyle/VisualBasic/CodeFixes/build/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.props
@@ -8,6 +8,6 @@
     NOTE: Keep this file in sync with 'Microsoft.CodeAnalysis.CSharp.CodeStyle.props'
   -->
   <PropertyGroup>
-    <EnableCodeStyleAnalyzers>false</EnableCodeStyleAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
…alyzers in .NET SDK when CodeStyle NuGet package is installed by the user

Mimics the approach in https://github.com/dotnet/roslyn-analyzers/pull/3974. Added props file should not be inserted into the SDK.

TBD: Name of the user facing MSBuild property in the SDK to enable/disable code style build enforcement. Currently chose: 'EnableStyleAnalyzers' analogous to 'EnableNetAnalyzers'