### PR TITLE
Use same naming style for modules as classes

### DIFF
--- a/src/Analyzers/VisualBasic/Tests/NamingStyles/NamingStylesTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/NamingStyles/NamingStylesTests.vb
@@ -506,5 +506,15 @@ End Class",
 End Class",
                 New TestParameters(options:=s_options.MethodNamesArePascalCase))
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        Public Async Function TestModules() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Module [|m|]
+End Module",
+"Public Module M
+End Module",
+                options:=s_options.ClassNamesArePascalCase)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         private static readonly SymbolKindOrTypeKind _namespace = new(SymbolKind.Namespace);
         private static readonly SymbolKindOrTypeKind _class = new(TypeKind.Class);
+        private static readonly SymbolKindOrTypeKind _module = new(TypeKind.Module);
         private static readonly SymbolKindOrTypeKind _struct = new(TypeKind.Struct);
         private static readonly SymbolKindOrTypeKind _interface = new(TypeKind.Interface);
         private static readonly SymbolKindOrTypeKind _enum = new(TypeKind.Enum);
@@ -139,6 +140,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             ImmutableArray.Create(
                 _namespace,
                 _class,
+                _module,
                 _struct,
                 _interface,
                 _enum,
@@ -171,6 +173,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 {
                     case "class":
                         builder.Add(_class);
+                        builder.Add(_module);
                         break;
                     case "struct":
                         builder.Add(_struct);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
@@ -363,9 +363,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
             public bool MatchesSymbol(ISymbol symbol)
                 => SymbolKind.HasValue ? symbol.IsKind(SymbolKind.Value) :
-                   TypeKind.HasValue ? symbol is ITypeSymbol type && type.TypeKind == TypeKind.Value :
+                   TypeKind.HasValue ? symbol is ITypeSymbol type && MatchesTypeSymbolKind(type.TypeKind, TypeKind.Value) :
                    MethodKind.HasValue ? symbol is IMethodSymbol method && method.MethodKind == MethodKind.Value :
                    throw ExceptionUtilities.Unreachable;
+
+            private bool MatchesTypeSymbolKind(TypeKind kind1, TypeKind kind2)
+            {
+                if (kind1 == CodeAnalysis.TypeKind.Module && kind2 == CodeAnalysis.TypeKind.Class)
+                {
+                    return true;
+                }
+
+                if (kind1 == CodeAnalysis.TypeKind.Class && kind2 == CodeAnalysis.TypeKind.Module)
+                {
+                    return true;
+                }
+
+                return kind1 == kind2;
+            }
 
             internal XElement CreateXElement()
                 => SymbolKind.HasValue ? new XElement(nameof(SymbolKind), SymbolKind) :

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                    MethodKind.HasValue ? symbol is IMethodSymbol method && method.MethodKind == MethodKind.Value :
                    throw ExceptionUtilities.Unreachable;
 
-            private bool MatchesTypeSymbolKind(TypeKind kind1, TypeKind kind2)
+            private static bool MatchesTypeSymbolKind(TypeKind kind1, TypeKind kind2)
             {
                 if (kind1 == CodeAnalysis.TypeKind.Module && kind2 == CodeAnalysis.TypeKind.Class)
                 {


### PR DESCRIPTION
Related to https://github.com/dotnet/roslyn-analyzers/pull/4086#discussion_r479483657
cc: @mavasani