### PR TITLE
Recover gracefully from a decision dag that somehow has cycles during construction. (#45983)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -487,6 +487,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool operandCouldBeNull = false)
         {
             RoslynDebug.Assert((object)expressionType != null);
+
+            // Short-circuit a common case.  This also improves recovery for some error
+            // cases, e.g. when the type is void.
+            if (expressionType.Equals(patternType, TypeCompareKind.AllIgnoreOptions))
+            {
+                conversion = Conversion.Identity;
+                return true;
+            }
+
             if (expressionType.IsDynamic())
             {
                 // if operand is the dynamic type, we do the same thing as though it were object

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -809,7 +809,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void ComputeBoundDecisionDagNodes(DecisionDag decisionDag, BoundLeafDecisionDagNode defaultDecision)
         {
-            RoslynDebug.Assert(_defaultLabel != null);
+            Debug.Assert(_defaultLabel != null);
+            Debug.Assert(defaultDecision != null);
+
+            // Process the states in topological order, leaves first, and assign a BoundDecisionDag to each DagState.
+            bool wasAcyclic = decisionDag.TryGetTopologicallySortedReachableStates(out ImmutableArray<DagState> sortedStates);
+            if (!wasAcyclic)
+            {
+                // Since we intend the set of DagState nodes to be acyclic by construction, we do not expect
+                // this to occur. Just in case it does due to bugs, we recover gracefully to avoid crashing the
+                // compiler in production.  If you find that this happens (the assert fails), please modify the
+                // DagState construction process to avoid creating a cyclic state graph.
+                Debug.Assert(wasAcyclic); // force failure in debug builds
+
+                // If the dag contains a cycle, return a short-circuit dag instead.
+                decisionDag.RootNode.Dag = defaultDecision;
+                return;
+            }
 
             // We "intern" the dag nodes, so that we only have a single object representing one
             // semantic node. We do this because different states may end up mapping to the same
@@ -819,8 +835,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             _ = uniqifyDagNode(defaultDecision);
 
-            // Process the states in topological order, leaves first, and assign a BoundDecisionDag to each DagState.
-            ImmutableArray<DagState> sortedStates = decisionDag.TopologicallySortedReachableStates();
             for (int i = sortedStates.Length - 1; i >= 0; i--)
             {
                 var state = sortedStates[i];
@@ -1332,10 +1346,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            public ImmutableArray<DagState> TopologicallySortedReachableStates()
+            /// <summary>
+            /// Produce the states in topological order.
+            /// </summary>
+            /// <param name="result">Topologically sorted <see cref="DagState"/> nodes.</param>
+            /// <returns>True if the graph was acyclic.</returns>
+            public bool TryGetTopologicallySortedReachableStates(out ImmutableArray<DagState> result)
             {
-                // Now process the states in topological order, leaves first, and assign a BoundDecisionDag to each DagState.
-                return TopologicalSort.IterativeSort<DagState>(SpecializedCollections.SingletonEnumerable<DagState>(this.RootNode), Successor);
+                return TopologicalSort.TryIterativeSort<DagState>(SpecializedCollections.SingletonEnumerable<DagState>(this.RootNode), Successor, out result);
             }
 
 #if DEBUG
@@ -1345,7 +1363,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             internal string Dump()
             {
-                var allStates = this.TopologicallySortedReachableStates();
+                if (!this.TryGetTopologicallySortedReachableStates(out var allStates))
+                {
+                    return "(the dag contains a cycle!)";
+                }
+
                 var stateIdentifierMap = PooledDictionary<DagState, int>.GetInstance();
                 for (int i = 0; i < allStates.Length; i++)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -91,23 +91,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We only report exhaustive warnings when the default label is reachable through some series of
             // tests that do not include a test in which the value is known to be null.  Handling paths with
             // nulls is the job of the nullable walker.
-            if (!hasErrors)
+            bool wasAcyclic = TopologicalSort.TryIterativeSort<BoundDecisionDagNode>(new[] { decisionDag.RootNode }, nonNullSuccessors, out var nodes);
+            // Since decisionDag.RootNode is acyclic by construction, its subset of nodes sorted here cannot be cyclic
+            Debug.Assert(wasAcyclic);
+            foreach (var n in nodes)
             {
-                var nodes = TopologicalSort.IterativeSort<BoundDecisionDagNode>(new[] { decisionDag.RootNode }, nonNullSuccessors);
-                foreach (var n in nodes)
+                if (n is BoundLeafDecisionDagNode leaf && leaf.Label == defaultLabel)
                 {
-                    if (n is BoundLeafDecisionDagNode leaf && leaf.Label == defaultLabel)
-                    {
-                        diagnostics.Add(
-                            ErrorCode.WRN_SwitchExpressionNotExhaustive,
-                            node.SwitchKeyword.GetLocation(),
-                            PatternExplainer.SamplePatternForPathToDagNode(BoundDagTemp.ForOriginalInput(boundInputExpression), nodes, n, nullPaths: false));
-                        return true;
-                    }
+                    diagnostics.Add(
+                        ErrorCode.WRN_SwitchExpressionNotExhaustive,
+                        node.SwitchKeyword.GetLocation(),
+                        PatternExplainer.SamplePatternForPathToDagNode(BoundDagTemp.ForOriginalInput(boundInputExpression), nodes, n, nullPaths: false));
+                    return true;
                 }
             }
 
-            return hasErrors;
+            return false;
 
             ImmutableArray<BoundDecisionDagNode> nonNullSuccessors(BoundDecisionDagNode n)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
@@ -67,7 +67,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_topologicallySortedNodes.IsDefault)
                 {
                     // We use an iterative topological sort to avoid overflowing the compiler's runtime stack for a large switch statement.
-                    _topologicallySortedNodes = TopologicalSort.IterativeSort<BoundDecisionDagNode>(new[] { this.RootNode }, Successors);
+                    bool wasAcyclic = TopologicalSort.TryIterativeSort<BoundDecisionDagNode>(new[] { this.RootNode }, Successors, out _topologicallySortedNodes);
+
+                    // Since these nodes were constructed by an isomorphic mapping from a known acyclic graph, it cannot be cyclic
+                    Debug.Assert(wasAcyclic);
                 }
 
                 return _topologicallySortedNodes;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -2943,5 +2943,41 @@ class F
                 }
             }
         }
+
+        [Fact, WorkItem(45946, "https://github.com/dotnet/roslyn/issues/45946")]
+        public void VoidPattern_01()
+        {
+            var source = @"
+class C
+{
+    void F(object o)
+    {
+        _ = is this.F(1);
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (6,13): error CS1525: Invalid expression term 'is'
+                //         _ = is this.F(1);
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "is").WithArguments("is").WithLocation(6, 13)
+                );
+        }
+
+        [Fact, WorkItem(45946, "https://github.com/dotnet/roslyn/issues/45946")]
+        public void VoidPattern_02()
+        {
+            var source = @"
+class C
+{
+    void F(object o)
+    {
+        _ = switch { this.F(1) => 1 };
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (6,13): error CS1525: Invalid expression term 'switch'
+                //         _ = switch { this.F(1) => 1 };
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "switch").WithArguments("switch").WithLocation(6, 13)
+                );
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             Func<int, IEnumerable<int>> succF = x => successors[x];
-            var sorted = TopologicalSort.IterativeSort<int>(new[] { 4, 5 }, i => succF(i).ToImmutableArray());
+            var wasAcyclic = TopologicalSort.TryIterativeSort<int>(new[] { 4, 5 }, i => succF(i).ToImmutableArray(), out var sorted);
+            Assert.True(wasAcyclic);
             AssertTopologicallySorted(sorted, succF, "Test01");
             Assert.Equal(6, sorted.Length);
             AssertEx.Equal(new[] { 4, 5, 2, 3, 1, 0 }, sorted);
@@ -48,7 +49,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             Func<string, IEnumerable<string>> succF = x => successors[int.Parse(x)];
-            var sorted = TopologicalSort.IterativeSort<string>(new[] { "4", "5" }, i => succF(i).ToImmutableArray());
+            var wasAcyclic = TopologicalSort.TryIterativeSort<string>(new[] { "4", "5" }, i => succF(i).ToImmutableArray(), out var sorted);
+            Assert.True(wasAcyclic);
             AssertTopologicallySorted(sorted, succF, "Test01");
             Assert.Equal(6, sorted.Length);
             AssertEx.Equal(new[] { "4", "5", "2", "3", "1", "0" }, sorted);
@@ -70,7 +72,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             Func<int, IEnumerable<int>> succF = x => successors[x];
-            var sorted = TopologicalSort.IterativeSort<int>(new[] { 1, 6 }, i => succF(i).ToImmutableArray());
+            var wasAcyclic = TopologicalSort.TryIterativeSort<int>(new[] { 1, 6 }, i => succF(i).ToImmutableArray(), out var sorted);
+            Assert.True(wasAcyclic);
             AssertTopologicallySorted(sorted, succF, "Test02");
             Assert.Equal(7, sorted.Length);
             AssertEx.Equal(new[] { 1, 4, 3, 5, 6, 7, 2 }, sorted);
@@ -92,10 +95,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             // 1 -> 4 -> 3 -> 5 -> 1
-            Assert.Throws<ArgumentException>(() =>
-            {
-                var sorted = TopologicalSort.IterativeSort<int>(new[] { 1 }, x => successors[x].ToImmutableArray());
-            });
+            var wasAcyclic = TopologicalSort.TryIterativeSort<int>(new[] { 1 }, x => successors[x].ToImmutableArray(), out var sorted);
+            Assert.False(wasAcyclic);
         }
 
         [Theory]
@@ -138,7 +139,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             // Perform a topological sort and check it.
             Func<int, IEnumerable<int>> succF = x => successors[x];
-            var sorted = TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), i => succF(i).ToImmutableArray());
+            var wasAcyclic = TopologicalSort.TryIterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), i => succF(i).ToImmutableArray(), out var sorted);
+            Assert.True(wasAcyclic);
             Assert.Equal(numberOfNodes, sorted.Length);
             AssertTopologicallySorted(sorted, succF, $"TestRandom(seed: {seed})");
 
@@ -151,10 +153,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             // time.
             successors[possibleSort[0]] = successors[possibleSort[0]].Concat(new int[] { possibleSort[numberOfNodes - 1] }).ToArray();
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), i => succF(i).ToImmutableArray());
-            });
+            wasAcyclic = TopologicalSort.TryIterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), i => succF(i).ToImmutableArray(), out sorted);
+            Assert.False(wasAcyclic);
 
             // where
             void shuffle(int[] data)


### PR DESCRIPTION
Cherry-picked https://github.com/dotnet/roslyn/pull/45983 to 16.7 for servicing.
Relates to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1131818
