### PR TITLE
Disable formatting around unresolvable issues

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
             // Look for the form: !(x is Y y)
             if (!(node is PrefixUnaryExpressionSyntax
+#pragma warning disable format
             {
                 Operand: ParenthesizedExpressionSyntax
                 {
@@ -73,6 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                     } isPattern,
                 },
             } notExpression))
+#pragma warning restore format
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -721,12 +721,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var member in containingType.GetMembers(WellKnownMemberNames.CloneMethodName))
             {
                 if (member is IMethodSymbol
+#pragma warning disable format
                 {
                     DeclaredAccessibility: Accessibility.Public,
                     IsStatic: false,
                     Parameters: { Length: 0 },
                     Arity: 0
                 } method)
+#pragma warning restore format
                 {
                     if (candidate is object)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
@@ -157,12 +157,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var member in containingType.GetMembers(WellKnownMemberNames.CloneMethodName))
             {
                 if (member is MethodSymbol
+#pragma warning disable format
                 {
                     DeclaredAccessibility: Accessibility.Public,
                     IsStatic: false,
                     ParameterCount: 0,
                     Arity: 0
                 } method)
+#pragma warning restore format
                 {
                     if (candidate is object)
                     {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -599,10 +599,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 if (CSharpSelectionResult.ShouldCallConfigureAwaitFalse())
                 {
                     if (AnalyzerResult.ReturnType.GetMembers().Any(x => x is IMethodSymbol
+#pragma warning disable format
                     {
                         Name: nameof(Task.ConfigureAwait),
                         Parameters: { Length: 1 } parameters
                     } && parameters[0].Type.SpecialType == SpecialType.System_Boolean))
+#pragma warning restore format
                     {
                         invocation = SyntaxFactory.InvocationExpression(
                             SyntaxFactory.MemberAccessExpression(


### PR DESCRIPTION
In multi-targeted projects, Roslyn only enables FormattingAnalyzer via the CodeStyle layer in one of the targets. Other targets use the built-in FormattingAnalyzer provided by the IDE. This pull request disables formatting around several constructs where the two have different behaviors, and no single formatting works for both.