### PR TITLE
Remove unnecessary initialize request to liveshare server from livesh…

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/Client/RoslynLSPClientService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RoslynLSPClientService.cs
@@ -8,13 +8,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.LanguageServices.LiveShare.CustomProtocol;
 using Microsoft.VisualStudio.LiveShare;
 using Newtonsoft.Json.Linq;
 using Task = System.Threading.Tasks.Task;
 using LS = Microsoft.VisualStudio.LiveShare.LanguageServices;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
@@ -26,8 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
         protected abstract RoslynLSPClientLifeTimeService LspClientLifeTimeService { get; }
 
         public LS.ILanguageServerClient ActiveLanguageServerClient { get; private set; }
-
-        public ServerCapabilities ServerCapabilities { get; private set; }
 
         public Task<ICollaborationService> CreateServiceAsync(CollaborationSession collaborationSession, CancellationToken cancellationToken)
         {
@@ -55,8 +50,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
                 {
                     ActiveLanguageServerClient = languageServerGuestService.CreateLanguageServerClient(anyLspServerProviderName);
                 }
-
-                InitializeServerCapabilities(cancellationToken);
             };
 
             // Register Roslyn supported capabilities
@@ -104,25 +97,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
 
             public void Dispose()
                 => Disposed?.Invoke(this, null);
-        }
-
-        /// <summary>
-        /// Retrieve the server's capabilities before additional requests are made to the remote host.
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        public void InitializeServerCapabilities(CancellationToken cancellationToken)
-        {
-            if (ActiveLanguageServerClient == null || ServerCapabilities != null)
-            {
-                return;
-            }
-
-            var initializeRequest = new LS.LspRequest<InitializeParams, InitializeResult>(Methods.InitializeName);
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var intializeResult = await ActiveLanguageServerClient.RequestAsync(initializeRequest, new InitializeParams(), cancellationToken).ConfigureAwait(false);
-                ServerCapabilities = intializeResult?.Capabilities;
-            });
         }
     }
 


### PR DESCRIPTION
…are client

These were previously used for the classifications experiment, but that code no longer exists.  We no longer need to retrieve these again (liveshare already initializes once).

Since this is hanging we should just remove it.

fixes [#AB1174053](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1174053)