### PR TITLE
Adjust PrintMembers to avoid boxing and avoid extra space

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // builder.Append(<name>);
                     // builder.Append(" = ");
-                    // builder.Append((object)<value>); OR builder.Append(<value>.ToString());
+                    // builder.Append((object)<value>); OR builder.Append(<value>.ToString()); for value types
                     // builder.Append(", "); // except for last member
 
                     var member = printableMembers[i];

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -139,13 +139,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var basePrintCall = F.Call(receiver: F.Base(ContainingType.BaseTypeNoUseSiteDiagnostics), printMethod, builder);
                     if (printableMembers.IsEmpty)
                     {
-                        // return base.print(builder);
+                        // return base.PrintMembers(builder);
                         F.CloseMethod(F.Return(basePrintCall));
                         return;
                     }
                     else
                     {
-                        // if (base.print(builder))
+                        // if (base.PrintMembers(builder))
                         //     builder.Append(", ")
                         block!.Add(F.If(basePrintCall, makeAppendString(F, builder, ", ")));
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // builder.Append(<name>);
                     // builder.Append(" = ");
-                    // builder.Append(<value>.ToString()); OR builder.Append(<value>.ToString());
+                    // builder.Append((object)<value>); OR builder.Append(<value>.ToString());
                     // builder.Append(", "); // except for last member
 
                     var member = printableMembers[i];

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // builder.Append(<name>);
                     // builder.Append(" = ");
-                    // builder.Append((object)<value>);
+                    // builder.Append(<value>.ToString()); OR builder.Append(<value>.ToString());
                     // builder.Append(", "); // except for last member
 
                     var member = printableMembers[i];
@@ -171,10 +171,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         _ => throw ExceptionUtilities.UnexpectedValue(member.Kind)
                     };
 
-                    block.Add(F.ExpressionStatement(
-                        F.Call(receiver: builder,
-                            F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendObject),
-                            F.Convert(F.SpecialType(SpecialType.System_Object), value))));
+                    Debug.Assert(value.Type is not null);
+                    if (value.Type.IsValueType)
+                    {
+                        block.Add(F.ExpressionStatement(
+                            F.Call(receiver: builder,
+                                F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendString),
+                                F.Call(value, F.SpecialMethod(SpecialMember.System_Object__ToString)))));
+                    }
+                    else
+                    {
+                        block.Add(F.ExpressionStatement(
+                            F.Call(receiver: builder,
+                                F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendObject),
+                                F.Convert(F.SpecialType(SpecialType.System_Object), value))));
+                    }
 
                     if (i < printableMembers.Length - 1)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // builder.Append(" { ");
                 block.Add(makeAppendString(F, builderLocal, " { "));
 
-                // if (this.print(builder)) builder.Append(" ");
+                // if (this.PrintMembers(builder)) builder.Append(" ");
                 block.Add(F.If(F.Call(F.This(), _printMethod, builderLocal), makeAppendString(F, builderLocal, " ")));
 
                 // builder.Append("}");

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
@@ -68,8 +68,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // this.print(builder);
                 block.Add(F.ExpressionStatement(F.Call(F.This(), _printMethod, builderLocal)));
 
-                // builder.Append(" } ");
-                block.Add(makeAppendString(F, builderLocal, " } "));
+                // builder.Append(" }");
+                block.Add(makeAppendString(F, builderLocal, " }"));
 
                 // return builder.ToString();
                 block.Add(F.Return(F.Call(builderLocal, F.SpecialMethod(SpecialMember.System_Object__ToString))));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
@@ -65,11 +65,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // builder.Append(" { ");
                 block.Add(makeAppendString(F, builderLocal, " { "));
 
-                // this.print(builder);
-                block.Add(F.ExpressionStatement(F.Call(F.This(), _printMethod, builderLocal)));
+                // if (this.print(builder)) builder.Append(" ");
+                block.Add(F.If(F.Call(F.This(), _printMethod, builderLocal), makeAppendString(F, builderLocal, " ")));
 
