### PR TITLE
Make "warnaserror-" doesn't enable disabled rules

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -873,7 +873,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     {
                                         warnAsErrors[id] = ruleSetValue;
                                     }
-                                    else
+                                    else if (ruleSetValue == ReportDiagnostic.Warning)
                                     {
                                         warnAsErrors[id] = ReportDiagnostic.Default;
                                     }


### PR DESCRIPTION
Fixes #47017

Notes:

- I'm completely unsure if this change is the correct one :-( (**Edit:** It's indeed **completely** wrong 😄 )
- If this is correct, I need to make parallel change to Visual Basic.
- I still haven't looked into the tests for this. I'll check them and add tests.