### PR TITLE
Fix doc comment

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/IParameterSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IParameterSymbol.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns true if the parameter specifies a default value to be passed
         /// when no value is provided as an argument to a call. The default value
-        /// can be obtained with the DefaultValue property.
+        /// can be obtained with the <see cref="ExplicitDefaultValue"/> property.
         /// </summary>
         bool HasExplicitDefaultValue { get; }
 


### PR DESCRIPTION
There is no `DefaultValue` property. I think it was meant to be `ExplicitDefaultValue`. I also used `<see cref=""/>` for it so it can have a hyperlink in the API reference site.