### PR TITLE
Fix extract method crash with conditional access expressions.

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
@@ -167,7 +167,8 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         {
             foreach (var subExpression in expression.DescendantNodesAndSelf().OfType<TExpressionSyntax>())
             {
-                if (!_syntaxFacts.IsNameOfMemberAccessExpression(subExpression))
+                if (!_syntaxFacts.IsNameOfSimpleMemberAccessExpression(subExpression) &&
+                    !_syntaxFacts.IsNameOfMemberBindingExpression(subExpression))
                 {
                     if (ValuePatternMatches(subExpression))
                     {

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -3972,7 +3972,7 @@ namespace N
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess1()
         {
             await TestInRegularAndScript1Async(@"
@@ -4005,7 +4005,7 @@ class C
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess2()
         {
             await TestInRegularAndScript1Async(@"
@@ -4038,7 +4038,7 @@ class C
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess3()
         {
             await TestInRegularAndScript1Async(@"
@@ -4071,7 +4071,7 @@ class C
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess4()
         {
             await TestInRegularAndScript1Async(@"
@@ -4104,7 +4104,7 @@ class C
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess5()
         {
             await TestInRegularAndScript1Async(@"
@@ -4137,7 +4137,7 @@ class C
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess6()
         {
             await TestInRegularAndScript1Async(@"
@@ -4170,7 +4170,7 @@ class C
 }");
         }
 
-        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        [Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")]
         public async Task TestConditionalAccess7()
         {
             await TestInRegularAndScript1Async(@"

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -3971,5 +3971,236 @@ namespace N
     }
 }");
         }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess1()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?.[|ToString|]();
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static string NewMethod(List<int> b)
+    {
+        return b?.ToString();
+    }
+}");
+        }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess2()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?.[|ToString|]().Length;
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static int? NewMethod(List<int> b)
+    {
+        return b?.ToString().Length;
+    }
+}");
+        }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess3()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?.Count.[|ToString|]();
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static string NewMethod(List<int> b)
+    {
+        return b?.Count.ToString();
+    }
+}");
+        }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess4()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?.[|Count|].ToString();
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static string NewMethod(List<int> b)
+    {
+        return b?.Count.ToString();
+    }
+}");
+        }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess5()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?.[|ToString|]()?.ToString();
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static string NewMethod(List<int> b)
+    {
+        return b?.ToString()?.ToString();
+    }
+}");
+        }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess6()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?.ToString()?.[|ToString|]();
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static string NewMethod(List<int> b)
+    {
+        return b?.ToString()?.ToString();
+    }
+}");
+        }
+
+        [Fact, WorkItem(43834, "https://github.com/dotnet/roslyn/issues/43834")]
+        public async Task TestConditionalAccess7()
+        {
+            await TestInRegularAndScript1Async(@"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = b?[|[0]|];
+    }
+}", @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    void Test()
+    {
+        List<int> b = null;
+        b?.Clear();
+        _ = {|Rename:NewMethod|}(b);
+    }
+
+    private static int? NewMethod(List<int> b)
+    {
+        return b?[0];
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -834,5 +834,180 @@ End Class",
     End Function
 End Class")
         End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess1() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?.[|ToString|]()
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As String
+        Return b?.ToString()
+    End Function
+end class")
+        End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess2() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?.[|ToString|]().Length
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As Integer?
+        Return b?.ToString().Length
+    End Function
+end class")
+        End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess3() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?.Count.[|ToString|]()
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As String
+        Return b?.Count.ToString()
+    End Function
+end class")
+        End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess4() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?.[|Count|].ToString()
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As String
+        Return b?.Count.ToString()
+    End Function
+end class")
+        End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess5() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?.[|ToString|]()?.ToString()
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As String
+        Return b?.ToString()?.ToString()
+    End Function
+end class")
+        End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess6() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?.ToString()?.[|ToString|]()
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As String
+        Return b?.ToString()?.ToString()
+    End Function
+end class")
+        End Function
+
+        <Fact, WorkItem(41895, "https://github.com/dotnet/roslyn/issues/41895")>
+        Public Async Function TestConditionalAccess7() As Task
+            Await TestInRegularAndScript1Async("
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = b?[|(0)|]
+    end sub
+end class", "
+imports System
+imports System.Collections.Generic
+class C
+    sub Test()
+        dim b as new List(of integer)
+        dim x = {|Rename:GetX|}(b)
+    end sub
+
+    Private Shared Function GetX(b As List(Of Integer)) As Integer?
+        Return b?(0)
+    End Function
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -129,7 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
                 return false;
             }
 
-            if (!syntaxFacts.IsNameOfMemberAccessExpression(node))
+            if (!syntaxFacts.IsNameOfSimpleMemberAccessExpression(node) &&
+                !syntaxFacts.IsNameOfMemberBindingExpression(node))
             {
                 return false;
             }

--- a/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
@@ -159,7 +159,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeNamespace
                 newNode = newNode.WithTriviaFrom(oldNode);
                 return true;
             }
-            else if (syntaxFacts.IsNameOfMemberAccessExpression(nameRef))
+            else if (syntaxFacts.IsNameOfSimpleMemberAccessExpression(nameRef) ||
+                     syntaxFacts.IsNameOfMemberBindingExpression(nameRef))
             {
                 RoslynDebug.Assert(nameRef.Parent is object);
                 oldNode = nameRef.Parent;

--- a/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
+++ b/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
                     var curr = expression;
                     while (true)
                     {
-                        var conditionalAccess = curr.GetParentConditionalAccessExpression();
+                        var conditionalAccess = curr.GetRootConditionalAccessExpression();
                         if (conditionalAccess == null)
                         {
                             break;

--- a/src/Features/CSharp/Portable/DisambiguateSameVariable/CSharpDisambiguateSameVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/DisambiguateSameVariable/CSharpDisambiguateSameVariableCodeFixProvider.cs
@@ -161,7 +161,8 @@ namespace Microsoft.CodeAnalysis.CSharp.DisambiguateSameVariable
 
                 var newNameNode = matchingMember.Name.ToIdentifierName();
                 var newExpr = (ExpressionSyntax)newNameNode;
-                if (!syntaxFacts.IsNameOfMemberAccessExpression(nameNode))
+                if (!syntaxFacts.IsNameOfSimpleMemberAccessExpression(nameNode) &&
+                    !syntaxFacts.IsNameOfMemberBindingExpression(nameNode))
                 {
                     newExpr = MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), newNameNode).WithAdditionalAnnotations(Simplifier.Annotation);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
@@ -220,28 +220,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     // however complexification of names is prepended, so the last annotation should be the original one.
                     sourceNode = updatedRoot.GetAnnotatedNodesAndTokens(sourceNodeAnnotation).Last().AsNode();
 
-                    // we want to replace the old identifier with a invocation expression, but because of MakeExplicit we might have
-                    // a member access now instead of the identifier. So more syntax fiddling is needed.
-                    if (sourceNode.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression, out MemberAccessExpressionSyntax explicitMemberAccess) &&
-                        sourceNode == explicitMemberAccess.Name)
-                    {
-                        var replacementMemberAccess = explicitMemberAccess.CopyAnnotationsTo(
-                            SyntaxFactory.MemberAccessExpression(
-                                sourceNode.Parent.Kind(),
-                                explicitMemberAccess.Expression,
-                                (SimpleNameSyntax)invocation.Expression));
-                        var newInvocation = SyntaxFactory.InvocationExpression(
-                            replacementMemberAccess,
-                            invocation.ArgumentList);
-
-                        if (invocationWithAwaitOpt != null)
-                            invocationWithAwaitOpt = invocationWithAwaitOpt.ReplaceNode(invocation, newInvocation);
-
-                        invocation = newInvocation;
-
-                        sourceNode = sourceNode.Parent;
-                    }
-
                     var callSignature = (ExpressionSyntax)invocationWithAwaitOpt ?? invocation;
                     callSignature = callSignature.WithAdditionalAnnotations(CallSiteAnnotation);
                     return newEnclosingStatement.ReplaceNode(sourceNode, callSignature);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 {
                     var enclosingStatement = GetFirstStatementOrInitializerSelectedAtCallSite();
 
-                    var (invocation, invocationWithAwaitOpt) = CreateCallSignatureParts();
+                    var callSignature = CreateCallSignature().WithAdditionalAnnotations(CallSiteAnnotation);
 
                     var sourceNode = CSharpSelectionResult.GetContainingScope();
                     Contract.ThrowIfTrue(
@@ -220,8 +220,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     // however complexification of names is prepended, so the last annotation should be the original one.
                     sourceNode = updatedRoot.GetAnnotatedNodesAndTokens(sourceNodeAnnotation).Last().AsNode();
 
-                    var callSignature = (ExpressionSyntax)invocationWithAwaitOpt ?? invocation;
-                    callSignature = callSignature.WithAdditionalAnnotations(CallSiteAnnotation);
                     return newEnclosingStatement.ReplaceNode(sourceNode, callSignature);
                 }
             }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return methodName;
                 }
 
-                protected override IEnumerable<StatementSyntax> GetInitialStatementsForMethodDefinitions()
+                protected override ImmutableArray<StatementSyntax> GetInitialStatementsForMethodDefinitions()
                 {
                     Contract.ThrowIfFalse(IsExtractMethodOnExpression(CSharpSelectionResult));
 
@@ -113,13 +114,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
                     if (AnalyzerResult.HasReturnType)
                     {
-                        return SpecializedCollections.SingletonEnumerable<StatementSyntax>(
+                        return ImmutableArray.Create<StatementSyntax>(
                             SyntaxFactory.ReturnStatement(
                                 WrapInCheckedExpressionIfNeeded(expression)));
                     }
                     else
                     {
-                        return SpecializedCollections.SingletonEnumerable<StatementSyntax>(
+                        return ImmutableArray.Create<StatementSyntax>(
                             SyntaxFactory.ExpressionStatement(
                                 WrapInCheckedExpressionIfNeeded(expression)));
                     }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
@@ -115,11 +115,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 protected override SyntaxNode GetLastStatementOrInitializerSelectedAtCallSite()
                     => CSharpSelectionResult.GetLastStatementUnderContainer();
 
-                protected override Task<SyntaxNode> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(
-                    SyntaxAnnotation callSiteAnnotation, CancellationToken cancellationToken)
+                protected override Task<SyntaxNode> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(CancellationToken cancellationToken)
                 {
                     var statement = GetStatementContainingInvocationToExtractedMethodWorker();
-                    return Task.FromResult<SyntaxNode>(statement.WithAdditionalAnnotations(callSiteAnnotation));
+                    return Task.FromResult<SyntaxNode>(statement.WithAdditionalAnnotations(CallSiteAnnotation));
                 }
             }
         }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
@@ -47,13 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
                 protected override SyntaxToken CreateMethodName() => GenerateMethodNameForStatementGenerators();
 
-                protected override IEnumerable<StatementSyntax> GetInitialStatementsForMethodDefinitions()
+                protected override ImmutableArray<StatementSyntax> GetInitialStatementsForMethodDefinitions()
                 {
                     var firstSeen = false;
                     var firstStatementUnderContainer = CSharpSelectionResult.GetFirstStatementUnderContainer();
                     var lastStatementUnderContainer = CSharpSelectionResult.GetLastStatementUnderContainer();
 
-                    var list = new List<StatementSyntax>();
+                    using var _ = ArrayBuilder<StatementSyntax>.GetInstance(out var list);
                     foreach (var statement in GetStatementsFromContainer(firstStatementUnderContainer.Parent))
                     {
                         // reset first seen
@@ -77,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                         }
                     }
 
-                    return list;
+                    return list.ToImmutable();
                 }
 
                 protected override SyntaxNode GetOutermostCallSiteContainerToProcess(CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
@@ -71,11 +71,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return CSharpSelectionResult.GetFirstStatement();
                 }
 
-                protected override Task<SyntaxNode> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(
-                    SyntaxAnnotation callSiteAnnotation, CancellationToken cancellationToken)
+                protected override Task<SyntaxNode> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(CancellationToken cancellationToken)
                 {
                     var statement = GetStatementContainingInvocationToExtractedMethodWorker();
-                    return Task.FromResult<SyntaxNode>(statement.WithAdditionalAnnotations(callSiteAnnotation));
+                    return Task.FromResult<SyntaxNode>(statement.WithAdditionalAnnotations(CallSiteAnnotation));
                 }
             }
         }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -39,11 +40,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
                 protected override SyntaxToken CreateMethodName() => GenerateMethodNameForStatementGenerators();
 
