### PR TITLE
NullableContextAttribute for property parameters is from accessor rather than containing type

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -132,8 +132,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             bool isBad;
 
             _parameters = setMethodParams is null
-                ? GetParameters(moduleSymbol, this, propertyParams, getMethodParams, getMethod.IsMetadataVirtual(), out isBad)
-                : GetParameters(moduleSymbol, this, propertyParams, setMethodParams, setMethod.IsMetadataVirtual(), out isBad);
+                ? GetParameters(moduleSymbol, this, getMethod, propertyParams, getMethodParams, out isBad)
+                : GetParameters(moduleSymbol, this, setMethod, propertyParams, setMethodParams, out isBad);
 
             if (getEx != null || setEx != null || mrEx != null || isBad)
             {
@@ -670,9 +670,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private static ImmutableArray<ParameterSymbol> GetParameters(
             PEModuleSymbol moduleSymbol,
             PEPropertySymbol property,
+            PEMethodSymbol accessor,
             ParamInfo<TypeSymbol>[] propertyParams,
             ParamInfo<TypeSymbol>[] accessorParams,
-            bool isPropertyVirtual,
             out bool anyParameterIsBad)
         {
             anyParameterIsBad = false;
@@ -691,11 +691,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 // NOTE: this is a best guess at the Dev10 behavior.  The actual behavior is
                 // in the unmanaged helper code that Dev10 uses to load the metadata.
                 var propertyParam = propertyParams[i];
-                var paramHandle = i < numAccessorParams ? accessorParams[i].Handle : propertyParam.Handle;
+                ParameterHandle paramHandle;
+                Symbol nullableContext;
+                if (i < numAccessorParams)
+                {
+                    paramHandle = accessorParams[i].Handle;
+                    nullableContext = accessor;
+                }
+                else
+                {
+                    paramHandle = propertyParam.Handle;
+                    nullableContext = property;
+                }
                 var ordinal = i - 1;
                 bool isBad;
 
-                parameters[ordinal] = PEParameterSymbol.Create(moduleSymbol, property, isPropertyVirtual, ordinal, paramHandle, propertyParam, nullableContext: property, out isBad);
+                parameters[ordinal] = PEParameterSymbol.Create(moduleSymbol, property, accessor.IsMetadataVirtual(), ordinal, paramHandle, propertyParam, nullableContext, out isBad);
 
                 if (isBad)
                 {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -2011,10 +2011,10 @@ public class Program
             var expected =
 @"[NullableContext(1)] [Nullable(0)] Program
     Program()
-    System.Object! this[System.Object! x, System.Object! y] { get; }
-        System.Object! x
-        System.Object! y
-        [NullableContext(2)] [Nullable(1)] System.Object! this[System.Object! x, System.Object! y].get
+    System.Object! this[System.Object? x, System.Object? y] { get; }
+        System.Object? x
+        System.Object? y
+        [NullableContext(2)] [Nullable(1)] System.Object! this[System.Object? x, System.Object? y].get
             System.Object? x
             System.Object? y
     System.Object! this[System.Object? z] { set; }
@@ -4821,6 +4821,138 @@ public class C
 ";
                 AssertNullableAttributes(module, expected);
             });
+        }
+
+        [Fact]
+        [WorkItem(47221, "https://github.com/dotnet/roslyn/issues/47221")]
+        public void PropertyAccessorWithNullableContextAttribute_01()
+        {
+            var source =
+@"#nullable enable
+public class A
+{
+    public object? this[object x, object? y] => null;
+    public static A F(object x) => new A();
+    public static A F(object x, object? y) => new A();
+}";
+            var comp = CreateCompilation(source);
+            var expected =
+@"[NullableContext(1)] [Nullable(0)] A
+    A! F(System.Object! x)
+        System.Object! x
+    A! F(System.Object! x, System.Object? y)
+        System.Object! x
+        [Nullable(2)] System.Object? y
+    A()
+    [Nullable(2)] System.Object? this[System.Object! x, System.Object? y] { get; }
+        [Nullable(1)] System.Object! x
+        System.Object? y
+        [NullableContext(2)] System.Object? this[System.Object! x, System.Object? y].get
+            [Nullable(1)] System.Object! x
+            System.Object? y
+";
+            AssertNullableAttributes(comp, expected);
+        }
+
+        [Fact]
+        [WorkItem(47221, "https://github.com/dotnet/roslyn/issues/47221")]
+        public void PropertyAccessorWithNullableContextAttribute_02()
+        {
+            var source =
+@"#nullable enable
+public class A
+{
+    public object? this[object x, object? y] { set { } }
+    public static A F(object x) => new A();
+    public static A F(object x, object? y) => new A();
+}";
+            var comp = CreateCompilation(source);
+            var expected =
+@"[NullableContext(1)] [Nullable(0)] A
+    A! F(System.Object! x)
+        System.Object! x
+    A! F(System.Object! x, System.Object? y)
+        System.Object! x
+        [Nullable(2)] System.Object? y
+    A()
+    [Nullable(2)] System.Object? this[System.Object! x, System.Object? y] { set; }
+        [Nullable(1)] System.Object! x
+        System.Object? y
+        [NullableContext(2)] void this[System.Object! x, System.Object? y].set
+            [Nullable(1)] System.Object! x
+            System.Object? y
+            System.Object? value
+";
+            AssertNullableAttributes(comp, expected);
+        }
+
+        [Fact]
+        [WorkItem(47221, "https://github.com/dotnet/roslyn/issues/47221")]
+        public void PropertyAccessorWithNullableContextAttribute_03()
+        {
+            var source =
+@"#nullable enable
+public class A
+{
+    public object this[object? x, object y] => null;
+    public static A? F0;
+    public static A? F1;
+    public static A? F2;
+    public static A? F3;
+    public static A? F4;
+}";
+            var comp = CreateCompilation(source);
+            var expected =
+@"[NullableContext(2)] [Nullable(0)] A
+    A? F0
+    A? F1
+    A? F2
+    A? F3
+    A? F4
+    A()
+    [Nullable(1)] System.Object! this[System.Object? x, System.Object! y] { get; }
+        [Nullable(2)] System.Object? x
+        System.Object! y
+        [NullableContext(1)] System.Object! this[System.Object? x, System.Object! y].get
+            [Nullable(2)] System.Object? x
+            System.Object! y
+";
+            AssertNullableAttributes(comp, expected);
+        }
+
+        [Fact]
+        [WorkItem(47221, "https://github.com/dotnet/roslyn/issues/47221")]
+        public void PropertyAccessorWithNullableContextAttribute_04()
+        {
+            var source =
+@"#nullable enable
+public class A
+{
+    public object this[object? x, object y] { set { } }
+    public static A? F0;
+    public static A? F1;
+    public static A? F2;
+    public static A? F3;
+    public static A? F4;
+}";
+            var comp = CreateCompilation(source);
+            var expected =
+@"[NullableContext(2)] [Nullable(0)] A
+    A? F0
+    A? F1
+    A? F2
+    A? F3
+    A? F4
+    A()
+    [Nullable(1)] System.Object! this[System.Object? x, System.Object! y] { set; }
+        [Nullable(2)] System.Object? x
+        System.Object! y
+        [NullableContext(1)] void this[System.Object? x, System.Object! y].set
+            [Nullable(2)] System.Object? x
+            System.Object! y
+            System.Object! value
+";
+            AssertNullableAttributes(comp, expected);
         }
 
         private static void AssertNoNullableAttribute(ImmutableArray<CSharpAttributeData> attributes)


### PR DESCRIPTION
Properties from metadata have parameters defined by the accessor including any `[Nullable]` attributes, so the `[NullableContext]` attribute should also be taken from the accessor as well.

(The `[NullableContext]` attribute for a method parameter, including accessors, is the nearest attribute on the method, or the containing types.)

Fixes #47221.