### PR TITLE
Null annotate annotation

### DIFF
--- a/src/Tools/ExternalAccess/Razor/IRazorDocumentServiceProvider.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorDocumentServiceProvider.cs
@@ -10,6 +10,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         /// Gets a document specific service provided by the host identified by the service type. 
         /// If the host does not provide the service, this method returns null.
         /// </summary>
-        TService GetService<TService>() where TService : class;
+        TService? GetService<TService>() where TService : class;
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.ExternalAccess.Razor</RootNamespace>
     <Nullable>enable</Nullable>
+    <DisableNullableWarnings>false</DisableNullableWarnings>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- NuGet -->

--- a/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
@@ -38,7 +38,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                         if (_spanMappingService == null)
                         {
                             var razorMappingService = _innerDocumentServiceProvider.GetService<IRazorSpanMappingService>();
-                            _spanMappingService = new RazorSpanMappingServiceWrapper(razorMappingService);
+                            if (razorMappingService != null)
+                            {
+                                _spanMappingService = new RazorSpanMappingServiceWrapper(razorMappingService);
+                            }
+                            else
+                            {
+                                return this as TService;
+                            }
                         }
                     }
                 }
@@ -55,7 +62,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                         if (_excerptService == null)
                         {
                             var excerptService = _innerDocumentServiceProvider.GetService<IRazorDocumentExcerptService>();
-                            _excerptService = new RazorDocumentExcerptServiceWrapper(excerptService);
+                            if (excerptService != null)
+                            {
+                                _excerptService = new RazorDocumentExcerptServiceWrapper(excerptService);
+                            }
+                            else
+                            {
+                                return this as TService;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The GetService call here was incorrectly annotated, and a correct annotation would have prevented the RPS regression. Sadly because the project is netstandard, it also wasn't showing nullability warnings, so I've opted it in.

It was already annotated though, so not much actual change.

FYI @NTaylorMullen this is a source breaking change for Razor, if your end is annotated.