-                protected override IEnumerable<StatementSyntax> GetInitialStatementsForMethodDefinitions()
+                protected override ImmutableArray<StatementSyntax> GetInitialStatementsForMethodDefinitions()
                 {
                     Contract.ThrowIfFalse(IsExtractMethodOnSingleStatement(CSharpSelectionResult));
 
-                    return SpecializedCollections.SingletonEnumerable<StatementSyntax>(CSharpSelectionResult.GetFirstStatement());
+                    return ImmutableArray.Create(CSharpSelectionResult.GetFirstStatement());
                 }
 
                 protected override SyntaxNode GetOutermostCallSiteContainerToProcess(CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -30,12 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 {
     internal partial class CSharpMethodExtractor
     {
-        private abstract partial class CSharpCodeGenerator : CodeGenerator<
-            StatementSyntax,
-            ExpressionSyntax,
-            InvocationExpressionSyntax,
-            AwaitExpressionSyntax,
-            SyntaxNode>
+        private abstract partial class CSharpCodeGenerator : CodeGenerator<StatementSyntax, ExpressionSyntax, SyntaxNode>
         {
             private readonly SyntaxToken _methodName;
 
@@ -579,7 +574,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     : SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(identifierName));
             }
 
-            protected override (InvocationExpressionSyntax invocation, AwaitExpressionSyntax awaitExpressionOpt) CreateCallSignatureParts()
+            protected override ExpressionSyntax CreateCallSignature()
             {
                 var methodName = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation);
 
@@ -598,7 +593,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var shouldPutAsyncModifier = CSharpSelectionResult.ShouldPutAsyncModifier();
                 if (!shouldPutAsyncModifier)
                 {
-                    return (invocation, awaitExpressionOpt: null);
+                    return invocation;
                 }
 
                 if (CSharpSelectionResult.ShouldCallConfigureAwaitFalse())
@@ -619,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     }
                 }
 
-                return (invocation, SyntaxFactory.AwaitExpression(invocation));
+                return SyntaxFactory.AwaitExpression(invocation);
             }
 
             protected override StatementSyntax CreateAssignmentExpressionStatement(SyntaxToken identifier, ExpressionSyntax rvalue)

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.PostProcessor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.PostProcessor.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -25,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 _contextPosition = contextPosition;
             }
 
-            public static IEnumerable<StatementSyntax> RemoveRedundantBlock(IEnumerable<StatementSyntax> statements)
+            public static ImmutableArray<StatementSyntax> RemoveRedundantBlock(ImmutableArray<StatementSyntax> statements)
             {
                 // it must have only one statement
                 if (statements.Count() != 1)
@@ -43,15 +45,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 return RemoveRedundantBlock(block);
             }
 
-            private static IEnumerable<StatementSyntax> RemoveRedundantBlock(BlockSyntax block)
+            private static ImmutableArray<StatementSyntax> RemoveRedundantBlock(BlockSyntax block)
             {
                 // if block doesn't have any statement
                 if (block.Statements.Count == 0)
                 {
                     // either remove the block if it doesn't have any trivia, or return as it is if
                     // there are trivia attached to block
-                    return (block.OpenBraceToken.GetAllTrivia().IsEmpty() && block.CloseBraceToken.GetAllTrivia().IsEmpty()) ?
-                        SpecializedCollections.EmptyEnumerable<StatementSyntax>() : SpecializedCollections.SingletonEnumerable<StatementSyntax>(block);
+                    return (block.OpenBraceToken.GetAllTrivia().IsEmpty() && block.CloseBraceToken.GetAllTrivia().IsEmpty())
+                        ? ImmutableArray<StatementSyntax>.Empty
+                        : ImmutableArray.Create<StatementSyntax>(block);
                 }
 
                 // okay transfer asset attached to block to statements
@@ -67,10 +70,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 block = block.ReplaceTokens(new[] { firstToken, lastToken }, (o, c) => (o == firstToken) ? firstTokenWithAsset : lastTokenWithAsset);
 
                 // return only statements without the wrapping block
-                return block.Statements;
+                return ImmutableArray.CreateRange(block.Statements);
             }
 
-            public IEnumerable<StatementSyntax> MergeDeclarationStatements(IEnumerable<StatementSyntax> statements)
+            public ImmutableArray<StatementSyntax> MergeDeclarationStatements(ImmutableArray<StatementSyntax> statements)
             {
                 if (statements.FirstOrDefault() == null)
                 {
@@ -80,19 +83,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 return MergeDeclarationStatementsWorker(statements);
             }
 
-            private IEnumerable<StatementSyntax> MergeDeclarationStatementsWorker(IEnumerable<StatementSyntax> statements)
+            private ImmutableArray<StatementSyntax> MergeDeclarationStatementsWorker(ImmutableArray<StatementSyntax> statements)
             {
+                using var _ = ArrayBuilder<StatementSyntax>.GetInstance(out var result);
+
                 var map = new Dictionary<ITypeSymbol, List<LocalDeclarationStatementSyntax>>();
                 foreach (var statement in statements)
                 {
                     if (!IsDeclarationMergable(statement))
                     {
                         foreach (var declStatement in GetMergedDeclarationStatements(map))
-                        {
-                            yield return declStatement;
-                        }
+                            result.Add(declStatement);
 
-                        yield return statement;
+                        result.Add(statement);
                         continue;
                     }
 
@@ -100,15 +103,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 // merge leftover
-                if (map.Count <= 0)
-                {
-                    yield break;
-                }
+                if (map.Count > 0)
+                    result.AddRange(GetMergedDeclarationStatements(map));
 
-                foreach (var declStatement in GetMergedDeclarationStatements(map))
-                {
-                    yield return declStatement;
-                }
+                return result.ToImmutable();
             }
 
             private void AppendDeclarationStatementToMap(
@@ -223,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 return true;
             }
 
-            public static IEnumerable<StatementSyntax> RemoveInitializedDeclarationAndReturnPattern(IEnumerable<StatementSyntax> statements)
+            public static ImmutableArray<StatementSyntax> RemoveInitializedDeclarationAndReturnPattern(ImmutableArray<StatementSyntax> statements)
             {
                 // if we have inline temp variable as service, we could just use that service here.
                 // since it is not a service right now, do very simple clean up
@@ -258,10 +256,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return statements;
                 }
 
-                return SpecializedCollections.SingletonEnumerable<StatementSyntax>(SyntaxFactory.ReturnStatement(declaration.Declaration.Variables[0].Initializer.Value));
+                return ImmutableArray.Create<StatementSyntax>(SyntaxFactory.ReturnStatement(declaration.Declaration.Variables[0].Initializer.Value));
             }
 
-            public static IEnumerable<StatementSyntax> RemoveDeclarationAssignmentPattern(IEnumerable<StatementSyntax> statements)
+            public static ImmutableArray<StatementSyntax> RemoveDeclarationAssignmentPattern(ImmutableArray<StatementSyntax> statements)
             {
                 if (!(statements.ElementAtOrDefault(0) is LocalDeclarationStatementSyntax declaration) || !(statements.ElementAtOrDefault(1) is ExpressionStatementSyntax assignment))
                 {
@@ -294,10 +292,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 var variable = declaration.Declaration.Variables[0].WithInitializer(SyntaxFactory.EqualsValueClause(assignmentExpression.Right));
-                return SpecializedCollections.SingletonEnumerable<StatementSyntax>(
-                    declaration.WithDeclaration(
-                        declaration.Declaration.WithVariables(
-                            SyntaxFactory.SingletonSeparatedList(variable)))).Concat(statements.Skip(2));
+                using var _ = ArrayBuilder<StatementSyntax>.GetInstance(out var result);
+
+                result.Add(declaration.WithDeclaration(
+                    declaration.Declaration.WithVariables(
+                        SyntaxFactory.SingletonSeparatedList(variable))));
+                result.AddRange(statements.Skip(2));
+
+                return result.ToImmutable();
             }
         }
     }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ExtractMethod;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -48,15 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 if (scope == null)
                     return null;
 
