### PR TITLE
Bump StreamJsonRpc to 2.6.21-alpha

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -242,7 +242,7 @@
       create a test insertion in Visual Studio to validate.
     -->
     <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
-    <StreamJsonRpcVersion>2.4.34</StreamJsonRpcVersion>
+    <StreamJsonRpcVersion>2.6.21-alpha</StreamJsonRpcVersion>
     <SystemCollectionsImmutableVersion>5.0.0-preview.8.20371.14</SystemCollectionsImmutableVersion>
     <SystemReflectionMetadataVersion>5.0.0-preview.8.20371.14</SystemReflectionMetadataVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.1</MicrosoftBclAsyncInterfacesVersion>


### PR DESCRIPTION
VS Mac insertion is failing because of this, and VS is already shipping with this version, plus this opts explicitly into new behavior around concurrency that we'd be getting anyway (since VS ships with this) but its nice to be explicit.

Will create a test insertion, once I work out how :)