-                // builder.Append(" }");
-                block.Add(makeAppendString(F, builderLocal, " }"));
+                // builder.Append("}");
+                block.Add(makeAppendString(F, builderLocal, "}"));
 
                 // return builder.ToString();
                 block.Add(F.Return(F.Call(builderLocal, F.SpecialMethod(SpecialMember.System_Object__ToString))));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -3729,7 +3729,7 @@ public record C : B {
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(47093, "https://github.com/dotnet/roslyn/issues/47093")]
         public void ToString_TopLevelRecord_Empty()
         {
             var src = @"
@@ -3741,7 +3741,7 @@ record C1;
 
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            var v = CompileAndVerify(comp, expectedOutput: "C1 {  }");
+            var v = CompileAndVerify(comp, expectedOutput: "C1 { }");
 
             var print = comp.GetMember<MethodSymbol>("C1." + WellKnownMemberNames.PrintMembersMethodName);
             Assert.Equal(Accessibility.Protected, print.DeclaredAccessibility);
@@ -3769,7 +3769,7 @@ record C1;
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       57 (0x39)
+  // Code size       70 (0x46)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -3785,14 +3785,18 @@ record C1;
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  callvirt   ""bool C1.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  pop
-  IL_0026:  ldloc.0
-  IL_0027:  ldstr      "" }""
-  IL_002c:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0031:  pop
-  IL_0032:  ldloc.0
-  IL_0033:  callvirt   ""string object.ToString()""
-  IL_0038:  ret
+  IL_0025:  brfalse.s  IL_0033
+  IL_0027:  ldloc.0
+  IL_0028:  ldstr      "" ""
+  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0032:  pop
+  IL_0033:  ldloc.0
+  IL_0034:  ldstr      ""}""
+  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_003e:  pop
+  IL_003f:  ldloc.0
+  IL_0040:  callvirt   ""string object.ToString()""
+  IL_0045:  ret
 }
 ");
         }
@@ -3812,7 +3816,7 @@ record C2 : C1
 ";
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            var v = CompileAndVerify(comp, expectedOutput: "C1 {  }");
+            var v = CompileAndVerify(comp, expectedOutput: "C1 { }");
 
             var print = comp.GetMember<MethodSymbol>("C1." + WellKnownMemberNames.PrintMembersMethodName);
             Assert.Equal(Accessibility.Protected, print.DeclaredAccessibility);
@@ -3840,7 +3844,7 @@ record C2 : C1
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       57 (0x39)
+  // Code size       70 (0x46)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -3856,14 +3860,18 @@ record C2 : C1
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  callvirt   ""bool C1.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  pop
-  IL_0026:  ldloc.0
-  IL_0027:  ldstr      "" }""
-  IL_002c:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0031:  pop
-  IL_0032:  ldloc.0
-  IL_0033:  callvirt   ""string object.ToString()""
-  IL_0038:  ret
+  IL_0025:  brfalse.s  IL_0033
+  IL_0027:  ldloc.0
+  IL_0028:  ldstr      "" ""
+  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0032:  pop
+  IL_0033:  ldloc.0
+  IL_0034:  ldstr      ""}""
+  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_003e:  pop
+  IL_003f:  ldloc.0
+  IL_0040:  callvirt   ""string object.ToString()""
+  IL_0045:  ret
 }
 ");
         }
@@ -3885,7 +3893,7 @@ record C2 : C1
 
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            var v = CompileAndVerify(comp, expectedOutput: "C1 {  }");
+            var v = CompileAndVerify(comp, expectedOutput: "C1 { }");
 
             var print = comp.GetMember<MethodSymbol>("C1." + WellKnownMemberNames.PrintMembersMethodName);
             Assert.Equal(Accessibility.Protected, print.DeclaredAccessibility);
@@ -3915,7 +3923,7 @@ record C2 : C1
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       57 (0x39)
+  // Code size       70 (0x46)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -3931,14 +3939,18 @@ record C2 : C1
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  callvirt   ""bool Base.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  pop
-  IL_0026:  ldloc.0
-  IL_0027:  ldstr      "" }""
-  IL_002c:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0031:  pop
-  IL_0032:  ldloc.0
-  IL_0033:  callvirt   ""string object.ToString()""
-  IL_0038:  ret
+  IL_0025:  brfalse.s  IL_0033
+  IL_0027:  ldloc.0
+  IL_0028:  ldstr      "" ""
+  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0032:  pop
+  IL_0033:  ldloc.0
+  IL_0034:  ldstr      ""}""
+  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_003e:  pop
+  IL_003f:  ldloc.0
+  IL_0040:  callvirt   ""string object.ToString()""
+  IL_0045:  ret
 }
 ");
         }
@@ -4028,7 +4040,7 @@ sealed record C1;
 
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "C1 {  }");
+            CompileAndVerify(comp, expectedOutput: "C1 { }");
 
             var print = comp.GetMember<MethodSymbol>("C1." + WellKnownMemberNames.PrintMembersMethodName);
             Assert.Equal(Accessibility.Private, print.DeclaredAccessibility);
@@ -5963,7 +5975,7 @@ record @base;
 
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "base {  }");
+            CompileAndVerify(comp, expectedOutput: "base { }");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47093
Fixes https://github.com/dotnet/roslyn/issues/47092