-                // If the selection ends up mapping to the name on the right in `x.y` or `x?.y`, then grab
-                // the full expr `x.y` or `x?.y` as the part to extract.
-
-                scope = SyntaxFactory.GetStandaloneExpression(scope);
-
-                // If we're in a chain in a conditional access expression, then grab the top of that ?. chain.
-                scope = scope.GetRootConditionalAccessExpression() ?? scope;
-
-                return scope;
+                return CSharpSyntaxFacts.Instance.GetRootStandaloneExpression(scope);
             }
 
             public override ITypeSymbol? GetContainingScopeType()

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -43,7 +43,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
                 var firstToken = GetFirstTokenInSelection();
                 var lastToken = GetLastTokenInSelection();
-                return firstToken.GetCommonRoot(lastToken).GetAncestorOrThis<ExpressionSyntax>();
+                var scope = firstToken.GetCommonRoot(lastToken).GetAncestorOrThis<ExpressionSyntax>();
+                return scope.IsRightSideOfDotOrArrowOrColonColon()
+                    ? scope.Parent
+                    : scope;
             }
 
             public override ITypeSymbol? GetContainingScopeType()

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -51,14 +51,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 // If the selection ends up mapping to the name on the right in `x.y` or `x?.y`, then grab
                 // the full expr `x.y` or `x?.y` as the part to extract.
 
-                if (scope.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == scope)
-                    scope = (ExpressionSyntax)scope.Parent;
+                scope = SyntaxFactory.GetStandaloneExpression(scope);
 
-                if (scope.Parent is MemberBindingExpressionSyntax memberBinding && memberBinding.Name == scope)
-                    scope = (ExpressionSyntax)scope.Parent;
-
-                if (scope is MemberBindingExpressionSyntax || scope is ElementBindingExpressionSyntax)
-                    scope = scope.GetParentConditionalAccessExpression();
+                // If we're in a chain in a conditional access expression, then grab the top of that ?. chain.
+                scope = scope.GetRootConditionalAccessExpression() ?? scope;
 
                 return scope;
             }

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             if (identifierName == null || !syntaxFacts.IsIdentifierName(identifierName))
                 return;
 
-            var node = syntaxFacts.IsNameOfMemberAccessExpression(identifierName) || syntaxFacts.IsMemberBindingExpression(identifierName.Parent)
+            var node = syntaxFacts.IsNameOfSimpleMemberAccessExpression(identifierName) || syntaxFacts.IsNameOfMemberBindingExpression(identifierName)
                 ? identifierName.Parent
                 : identifierName;
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -302,7 +302,8 @@ namespace Microsoft.CodeAnalysis.AddImport
                     // 'Black' did not bind.  We want to find a type called 'Color' that will actually
                     // allow 'Black' to bind.
                     var syntaxFacts = _document.GetLanguageService<ISyntaxFactsService>();
-                    if (syntaxFacts.IsNameOfMemberAccessExpression(nameNode))
+                    if (syntaxFacts.IsNameOfSimpleMemberAccessExpression(nameNode) ||
+                        syntaxFacts.IsNameOfMemberBindingExpression(nameNode))
                     {
                         var expression =
                             syntaxFacts.GetExpressionOfMemberAccessExpression(nameNode.Parent, allowImplicitTarget: true) ??

--- a/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
@@ -170,7 +170,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
 
             foreach (var identifier in identifiers)
             {
-                if (!syntaxFacts.IsNameOfMemberAccessExpression(identifier))
+                if (!syntaxFacts.IsNameOfSimpleMemberAccessExpression(identifier) &&
+                    !syntaxFacts.IsNameOfMemberBindingExpression(identifier))
                 {
                     continue;
                 }

--- a/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.Result.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.Result.cs
@@ -110,15 +110,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                                             location => location,
                                             location => resolver(root, location, _annotations[location]));
 
-                // check variable assumption. ordering of two pairs can't be changed
                 Contract.ThrowIfFalse(
-                    tokens[TriviaLocation.BeforeBeginningOfSpan].RawKind == 0 /* && don't care */ ||
-                    /* don't care && */ tokens[TriviaLocation.AfterEndOfSpan].RawKind == 0 ||
-                    tokens[TriviaLocation.BeforeBeginningOfSpan].Span.End <= tokens[TriviaLocation.AfterEndOfSpan].SpanStart);
-
-                Contract.ThrowIfFalse(
-                    tokens[TriviaLocation.AfterBeginningOfSpan].RawKind == 0 /* && don't care */ ||
-                    /* don't care && */ tokens[TriviaLocation.BeforeEndOfSpan].RawKind == 0 ||
+                    tokens[TriviaLocation.AfterBeginningOfSpan].RawKind == 0 /* don't care */ ||
+                    tokens[TriviaLocation.BeforeEndOfSpan].RawKind == 0 /* don't care */  ||
                     tokens[TriviaLocation.AfterBeginningOfSpan] == tokens[TriviaLocation.BeforeEndOfSpan] ||
                     tokens[TriviaLocation.AfterBeginningOfSpan].GetPreviousToken(includeZeroWidth: true) == tokens[TriviaLocation.BeforeEndOfSpan] ||
                     tokens[TriviaLocation.AfterBeginningOfSpan].Span.End <= tokens[TriviaLocation.BeforeEndOfSpan].SpanStart);

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -6,11 +6,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -229,7 +231,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 }
             }
 
-            private (IList<VariableInfo> parameters, ITypeSymbol returnType, VariableInfo? variableToUseAsReturnValue, bool unsafeAddressTakenUsed)
+            private (ImmutableArray<VariableInfo> parameters, ITypeSymbol returnType, VariableInfo? variableToUseAsReturnValue, bool unsafeAddressTakenUsed)
                 GetSignatureInformation(
                     DataFlowAnalysis dataFlowAnalysisData,
                     IDictionary<ISymbol, VariableInfo> variableInfoMap,
@@ -384,22 +386,22 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 return analysis.EndPointIsReachable;
             }
 
-            private IList<VariableInfo> MarkVariableInfoToUseAsReturnValueIfPossible(IList<VariableInfo> variableInfo)
+            private ImmutableArray<VariableInfo> MarkVariableInfoToUseAsReturnValueIfPossible(ImmutableArray<VariableInfo> variableInfo)
             {
-                var variableToUseAsReturnValueIndex = GetIndexOfVariableInfoToUseAsReturnValue(variableInfo);
-                if (variableToUseAsReturnValueIndex >= 0)
-                {
-                    variableInfo[variableToUseAsReturnValueIndex] = VariableInfo.CreateReturnValue(variableInfo[variableToUseAsReturnValueIndex]);
-                }
+                var index = GetIndexOfVariableInfoToUseAsReturnValue(variableInfo);
+                if (index < 0)
+                    return variableInfo;
 
-                return variableInfo;
+                return variableInfo.RemoveAt(index).Insert(index, VariableInfo.CreateReturnValue(variableInfo[index]));
             }
 
