### PR TITLE
Enable more nullable analysis

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -38,7 +38,7 @@
       We still check $(TargetFrameworks) for empty though, because for single-targeted builds we want to
       allow nullable warnings regardless of target framework.
     -->
-    <DisableNullableWarnings Condition="'$(DisableNullableWarnings)' == '' AND  '$(TargetFrameworks)' != ''AND '$(TargetFramework)' != '' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</DisableNullableWarnings>
+    <DisableNullableWarnings Condition="'$(DisableNullableWarnings)' == '' AND  '$(TargetFrameworks)' != '' AND '$(TargetFramework)' != '' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</DisableNullableWarnings>
 
     <!--
       Disable code style analyzers in "older" targets for a multi-targeted project. These analyzers don't

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -35,8 +35,10 @@
       Disable nullable warnings when targeting anything other than our supported .NET core version(s). 
       This condition will be evaluated multiple times in multi-targeted projects hence need to be careful
       to only set in the inner builds, not the outer build where only $(TargetFrameworks) is defined.
+      We still check $(TargetFrameworks) for empty though, because for single-targeted builds we want to
+      allow nullable warnings regardless of target framework.
     -->
-    <DisableNullableWarnings Condition="'$(DisableNullableWarnings)' == '' AND '$(TargetFramework)' != '' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</DisableNullableWarnings>
+    <DisableNullableWarnings Condition="'$(DisableNullableWarnings)' == '' AND  '$(TargetFrameworks)' != ''AND '$(TargetFramework)' != '' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</DisableNullableWarnings>
 
     <!--
       Disable code style analyzers in "older" targets for a multi-targeted project. These analyzers don't

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
@@ -41,7 +41,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
         protected override void InitializeWorker(AnalysisContext context)
         {
-#if !CODE_STYLE // CODE_STYLE layer doesn't currently support generating 'not patterns'.  Do not bother analyzing.
             context.RegisterSyntaxNodeAction(SyntaxNodeAction, SyntaxKind.LogicalNotExpression);
         }
 
@@ -85,7 +84,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 styleOption.Notification.Severity,
                 ImmutableArray.Create(notExpression.GetLocation()),
                 properties: null));
-#endif
         }
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         {
 #if !CODE_STYLE // CODE_STYLE layer doesn't currently support generating 'not patterns'.  Do not bother analyzing.
             context.RegisterSyntaxNodeAction(SyntaxNodeAction, SyntaxKind.LogicalNotExpression);
-#endif
         }
 
         private void SyntaxNodeAction(SyntaxNodeAnalysisContext syntaxContext)
@@ -86,6 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 styleOption.Notification.Severity,
                 ImmutableArray.Create(notExpression.GetLocation()),
                 properties: null));
+#endif
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -235,9 +235,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                                 else
                                 {
                                     // A boolean flag.
-                                    bool flagSet = false;
-
-                                    flagSet = Utilities.TryConvertItemMetadataToBool(parameter, metadataNames[i]);
+                                    bool flagSet = Utilities.TryConvertItemMetadataToBool(parameter, metadataNames[i]);
 
                                     if (flagSet)
                                     {

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -709,8 +709,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         return;
                     }
 
-                    string? newLine = null;
-                    newLine = originalVBErrorString.Substring(0, endParenthesisLocation) + "," + column + originalVBErrorString.Substring(endParenthesisLocation);
+                    string? newLine = originalVBErrorString.Substring(0, endParenthesisLocation) + "," + column + originalVBErrorString.Substring(endParenthesisLocation);
 
                     // Output all of the lines of the error, but with the modified first line as well.
                     Log.LogMessageFromText(newLine, originalVBError.MessageImportance);

--- a/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
@@ -49,8 +49,7 @@ namespace Roslyn.Utilities
         /// </remarks>
         public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments)
         {
-            char? unused;
-            return SplitCommandLineIntoArguments(commandLine, removeHashComments, out unused);
+            return SplitCommandLineIntoArguments(commandLine, removeHashComments, out _);
         }
 
         public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Debugging
             }
 
             var offset = 0;
