### PR TITLE
Don't throw CS1029 if it's unnecessary

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -316,27 +316,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 int triviaOffset = eod.GetLeadingTriviaWidth() - triviaWidth;
 
                 string errorText = triviaBuilder.ToString();
-                eod = this.AddError(eod, triviaOffset, triviaWidth, isError ? ErrorCode.ERR_ErrorDirective : ErrorCode.WRN_WarningDirective, errorText);
 
-                if (isError)
+                const string versionMarker = "version:";
+                if (isError && errorText.Equals("version", StringComparison.Ordinal))
                 {
-                    if (errorText.Equals("version", StringComparison.Ordinal))
-                    {
-                        string version = CommonCompiler.GetProductVersion(typeof(CSharpCompiler));
-                        eod = this.AddError(eod, triviaOffset, triviaWidth, ErrorCode.ERR_CompilerAndLanguageVersion, version,
-                            this.Options.SpecifiedLanguageVersion.ToDisplayString());
-                    }
-                    else
-                    {
-                        const string versionMarker = "version:";
-                        if (this.Options.LanguageVersion != LanguageVersion.Preview &&
-                            errorText.StartsWith(versionMarker, StringComparison.Ordinal) &&
-                            LanguageVersionFacts.TryParse(errorText.Substring(versionMarker.Length), out var languageVersion))
-                        {
-                            ErrorCode error = this.Options.LanguageVersion.GetErrorCode();
-                            eod = this.AddError(eod, triviaOffset, triviaWidth, error, "version", new CSharpRequiredLanguageVersion(languageVersion));
-                        }
-                    }
+                    string version = CommonCompiler.GetProductVersion(typeof(CSharpCompiler));
+                    eod = this.AddError(eod, triviaOffset, triviaWidth, ErrorCode.ERR_CompilerAndLanguageVersion, version,
+                        this.Options.SpecifiedLanguageVersion.ToDisplayString());
+                }
+                else if (isError && this.Options.LanguageVersion != LanguageVersion.Preview &&
+                         errorText.StartsWith(versionMarker, StringComparison.Ordinal) &&
+                         LanguageVersionFacts.TryParse(errorText.Substring(versionMarker.Length), out var languageVersion))
+                {
+                    ErrorCode error = this.Options.LanguageVersion.GetErrorCode();
+                    eod = this.AddError(eod, triviaOffset, triviaWidth, error, "version", new CSharpRequiredLanguageVersion(languageVersion));
+                }
+                else
+                {
+                    eod = this.AddError(eod, triviaOffset, triviaWidth, isError ? ErrorCode.ERR_ErrorDirective : ErrorCode.WRN_WarningDirective, errorText);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3046,9 +3046,6 @@ class A { }
             });
 
             node.GetDiagnostics().Verify(
-                // (1,8): error CS1029: #error: 'version'
-                // #error version
-                Diagnostic(ErrorCode.ERR_ErrorDirective, "version").WithArguments("version").WithLocation(1, 8),
                 // (1,8): error CS8304: Compiler version: '42.42.42.42424 (<developer build>)'. Language version: 4.
                 // #error version
                 Diagnostic(ErrorCode.ERR_CompilerAndLanguageVersion, "version").WithArguments(GetExpectedVersion(), "4").WithLocation(1, 8)
@@ -3069,9 +3066,6 @@ class A { }
             });
 
             node.GetDiagnostics().Verify(
-                // (1,8): error CS1029: #error: 'version:7.1'
-                // #error version:7.1
-                Diagnostic(ErrorCode.ERR_ErrorDirective, "version:7.1").WithArguments("version:7.1"),
                 // (1,8): error CS8025: Feature 'version' is not available in C# 4. Please use language version 7.1 or greater.
                 // #error version:7.1
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion4, "version:7.1").WithArguments("version", "7.1").WithLocation(1, 8)


### PR DESCRIPTION
Currently, `#error version` produces two diagnostics.

```
    error CS1029: #error: 'version'
    error CS8304: Compiler version: '3.7.0-ci (<developer build>)'. Language version: preview.
```

I think CS8304 is enough as "version" as a special word for #error, and let CS1029 for something like `#error NonSpecialWord`.

~~Some of the current tests are expected to fail, I'll fix that.~~ (Should be fixed now)