-            private IList<VariableInfo> GetMethodParameters(ICollection<VariableInfo> variableInfo)
+            private ImmutableArray<VariableInfo> GetMethodParameters(ICollection<VariableInfo> variableInfo)
             {
-                var list = new List<VariableInfo>(variableInfo);
+                using var _ = ArrayBuilder<VariableInfo>.GetInstance(out var list);
+                list.AddRange(variableInfo);
+
                 VariableInfo.SortVariables(_semanticDocument.SemanticModel.Compilation, list);
-                return list;
+                return list.ToImmutable();
             }
 
             /// <param name="bestEffort">When false, variables whose data flow is not understood

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -16,14 +17,14 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         {
             private readonly IList<ITypeParameterSymbol> _typeParametersInDeclaration;
             private readonly IList<ITypeParameterSymbol> _typeParametersInConstraintList;
-            private readonly IList<VariableInfo> _variables;
+            private readonly ImmutableArray<VariableInfo> _variables;
             private readonly VariableInfo _variableToUseAsReturnValue;
 
             public AnalyzerResult(
                 SemanticDocument document,
                 IEnumerable<ITypeParameterSymbol> typeParametersInDeclaration,
                 IEnumerable<ITypeParameterSymbol> typeParametersInConstraintList,
-                IList<VariableInfo> variables,
+                ImmutableArray<VariableInfo> variables,
                 VariableInfo variableToUseAsReturnValue,
                 ITypeSymbol returnType,
                 bool awaitTaskReturn,
@@ -152,11 +153,11 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 }
             }
 
