### PR TITLE
Fix F1 keyword for interpolated and verbatim strings

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -118,8 +118,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 TryGetTextForCombinationKeyword(token, syntaxFacts, out text) ||
                 TryGetTextForKeyword(token, syntaxFacts, out text) ||
                 TryGetTextForPreProcessor(token, syntaxFacts, out text) ||
-                TryGetTextForSymbol(token, semanticModel, document, cancellationToken, out text) ||
-                TryGetTextForOperator(token, document, out text))
+                TryGetTextForOperator(token, document, out text) ||
+                TryGetTextForSymbol(token, semanticModel, document, cancellationToken, out text))
             {
                 return text;
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -186,6 +186,20 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
+            if (token.IsKind(SyntaxKind.InterpolatedStringStartToken) ||
+                token.IsKind(SyntaxKind.InterpolatedStringEndToken) ||
+                token.IsKind(SyntaxKind.InterpolatedStringTextToken))
+            {
+                text = "$_CSharpKeyword";
+                return true;
+            }
+
+            if (token.IsKind(SyntaxKind.StringLiteralToken) && token.ValueText[0] == '@')
+            {
+                text = "@_CSharpKeyword";
+                return true;
+            }
+
             if (token.IsKind(SyntaxKind.ColonColonToken))
             {
                 text = "::_CSharpKeyword";

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         private string TryGetText(SyntaxToken token, SemanticModel semanticModel, Document document, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken)
         {
             if (TryGetTextForSpecialCharacters(token, out var text) ||
-                TryGetTextForContextualKeyword(token, out var text) ||
+                TryGetTextForContextualKeyword(token, out text) ||
                 TryGetTextForCombinationKeyword(token, syntaxFacts, out text) ||
                 TryGetTextForKeyword(token, syntaxFacts, out text) ||
                 TryGetTextForPreProcessor(token, syntaxFacts, out text) ||

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         private static bool TryGetTextForOperator(SyntaxToken token, Document document, out string text)
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            if (syntaxFacts.IsOperator(token) || syntaxFacts.IsPredefinedOperator(token) || SyntaxFacts.IsAssignmentExpressionOperatorToken(token.Kind()))
+            if (syntaxFacts.IsOperator(token) || syntaxFacts.IsPredefinedOperator(token))
             {
                 text = Keyword(syntaxFacts.GetText(token.RawKind));
                 return true;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -213,9 +213,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.ColonToken && token.Parent is NameColonSyntax)
+            if (token.IsKind(SyntaxKind.ColonToken) && token.Parent is NameColonSyntax)
             {
-                text = "cs_namedParameter";
+                text = "namedParameter_CSharpKeyword";
                 return true;
             }
 
@@ -322,7 +322,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         private static bool TryGetTextForKeyword(SyntaxToken token, ISyntaxFactsService syntaxFacts, out string text)
         {
-            if (token.Kind() == SyntaxKind.InKeyword)
+            if (token.IsKind(SyntaxKind.InKeyword))
             {
                 if (token.GetAncestor<FromClauseSyntax>() != null)
                 {

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
-            if (token.IsKind(SyntaxKind.StringLiteralToken) && token.ValueText[0] == '@')
+            if (token.IsVerbatimStringLiteral())
             {
                 text = "@_CSharpKeyword";
                 return true;
@@ -221,18 +221,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             if (token.IsKind(SyntaxKind.EqualsGreaterThanToken))
             {
                 text = "=>_CSharpKeyword";
-                return true;
-            }
-
-            if (token.IsKind(SyntaxKind.PlusEqualsToken))
-            {
-                text = "+=_CSharpKeyword";
-                return true;
-            }
-
-            if (token.IsKind(SyntaxKind.MinusEqualsToken))
-            {
-                text = "-=_CSharpKeyword";
                 return true;
             }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -144,6 +144,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
+            if (token.IsKind(SyntaxKind.InterpolatedVerbatimStringStartToken))
+            {
+                text = "@$_CSharpKeyword";
+                return true;
+            }
+
             text = null;
             return false;
         }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         private static bool TryGetTextForOperator(SyntaxToken token, Document document, out string text)
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            if (syntaxFacts.IsOperator(token) || syntaxFacts.IsPredefinedOperator(token))
+            if (syntaxFacts.IsOperator(token) || syntaxFacts.IsPredefinedOperator(token) || SyntaxFacts.IsAssignmentExpressionOperatorToken(token.Kind()))
             {
                 text = Keyword(syntaxFacts.GetText(token.RawKind));
                 return true;

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -658,7 +658,7 @@ class Program
         e +[||]= () => {
         };
     }
-}", "CCC.e.add");
+}", "+=_CSharpKeyword");
         }
 
         [WorkItem(867554, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867554")]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -529,6 +529,38 @@ class Program
 }", "::_CSharpKeyword");
         }
 
+        [WorkItem(46986, "https://github.com/dotnet/roslyn/issues/46986")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStringInterpolation()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($[||]""Hello, {args[0]}"");
+    }
+}", "$_CSharpKeyword");
+        }
+
+        [WorkItem(46986, "https://github.com/dotnet/roslyn/issues/46986")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestVerbatimString()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(@[||]""Hello\"");
+    }
+}", "@_CSharpKeyword");
+        }
+
         [WorkItem(864658, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/864658")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestNullable()

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -561,6 +561,38 @@ class Program
 }", "@_CSharpKeyword");
         }
 
+        [WorkItem(46986, "https://github.com/dotnet/roslyn/issues/46986")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestVerbatimInterpolatedString1()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(@[||]$""Hello\ {args[0]}"");
+    }
+}", "@$_CSharpKeyword");
+        }
+
+        [WorkItem(46986, "https://github.com/dotnet/roslyn/issues/46986")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestVerbatimInterpolatedString2()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($[||]@""Hello\ {args[0]}"");
+    }
+}", "@$_CSharpKeyword");
+        }
+
         [WorkItem(864658, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/864658")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestNullable()


### PR DESCRIPTION
Fixes #46986

`$_CSharpKeyword`: [This](https://github.com/dotnet/docs/blob/master/docs/csharp/language-reference/tokens/interpolated.md) article is what have this f1 keyword.

`@_CSharpKeyword`: [This](https://github.com/dotnet/docs/blob/master/docs/csharp/language-reference/tokens/verbatim.md) article is what have this f1 keyword.

I removed the following part:

```
            if (token.IsKind(SyntaxKind.PlusEqualsToken))
            {
                text = "+=_CSharpKeyword";
                return true;
            }

            if (token.IsKind(SyntaxKind.MinusEqualsToken))
            {
                text = "-=_CSharpKeyword";
                return true;
            }
```

These if conditions are impossible to be met because of the check `SyntaxFacts.IsAssignmentExpressionOperatorToken` before them. `SyntaxFacts.IsAssignmentExpressionOperatorToken` will already return true for MinusEqualsToken and PlusEqualsTokene.

~~It even seem that `SyntaxFacts.IsAssignmentExpressionOperatorToken` is also redundant, this check is already done in `IsOperator`.~~ (This was incorrect, I'll revert it)