-            ReadGlobalHeader(customDebugInfo, ref offset, out var globalVersion, out var globalCount);
+            ReadGlobalHeader(customDebugInfo, ref offset, out var globalVersion, out _);
 
             if (globalVersion != CustomDebugInfoConstants.Version)
             {

--- a/src/EditorFeatures/CSharpTest/Extensions/TelemetryExtensionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Extensions/TelemetryExtensionTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Extensions
             // The first 4 bytes are using platform dependent hashcode and 
             // are not deterministic. This is a known limitation and corrected 
             // with the last 8 bytes of the GUID
-            for (int i = 0; i < 4; i++)
+            for (var i = 0; i < 4; i++)
             {
                 actualBytes[i] = 0;
             }

--- a/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineParameterNameHints/InlineParameterNameHintsTag.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                 {
                     var workspace = document.Project.Solution.Workspace;
                     var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                    var symbolDisplayService = document.Project.LanguageServices.GetService<ISymbolDisplayService>();
+                    var symbolDisplayService = document.Project.LanguageServices.GetRequiredService<ISymbolDisplayService>();
                     var formatter = document.Project.LanguageServices.GetService<IDocumentationCommentFormattingService>();
                     var sections = await symbolDisplayService.ToDescriptionGroupsAsync(workspace, semanticModel, _span.Start, ImmutableArray.Create(symbol), cancellationToken).ConfigureAwait(false);
                     textContentBuilder.AddRange(sections[SymbolDescriptionGroups.MainDescription]);
@@ -113,11 +113,13 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
                         }
                     }
                 }
+
+                var uiCollection = Implementation.IntelliSense.Helpers.BuildInteractiveTextElements(textContentBuilder.ToImmutableArray<TaggedText>(),
+                    document, _threadingContext, _streamingPresenter);
+                return uiCollection;
             }
 
-            var uiCollection = Implementation.IntelliSense.Helpers.BuildInteractiveTextElements(textContentBuilder.ToImmutableArray<TaggedText>(),
-                document, _threadingContext, _streamingPresenter);
-            return uiCollection;
+            return Array.Empty<object>();
         }
 
         private static FrameworkElement CreateElement(string text, IWpfTextView textView, TextFormattingRunProperties format)

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         return null;
                     }
 
-                    return filteredSets.Value.Select(s => ConvertToSuggestedActionSet(s));
+                    return filteredSets.Value.Select(s => ConvertToSuggestedActionSet(s)).WhereNotNull();
                 }
             }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -455,31 +455,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             }
         }
 