-            public IEnumerable<VariableInfo> GetVariablesToSplitOrMoveIntoMethodDefinition(CancellationToken cancellationToken)
+            public ImmutableArray<VariableInfo> GetVariablesToSplitOrMoveIntoMethodDefinition(CancellationToken cancellationToken)
             {
-                return _variables
-                           .Where(v => v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.SplitIn ||
-                                       v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.MoveIn);
+                return _variables.WhereAsArray(
+                    v => v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.SplitIn ||
+                    v.GetDeclarationBehavior(cancellationToken) == DeclarationBehavior.MoveIn);
             }
 
             public IEnumerable<VariableInfo> GetVariablesToMoveIntoMethodDefinition(CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -20,16 +20,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 {
     internal abstract partial class MethodExtractor
     {
-        protected abstract partial class CodeGenerator<
-            TStatement,
-            TExpression,
-            TInvocationExpression,
-            TAwaitExpression,
-            TNodeUnderContainer>
+        protected abstract partial class CodeGenerator<TStatement, TExpression, TNodeUnderContainer>
             where TStatement : SyntaxNode
             where TExpression : SyntaxNode
-            where TInvocationExpression : TExpression
-            where TAwaitExpression : TExpression
             where TNodeUnderContainer : SyntaxNode
         {
             protected readonly SyntaxAnnotation MethodNameAnnotation;
@@ -77,7 +70,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             protected abstract TNodeUnderContainer GetLastStatementOrInitializerSelectedAtCallSite();
             protected abstract Task<TNodeUnderContainer> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(CancellationToken cancellationToken);
 
-            protected abstract (TInvocationExpression invocation, TAwaitExpression awaitExpressionOpt) CreateCallSignatureParts();
+            protected abstract TExpression CreateCallSignature();
             protected abstract TStatement CreateDeclarationStatement(VariableInfo variable, TExpression initialValue, CancellationToken cancellationToken);
             protected abstract TStatement CreateAssignmentExpressionStatement(SyntaxToken identifier, TExpression rvalue);
             protected abstract TStatement CreateReturnStatement(string identifierName = null);
@@ -217,12 +210,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 // add invocation expression
                 return statements.Concat(
                     (TStatement)(SyntaxNode)await GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken).ConfigureAwait(false));
-            }
-
-            protected TExpression CreateCallSignature()
-            {
-                var (invocation, awaitExpressionOpt) = CreateCallSignatureParts();
-                return (TExpression)awaitExpressionOpt ?? invocation;
             }
 
             protected ImmutableArray<TStatement> AddAssignmentStatementToCallSite(

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractMethod
@@ -120,7 +121,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             public SyntaxToken GetIdentifierTokenAtDeclaration(SyntaxNode node)
                 => node.GetAnnotatedTokens(_variableSymbol.IdentifierTokenAnnotation).SingleOrDefault();
 
-            public static void SortVariables(Compilation compilation, List<VariableInfo> list)
+            public static void SortVariables(Compilation compilation, ArrayBuilder<VariableInfo> list)
             {
                 var cancellationTokenType = compilation.GetTypeByMetadataName(typeof(CancellationToken).FullName);
                 list.Sort((v1, v2) => Compare(v1, v2, cancellationTokenType));

--- a/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
@@ -199,7 +199,8 @@ namespace Microsoft.CodeAnalysis.MakeMethodSynchronous
             //  await <expr>.M(...).ConfigureAwait(...)
 
             var expressionNode = nameNode;
-            if (syntaxFacts.IsNameOfMemberAccessExpression(nameNode))
+            if (syntaxFacts.IsNameOfSimpleMemberAccessExpression(nameNode) ||
+                syntaxFacts.IsNameOfMemberBindingExpression(nameNode))
             {
                 expressionNode = nameNode.Parent;
             }

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
@@ -115,7 +115,8 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
 
                 _expression = _identifierName;
                 _cref = _service.TryGetCrefSyntax(_identifierName);
-                if (_syntaxFacts.IsNameOfMemberAccessExpression(_expression))
+                if (_syntaxFacts.IsNameOfSimpleMemberAccessExpression(_expression) ||
+                    _syntaxFacts.IsNameOfMemberBindingExpression(_expression))
                 {
                     _expression = (TExpressionSyntax)_expression.Parent!;
                 }

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/SyncNamespace/VisualBasicChangeNamespaceService.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/SyncNamespace/VisualBasicChangeNamespaceService.vb
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeNamespace
 
                 [new] = [new].WithTriviaFrom(old)
 
-            ElseIf syntaxFacts.IsNameOfMemberAccessExpression(nameRef) Then
+            ElseIf syntaxFacts.IsNameOfsimpleMemberAccessExpression(nameRef) Then
                 old = nameRef.Parent
                 If IsGlobalNamespace(newNamespaceParts) Then
                     [new] = SyntaxFactory.SimpleMemberAccessExpression(SyntaxFactory.GlobalName(), nameRef.WithoutTrivia())

--- a/src/Features/VisualBasic/Portable/Debugging/DataTipInfoGetter.vb
+++ b/src/Features/VisualBasic/Portable/Debugging/DataTipInfoGetter.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Debugging
 
                     Dim curr = expression
                     While True
-                        curr = curr.GetCorrespondingConditionalAccessExpression()
+                        curr = curr.GetParentConditionalAccessExpression()
                         If curr Is Nothing Then
                             Exit While
                         End If

--- a/src/Features/VisualBasic/Portable/Debugging/DataTipInfoGetter.vb
+++ b/src/Features/VisualBasic/Portable/Debugging/DataTipInfoGetter.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Debugging
 
                     Dim curr = expression
                     While True
-                        curr = curr.GetParentConditionalAccessExpression()
+                        curr = curr.GetRootConditionalAccessExpression()
                         If curr Is Nothing Then
                             Exit While
                         End If

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.PostProcessor.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.PostProcessor.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -19,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Me._contextPosition = contextPosition
             End Sub
 
-            Public Function MergeDeclarationStatements(statements As IEnumerable(Of StatementSyntax)) As IEnumerable(Of StatementSyntax)
+            Public Function MergeDeclarationStatements(statements As ImmutableArray(Of StatementSyntax)) As ImmutableArray(Of StatementSyntax)
                 If statements.FirstOrDefault() Is Nothing Then
                     Return statements
                 End If
@@ -27,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return MergeDeclarationStatementsWorker(statements)
             End Function
 
-            Private Function MergeDeclarationStatementsWorker(statements As IEnumerable(Of StatementSyntax)) As IEnumerable(Of StatementSyntax)
+            Private Function MergeDeclarationStatementsWorker(statements As ImmutableArray(Of StatementSyntax)) As ImmutableArray(Of StatementSyntax)
                 Dim declarationStatements = New List(Of StatementSyntax)()
 
                 Dim map = New Dictionary(Of ITypeSymbol, List(Of LocalDeclarationStatementSyntax))()
@@ -51,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Next declStatement
                 End If
 
-                Return declarationStatements
+                Return declarationStatements.ToImmutableArray()
             End Function
 
             Private Sub AppendDeclarationStatementToMap(statement As LocalDeclarationStatementSyntax, map As Dictionary(Of ITypeSymbol, List(Of LocalDeclarationStatementSyntax)))
@@ -171,7 +172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return True
             End Function
 
-            Public Shared Function RemoveDeclarationAssignmentPattern(statements As IEnumerable(Of StatementSyntax)) As IEnumerable(Of StatementSyntax)
+            Public Shared Function RemoveDeclarationAssignmentPattern(statements As ImmutableArray(Of StatementSyntax)) As ImmutableArray(Of StatementSyntax)
                 If statements.Count() < 2 Then
                     Return statements
                 End If
@@ -207,10 +208,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Dim variable = declaration.Declarators(0).WithoutTrailingTrivia().WithInitializer(SyntaxFactory.EqualsValue(assignment.Right))
                 Dim newDeclaration = declaration.WithDeclarators(SyntaxFactory.SingletonSeparatedList(variable))
 
-                Return SpecializedCollections.SingletonEnumerable(Of StatementSyntax)(newDeclaration).Concat(statements.Skip(2))
+                Return SpecializedCollections.SingletonEnumerable(Of StatementSyntax)(newDeclaration).Concat(statements.Skip(2)).ToImmutableArray()
             End Function
 
-            Public Shared Function RemoveInitializedDeclarationAndReturnPattern(statements As IEnumerable(Of StatementSyntax)) As IEnumerable(Of StatementSyntax)
+            Public Shared Function RemoveInitializedDeclarationAndReturnPattern(statements As ImmutableArray(Of StatementSyntax)) As ImmutableArray(Of StatementSyntax)
                 ' if we have inline temp variable as service, we could just use that service here.
                 ' since it is not a service right now, do very simple clean up
                 If statements.Count() <> 2 Then
@@ -241,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 End If
 
                 Return SpecializedCollections.SingletonEnumerable(Of StatementSyntax)(
-                    SyntaxFactory.ReturnStatement(declaration.Declarators(0).Initializer.Value)).Concat(statements.Skip(2))
+                    SyntaxFactory.ReturnStatement(declaration.Declarators(0).Initializer.Value)).Concat(statements.Skip(2)).ToImmutableArray()
             End Function
         End Class
     End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
@@ -116,9 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 
                 Protected Overrides Async Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
                     Dim enclosingStatement = GetFirstStatementOrInitializerSelectedAtCallSite()
-                    Dim callSignatureParts = CreateCallSignatureParts()
-                    Dim invocation = callSignatureParts.invocation
-                    Dim invocationWithAwaitOpt = callSignatureParts.awaitExpressionOpt
+                    Dim callSignature = CreateCallSignature().WithAdditionalAnnotations(CallSiteAnnotation)
 
                     Dim sourceNode = VBSelectionResult.GetContainingScope()
                     Contract.ThrowIfTrue(
@@ -145,8 +143,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     ' however complexification of names is prepended, so the last annotation should be the original one.
                     sourceNode = updatedRoot.GetAnnotatedNodesAndTokens(sourceNodeAnnotation).Last().AsNode()
 
-                    Dim callSignature = If(DirectCast(invocationWithAwaitOpt, ExpressionSyntax), invocation)
-                    callSignature = callSignature.WithAdditionalAnnotations(CallSiteAnnotation)
                     Return newEnclosingStatement.ReplaceNode(sourceNode, callSignature)
                 End Function
             End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ExtractMethod
@@ -65,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return methodName
                 End Function
 
-                Protected Overrides Function GetInitialStatementsForMethodDefinitions() As IEnumerable(Of StatementSyntax)
+                Protected Overrides Function GetInitialStatementsForMethodDefinitions() As ImmutableArray(Of StatementSyntax)
                     Contract.ThrowIfFalse(IsExtractMethodOnExpression(VBSelectionResult))
 
                     Dim expression = DirectCast(VBSelectionResult.GetContainingScope(), ExpressionSyntax)
@@ -80,13 +81,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         ' return error code
                         If expression.Kind <> SyntaxKind.InvocationExpression AndAlso
                            expression.Kind <> SyntaxKind.SimpleMemberAccessExpression Then
-                            Return SpecializedCollections.EmptyEnumerable(Of StatementSyntax)()
+                            Return ImmutableArray(Of StatementSyntax).Empty
                         End If
 
                         statement = SyntaxFactory.ExpressionStatement(expression:=expression)
                     End If
 
-                    Return SpecializedCollections.SingletonEnumerable(Of StatementSyntax)(statement)
+                    Return ImmutableArray.Create(statement)
                 End Function
 
                 Protected Overrides Function GetOutermostCallSiteContainerToProcess(cancellationToken As CancellationToken) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
@@ -145,31 +145,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     ' however complexification of names is prepended, so the last annotation should be the original one.
                     sourceNode = updatedRoot.GetAnnotatedNodesAndTokens(sourceNodeAnnotation).Last().AsNode()
 
-                    ' we want to replace the old identifier with a invocation expression, but because of MakeExplicit we might have
-                    ' a member access now instead of the identifier. So more syntax fiddling is needed.
-                    If sourceNode.Parent.Kind = SyntaxKind.SimpleMemberAccessExpression Then
-                        Dim explicitMemberAccess = DirectCast(sourceNode.Parent, MemberAccessExpressionSyntax)
-                        If explicitMemberAccess.Name Is sourceNode Then
-                            Dim replacementMemberAccess = explicitMemberAccess.CopyAnnotationsTo(
-                                SyntaxFactory.MemberAccessExpression(
-                                    sourceNode.Parent.Kind(),
-                                    explicitMemberAccess.Expression,
-                                    SyntaxFactory.Token(SyntaxKind.DotToken),
-                                    DirectCast(invocation.Expression, SimpleNameSyntax)))
-
-                            Dim newInvocation = SyntaxFactory.InvocationExpression(
-                                replacementMemberAccess,
-                                invocation.ArgumentList).WithTrailingTrivia(sourceNode.GetTrailingTrivia())
-
-                            If invocationWithAwaitOpt IsNot Nothing Then
-                                invocationWithAwaitOpt = invocationWithAwaitOpt.ReplaceNode(invocation, newInvocation)
-                            End If
-
-                            invocation = newInvocation
-                            sourceNode = sourceNode.Parent
-                        End If
-                    End If
-
                     Dim callSignature = If(DirectCast(invocationWithAwaitOpt, ExpressionSyntax), invocation)
                     callSignature = callSignature.WithAdditionalAnnotations(CallSiteAnnotation)
                     Return newEnclosingStatement.ReplaceNode(sourceNode, callSignature)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
@@ -25,11 +25,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 
                 Protected Overrides Function CreateMethodName() As SyntaxToken
                     Dim methodName = "NewMethod"
-                    Dim containingScope = CType(VBSelectionResult.GetContainingScope(), SyntaxNode)
+                    Dim containingScope = VBSelectionResult.GetContainingScope()
 
                     methodName = GetMethodNameBasedOnExpression(methodName, containingScope)
 
-                    Dim semanticModel = CType(SemanticDocument.SemanticModel, SemanticModel)
+                    Dim semanticModel = SemanticDocument.SemanticModel
                     Dim nameGenerator = New UniqueNameGenerator(semanticModel)
                     Return SyntaxFactory.Identifier(
                         nameGenerator.CreateUniqueMethodName(containingScope, methodName))

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ExtractMethod
@@ -39,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return SyntaxFactory.Identifier(nameGenerator.CreateUniqueMethodName(containingScope, "NewMethod"))
                 End Function
 
-                Protected Overrides Function GetInitialStatementsForMethodDefinitions() As IEnumerable(Of StatementSyntax)
+                Protected Overrides Function GetInitialStatementsForMethodDefinitions() As ImmutableArray(Of StatementSyntax)
                     Dim firstStatementUnderContainer = Me.VBSelectionResult.GetFirstStatementUnderContainer()
                     Dim lastStatementUnderContainer = Me.VBSelectionResult.GetLastStatementUnderContainer()
 
@@ -55,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                                 Skip(firstStatementIndex).
                                 Take(lastStatementIndex - firstStatementIndex + 1)
 
-                    Return nodes
+                    Return nodes.ToImmutableArray()
                 End Function
 
                 Protected Overrides Function GetOutermostCallSiteContainerToProcess(cancellationToken As CancellationToken) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
@@ -72,8 +72,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return Me.VBSelectionResult.GetLastStatementUnderContainer()
                 End Function
 
-                Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(callSiteAnnotation As SyntaxAnnotation, cancellationToken As CancellationToken) As Task(Of StatementSyntax)
-                    Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(callSiteAnnotation))
+                Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
+                    Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
                 End Function
             End Class
         End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ExtractMethod
@@ -34,10 +35,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         nameGenerator.CreateUniqueMethodName(containingScope, "NewMethod"))
                 End Function
 
-                Protected Overrides Function GetInitialStatementsForMethodDefinitions() As IEnumerable(Of StatementSyntax)
+                Protected Overrides Function GetInitialStatementsForMethodDefinitions() As ImmutableArray(Of StatementSyntax)
                     Contract.ThrowIfFalse(IsExtractMethodOnSingleStatement(VBSelectionResult))
 
-                    Return SpecializedCollections.SingletonEnumerable(Of StatementSyntax)(VBSelectionResult.GetFirstStatement())
+                    Return ImmutableArray.Create(Of StatementSyntax)(VBSelectionResult.GetFirstStatement())
                 End Function
 
                 Protected Overrides Function GetOutermostCallSiteContainerToProcess(cancellationToken As CancellationToken) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
@@ -61,8 +61,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Return VBSelectionResult.GetFirstStatement()
                 End Function
 
-                Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(callSiteAnnotation As SyntaxAnnotation, cancellationToken As CancellationToken) As Task(Of StatementSyntax)
-                    Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(callSiteAnnotation))
+                Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
+                    Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
                 End Function
             End Class
         End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -16,7 +16,12 @@ Imports System.Collections.Immutable
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
     Partial Friend Class VisualBasicMethodExtractor
         Partial Private MustInherit Class VisualBasicCodeGenerator
-            Inherits CodeGenerator(Of StatementSyntax, ExpressionSyntax, StatementSyntax)
+            Inherits CodeGenerator(Of
+                StatementSyntax,
+                ExpressionSyntax,
+                InvocationExpressionSyntax,
+                AwaitExpressionSyntax,
+                StatementSyntax)
 
             Private ReadOnly _methodName As SyntaxToken
 
@@ -319,7 +324,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return statements(index + 1).IsKind(SyntaxKind.ReturnStatement, SyntaxKind.ExitSubStatement)
             End Function
 
-            Protected Overrides Function CreateCallSignature() As ExpressionSyntax
+            Protected Overrides Function CreateCallSignatureParts() As (invocation As InvocationExpressionSyntax, awaitExpressionOpt As AwaitExpressionSyntax)
                 Dim methodName As ExpressionSyntax = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation)
 
                 Dim arguments = New List(Of ArgumentSyntax)()
