### PR TITLE
Update remaining references to MyGet with Azure DevOps

### DIFF
--- a/docs/compilers/Compiler Toolset NuPkgs.md
+++ b/docs/compilers/Compiler Toolset NuPkgs.md
@@ -31,9 +31,9 @@ To install the NuPgk run the following:
 > nuget install Microsoft.Net.Compilers.Toolset   # Install C# and VB compilers
 ```
 
-Daily NuGet builds of the project are also available in our MyGet feed:
+Daily NuGet builds of the project are also available in our [Azure DevOps feed](https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-tools):
 
-> [https://dotnet.myget.org/F/roslyn/api/v3/index.json](https://dotnet.myget.org/F/roslyn/api/v3/index.json)
+> https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
 
 ## Microsoft.Net.Compilers
 

--- a/docs/wiki/NuGet-packages.md
+++ b/docs/wiki/NuGet-packages.md
@@ -2,7 +2,7 @@
 
 A number of NuGet packages are published from the Roslyn repo:
 * Official released packages are published to [nuget.org](https://www.nuget.org/profiles/RoslynTeam), when Visual Studio releases a new RTM or Preview version.
-* Pre-release packages are published daily to [myget.org](https://dotnet.myget.org/gallery/roslyn).
+* Pre-release packages are published daily to [Azure Devops](https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-tools).
 
 ### Microsoft.Net.Compilers.Toolset
 

--- a/docs/wiki/Troubleshooting-tips.md
+++ b/docs/wiki/Troubleshooting-tips.md
@@ -37,7 +37,7 @@ Those are scenarios where you need to compile the same code with different versi
 
 The latest native compiler (pre-Roslyn) is part of the .NET Framework, so you can run it from `c:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe`.
 
-For trying various Roslyn versions, you can create a new project with your code, and add a reference to the `Microsoft.Net.Compilers`. By choosing the source (nuget.org or myget.org) and the package version (see [versioning help](https://github.com/dotnet/roslyn/blob/master/docs/wiki/NuGet-packages.md#versioning)), you will be able to control what version of the compiler is used. Note that you need to _Build_ your project to compile the code with the desired compiler version (the IDE may show squiggles and use a different version).
+For trying various Roslyn versions, you can create a new project with your code, and add a reference to [`Microsoft.Net.Compilers.Toolset`](../compilers/Compiler%20Toolset%20NuPkgs.md). By choosing the source (nuget.org or Azure DevOps) and the package version (see [versioning help](https://github.com/dotnet/roslyn/blob/master/docs/wiki/NuGet-packages.md#versioning)), you will be able to control what version of the compiler is used. Note that you need to _Build_ your project to compile the code with the desired compiler version (the IDE may show squiggles and use a different version).
 
 # Running and debugging a test on Core on Windows
 To run all Core tests on Windows, you can use `Build.cmd -testCoreClr`.


### PR DESCRIPTION
This change replaces a few outdated references to MyGet that were scattered across documentation.

I also updated an ancient reference to the deprecated Microsoft.Net.Compilers package with Microsoft.Net.Compilers.Toolset.