### PR TITLE
Experiment with build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -297,7 +297,7 @@ function BuildSolution {
     $properties
 }
 
-InitializeDotNetCli $restore
+# InitializeDotNetCli $restore
 if [[ "$restore" == true ]]; then
   dotnet tool restore
 fi


### PR DESCRIPTION
ad-hoc determining if our build machines have dotnet on the PATH. If the dotnet command after this commented-out line succeeds then we know that is the case and our build machines have been effectively hiding the bug #47074 in our build scripts.