@@ -363,10 +368,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                                         SyntaxFactory.Token(SyntaxKind.FalseKeyword))))))
                         End If
                     End If
-                    Return SyntaxFactory.AwaitExpression(invocation)
+                    Return (invocation, SyntaxFactory.AwaitExpression(invocation))
                 End If
 
-                Return invocation
+                Return (invocation, awaitExpressionOpt:=Nothing)
             End Function
 
             Private Shared Function GetIdentifierName(name As String) As ExpressionSyntax

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -161,12 +161,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return New DeclarationModifiers(isStatic:=isShared, isAsync:=isAsync)
             End Function
 
-            Private Function CreateMethodBody(cancellationToken As CancellationToken) As OperationStatus(Of IEnumerable(Of StatementSyntax))
+            Private Function CreateMethodBody(cancellationToken As CancellationToken) As OperationStatus(Of ImmutableArray(Of StatementSyntax))
                 Dim statements = GetInitialStatementsForMethodDefinitions()
                 statements = SplitOrMoveDeclarationIntoMethodDefinition(statements, cancellationToken)
                 statements = MoveDeclarationOutFromMethodDefinition(statements, cancellationToken)
 
-                Dim emptyStatements = SpecializedCollections.EmptyEnumerable(Of StatementSyntax)()
+                Dim emptyStatements = ImmutableArray(Of StatementSyntax).Empty
                 Dim returnStatements = AppendReturnStatementIfNeeded(emptyStatements)
 
                 statements = statements.Concat(returnStatements)
@@ -174,14 +174,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Dim semanticModel = SemanticDocument.SemanticModel
                 Dim context = Me.InsertionPoint.GetContext()
                 Dim postProcessor = New PostProcessor(semanticModel, context.SpanStart)
-                statements = postProcessor.RemoveDeclarationAssignmentPattern(statements)
-                statements = postProcessor.RemoveInitializedDeclarationAndReturnPattern(statements)
+                statements = PostProcessor.RemoveDeclarationAssignmentPattern(statements)
+                statements = PostProcessor.RemoveInitializedDeclarationAndReturnPattern(statements)
 
                 ' assign before checking issues so that we can do negative preview
                 Return CheckActiveStatements(statements).With(statements)
             End Function
 
-            Private Shared Function CheckActiveStatements(statements As IEnumerable(Of StatementSyntax)) As OperationStatus
+            Private Shared Function CheckActiveStatements(statements As ImmutableArray(Of StatementSyntax)) As OperationStatus
                 Dim count = statements.Count()
                 If count = 0 Then
                     Return OperationStatus.NoActiveStatement
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return OperationStatus.NoActiveStatement
             End Function
 
-            Private Function MoveDeclarationOutFromMethodDefinition(statements As IEnumerable(Of StatementSyntax), cancellationToken As CancellationToken) As IEnumerable(Of StatementSyntax)
+            Private Function MoveDeclarationOutFromMethodDefinition(statements As ImmutableArray(Of StatementSyntax), cancellationToken As CancellationToken) As ImmutableArray(Of StatementSyntax)
                 Dim variableToRemoveMap = CreateVariableDeclarationToRemoveMap(
                     Me.AnalyzerResult.GetVariablesToMoveOutToCallSiteOrDelete(cancellationToken), cancellationToken)
 
@@ -271,10 +271,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Next expressionStatement
                 Next
 
-                Return declarationStatements
+                Return declarationStatements.ToImmutableArray()
             End Function
 
-            Private Function SplitOrMoveDeclarationIntoMethodDefinition(statements As IEnumerable(Of StatementSyntax), cancellationToken As CancellationToken) As IEnumerable(Of StatementSyntax)
+            Private Function SplitOrMoveDeclarationIntoMethodDefinition(statements As ImmutableArray(Of StatementSyntax), cancellationToken As CancellationToken) As ImmutableArray(Of StatementSyntax)
                 Dim semanticModel = CType(Me.SemanticDocument.SemanticModel, SemanticModel)
                 Dim context = Me.InsertionPoint.GetContext()
                 Dim postProcessor = New PostProcessor(semanticModel, context.SpanStart)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -16,12 +16,7 @@ Imports System.Collections.Immutable
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
     Partial Friend Class VisualBasicMethodExtractor
         Partial Private MustInherit Class VisualBasicCodeGenerator
-            Inherits CodeGenerator(Of
-                StatementSyntax,
-                ExpressionSyntax,
-                InvocationExpressionSyntax,
-                AwaitExpressionSyntax,
-                StatementSyntax)
+            Inherits CodeGenerator(Of StatementSyntax, ExpressionSyntax, StatementSyntax)
 
             Private ReadOnly _methodName As SyntaxToken
 
@@ -324,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return statements(index + 1).IsKind(SyntaxKind.ReturnStatement, SyntaxKind.ExitSubStatement)
             End Function
 
-            Protected Overrides Function CreateCallSignatureParts() As (invocation As InvocationExpressionSyntax, awaitExpressionOpt As AwaitExpressionSyntax)
+            Protected Overrides Function CreateCallSignature() As ExpressionSyntax
                 Dim methodName As ExpressionSyntax = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation)
 
                 Dim arguments = New List(Of ArgumentSyntax)()
@@ -368,10 +363,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                                         SyntaxFactory.Token(SyntaxKind.FalseKeyword))))))
                         End If
                     End If
-                    Return (invocation, SyntaxFactory.AwaitExpression(invocation))
+                    Return SyntaxFactory.AwaitExpression(invocation)
                 End If
 
-                Return (invocation, awaitExpressionOpt:=Nothing)
+                Return invocation
             End Function
 
             Private Shared Function GetIdentifierName(name As String) As ExpressionSyntax

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -120,7 +120,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             If SelectionInExpression Then
                 Dim last = GetLastTokenInSelection()
 
-                Return first.GetCommonRoot(last).GetAncestorOrThis(Of ExpressionSyntax)()
+                Dim expression = first.GetCommonRoot(last).GetAncestorOrThis(Of ExpressionSyntax)()
+                Return If(expression.IsRightSideOfDotOrBang(),
+                          expression.Parent,
+                          expression)
             End If
 
             ' it contains statements

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -126,20 +126,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 
                 ' If the selection ends up mapping to the name on the right in `x.y` Or `x?.y`, then grab
                 ' the full expr `x.y` Or `x?.y` as the part to extract.
-                Dim memberAccess = TryCast(scope.Parent, MemberAccessExpressionSyntax)
-                If memberAccess?.Name Is scope Then
-                    If memberAccess.Expression Is Nothing Then
-                        ' .y      or
-                        ' x?.y
-                        scope = If(memberAccess.GetParentConditionalAccessExpression(), DirectCast(memberAccess, ExpressionSyntax))
-                    End If
-                End If
+                scope = SyntaxFactory.GetStandaloneExpression(scope)
 
-                Dim invocation = TryCast(scope, InvocationExpressionSyntax)
-                If invocation IsNot Nothing AndAlso invocation.Expression Is Nothing Then
-                    ' x?(y)
-                    scope = invocation.GetParentConditionalAccessExpression()
-                End If
+                ' If we're in a chain in a conditional access expression, then grab the top of that ?. chain.
+                scope = If(scope.GetRootConditionalAccessExpression(), scope)
 
                 Return scope
             Else

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -5,6 +5,7 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ExtractMethod
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -124,14 +125,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Dim scope = first.GetCommonRoot(last).GetAncestorOrThis(Of ExpressionSyntax)()
                 Contract.ThrowIfNull(scope, "Should always find an expression given that SelectionInExpression was true")
 
-                ' If the selection ends up mapping to the name on the right in `x.y` Or `x?.y`, then grab
-                ' the full expr `x.y` Or `x?.y` as the part to extract.
-                scope = SyntaxFactory.GetStandaloneExpression(scope)
-
-                ' If we're in a chain in a conditional access expression, then grab the top of that ?. chain.
-                scope = If(scope.GetRootConditionalAccessExpression(), scope)
-
-                Return scope
+                Return VisualBasicSyntaxFacts.Instance.GetRootStandaloneExpression(scope)
             Else
                 ' it contains statements
                 Return first.GetAncestors(Of SyntaxNode).FirstOrDefault(Function(n) TypeOf n Is MethodBlockBaseSyntax OrElse TypeOf n Is LambdaExpressionSyntax)

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/SyntaxTokenClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/SyntaxTokenClassifier.cs
@@ -72,10 +72,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             }
 
             // ?.X.Identifier   or  ?.X.Y.Identifier  is never a generic type.
-            if (identifierName.IsMemberAccessExpressionName() &&
-                identifier.Parent.IsParentKind(SyntaxKind.ConditionalAccessExpression))
+            if (identifierName.IsSimpleMemberAccessExpressionName() ||
+                identifierName.IsMemberBindingExpressionName())
             {
-                return false;
+                if (identifier.Parent.IsParentKind(SyntaxKind.ConditionalAccessExpression))
+                    return false;
             }
 
             // Add more cases as necessary.

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
             }
             else if (node.Kind() == SyntaxKind.MemberBindingExpression)
             {
-                var parentConditionalAccess = node.GetParentConditionalAccessExpression();
+                var parentConditionalAccess = node.GetRootConditionalAccessExpression();
                 return GetSymbolsOffOfConditionalReceiver(parentConditionalAccess.Expression);
             }
             else

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 // Bail out on extension method invocations in conditional access expression.
                 // Note that this is a temporary workaround for https://github.com/dotnet/roslyn/issues/2593.
                 // Issue https://github.com/dotnet/roslyn/issues/3260 tracks fixing this workaround.
