### PR TITLE
Fix flaky compiler server test.

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             foreach (var streamTask in list)
             {
                 using var stream = await streamTask.ConfigureAwait(false);
-                Assert.NotNull(stream);
+                AssertEx.NotNull(stream);
                 var readCount = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                 Assert.Equal(0, readCount);
                 Assert.False(stream.IsConnected);

--- a/src/Compilers/Server/VBCSCompilerTests/TestableClientConnectionHost.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TestableClientConnectionHost.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.CodeAnalysis.CommandLine;
 using System;
 using System.Collections.Generic;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
-
-#nullable enable
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {


### PR DESCRIPTION
The test was using a timeout when connecting to the server. This was
likely leading to the connect failing during a load situation. Removed
the timeout and added a proper `Assert.NotNull` check to catch the issue
if this doesn't truly fix it.

closes #47231