### PR TITLE
Update configure severity code fix for IDE code style diagnostics to use dotnet_diagnostic entries

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CSharpCodeStyleOptionBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CSharpCodeStyleOptionBasedSeverityConfigurationTests.cs
@@ -7,10 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues;
-using Microsoft.CodeAnalysis.CSharp.UseObjectInitializer;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -74,7 +72,7 @@ public class Class1
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 
 # IDE0059: Unnecessary assignment of a value
-csharp_style_unused_value_assignment_preference = discard_variable:error
+dotnet_diagnostic.IDE0059.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -104,6 +102,7 @@ public class Class1
 
 # IDE0059: Unnecessary assignment of a value
 csharp_style_unused_value_assignment_preference = discard_variable:warning
+dotnet_diagnostic.IDE0059.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -127,6 +126,7 @@ public class Class1
 
 # IDE0059: Unnecessary assignment of a value
 csharp_style_unused_value_assignment_preference = discard_variable:error
+dotnet_diagnostic.IDE0059.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -156,6 +156,7 @@ public class Class1
 
 # IDE0059: Unnecessary assignment of a value
 csharp_style_unused_value_assignment_preference = discard_variable:warning
+dotnet_diagnostic.IDE0059.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -179,6 +180,7 @@ public class Class1
 
 # IDE0059: Unnecessary assignment of a value
 csharp_style_unused_value_assignment_preference = discard_variable:error
+dotnet_diagnostic.IDE0059.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -232,7 +234,7 @@ public class Class1
 csharp_style_expression_bodied_methods = false:silent
 
 # IDE0059: Unnecessary assignment of a value
-csharp_style_unused_value_assignment_preference = discard_variable:error
+dotnet_diagnostic.IDE0059.severity = error
 
 [*.{vb,cs}]
 dotnet_style_qualification_for_field = false:silent
@@ -292,7 +294,7 @@ dotnet_style_qualification_for_field = false:silent
 csharp_style_expression_bodied_methods = false:silent
 
 # IDE0059: Unnecessary assignment of a value
-csharp_style_unused_value_assignment_preference = discard_variable:error
+dotnet_diagnostic.IDE0059.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity;
 using Microsoft.CodeAnalysis.CSharp.UseObjectInitializer;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -96,7 +95,7 @@ class Program1
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:none
+dotnet_diagnostic.IDE0017.severity = none
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -136,6 +135,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]    # Comment1
 dotnet_style_object_initializer = true:suggestion    ; Comment2
+dotnet_diagnostic.IDE0017.severity = suggestion    ;; Comment3
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -169,6 +169,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]    # Comment1
 dotnet_style_object_initializer = true:none    ; Comment2