-                if (originalMemberAccess.GetParentConditionalAccessExpression() == null)
+                if (originalMemberAccess.GetRootConditionalAccessExpression() == null)
                 {
                     var speculationPosition = originalNode.SpanStart;
                     var expression = RewriteExtensionMethodInvocation(speculationPosition, rewrittenNode, thisExpression, reducedExtensionMethod);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -793,7 +793,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 return true;
             }
 
-            if (syntaxFacts.IsRightSideOfQualifiedName(node) || syntaxFacts.IsNameOfMemberAccessExpression(node))
+            if (syntaxFacts.IsRightSideOfQualifiedName(node) ||
+                syntaxFacts.IsNameOfSimpleMemberAccessExpression(node) ||
+                syntaxFacts.IsNameOfMemberBindingExpression(node))
             {
                 return syntaxFacts.IsLeftSideOfDot(node.Parent);
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -67,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static bool IsRightSideOfDotOrColonColon(this ExpressionSyntax name)
             => IsRightSideOfDot(name) || IsRightSideOfColonColon(name);
 
-        public static bool IsRightSideOfDotOrArrowOrColonColon(this ExpressionSyntax name)
+        public static bool IsRightSideOfDotOrArrowOrColonColon([NotNullWhen(true)] this ExpressionSyntax name)
             => IsRightSideOfDotOrArrow(name) || IsRightSideOfColonColon(name);
 
         public static bool IsRightOfCloseParen(this ExpressionSyntax expression)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -34,9 +34,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static bool IsQualifiedCrefName(this ExpressionSyntax expression)
             => expression.IsParentKind(SyntaxKind.NameMemberCref) && expression.Parent.IsParentKind(SyntaxKind.QualifiedCref);
 
-        public static bool IsMemberAccessExpressionName(this ExpressionSyntax expression)
-            => (expression.IsParentKind(SyntaxKind.SimpleMemberAccessExpression, out MemberAccessExpressionSyntax memberAccess) && memberAccess.Name == expression) ||
-               IsMemberBindingExpressionName(expression);
+        public static bool IsSimpleMemberAccessExpressionName(this ExpressionSyntax expression)
+            => expression.IsParentKind(SyntaxKind.SimpleMemberAccessExpression, out MemberAccessExpressionSyntax memberAccess) && memberAccess.Name == expression;
 
         public static bool IsAnyMemberAccessExpressionName(this ExpressionSyntax expression)
         {
@@ -49,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 expression.IsMemberBindingExpressionName();
         }
 
-        private static bool IsMemberBindingExpressionName(this ExpressionSyntax expression)
+        public static bool IsMemberBindingExpressionName(this ExpressionSyntax expression)
             => expression.IsParentKind(SyntaxKind.MemberBindingExpression, out MemberBindingExpressionSyntax memberBinding) &&
                memberBinding.Name == expression;
 
@@ -60,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             => expression.IsParentKind(SyntaxKind.AliasQualifiedName, out AliasQualifiedNameSyntax aliasName) && aliasName.Name == expression;
 
         public static bool IsRightSideOfDot(this ExpressionSyntax name)
-            => IsMemberAccessExpressionName(name) || IsRightSideOfQualifiedName(name) || IsQualifiedCrefName(name);
+            => IsSimpleMemberAccessExpressionName(name) || IsMemberBindingExpressionName(name) || IsRightSideOfQualifiedName(name) || IsQualifiedCrefName(name);
 
         public static bool IsRightSideOfDotOrArrow(this ExpressionSyntax name)
             => IsAnyMemberAccessExpressionName(name) || IsRightSideOfQualifiedName(name);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SimpleNameSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SimpleNameSyntaxExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
             else if (name.IsMemberBindingExpressionName())
             {
-                return name.GetParentConditionalAccessExpression().Expression;
+                return name.GetRootConditionalAccessExpression().Expression;
             }
             else if (name.IsRightSideOfQualifiedName())
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SimpleNameSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SimpleNameSyntaxExtensions.cs
@@ -11,18 +11,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     {
         public static ExpressionSyntax GetLeftSideOfDot(this SimpleNameSyntax name)
         {
-            Debug.Assert(name.IsMemberAccessExpressionName() || name.IsRightSideOfQualifiedName() || name.IsParentKind(SyntaxKind.NameMemberCref));
-            if (name.IsMemberAccessExpressionName())
+            Debug.Assert(name.IsSimpleMemberAccessExpressionName() || name.IsMemberBindingExpressionName() || name.IsRightSideOfQualifiedName() || name.IsParentKind(SyntaxKind.NameMemberCref));
+            if (name.IsSimpleMemberAccessExpressionName())
             {
-                var conditionalAccess = name.GetParentConditionalAccessExpression();
-                if (conditionalAccess != null)
-                {
-                    return conditionalAccess.Expression;
-                }
-                else
-                {
-                    return ((MemberAccessExpressionSyntax)name.Parent).Expression;
-                }
+                return ((MemberAccessExpressionSyntax)name.Parent).Expression;
+            }
+            else if (name.IsMemberBindingExpressionName())
+            {
+                return name.GetParentConditionalAccessExpression().Expression;
             }
             else if (name.IsRightSideOfQualifiedName())
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 _ => default,
             };
 
-        public static ConditionalAccessExpressionSyntax? GetParentConditionalAccessExpression(this SyntaxNode node)
+        public static ConditionalAccessExpressionSyntax? GetParentConditionalAccessExpression(this SyntaxNode? node)
         {
             var current = node;
             while (current?.Parent != null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -163,6 +163,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             return name.IsMemberBindingExpressionName();
         }
 
+        public SyntaxNode? GetStandaloneExpression(SyntaxNode? node)
+            => SyntaxFactory.GetStandaloneExpression(node as ExpressionSyntax);
+
         public SyntaxNode? GetRootConditionalAccessExpression(SyntaxNode? node)
             => node.GetRootConditionalAccessExpression();
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -163,8 +163,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             return name.IsMemberBindingExpressionName();
         }
 
-        public SyntaxNode GetParentConditionalAccessExpression(SyntaxNode node)
-            => node.GetParentConditionalAccessExpression();
+        public SyntaxNode? GetRootConditionalAccessExpression(SyntaxNode? node)
+            => node.GetRootConditionalAccessExpression();
 
 #nullable restore
 
@@ -567,7 +567,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                simpleName.GetLastToken().GetNextToken().Kind() == SyntaxKind.LessThanToken;
 
         public SyntaxNode GetTargetOfMemberBinding(SyntaxNode node)
-            => (node as MemberBindingExpressionSyntax).GetParentConditionalAccessExpression()?.Expression;
+            => (node as MemberBindingExpressionSyntax).GetRootConditionalAccessExpression()?.Expression;
 
         public SyntaxNode GetExpressionOfMemberAccessExpression(SyntaxNode node, bool allowImplicitTarget)
             => (node as MemberAccessExpressionSyntax)?.Expression;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -147,11 +147,25 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         }
 
 #nullable enable
-        public bool IsNameOfMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node)
+
+        public bool IsNameOfSimpleMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node)
         {
             var name = node as SimpleNameSyntax;
-            return name.IsMemberAccessExpressionName();
+            return name.IsSimpleMemberAccessExpressionName();
         }
+
+        public bool IsNameOfAnyMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node)
+            => node?.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node;
+
+        public bool IsNameOfMemberBindingExpression([NotNullWhen(true)] SyntaxNode? node)
+        {
+            var name = node as SimpleNameSyntax;
+            return name.IsMemberBindingExpressionName();
+        }
+
+        public SyntaxNode GetParentConditionalAccessExpression(SyntaxNode node)
+            => node.GetParentConditionalAccessExpression();
+
 #nullable restore
 
         public bool IsObjectCreationExpressionType(SyntaxNode node)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -185,8 +185,18 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsLeftSideOfExplicitInterfaceSpecifier(SyntaxNode node);
 
 #nullable enable
-        bool IsNameOfMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node);
+        bool IsNameOfSimpleMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node);
+        bool IsNameOfAnyMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node);
+        bool IsNameOfMemberBindingExpression([NotNullWhen(true)] SyntaxNode? node);
 #nullable restore
