### PR TITLE
Don't handle local documentation comment commands in the cloud

### DIFF
--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -118,6 +118,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
                 return;
             }
 
+            // Don't execute in cloud environment, as we let LSP handle that
+            if (args.SubjectBuffer.IsInCloudEnvironmentClientContext())
+            {
+                return;
+            }
+
             CompleteComment(args.SubjectBuffer, args.TextView, InsertOnCharacterTyped, CancellationToken.None);
         }
 
@@ -126,6 +132,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 
         public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
         {
+            // Don't execute in cloud environment, as we let LSP handle that
+            if (args.SubjectBuffer.IsInCloudEnvironmentClientContext())
+            {
+                return false;
+            }
+
             // Check to see if the current line starts with exterior trivia. If so, we'll take over.
             // If not, let the nextHandler run.
 


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/46301 discovered today in testing.

Forgot to disable the local handling of these. Fortunately it doesn't cause a bug, as currently the local service inserts the comments, and then the remote service doesn't do anything because it's no longer a valid spot to insert doc comments.