+dotnet_diagnostic.IDE0017.severity = none    ;; Comment3
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -207,7 +208,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -240,12 +241,12 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 
 [*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:none
+dotnet_diagnostic.IDE0017.severity = none
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -285,6 +286,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
 dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -318,6 +320,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
 dotnet_style_object_initializer = true:none
+dotnet_diagnostic.IDE0017.severity = none
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -357,6 +360,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializerr = true:suggestion
+dotnet_diagnostic.IDE0017.severityyy = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -390,9 +394,10 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializerr = true:suggestion
+dotnet_diagnostic.IDE0017.severityyy = suggestion
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:none
+dotnet_diagnostic.IDE0017.severity = none
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -469,7 +474,7 @@ class Program1
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:silent
+dotnet_diagnostic.IDE0017.severity = silent
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -508,7 +513,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -541,231 +546,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_InvalidHeader_Silent()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_MaintainOption_Silent()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = new Customer();
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_InvalidRule_Silent()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializerr = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializerr = true:suggestion
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:silent
+dotnet_diagnostic.IDE0017.severity = silent
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -842,7 +623,7 @@ class Program1
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -882,6 +663,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -915,230 +697,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_InvalidHeader_Suggestion()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_MaintainOption_Suggestion()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = new Customer();
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_InvalidRule_Suggestion()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializerr = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializerr = true:warning
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -1215,7 +774,7 @@ class Program1
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -1254,7 +813,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -1287,1306 +846,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_InvalidHeader_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_MaintainOption_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = new Customer();
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_InvalidRule_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializerr = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializerr = true:warning
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_ConcreteHeader_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_NestedDirectory_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_NestedDirectoryNestedHeader_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolder/File.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolder/File.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_NestedDirectoryIncorrectHeader_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolderr/File.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolderr/File.cs]
-dotnet_style_object_initializer = true:error
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_IncorrectExtension_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
-dotnet_style_object_initializer = true:error
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_HeaderRegex_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[Parent*r/Fil*.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[Parent*r/Fil*.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_HeaderAllFiles_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_MultipleHeaders_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
-dotnet_style_object_initializer = true:error
-
-[File.cs]
-dotnet_style_object_initializer = true:error
-
-[cs.vb]
-dotnet_style_object_initializer = true:error
-
-[test.test]
-dotnet_style_object_initializer = true:error
-
-[WrongName.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/File.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
-dotnet_style_object_initializer = true:error
-
-[File.cs]
-dotnet_style_object_initializer = true:warning
-
-[cs.vb]
-dotnet_style_object_initializer = true:error
-
-[test.test]
-dotnet_style_object_initializer = true:error
-
-[WrongName.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_RegexPartialMatch_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[gram.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\ParentFolder/Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[gram.cs]
-dotnet_style_object_initializer = true:error
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_VerifyCaseInsensitive_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\PARENTfoldeR/ProGRAM.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[PROgram.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\PARENTfoldeR/ProGRAM.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[PROgram.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_DuplicateRule_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:error
-
-[Program.cs]
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:error
-
-[Program.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_ChooseBestHeader_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_qualification_for_field = false:silent
-
-[*.cs]
-csharp_style_expression_bodied_methods = false:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_qualification_for_field = false:silent
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-
-[*.cs]
-csharp_style_expression_bodied_methods = false:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_ChooseBestHeaderReversed_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-csharp_style_expression_bodied_methods = false:silent
-
-[*.{cs,vb}]
-dotnet_style_qualification_for_field = false:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-csharp_style_expression_bodied_methods = false:silent
-
-[*.{cs,vb}]
-dotnet_style_qualification_for_field = false:silent
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_DotFileName_Warning()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program/Test.file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[Test.file.cs]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\Program/Test.file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[Test.file.cs]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2663,7 +923,7 @@ class Program1
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2672,7 +932,7 @@ dotnet_style_object_initializer = true:error
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_RuleExists_Error()
+            public async Task ConfigureEditorconfig_RuleExists_CodeStyleBased_Error()
             {
                 var input = @"
 <Workspace>
@@ -2736,6 +996,155 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializer = true:error
+
+# IDE0017: Simplify object initialization
+dotnet_diagnostic.IDE0017.severity = error
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RuleExists_SeverityBased_Error()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        // dotnet_style_object_initializer = true
+        var obj = new Customer() { _age = 21 };
+
+        // dotnet_style_object_initializer = false
+        Customer obj2 = [|new Customer()|];
+        obj2._age = 21;
+    }
+
+    internal class Customer
+    {
+        public int _age;
+
+        public Customer()
+        {
+
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_diagnostic.IDE0017.severity = suggestion
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        // dotnet_style_object_initializer = true
+        var obj = new Customer() { _age = 21 };
+
+        // dotnet_style_object_initializer = false
+        Customer obj2 = new Customer();
+        obj2._age = 21;
+    }
+
+    internal class Customer
+    {
+        public int _age;
+
+        public Customer()
+        {
+
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_diagnostic.IDE0017.severity = error
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_RuleExists_CodeStyleAndSeverityBased_Error()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        // dotnet_style_object_initializer = true
+        var obj = new Customer() { _age = 21 };
+
+        // dotnet_style_object_initializer = false
+        Customer obj2 = [|new Customer()|];
+        obj2._age = 21;
+    }
+
+    internal class Customer
+    {
+        public int _age;
+
+        public Customer()
+        {
+
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        // dotnet_style_object_initializer = true
+        var obj = new Customer() { _age = 21 };
+
+        // dotnet_style_object_initializer = false
+        Customer obj2 = new Customer();
+        obj2._age = 21;
+    }
+
+    internal class Customer
+    {
+        public int _age;
+
+        public Customer()
+        {
+
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
+dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2774,7 +1183,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2807,84 +1216,12 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 
 [*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
-            }
-
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-            public async Task ConfigureEditorconfig_MaintainOption_Error()
-            {
-                var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = [|new Customer()|];
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>";
-
-                var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.cs"">
-class Program1
-{
-    static void Main()
-    {
-        // dotnet_style_object_initializer = true
-        var obj = new Customer() { _age = 21 };
-
-        // dotnet_style_object_initializer = false
-        Customer obj2 = new Customer();
-        obj2._age = 21;
-    }
-
-    internal class Customer
-    {
-        public int _age;
-
-        public Customer()
-        {
-
-        }
-    }
-}
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{vb,cs}]
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2924,6 +1261,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializerr = true:warning
+dotnet_diagnostic.IDE0017.severityyy = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2957,9 +1295,10 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializerr = true:warning
+dotnet_diagnostic.IDE0017.severityyy = suggestion
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -2999,6 +1338,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3032,6 +1372,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3071,6 +1412,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3104,6 +1446,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.cs]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3143,6 +1486,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolder/File.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3176,6 +1520,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolder/File.cs]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3214,7 +1559,8 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolderr/File.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3247,12 +1593,13 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[ParentFolderr/File.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = warning
 
 [*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3292,6 +1639,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3325,11 +1673,12 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3369,6 +1718,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[Parent*r/Fil*.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3402,6 +1752,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[Parent*r/Fil*.cs]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3441,6 +1792,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3474,6 +1826,7 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3512,19 +1865,23 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [File.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [cs.vb]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [test.test]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [WrongName.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
+
+[WrongName2.cs]
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3557,19 +1914,23 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[File.vb]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [File.cs]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 
 [cs.vb]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [test.test]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [WrongName.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
+
+[WrongName2.cs]
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3608,7 +1969,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[gram.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3641,12 +2002,12 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[gram.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3685,7 +2046,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[PROgram.cs]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3718,7 +2079,7 @@ class Program1
 }
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[PROgram.cs]
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3758,9 +2119,11 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [Program.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3794,9 +2157,11 @@ class Program1
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 
 [Program.cs]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -3874,7 +2239,7 @@ class Program1
 dotnet_style_qualification_for_field = false:silent
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 
 [*.cs]
 csharp_style_expression_bodied_methods = false:silent
@@ -3958,7 +2323,7 @@ csharp_style_expression_bodied_methods = false:silent
 dotnet_style_qualification_for_field = false:silent
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -4000,6 +2365,7 @@ class Program1
 
 # IDE0017: Simplify object initialization
 dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -4035,6 +2401,7 @@ class Program1
 
 # IDE0017: Simplify object initialization
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.cs
@@ -931,7 +931,7 @@ dotnet_diagnostic.IDE0017.severity = error
                 await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
             }
 
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
             public async Task ConfigureEditorconfig_RuleExists_CodeStyleBased_Error()
             {
                 var input = @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/MultipleCodeStyleOptionBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/MultipleCodeStyleOptionBasedSeverityConfigurationTests.cs
@@ -95,10 +95,7 @@ namespace ConsoleApp5
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0037: Use inferred member name
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
-
-# IDE0037: Use inferred member name
-dotnet_style_prefer_inferred_tuple_names = true:error
+dotnet_diagnostic.IDE0037.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -180,6 +177,9 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
 
 # IDE0037: Use inferred member name
 dotnet_style_prefer_inferred_tuple_names = true:error
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";
@@ -257,7 +257,94 @@ namespace ConsoleApp5
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
 
 # IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = error
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+            }
+
+            [WorkItem(39664, "https://github.com/dotnet/roslyn/issues/39664")]
+            [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+            public async Task ConfigureEditorconfig_AllPossibleEntriesExist_Error()
+            {
+                var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""z:\\file.cs"">
+using System;
+
+namespace ConsoleApp5
+{
+    class Foo 
+    {
+        public string RuleName = ""test"";
+    }
+
+    class Bar
+    {
+        static void Main(string[] args)
+        {
+            var foo = new Foo();
+
+            var bar = new { [|RuleName|] = foo.RuleName };
+
+            Console.WriteLine(bar.RuleName);
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+                var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+using System;
+
+namespace ConsoleApp5
+{
+    class Foo 
+    {
+        public string RuleName = ""test"";
+    }
+
+    class Bar
+    {
+        static void Main(string[] args)
+        {
+            var foo = new Foo();
+
+            var bar = new { RuleName = foo.RuleName };
+
+            Console.WriteLine(bar.RuleName);
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
+
+# IDE0037: Use inferred member name
 dotnet_style_prefer_inferred_tuple_names = true:error
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>";

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.vb
@@ -92,7 +92,7 @@ End Class
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:none
+dotnet_diagnostic.IDE0017.severity = none
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -126,6 +126,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]    # Comment1
 dotnet_style_object_initializer = true:suggestion    ; Comment2
+dotnet_diagnostic.IDE0017.severity = warning   ;; Comment3
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -154,197 +155,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]    # Comment1
 dotnet_style_object_initializer = true:none    ; Comment2
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidHeader_None() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:none
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_MaintainCurrentOption_None() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:none
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidRule_None() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:suggestion
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:none
+dotnet_diagnostic.IDE0017.severity = none   ;; Comment3
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -415,7 +226,7 @@ End Class
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:silent
+dotnet_diagnostic.IDE0017.severity = silent
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -448,7 +259,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -476,198 +287,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidHeader_Silent() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_MaintainCurrentOption_Silent() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:silent
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidRule_Silent() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:suggestion
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:silent
+dotnet_diagnostic.IDE0017.severity = silent
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -738,7 +358,7 @@ End Class
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -771,7 +391,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -799,198 +419,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidHeader_Suggestion() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:warning
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_MaintainCurrentOption_Suggestion() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidRule_Suggestion() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:warning
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1061,7 +490,7 @@ End Class
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1094,7 +523,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1122,198 +551,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidHeader_Warning() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
-
-[*.{cs,vb}]
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_MaintainCurrentOption_Warning() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
-dotnet_style_object_initializer = true:warning
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
-            End Function
-
-            <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
-            Public Async Function ConfigureEditorconfig_InvalidRule_Warning() As Task
-                Dim input = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:suggestion
-</AnalyzerConfigDocument>
-    </Project>
-</Workspace>"
-                Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-         <Document FilePath=""z:\\file.vb"">
-Class Program1
-    Private Shared Sub Main()
-        ' dotnet_style_object_initializer = true
-        Dim obj = New Customer() With {
-            ._age = 21
-        }
-        ' dotnet_style_object_initializer = false
-        Dim obj2 As Customer = [|New Customer()|]
-        obj2._age = 21
-    End Sub
-
-    Friend Class Customer
-        Public _age As Integer
-
-        Public Sub New()
-        End Sub
-    End Class
-End Class
-        </Document>
-        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
-dotnet_style_object_initializerr = true:suggestion
-
-# IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:warning
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1384,7 +622,7 @@ End Class
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1418,6 +656,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
 dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1446,6 +685,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1478,7 +718,7 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1506,12 +746,12 @@ Class Program1
 End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.cs]
-dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = suggestion
 
 [*.{cs,vb}]
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1545,6 +785,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 dotnet_style_object_initializer = true:suggestion
+dotnet_diagnostic.IDE0017.severity = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1573,6 +814,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1606,6 +848,7 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
 dotnet_style_object_initializerr = true:suggestion
+dotnet_diagnostic.IDE0017.severityyy = warning
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -1634,9 +877,10 @@ End Class
         </Document>
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.vb]
 dotnet_style_object_initializerr = true:suggestion
+dotnet_diagnostic.IDE0017.severityyy = warning
 
 # IDE0017: Simplify object initialization
-dotnet_style_object_initializer = true:error
+dotnet_diagnostic.IDE0017.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/MultipleCodeStyleOptionBasedConfigureSeverityTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/MultipleCodeStyleOptionBasedConfigureSeverityTests.vb
@@ -6,10 +6,9 @@ Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
 
-Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Configuration.ConfigureCodeStyle
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Configuration.ConfigureSeverity
     Partial Public MustInherit Class MultipleCodeStyleOptionBasedConfigureSeverityTests
         Inherits AbstractSuppressionDiagnosticTest
 
@@ -70,10 +69,7 @@ End Class
         <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
 
 # IDE0037: Use inferred member name
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
-
-# IDE0037: Use inferred member name
-dotnet_style_prefer_inferred_tuple_names = true:error
+dotnet_diagnostic.IDE0037.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -122,6 +118,9 @@ dotnet_style_prefer_inferred_tuple_names = true:error
 
 # IDE0037: Use inferred member name
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"
@@ -166,7 +165,61 @@ End Class
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
 
 # IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = error
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>"
+            Await TestInRegularAndScriptAsync(input, expected, CodeActionIndex)
+        End Function
+
+        <WorkItem(39664, "https://github.com/dotnet/roslyn/issues/39664")>
+        <ConditionalFact(GetType(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)>
+        Public Async Function ConfigureEditorconfig_AllPossibleEntriesExist_Error() As Task
+            Dim input = "
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""z:\\file.vb"">
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = ([||]a:= a, 2)
+    End Sub
+End Class
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>"
+            Dim expected = "
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""z:\\file.vb"">
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = (a:= a, 2)
+    End Sub
+End Class
+        </Document>
+        <AnalyzerConfigDocument FilePath=""z:\\.editorconfig"">[*.{cs,vb}]
+
+# IDE0037: Use inferred member name
 dotnet_style_prefer_inferred_tuple_names = true:error
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = error
 </AnalyzerConfigDocument>
     </Project>
 </Workspace>"

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
@@ -68,6 +68,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
         private readonly bool _isPerLanguage;
         private readonly Project _project;
         private readonly CancellationToken _cancellationToken;
+        private readonly bool _addNewEntryIfNoExistingEntryFound;
         private readonly string _language;
 
         private ConfigurationUpdater(
@@ -79,6 +80,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             string? categoryToBulkConfigure,
             bool isPerLanguage,
             Project project,
+            bool addNewEntryIfNoExistingEntryFound,
             CancellationToken cancellationToken)
         {
             Debug.Assert(configurationKind != ConfigurationKind.OptionValue || !string.IsNullOrEmpty(newOptionValueOpt));
@@ -95,6 +97,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             _isPerLanguage = isPerLanguage;
             _project = project;
             _cancellationToken = cancellationToken;
+            _addNewEntryIfNoExistingEntryFound = addNewEntryIfNoExistingEntryFound;
             _language = project.Language;
         }
 
@@ -142,7 +145,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             else
             {
                 updater = new ConfigurationUpdater(optionNameOpt: null, newOptionValueOpt: null, editorConfigSeverity,
-                    configurationKind: ConfigurationKind.Severity, diagnostic, categoryToBulkConfigure: null, isPerLanguage: false, project, cancellationToken);
+                    configurationKind: ConfigurationKind.Severity, diagnostic, categoryToBulkConfigure: null,
+                    isPerLanguage: false, project, addNewEntryIfNoExistingEntryFound: true, cancellationToken);
                 return updater.ConfigureAsync();
             }
         }
@@ -183,7 +187,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
         {
             Contract.ThrowIfNull(category);
             var updater = new ConfigurationUpdater(optionNameOpt: null, newOptionValueOpt: null, editorConfigSeverity,
-                configurationKind: ConfigurationKind.BulkConfigure, diagnosticToConfigure: null, category, isPerLanguage: false, project, cancellationToken);
+                configurationKind: ConfigurationKind.BulkConfigure, diagnosticToConfigure: null, category,
+                isPerLanguage: false, project, addNewEntryIfNoExistingEntryFound: true, cancellationToken);
             return updater.ConfigureAsync();
         }
 
@@ -210,7 +215,23 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             ConfigurationKind configurationKind,
             CancellationToken cancellationToken)
         {
+            Debug.Assert(!codeStyleOptionValues.IsEmpty());
+
+            // For severity configuration for IDE code style diagnostics, we want to ensure the following:
+            //  1. For code style option based entries, i.e. "%option_name% = %option_value%:%severity%,
+            //     we only update existing entries, but do not add a new entry.
+            //  2. For "dotnet_diagnostic.<%DiagnosticId%>.severity = %severity%" entries, we update existing entries, and if none found
+            //     we add a single new severity configuration entry for all code style options that share the same diagnostic ID.
+            //  This behavior is required to ensure that we always add the up-to-date dotnet_diagnostic based severity entry
+            //  so the IDE code style diagnostics can be enforced in build, as the compiler only understands dotnet_diagnostic entries.
+            //  See https://github.com/dotnet/roslyn/issues/44201 for more details.
+
+            // First handle "%option_name% = %option_value%:%severity% entries.
+            // For option value configuration, we always want to add new entry if no existing value is found.
+            // For severity configuration, we only want to update existing value if found.
             var currentProject = project;
+            var areAllOptionsPerLanguage = true;
+            var addNewEntryIfNoExistingEntryFound = configurationKind != ConfigurationKind.Severity;
             foreach (var (optionName, optionValue, severity, isPerLanguage) in codeStyleOptionValues)
             {
                 Debug.Assert(!string.IsNullOrEmpty(optionName));
@@ -218,7 +239,22 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                 Debug.Assert(!string.IsNullOrEmpty(severity));
 
                 var updater = new ConfigurationUpdater(optionName, optionValue, severity, configurationKind,
-                    diagnostic, categoryToBulkConfigure: null, isPerLanguage, currentProject, cancellationToken);
+                    diagnostic, categoryToBulkConfigure: null, isPerLanguage, currentProject,
+                    addNewEntryIfNoExistingEntryFound, cancellationToken);
+                var solution = await updater.ConfigureAsync().ConfigureAwait(false);
+                currentProject = solution.GetProject(project.Id)!;
+                areAllOptionsPerLanguage = areAllOptionsPerLanguage && isPerLanguage;
+            }
+
+            // For severity configuration, handle "dotnet_diagnostic.<%DiagnosticId%>.severity = %severity%" entry.
+            // We want to update existing entry + add new entry if no existing value is found.
+            if (configurationKind == ConfigurationKind.Severity)
+            {
+                var editorConfigSeverity = codeStyleOptionValues.First().optionSeverity;
+                Debug.Assert(codeStyleOptionValues.All(v => v.optionSeverity == editorConfigSeverity));
+                var updater = new ConfigurationUpdater(optionNameOpt: null, newOptionValueOpt: null, editorConfigSeverity,
+                    configurationKind: ConfigurationKind.Severity, diagnostic, categoryToBulkConfigure: null,
+                    isPerLanguage: areAllOptionsPerLanguage, currentProject, addNewEntryIfNoExistingEntryFound: true, cancellationToken);
                 var solution = await updater.ConfigureAsync().ConfigureAwait(false);
                 currentProject = solution.GetProject(project.Id)!;
             }
@@ -241,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             // Compute the updated text for analyzer config document.
             var newText = GetNewAnalyzerConfigDocumentText(originalText, editorConfigDocument);
 
-            if (newText == null)
+            if (newText == null || newText.Equals(originalText))
             {
                 return solution;
             }
@@ -396,6 +432,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                 return newText;
             }
 
+            if (!_addNewEntryIfNoExistingEntryFound)
+            {
+                return originalText;
+            }
+
             // We did not find any existing entry in the in the .editorconfig file to configure rule severity.
             // So we add a new configuration entry to the .editorconfig file.
             return AddMissingRule(originalText, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
@@ -439,10 +480,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
                 var curLineText = curLine.ToString();
 
                 // We might have a diagnostic ID configuration entry based on either s_optionBasedEntryPattern or
-                // s_severityBasedEntryPattern. Both of these are considered valid severity configurations
-                // and should be detected here.
+                // s_severityBasedEntryPattern. Both of these are considered valid severity configurations.
                 var isOptionBasedMatch = s_optionBasedEntryPattern.IsMatch(curLineText);
+
+                // We want to detect severity based entry only when we are configuring severity and have no option name specified.
                 var isSeverityBasedMatch = _configurationKind != ConfigurationKind.OptionValue &&
+                    _optionNameOpt == null &&
                     !isOptionBasedMatch &&
                     s_severityBasedEntryPattern.IsMatch(curLineText);
                 if (isOptionBasedMatch || isSeverityBasedMatch)

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
                         nestedActions.Add(
                             new SolutionChangeAction(
                                 parts.optionValue,
-                                solution => ConfigurationUpdater.ConfigureCodeStyleOptionAsync(parts.optionName, parts.optionValue, parts.optionSeverity, diagnostic, isPerLanguage, project, cancellationToken)));
+                                solution => ConfigurationUpdater.ConfigureCodeStyleOptionAsync(parts.optionName, parts.optionValue, diagnostic, isPerLanguage, project, cancellationToken)));
                     }
                 }
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticSeverityExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticSeverityExtensions.cs
@@ -28,5 +28,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 DiagnosticSeverity.Error => ReportDiagnostic.Error,
                 _ => throw ExceptionUtilities.UnexpectedValue(diagnosticSeverity),
             };
+
+        public static string ToEditorConfigString(this DiagnosticSeverity diagnosticSeverity)
+        {
+            return diagnosticSeverity switch
+            {
+                DiagnosticSeverity.Hidden => EditorConfigSeverityStrings.Silent,
+                DiagnosticSeverity.Info => EditorConfigSeverityStrings.Suggestion,
+                DiagnosticSeverity.Warning => EditorConfigSeverityStrings.Warning,
+                DiagnosticSeverity.Error => EditorConfigSeverityStrings.Error,
+                _ => throw ExceptionUtilities.UnexpectedValue(diagnosticSeverity)
+            };
+        }
     }
 }


### PR DESCRIPTION
Implements changes to configure severity code fix as per https://github.com/dotnet/roslyn/issues/44201. The code fix now does the following for IDE code style diagnostics:
1. Updates the last applicable existing code style option value based entries, i.e. `"%option_name% = %option_value%:%severity%`, to use the new severity. If no such entries are found, we do not add new code style option value based entries.
2. Updates the last applicable existing severity based entries, i.e. `dotnet_diagnostic.<%DiagnosticId%>.severity = %severity%`, to use the new severity. If no such entries are found, we add a new dotnet_diagnostic based entry with new severity.

This ensures couple of things:
1. **Allow build enforcement of code style diagnostics** as compiler only understands dotnet_diagnostic entries. In absence of these entries, compiler will not even execute the code style analyzers on build as these are hidden diagnostics by default.
2. **Consistency in severity configuration entries with third party analyzer diagnostics**, which can only use dotnet_diagnostic entries.

**Before**
![image](https://user-images.githubusercontent.com/10605811/90942638-72ac9280-e3cb-11ea-9abe-301de0d1dfa8.png)

**After (no existing entry)**
![image](https://user-images.githubusercontent.com/10605811/90942562-26615280-e3cb-11ea-85d8-202bb7c0d01e.png)

**After (with existing entry)**
![image](https://user-images.githubusercontent.com/10605811/90942745-f5355200-e3cb-11ea-9c1f-2e06956a05e7.png)

We have follow-up work planned to have some UX to allow viewing and configuring code style option values and severities, so the additional dotnet_diagnostic severity entries in the editorconfig file themselves will not be bothersome for majority of the users.