### PR TITLE
Remove reference to obsolete class

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISourceGenerator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis
         /// Called before generation occurs. A generator can use the <paramref name="context"/>
         /// to register callbacks required to perform generation.
         /// </summary>
-        /// <param name="context">The <see cref="InitializationContext"/> to register callbacks on</param>
+        /// <param name="context">The <see cref="GeneratorInitializationContext"/> to register callbacks on</param>
         void Initialize(GeneratorInitializationContext context);
 
         /// <summary>

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/IntegrationTestSourceGenerator.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/IntegrationTestSourceGenerator.cs
@@ -17,7 +17,7 @@ namespace Roslyn.VisualStudio.IntegrationTests
         {
         }
 
-        public void Execute(SourceGeneratorContext context)
+        public void Execute(GeneratorExecutionContext context)
         {
             context.AddSource(GeneratedClassName, SourceText.From(@"
 internal class " + GeneratedClassName + @"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/IntegrationTestSourceGenerator.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/IntegrationTestSourceGenerator.cs
@@ -13,10 +13,6 @@ namespace Roslyn.VisualStudio.IntegrationTests
     {
         public const string GeneratedClassName = nameof(IntegrationTestSourceGenerator) + "Output";
 
-        public void Initialize(InitializationContext context)
-        {
-        }
-
         public void Execute(SourceGeneratorContext context)
         {
             context.AddSource(GeneratedClassName, SourceText.From(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/IntegrationTestSourceGenerator.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/IntegrationTestSourceGenerator.cs
@@ -13,6 +13,10 @@ namespace Roslyn.VisualStudio.IntegrationTests
     {
         public const string GeneratedClassName = nameof(IntegrationTestSourceGenerator) + "Output";
 
+        public void Initialize(GeneratorInitializationContext context)
+        {
+        }
+
         public void Execute(SourceGeneratorContext context)
         {
             context.AddSource(GeneratedClassName, SourceText.From(@"


### PR DESCRIPTION
The master has a build error after merging #47222 due to the obsolete `InitializationContext` in this test class.

~~Just curious how the CI build passed in the PR, then failed on master?~~ Figured it out. ;-)