+
+        /// <summary>
+        /// Call on the `.y` part of a `x?.y` to get the entire `x?.y` conditional access expression.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        SyntaxNode GetParentConditionalAccessExpression(SyntaxNode node);
+
         bool IsExpressionOfMemberAccessExpression(SyntaxNode node);
 
         SyntaxNode GetNameOfMemberAccessExpression(SyntaxNode node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -191,6 +191,14 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 #nullable restore
 
         /// <summary>
+        /// Gets the containing expression that is actually a language expression and not just typed
+        /// as an ExpressionSyntax for convenience. For example, NameSyntax nodes on the right side
+        /// of qualified names and member access expressions are not language expressions, yet the
+        /// containing qualified names or member access expressions are indeed expressions.
+        /// </summary>
+        SyntaxNode GetStandaloneExpression(SyntaxNode node);
+
+        /// <summary>
         /// Call on the `.y` part of a `x?.y` to get the entire `x?.y` conditional access expression.  This also works
         /// when there are multiple chained conditional accesses.  For example, calling this on '.y' or '.z' in
         /// `x?.y?.z` will both return the full `x?.y?.z` node.  This can be used to effectively get 'out' of the RHS of
@@ -200,7 +208,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         SyntaxNode GetRootConditionalAccessExpression(SyntaxNode node);
 
         bool IsExpressionOfMemberAccessExpression(SyntaxNode node);
-
         SyntaxNode GetNameOfMemberAccessExpression(SyntaxNode node);
 
         /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -191,11 +191,13 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 #nullable restore
 
         /// <summary>
-        /// Call on the `.y` part of a `x?.y` to get the entire `x?.y` conditional access expression.
+        /// Call on the `.y` part of a `x?.y` to get the entire `x?.y` conditional access expression.  This also works
+        /// when there are multiple chained conditional accesses.  For example, calling this on '.y' or '.z' in
+        /// `x?.y?.z` will both return the full `x?.y?.z` node.  This can be used to effectively get 'out' of the RHS of
+        /// a conditional access, and commonly represents the full standalone expression that can be operated on
+        /// atomically.
         /// </summary>
-        /// <param name="node"></param>
-        /// <returns></returns>
-        SyntaxNode GetParentConditionalAccessExpression(SyntaxNode node);
+        SyntaxNode GetRootConditionalAccessExpression(SyntaxNode node);
 
         bool IsExpressionOfMemberAccessExpression(SyntaxNode node);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/ExpressionSyntaxExtensions.vb
@@ -53,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         <Extension()>
-        Public Function IsMemberAccessExpressionName(expression As ExpressionSyntax) As Boolean
+        Public Function IsSimpleMemberAccessExpressionName(expression As ExpressionSyntax) As Boolean
             Return expression.IsParentKind(SyntaxKind.SimpleMemberAccessExpression) AndAlso
                    DirectCast(expression.Parent, MemberAccessExpressionSyntax).Name Is expression
         End Function
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
         <Extension()>
         Public Function IsRightSideOfDot(expression As ExpressionSyntax) As Boolean
-            Return expression.IsMemberAccessExpressionName() OrElse expression.IsRightSideOfQualifiedName()
+            Return expression.IsSimpleMemberAccessExpressionName() OrElse expression.IsRightSideOfQualifiedName()
         End Function
 
         <Extension()>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/MemberAccessExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/MemberAccessExpressionSyntaxExtensions.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             ' 3) new T() With { .a = 1, .b = .a <-- 'a refers to the T type
 
             If allowImplicitTarget Then
-                Dim conditional = memberAccessExpression.GetParentConditionalAccessExpression()
+                Dim conditional = memberAccessExpression.GetRootConditionalAccessExpression()
                 If conditional IsNot Nothing Then
                     If conditional.Expression Is Nothing Then
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/MemberAccessExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/MemberAccessExpressionSyntaxExtensions.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             ' 3) new T() With { .a = 1, .b = .a <-- 'a refers to the T type
 
             If allowImplicitTarget Then
-                Dim conditional = memberAccessExpression.GetCorrespondingConditionalAccessExpression()
+                Dim conditional = memberAccessExpression.GetParentConditionalAccessExpression()
                 If conditional IsNot Nothing Then
                     If conditional.Expression Is Nothing Then
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
@@ -1004,7 +1004,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         ''' <param name="node"></param>
         ''' <returns></returns>
         <Extension>
-        Friend Function GetCorrespondingConditionalAccessExpression(node As ExpressionSyntax) As ConditionalAccessExpressionSyntax
+        Friend Function GetParentConditionalAccessExpression(node As ExpressionSyntax) As ConditionalAccessExpressionSyntax
             Dim access As SyntaxNode = node
             Dim parent As SyntaxNode = access.Parent
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -179,8 +179,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return memberAccess IsNot Nothing AndAlso memberAccess.Name Is node
         End Function
 
-        Public Function GetParentConditionalAccessExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetParentConditionalAccessExpression
-            Return TryCast(node, ExpressionSyntax).GetParentConditionalAccessExpression()
+        Public Function GetRootConditionalAccessExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetRootConditionalAccessExpression
+            Return TryCast(node, ExpressionSyntax).GetRootConditionalAccessExpression()
         End Function
 
         Public Sub GetPartsOfConditionalAccessExpression(node As SyntaxNode, ByRef expression As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef whenNotNull As SyntaxNode) Implements ISyntaxFacts.GetPartsOfConditionalAccessExpression

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -169,9 +169,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return vbNode IsNot Nothing AndAlso vbNode.IsRightSideOfQualifiedName()
         End Function
 
-        Public Function IsNameOfMemberAccessExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsNameOfMemberAccessExpression
-            Dim vbNode = TryCast(node, SimpleNameSyntax)
-            Return vbNode IsNot Nothing AndAlso vbNode.IsMemberAccessExpressionName()
+        Public Function IsNameOfSimpleMemberAccessExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsNameOfSimpleMemberAccessExpression
+            Dim vbNode = TryCast(node, ExpressionSyntax)
+            Return vbNode IsNot Nothing AndAlso vbNode.IsSimpleMemberAccessExpressionName()
+        End Function
+
+        Public Function IsNameOfAnyMemberAccessExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsNameOfAnyMemberAccessExpression
+            Dim memberAccess = TryCast(node?.Parent, MemberAccessExpressionSyntax)
+            Return memberAccess IsNot Nothing AndAlso memberAccess.Name Is node
+        End Function
+
+        Public Function GetParentConditionalAccessExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetParentConditionalAccessExpression
+            Return TryCast(node, ExpressionSyntax).GetParentConditionalAccessExpression()
         End Function
 
         Public Sub GetPartsOfConditionalAccessExpression(node As SyntaxNode, ByRef expression As SyntaxNode, ByRef operatorToken As SyntaxToken, ByRef whenNotNull As SyntaxNode) Implements ISyntaxFacts.GetPartsOfConditionalAccessExpression
@@ -1879,7 +1888,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
         End Function
 
         Public Function IsMemberBindingExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsMemberBindingExpression
-            ' Does not exist in VB.
+            ' Does not exist in VB.  VB represents a member binding as a MemberAccessExpression with null target.
+            Return False
+        End Function
+
+        Public Function IsNameOfMemberBindingExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsNameOfMemberBindingExpression
+            ' Does not exist in VB.  VB represents a member binding as a MemberAccessExpression with null target.
             Return False
         End Function
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -179,6 +179,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return memberAccess IsNot Nothing AndAlso memberAccess.Name Is node
         End Function
 
+        Public Function GetStandaloneExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetStandaloneExpression
+            Return SyntaxFactory.GetStandaloneExpression(TryCast(node, ExpressionSyntax))
+        End Function
+
         Public Function GetRootConditionalAccessExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetRootConditionalAccessExpression
             Return TryCast(node, ExpressionSyntax).GetRootConditionalAccessExpression()
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/SimpleNameSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/SimpleNameSyntaxExtensions.vb
@@ -10,8 +10,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
     Friend Module SimpleNameSyntaxExtensions
         <Extension()>
         Public Function GetLeftSideOfDot(name As SimpleNameSyntax) As ExpressionSyntax
-            Debug.Assert(IsMemberAccessExpressionName(name) OrElse IsRightSideOfQualifiedName(name))
-            If IsMemberAccessExpressionName(name) Then
+            Debug.Assert(IsSimpleMemberAccessExpressionName(name) OrElse IsRightSideOfQualifiedName(name))
+            If IsSimpleMemberAccessExpressionName(name) Then
                 Return DirectCast(name.Parent, MemberAccessExpressionSyntax).Expression
             Else
                 Return DirectCast(name.Parent, QualifiedNameSyntax).Left

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
@@ -224,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 reducedExtensionMethod As IMethodSymbol) As InvocationExpressionSyntax
 
                 Dim originalMemberAccess = DirectCast(originalNode.Expression, MemberAccessExpressionSyntax)
-                If originalMemberAccess.GetCorrespondingConditionalAccessExpression IsNot Nothing Then
+                If originalMemberAccess.GetParentConditionalAccessExpression() IsNot Nothing Then
                     ' Bail out on extension method invocations in conditional access expression.
                     ' Note that this is a temporary workaround for https://github.com/dotnet/roslyn/issues/2593.
                     ' Issue https//github.com/dotnet/roslyn/issues/3260 tracks fixing this workaround.

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
@@ -224,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 reducedExtensionMethod As IMethodSymbol) As InvocationExpressionSyntax
 
                 Dim originalMemberAccess = DirectCast(originalNode.Expression, MemberAccessExpressionSyntax)
-                If originalMemberAccess.GetParentConditionalAccessExpression() IsNot Nothing Then
+                If originalMemberAccess.GetRootConditionalAccessExpression() IsNot Nothing Then
                     ' Bail out on extension method invocations in conditional access expression.
                     ' Note that this is a temporary workaround for https://github.com/dotnet/roslyn/issues/2593.
                     ' Issue https//github.com/dotnet/roslyn/issues/3260 tracks fixing this workaround.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41895

Note: i ended up doing a lot of cleanup in this area.  The PR should be reviewed commit by commit.  Also, one commit effectively undoes a previous commit.  However, those steps were still very valuable for me to understand what was happening and ensure the change was correct.