### PR TITLE
Combine nearby loops to prevent crash building dotnet/runtime

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1216,19 +1216,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 if (anyToRemove)
                 {
                     var explicitInterfaceImplementationsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
+                    MethodSymbol uniqueClassOverride = null;
                     foreach (var method in explicitlyOverriddenMethods)
                     {
                         if (method.ContainingType.IsInterface)
                         {
                             explicitInterfaceImplementationsBuilder.Add(method);
                         }
-                    }
 
-                    explicitInterfaceImplementations = explicitInterfaceImplementationsBuilder.ToImmutableAndFree();
-
-                    MethodSymbol uniqueClassOverride = null;
-                    foreach (MethodSymbol method in explicitlyOverriddenMethods)
-                    {
                         if (method.ContainingType.IsClassType())
                         {
                             if (uniqueClassOverride is { })
@@ -1241,6 +1236,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             uniqueClassOverride = method;
                         }
                     }
+
+                    explicitInterfaceImplementations = explicitInterfaceImplementationsBuilder.ToImmutableAndFree();
 
                     if (uniqueClassOverride is { })
                     {


### PR DESCRIPTION
Related to #46575 (not closing till we are able to root-cause and make sure we have a tracking issue in the appropriate place).

I have verified locally that this resolves the crash when building dotnet/runtime. It's somewhat inconvenient to publish this build where dotnet/runtime can readily consume it, so I won't be able to verify in CI until after this is merged to master-vs-deps.

We currently believe this is working around a JIT bug.