### PR TITLE
Avoid first chance exception

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -53,6 +53,10 @@ namespace Microsoft.CodeAnalysis
 
         private void DeleteLeftoverDirectories()
         {
+            // Avoid first chance exception
+            if (!Directory.Exists(_baseDirectory))
+                return;
+
             IEnumerable<string> subDirectories;
             try
             {


### PR DESCRIPTION
This avoids the first chance exception when the directory doesn't exist.

Avoids the following while debugging:

```
System.IO.DirectoryNotFoundException: 'Could not find a part of the path 'C:\Users\davkean\AppData\Local\Temp\CodeAnalysis\AnalyzerShadowCopies'.'

 	mscorlib.dll!System.IO.__Error.WinIOError(int errorCode, string maybeFullPath) Line 151	C#
 	mscorlib.dll!System.IO.FileSystemEnumerableIterator<string>.CommonInit() Line 280	C#
 	mscorlib.dll!System.IO.FileSystemEnumerableIterator<string>.FileSystemEnumerableIterator(string path, string originalUserPath, string searchPattern, System.IO.SearchOption searchOption, System.IO.SearchResultHandler<string> resultHandler, bool checkHost) Line 260	C#
>	mscorlib.dll!System.IO.Directory.EnumerateDirectories(string path) Line 846	C#
 	Microsoft.CodeAnalysis.Workspaces.dll!Microsoft.CodeAnalysis.ShadowCopyAnalyzerAssemblyLoader.DeleteLeftoverDirectories()	Unknown
 	mscorlib.dll!System.Threading.Tasks.Task.InnerInvoke() Line 2884	C#
 	mscorlib.dll!System.Threading.Tasks.Task.Execute() Line 2498	C#
 	mscorlib.dll!System.Threading.Tasks.Task.ExecutionContextCallback(object obj) Line 2861	C#
 	mscorlib.dll!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx) Line 980	C#
 	mscorlib.dll!System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx) Line 928	C#
 	mscorlib.dll!System.Threading.Tasks.Task.ExecuteWithThreadLocal(ref System.Threading.Tasks.Task currentTaskSlot) Line 2827	C#
 	mscorlib.dll!System.Threading.Tasks.Task.ExecuteEntry(bool bPreventDoubleExecution) Line 2767	C#
 	mscorlib.dll!System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem() Line 2704	C#
 	mscorlib.dll!System.Threading.ThreadPoolWorkQueue.Dispatch() Line 820	C#
 	mscorlib.dll!System.Threading._ThreadPoolWaitCallback.PerformWaitCallback() Line 1161	C#
 	[Native to Managed Transition]	
 	kernel32.dll!75286719()	Unknown
 	kernel32.dll![Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	Unknown
 	ntdll.dll!76fe8abd()	Unknown
 	ntdll.dll!76fe8a8b()	Unknown


```