### PR TITLE
Fix bug when "End statement" is used in single-line if

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Parser/ParseScan.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseScan.vb
@@ -85,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' Dev10#708061: Treat Select in "From x in Sub() End Select" as part of End statement.
             Return If(Context.IsWithinSingleLineLambda,
                       CanFollowExpression(nextToken) AndAlso Not nextToken.Kind = SyntaxKind.SelectKeyword,
-                      IsValidStatementTerminator(nextToken))
+                      IsValidStatementTerminator(nextToken)) OrElse (Context.IsLineIf AndAlso nextToken.Kind = SyntaxKind.ElseKeyword)
         End Function
 
         ' Is this token a valid end of executable statement?

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -1742,7 +1742,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' But since "Select" is the solitary point of contention, I'll go for a uglier smaller fix:
 
             Dim nextToken = PeekToken(1)
-            If CanFollowStatementButIsNotSelectFollowingExpression(nextToken) Then
+            If CanFollowStatementButIsNotSelectFollowingExpression(nextToken) OrElse (Context.IsLineIf AndAlso nextToken.Kind = SyntaxKind.ElseKeyword) Then
                 Return ParseStopOrEndStatement()
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -1742,7 +1742,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' But since "Select" is the solitary point of contention, I'll go for a uglier smaller fix:
 
             Dim nextToken = PeekToken(1)
-            If CanFollowStatementButIsNotSelectFollowingExpression(nextToken) OrElse (Context.IsLineIf AndAlso nextToken.Kind = SyntaxKind.ElseKeyword) Then
+            If CanFollowStatementButIsNotSelectFollowingExpression(nextToken) Then
                 Return ParseStopOrEndStatement()
             End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
@@ -3741,6 +3741,7 @@ Done
 
         End Sub
 
+        <WorkItem(45158, "https://github.com/dotnet/roslyn/issues/45158")>
         <Fact>
         Public Sub EndWithSingleLineIf()
             Dim source =
@@ -3762,7 +3763,8 @@ End Module
             AssertTheseDiagnostics(compilation)
         End Sub
 
-        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:="https://github.com/dotnet/roslyn/issues/45158")>
+        <WorkItem(45158, "https://github.com/dotnet/roslyn/issues/45158")>
+        <Fact>
         Public Sub EndWithMultiLineIf()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
@@ -3785,8 +3785,8 @@ End Module
             AssertTheseDiagnostics(compilation,
 <expected>
 BC30615: 'End' statement cannot be used in class library projects.
-        End
-        ~~~
+        If True Then End Else Console.WriteLine("Test")
+                     ~~~
 </expected>)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
@@ -3741,7 +3741,7 @@ Done
 
         End Sub
 
-        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:="https://github.com/dotnet/roslyn/issues/45158")>
+        <Fact>
         Public Sub EndWithSingleLineIf()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
@@ -3765,6 +3765,33 @@ End Module
 
         <WorkItem(45158, "https://github.com/dotnet/roslyn/issues/45158")>
         <Fact>
+        Public Sub EndWithSingleLineIfWithDll()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+        <![CDATA[
+Imports System
+
+Module Module1
+    Public Sub Main()
+        If True Then End Else Console.WriteLine("Test")
+    End Sub
+End Module
+    ]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, TestOptions.ReleaseDll)
+            AssertTheseDiagnostics(compilation,
+<expected>
+BC30615: 'End' statement cannot be used in class library projects.
+        End
+        ~~~
+</expected>)
+        End Sub
+
+        <WorkItem(45158, "https://github.com/dotnet/roslyn/issues/45158")>
+        <Fact>
         Public Sub EndWithMultiLineIf()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Statements_Tests.vb
@@ -3741,6 +3741,52 @@ Done
 
         End Sub
 
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:="https://github.com/dotnet/roslyn/issues/45158")>
+        Public Sub EndWithSingleLineIf()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+        <![CDATA[
+Imports System
+
+Module Module1
+    Public Sub Main()
+        If True Then End Else Console.WriteLine("Test")
+    End Sub
+End Module
+    ]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, TestOptions.ReleaseExe)
+            AssertTheseDiagnostics(compilation)
+        End Sub
+
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:="https://github.com/dotnet/roslyn/issues/45158")>
+        Public Sub EndWithMultiLineIf()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+        <![CDATA[
+Imports System
+
+Module Module1
+    Public Sub Main()
+        If True Then
+            End
+        Else
+            Console.WriteLine("Test")
+        End If
+    End Sub
+End Module
+    ]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, TestOptions.ReleaseExe)
+            AssertTheseDiagnostics(compilation)
+        End Sub
+
         <WorkItem(660010, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/660010")>
         <Fact>
         Public Sub Regress660010()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/45158

The "OrElse" part was existing in `IsValidStatementTerminator` in `ParserScan.vb`.

It was removed in #14822 to fix #14761. However, this change caused the bug I mentioned in #45158.

If I put this "OrElse" part were it was originally, it will break the fix made in #14822. Hence, I moved it here where it's actually needed.

@AlekseyTs Please review.