### PR TITLE
Switch from throwing NotImplementedException and return E_NOTIMPL

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/AbstractLibraryManager_IVsSimpleLibrary2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/AbstractLibraryManager_IVsSimpleLibrary2.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library
             => CreateNavInfo(rgSymbolNodes, ulcNodes, out ppNavInfo);
 
         int IVsSimpleLibrary2.GetBrowseContainersForHierarchy(IVsHierarchy pHierarchy, uint celt, VSBROWSECONTAINER[] rgBrowseContainers, uint[] pcActual)
-            => throw new NotImplementedException();
+            => VSConstants.E_NOTIMPL;
 
         int IVsSimpleLibrary2.GetGuid(out Guid pguidLib)
         {


### PR DESCRIPTION
This is consistent with everything else in this class; I suspect this was an oversight when the original implementer used implement interface and missed updating this one. Oddly I saw this as a flagged exception in an integration test run, so it's possible some code isn't handling the CLR exception well.