-        private static void TestDiagnosticTags(
-            ImmutableArray<Diagnostic> diagnostics,
-            ImmutableArray<TextSpan> expectedSpans,
-            string diagnosticTag,
-            string markupKey,
-            string initialMarkupWithoutSpans)
-        {
-            var diagnosticsWithTag = diagnostics
-                .Where(d => d.Descriptor.CustomTags.Contains(diagnosticTag))
-                .OrderBy(s => s.Location.SourceSpan.Start)
-                .ToImmutableArray();
-
-            if (expectedSpans.Length != diagnosticsWithTag.Length)
-            {
-                AssertEx.Fail(BuildFailureMessage(expectedSpans, diagnosticTag, markupKey, initialMarkupWithoutSpans, diagnosticsWithTag));
-            }
-
-            for (var i = 0; i < expectedSpans.Length; i++)
-            {
-                var actual = diagnosticsWithTag[i].Location.SourceSpan;
-                var expected = expectedSpans[i];
-                Assert.Equal(expected, actual);
-            }
-        }
-
         private static string BuildFailureMessage(
             ImmutableArray<TextSpan> expectedSpans,
             string diagnosticTag,

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlCreation.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlCreation.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
             else if (vbOptions != null)
             {
-                return new XAttribute(LanguageVersionAttributeName, CodeAnalysis.VisualBasic.LanguageVersionFacts.ToDisplayString( vbOptions.LanguageVersion));
+                return new XAttribute(LanguageVersionAttributeName, CodeAnalysis.VisualBasic.LanguageVersionFacts.ToDisplayString(vbOptions.LanguageVersion));
             }
             else
             {

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.ExternalAccess.Razor</RootNamespace>
     <Nullable>enable</Nullable>
-    <DisableNullableWarnings>false</DisableNullableWarnings>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- NuGet -->

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -28,6 +28,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
@@ -297,6 +298,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var addedDocument = forkedSolution.GetDocument(documentId)!;
 
             var rootToFormat = addedDocument.GetSyntaxRootSynchronously(cancellationToken);
+            Contract.ThrowIfNull(rootToFormat);
             var documentOptions = ThreadHelper.JoinableTaskFactory.Run(() => addedDocument.GetOptionsAsync(cancellationToken));
 
             // Apply file header preferences

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 // for the local navbar implementation.
                 // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1163360
                 var service = document?.Project?.Solution?.Workspace?.Services?.GetRequiredService<IWorkspaceContextService>();
-                if (service != null && service.IsCloudEnvironmentClient() && document.Project.Language != "TypeScript")
+                if (service != null && service.IsCloudEnvironmentClient() && document!.Project!.Language != "TypeScript")
                 {
                     // Remove the existing dropdown bar if it is ours.
                     if (IsOurDropdownBar(dropdownManager, out var _))

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioFrameworkAssemblyPathResolverFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioFrameworkAssemblyPathResolverFactory.cs
@@ -40,10 +40,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private sealed class Service : ForegroundThreadAffinitizedObject, IFrameworkAssemblyPathResolver
         {
-            private readonly VisualStudioWorkspace _workspace;
+            private readonly VisualStudioWorkspace? _workspace;
             private readonly IServiceProvider _serviceProvider;
 
-            public Service(IThreadingContext threadingContext, VisualStudioWorkspace workspace, IServiceProvider serviceProvider)
+            public Service(IThreadingContext threadingContext, VisualStudioWorkspace? workspace, IServiceProvider serviceProvider)
                 : base(threadingContext, assertIsForeground: false)
             {
                 _workspace = workspace;
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return null;
             }
 
-            private bool CanResolveType(Assembly assembly, string fullyQualifiedTypeName)
+            private bool CanResolveType(Assembly assembly, string? fullyQualifiedTypeName)
             {
                 if (fullyQualifiedTypeName == null)
                 {
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return false;
             }
 
-            private Assembly ResolveAssembly(ProjectId projectId, string assemblyName)
+            private Assembly? ResolveAssembly(ProjectId projectId, string assemblyName)
             {
                 this.AssertIsForeground();
 
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 var hierarchy = _workspace.GetHierarchy(projectId);
                 if (hierarchy == null ||
-                    !hierarchy.TryGetProperty((__VSHPROPID)__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker, out string targetMoniker) ||
+                    !hierarchy.TryGetProperty((__VSHPROPID)__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker, out string? targetMoniker) ||
                     targetMoniker == null)
                 {
                     return null;

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -106,8 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             }
 
             var symbolId = SymbolKey.Create(symbol, cancellationToken);
-            var currentCompilation = currentProject.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            Contract.ThrowIfNull(currentCompilation);
+            var currentCompilation = currentProject.GetRequiredCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var symbolInfo = symbolId.Resolve(currentCompilation, cancellationToken: cancellationToken);
 
             if (symbolInfo.Symbol == null)

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -107,6 +107,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 
             var symbolId = SymbolKey.Create(symbol, cancellationToken);
             var currentCompilation = currentProject.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            Contract.ThrowIfNull(currentCompilation);
             var symbolInfo = symbolId.Resolve(currentCompilation, cancellationToken: cancellationToken);
 
             if (symbolInfo.Symbol == null)

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -82,6 +82,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         public async Task<T> GetValueAsync<T>(Checksum checksum)
         {
             var data = (await AssetStorage.GetTestAccessor().GetAssetAsync(checksum, CancellationToken.None).ConfigureAwait(false))!;
+            Contract.ThrowIfNull(data.Value);
 
             using var stream = SerializableBytes.CreateWritableStream();
             using (var writer = new ObjectWriter(stream, leaveOpen: true))


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/47026

Seems that disabling nullable warnings in single-targeted projects was unintentional, so this re-instates it and fixes a few things.

I've verified that this doesn't break the multi-targeting scenario, by specifically introducing a nullable warning in `ManagedCompiler` and verifying that it doesn't show up when switching to the .NET Standard context. I didn't check that bit in though, of course :)