### PR TITLE
Clean up redundant code action filtering

### DIFF
--- a/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -50,27 +50,10 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 document, selection, includeSuppressionFixes, isBlocking,
                 addOperationScope, cancellationToken), cancellationToken).ConfigureAwait(false);
 
-            var filteredFixes = FilterOnAnyThread(fixes);
+            var filteredFixes = fixes.Where(c => c.Fixes.Length > 0).ToImmutableArray();
             var organizedFixes = OrganizeFixes(workspace, filteredFixes, includeSuppressionFixes);
 
             return organizedFixes;
-        }
-
-        private static ImmutableArray<CodeFixCollection> FilterOnAnyThread(ImmutableArray<CodeFixCollection> collections)
-        {
-            return collections.Select(c => FilterIndividuallyOnAnyThread(c)).WhereNotNull().ToImmutableArray();
-        }
-
-        private static CodeFixCollection? FilterIndividuallyOnAnyThread(CodeFixCollection collection)
-        {
-            var applicableFixes = collection.Fixes;
-            return applicableFixes.Length == 0
-                ? null
-                : applicableFixes.Length == collection.Fixes.Length
-                    ? collection
-                    : new CodeFixCollection(
-                        collection.Provider, collection.TextSpan, applicableFixes,
-                        collection.FixAllState, collection.SupportedScopes, collection.FirstDiagnostic);
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 document, selection, includeSuppressionFixes, isBlocking,
                 addOperationScope, cancellationToken), cancellationToken).ConfigureAwait(false);
 
-            var filteredFixes = fixes.Where(c => c.Fixes.Length > 0).ToImmutableArray();
+            var filteredFixes = fixes.WhereAsArray(c => c.Fixes.Length > 0);
             var organizedFixes = OrganizeFixes(workspace, filteredFixes, includeSuppressionFixes);
 
             return organizedFixes;


### PR DESCRIPTION
Noticed this while responding to API changes in VS for Mac.