### PR TITLE
Disable CS0660 where Full Solution Analysis produces a different result

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
@@ -4,6 +4,8 @@
 
 using System.Collections.Immutable;
 
+#pragma warning disable CS0660 // Warning is reported only for Full Solution Analysis
+
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal partial class TypeSymbol


### PR DESCRIPTION
Full Solution Analysis reports CS0660 on a different part (file) from the location where CS0660 is reported by builds. This change adds a second suppression so this warning is not reported in either scenario.