### PR TITLE
Remove uses of Encoding.UTF7 that is causing obsoletion warnings

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
@@ -106,7 +106,7 @@ class TypeTwo
             var sourceThree = Parse(@"
 class TypeThree
 {
-}", options: parseOptions, encoding: Encoding.UTF7);
+}", options: parseOptions, encoding: Encoding.Unicode);
 
             var referenceOneCompilation = CreateCompilation(
 @"public struct StructWithReference

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTreeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTreeTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void WithRootAndOptions_ParsedTreeWithText()
         {
-            var oldText = SourceText.From("class B {}", Encoding.UTF7, SourceHashAlgorithm.Sha256);
+            var oldText = SourceText.From("class B {}", Encoding.Unicode, SourceHashAlgorithm.Sha256);
             var oldTree = SyntaxFactory.ParseSyntaxTree(oldText);
 
             var newRoot = SyntaxFactory.ParseCompilationUnit("class C {}");
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(newRoot.ToString(), newTree.GetRoot().ToString());
             Assert.Same(newOptions, newTree.Options);
-            Assert.Same(Encoding.UTF7, newText.Encoding);
+            Assert.Same(Encoding.Unicode, newText.Encoding);
             Assert.Equal(SourceHashAlgorithm.Sha256, newText.ChecksumAlgorithm);
         }
 
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void WithFilePath_ParsedTreeWithText()
         {
-            var oldText = SourceText.From("class B {}", Encoding.UTF7, SourceHashAlgorithm.Sha256);
+            var oldText = SourceText.From("class B {}", Encoding.Unicode, SourceHashAlgorithm.Sha256);
             var oldTree = SyntaxFactory.ParseSyntaxTree(oldText, path: "old.cs");
 
             var newTree = oldTree.WithFilePath("new.cs");
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("new.cs", newTree.FilePath);
             Assert.Equal(oldTree.ToString(), newTree.ToString());
 
-            Assert.Same(Encoding.UTF7, newText.Encoding);
+            Assert.Same(Encoding.Unicode, newText.Encoding);
             Assert.Equal(SourceHashAlgorithm.Sha256, newText.ChecksumAlgorithm);
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestSubTextAfterMultipleChanges()
         {
-            var text = SourceText.From("Hello World", Encoding.UTF7, SourceHashAlgorithm.Sha256);
+            var text = SourceText.From("Hello World", Encoding.Unicode, SourceHashAlgorithm.Sha256);
             var newText = text.WithChanges(
                 new TextChange(new TextSpan(4, 1), string.Empty),
                 new TextChange(new TextSpan(6, 5), "Universe"));
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("l Un", subText.ToString());
 
             Assert.Equal(SourceHashAlgorithm.Sha256, subText.ChecksumAlgorithm);
-            Assert.Same(Encoding.UTF7, subText.Encoding);
+            Assert.Same(Encoding.Unicode, subText.Encoding);
         }
 
         [Fact]
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestGetTextChangesToChangedText()
         {
-            var text = SourceText.From(new string('.', 2048), Encoding.UTF7, SourceHashAlgorithm.Sha256); // start bigger than GetText() copy buffer
+            var text = SourceText.From(new string('.', 2048), Encoding.Unicode, SourceHashAlgorithm.Sha256); // start bigger than GetText() copy buffer
             var changes = new TextChange[] {
                 new TextChange(new TextSpan(0, 1), "[1]"),
                 new TextChange(new TextSpan(1, 1), "[2]"),
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var newText = text.WithChanges(changes);
             Assert.Equal(SourceHashAlgorithm.Sha256, newText.ChecksumAlgorithm);
-            Assert.Same(Encoding.UTF7, newText.Encoding);
+            Assert.Same(Encoding.Unicode, newText.Encoding);
 
             var result = newText.GetTextChanges(text).ToList();
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxTreeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxTreeTests.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         <Fact>
         Public Sub WithRootAndOptions_ParsedTreeWithText()
-            Dim oldText = SourceText.From("Class B : End Class", Encoding.UTF7, SourceHashAlgorithm.Sha256)
+            Dim oldText = SourceText.From("Class B : End Class", Encoding.Unicode, SourceHashAlgorithm.Sha256)
             Dim oldTree = SyntaxFactory.ParseSyntaxTree(oldText)
 
             Dim newRoot = SyntaxFactory.ParseCompilationUnit("Class C : End Class")
@@ -125,7 +125,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal(newRoot.ToString(), newTree.GetRoot().ToString())
             Assert.Same(newOptions, newTree.Options)
 
-            Assert.Same(Encoding.UTF7, newText.Encoding)
+            Assert.Same(Encoding.Unicode, newText.Encoding)
             Assert.Equal(SourceHashAlgorithm.Sha256, newText.ChecksumAlgorithm)
         End Sub
 
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         <Fact>
         Public Sub WithFilePath_ParsedTreeWithText()
-            Dim oldText = SourceText.From("Class B : End Class", Encoding.UTF7, SourceHashAlgorithm.Sha256)
+            Dim oldText = SourceText.From("Class B : End Class", Encoding.Unicode, SourceHashAlgorithm.Sha256)
             Dim oldTree = SyntaxFactory.ParseSyntaxTree(oldText, path:="old.vb")
             Dim newTree = oldTree.WithFilePath("new.vb")
             Dim newText = newTree.GetText()
@@ -162,7 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal(newTree.FilePath, "new.vb")
             Assert.Equal(oldTree.ToString(), newTree.ToString())
 
-            Assert.Same(Encoding.UTF7, newText.Encoding)
+            Assert.Same(Encoding.Unicode, newText.Encoding)
             Assert.Equal(SourceHashAlgorithm.Sha256, newText.ChecksumAlgorithm)
         End Sub
 

--- a/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Test/Utilities/Portable/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -37,8 +37,8 @@ namespace Roslyn.Test.Utilities.PDB
 
             yield return emitOptions;
             yield return emitOptions.WithDefaultSourceFileEncoding(Encoding.ASCII);
-            yield return emitOptions.WithDefaultSourceFileEncoding(null).WithFallbackSourceFileEncoding(Encoding.UTF7);
-            yield return emitOptions.WithFallbackSourceFileEncoding(Encoding.UTF7).WithDefaultSourceFileEncoding(Encoding.ASCII);
+            yield return emitOptions.WithDefaultSourceFileEncoding(null).WithFallbackSourceFileEncoding(Encoding.Unicode);
+            yield return emitOptions.WithFallbackSourceFileEncoding(Encoding.Unicode).WithDefaultSourceFileEncoding(Encoding.ASCII);
         }
 
         internal static void AssertCommonOptions(EmitOptions emitOptions, CompilationOptions compilationOptions, Compilation compilation, ImmutableDictionary<string, string> pdbOptions)


### PR DESCRIPTION
Due to https://github.com/dotnet/docs/issues/19274, Encoding.UTF7 now causes warnings if you use it. We had some uses in our codebase, and it appears that they were being used whenever we wanted to fill in an encoding that wasn't UTF8 to ensure proper encoding handling. I chose to replace them with UTF-16 references since that's still not UTF8 since there are places we use UTF8 as a fallback automatically.