### PR TITLE
Do not include constructor references in the named-type section of a FAR result

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -104,7 +104,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SemanticModel semanticModel,
             CancellationToken cancellationToken)
         {
-            var symbolsMatch = GetStandardSymbolsMatchFunction(namedType, null, document.Project.Solution, cancellationToken);
+            // Get the parent node that best matches what this token represents.  For example, if we have `new a.b()`
+            // then the parent node of `b` won't be `a.b`, but rather `new a.b()`.  This will actually cause us to bind
+            // to the constructor not the type.  That's a good thing as we don't want these object-creations to
+            // associate with the type, but rather with the constructor itself.
+            var findParentNode = GetNamedTypeOrConstructorFindParentNodeFunction(document, namedType);
+            var symbolsMatch = GetStandardSymbolsMatchFunction(namedType, findParentNode, document.Project.Solution, cancellationToken);
 
             return FindReferencesInDocumentUsingIdentifierAsync(
                 namedType, namedType.Name, document, semanticModel, symbolsMatch, cancellationToken);


### PR DESCRIPTION
Fixes [AB#1177764](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1177764)

Note: this changes our FAR api slightly.  Previously:

1. type *and* constructor references would appear in the FAR api list for a type.  constructor references would appear in the api list for a constructor.  So, with cascading, you would have constructors show up from teh API twice.  
2. the UI would then display that information as is, showing duplicate results.

THere were two ways to approach this.  We could keep the FAR api the same, but add more info to the results to let teh UI then filter these out.  Or we could change the API.  @sharwell  and i discussed this and felt it was cleanest to just change the API.  Now, if an item would appear in a constructor list, it will not appear in the type list for the API.  There is no update to the UI needed here as the API results match waht we want to see from the UI.

