### PR TITLE
Do not fallback to special-char classifying, prior to doing regex classifying

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -3429,6 +3429,30 @@ Regex.OtherEscape("0020"),
 Regex.Grouping(")"));
         }
 
+        [Theory, WorkItem(47079, "https://github.com/dotnet/roslyn/issues/47079")]
+        [CombinatorialData]
+        public async Task TestRegexWithSpecialCSharpCharLiterals(TestHost testHost)
+        {
+            await TestAsync(
+@"
+using System.Text.RegularExpressions;
+
+class Program
+{
+    // the double-quote inside the string should not affect this being classified as a regex.
+    private Regex myRegex = new Regex(@""^ """" $"";
+}",
+testHost,
+Namespace("System"),
+Namespace("Text"),
+Namespace("RegularExpressions"),
+Class("Regex"),
+Class("Regex"),
+Regex.Anchor("^"),
+Regex.Text(@" """" "),
+Regex.Anchor("$"));
+        }
+
         [Theory]
         [CombinatorialData]
         public async Task TestIncompleteRegexLeadingToStringInsideSkippedTokensInsideADirective(TestHost testHost)

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.DateAndTime.LanguageServices
     {
         public readonly EmbeddedLanguageInfo Info;
 
+        // We don't currently expose a classifier for Date/Time literals.  However, one could always be added in the future.
         public ISyntaxClassifier? Classifier => null;
 
         public DateAndTimeEmbeddedLanguage(EmbeddedLanguageInfo info)

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
@@ -4,7 +4,6 @@
 
 #nullable enable
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
@@ -18,12 +17,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.DateAndTime.LanguageServices
     {
         public readonly EmbeddedLanguageInfo Info;
 
-        public ISyntaxClassifier Classifier { get; }
+        public ISyntaxClassifier? Classifier { get; }
 
         public DateAndTimeEmbeddedLanguage(EmbeddedLanguageInfo info)
         {
             Info = info;
-            Classifier = new FallbackSyntaxClassifier(info);
         }
 
         internal async Task<SyntaxToken?> TryGetDateAndTimeTokenAtPositionAsync(

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.DateAndTime.LanguageServices
     {
         public readonly EmbeddedLanguageInfo Info;
 
-        public ISyntaxClassifier? Classifier { get; }
+        public ISyntaxClassifier? Classifier => null;
 
         public DateAndTimeEmbeddedLanguage(EmbeddedLanguageInfo info)
         {

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/EmbeddedLanguagesClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/EmbeddedLanguagesClassifier.cs
@@ -22,7 +22,10 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers
         {
             _languagesProvider = languagesProvider;
             SyntaxTokenKinds =
-                languagesProvider.Languages.SelectMany(p => p.Classifier.SyntaxTokenKinds).Distinct().ToImmutableArray();
+                languagesProvider.Languages.Where(p => p.Classifier != null)
+                                           .SelectMany(p => p.Classifier.SyntaxTokenKinds)
+                                           .Distinct()
+                                           .ToImmutableArray();
         }
 
         public override void AddClassifications(Workspace workspace, SyntaxToken token, SemanticModel semanticModel, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47079

Before:

https://user-images.githubusercontent.com/4564579/90986452-c0460e00-e537-11ea-8479-c1781801dd84.png
![image](https://user-images.githubusercontent.com/4564579/90986736-f1bfd900-e539-11ea-8ae9-21366f128ff6.png)


After:

![image](https://user-images.githubusercontent.com/4564579/90986732-e8cf0780-e539-11ea-9fc2-1f8c4d8b1bfc.png)
