### PR TITLE
Use the same CDATA color for xml literals as for doc comments

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
     internal sealed class ClassificationTypeFormatDefinitions
     {
-        #region Preprocessor Text 
+        #region Preprocessor Text
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.PreprocessorText)]
         [Name(ClassificationTypeNames.PreprocessorText)]
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
         #endregion
         #region Keyword - Control
-        // Keyword - Control is ordered after Keyword to ensure this more specific 
+        // Keyword - Control is ordered after Keyword to ensure this more specific
         // classification will take precedence.
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.ControlKeyword)]
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         }
         #endregion
         #region Operator - Overloaded
-        // Operator - Overloaded is ordered after Operator to ensure this more specific 
+        // Operator - Overloaded is ordered after Operator to ensure this more specific
         // classification will take precedence.
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.OperatorOverloaded)]
@@ -151,14 +151,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             {
                 this.DisplayName = EditorFeaturesResources.Symbol_Static;
                 // The static classification is intended to be an additive classification
-                // that simply changes the font's styling (bold or not). Allowing 
-                // customization of the foreground color would cause issues with 
+                // that simply changes the font's styling (bold or not). Allowing
+                // customization of the foreground color would cause issues with
                 // TaggedText as it is currently implemented, since any particular
-                // span can only be tagged with a single TextTag. 
+                // span can only be tagged with a single TextTag.
 
                 // By restricting to only font style, the QuickInfo and FAR render with the
                 // colors the user would expect. The missing font style is not an problem
-                // for these experiences because the QuickInfo already renders the static 
+                // for these experiences because the QuickInfo already renders the static
                 // modifier as part of its text and the FAR window already applies its
                 // own bolding to the rendered output.
                 this.BackgroundCustomizable = false;
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         // so that, in the case both classifications are applied to the same
         // span, the styling for the identifier type would be chosen.
 
-        // User Types - * and User Members - * are ordered before Symbol - Static 
+        // User Types - * and User Members - * are ordered before Symbol - Static
         // so that the font styling chosen for static symbols would override the
         // styling chosen for specific identifier types.
         #region User Types - Classes
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Delegates 
+        #region User Types - Delegates
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.DelegateName)]
         [Name(ClassificationTypeNames.DelegateName)]
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Enums 
+        #region User Types - Enums
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.EnumName)]
         [Name(ClassificationTypeNames.EnumName)]
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Interfaces 
+        #region User Types - Interfaces
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.InterfaceName)]
         [Name(ClassificationTypeNames.InterfaceName)]
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Modules 
+        #region User Types - Modules
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.ModuleName)]
         [Name(ClassificationTypeNames.ModuleName)]
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Structures 
+        #region User Types - Structures
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.StructName)]
         [Name(ClassificationTypeNames.StructName)]
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Type Parameters 
+        #region User Types - Type Parameters
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.TypeParameterName)]
         [Name(ClassificationTypeNames.TypeParameterName)]
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         }
         #endregion
 
-        #region User Members - Fields 
+        #region User Members - Fields
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.FieldName)]
         [Name(ClassificationTypeNames.FieldName)]
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Fields;
         }
         #endregion
-        #region User Members - Enum Members 
+        #region User Members - Enum Members
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.EnumMemberName)]
         [Name(ClassificationTypeNames.EnumMemberName)]
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Enum_Members;
         }
         #endregion
-        #region User Members - Constants 
+        #region User Members - Constants
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.ConstantName)]
         [Name(ClassificationTypeNames.ConstantName)]
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Constants;
         }
         #endregion
-        #region User Members - Locals 
+        #region User Members - Locals
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.LocalName)]
         [Name(ClassificationTypeNames.LocalName)]
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Locals;
         }
         #endregion
-        #region User Members - Parameters 
+        #region User Members - Parameters
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.ParameterName)]
         [Name(ClassificationTypeNames.ParameterName)]
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Parameters;
         }
         #endregion
-        #region User Members - Methods 
+        #region User Members - Methods
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.MethodName)]
         [Name(ClassificationTypeNames.MethodName)]
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Extension_Methods;
         }
         #endregion
-        #region User Members - Properties 
+        #region User Members - Properties
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.PropertyName)]
         [Name(ClassificationTypeNames.PropertyName)]
@@ -450,7 +450,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Properties;
         }
         #endregion
-        #region User Members - Events 
+        #region User Members - Events
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.EventName)]
         [Name(ClassificationTypeNames.EventName)]
@@ -466,7 +466,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Events;
         }
         #endregion
-        #region User Members - Namespaces 
+        #region User Members - Namespaces
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.NamespaceName)]
         [Name(ClassificationTypeNames.NamespaceName)]
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 => this.DisplayName = EditorFeaturesResources.User_Members_Namespaces;
         }
         #endregion
-        #region User Members - Labels 
+        #region User Members - Labels
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.LabelName)]
         [Name(ClassificationTypeNames.LabelName)]
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         }
         #endregion
 
-        #region XML Doc Comments - Attribute Name 
+        #region XML Doc Comments - Attribute Name
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlDocCommentAttributeName)]
         [Name(ClassificationTypeNames.XmlDocCommentAttributeName)]
@@ -518,7 +518,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region XML Doc Comments - Attribute Quotes 
+        #region XML Doc Comments - Attribute Quotes
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlDocCommentAttributeQuotes)]
         [Name(ClassificationTypeNames.XmlDocCommentAttributeQuotes)]
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region XML Doc Comments - Attribute Value 
+        #region XML Doc Comments - Attribute Value
         // definition of how format is represented in tools options.
         // also specifies the default format.
         [Export(typeof(EditorFormatDefinition))]
@@ -556,7 +556,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region XML Doc Comments - CData Section 
+        #region XML Doc Comments - CData Section
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlDocCommentCDataSection)]
         [Name(ClassificationTypeNames.XmlDocCommentCDataSection)]
@@ -570,11 +570,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             public XmlDocCommentCDataSectionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_CData_Section;
-                this.ForegroundColor = Color.FromRgb(0x80, 0x80, 0x80);    // CIDARKGRAY    
+                this.ForegroundColor = Color.FromRgb(0x80, 0x80, 0x80);    // CIDARKGRAY
             }
         }
         #endregion
-        #region XML Doc Comments - Comment 
+        #region XML Doc Comments - Comment
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlDocCommentComment)]
         [Name(ClassificationTypeNames.XmlDocCommentComment)]
@@ -592,7 +592,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region XML Doc Comments - Delimiter 
+        #region XML Doc Comments - Delimiter
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlDocCommentDelimiter)]
         [Name(ClassificationTypeNames.XmlDocCommentDelimiter)]
@@ -664,7 +664,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region XML Doc Comments - Text 
+        #region XML Doc Comments - Text
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlDocCommentText)]
         [Name(ClassificationTypeNames.XmlDocCommentText)]
@@ -871,7 +871,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         }
         #endregion
 
-        #region VB XML Literals - Attribute Name 
+        #region VB XML Literals - Attribute Name
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralAttributeName)]
         [Name(ClassificationTypeNames.XmlLiteralAttributeName)]
@@ -888,7 +888,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Attribute Quotes 
+        #region VB XML Literals - Attribute Quotes
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralAttributeQuotes)]
         [Name(ClassificationTypeNames.XmlLiteralAttributeQuotes)]
@@ -905,7 +905,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Attribute Value 
+        #region VB XML Literals - Attribute Value
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralAttributeValue)]
         [Name(ClassificationTypeNames.XmlLiteralAttributeValue)]
@@ -922,7 +922,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - CData Section 
+        #region VB XML Literals - CData Section
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralCDataSection)]
         [Name(ClassificationTypeNames.XmlLiteralCDataSection)]
@@ -935,11 +935,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             public XmlLiteralCDataSectionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_CData_Section;
-                this.ForegroundColor = Color.FromRgb(0xC0, 0xC0, 0xC0); // HC_LIGHTGRAY
+                this.ForegroundColor = Color.FromRgb(0x80, 0x80, 0x80);    // CIDARKGRAY
             }
         }
         #endregion
-        #region VB XML Literals - Comment 
+        #region VB XML Literals - Comment
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralComment)]
         [Name(ClassificationTypeNames.XmlLiteralComment)]
@@ -956,7 +956,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Delimiter 
+        #region VB XML Literals - Delimiter
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralDelimiter)]
         [Name(ClassificationTypeNames.XmlLiteralDelimiter)]
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Embedded Expression 
+        #region VB XML Literals - Embedded Expression
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralEmbeddedExpression)]
         [Name(ClassificationTypeNames.XmlLiteralEmbeddedExpression)]
@@ -991,7 +991,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Entity Reference 
+        #region VB XML Literals - Entity Reference
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralEntityReference)]
         [Name(ClassificationTypeNames.XmlLiteralEntityReference)]
@@ -1008,7 +1008,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Name 
+        #region VB XML Literals - Name
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralName)]
         [Name(ClassificationTypeNames.XmlLiteralName)]
@@ -1025,7 +1025,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Processing Instruction 
+        #region VB XML Literals - Processing Instruction
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralProcessingInstruction)]
         [Name(ClassificationTypeNames.XmlLiteralProcessingInstruction)]
@@ -1042,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region VB XML Literals - Text 
+        #region VB XML Literals - Text
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.XmlLiteralText)]
         [Name(ClassificationTypeNames.XmlLiteralText)]

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2017.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2017.xml
@@ -1,8 +1,8 @@
 <Themes>
-    <!-- 
+    <!--
         Every Roslyn classification should be listed in this file for each theme.
         Some classifications do not define Foreground colors because we want them to
-        inherit their color from the their parent classification (For instance Type 
+        inherit their color from the their parent classification (For instance Type
         and Member name classifications inherit from Identifier).
     -->
     <Theme Name="Light" GUID="{de3dbbcd-f642-433c-8353-8f1df4370aba}">
@@ -134,7 +134,7 @@
                 <Foreground Type="CT_RAW" Source="FF6464B9" />
             </Color>
             <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+                <Foreground Type="CT_RAW" Source="FF808080" />
             </Color>
             <Color Name="xml literal - comment">
                 <Foreground Type="CT_RAW" Source="FF629755" />
@@ -289,7 +289,7 @@
                 <Foreground Type="CT_RAW" Source="FF6464B9" />
             </Color>
             <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+                <Foreground Type="CT_RAW" Source="FF808080" />
             </Color>
             <Color Name="xml literal - comment">
                 <Foreground Type="CT_RAW" Source="FF629755" />

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2019.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2019.xml
@@ -1,8 +1,8 @@
 <Themes>
-    <!-- 
+    <!--
         Every Roslyn classification should be listed in this file for each theme.
         Some classifications do not define Foreground colors because we want them to
-        inherit their color from the their parent classification (For instance Type 
+        inherit their color from the their parent classification (For instance Type
         and Member name classifications inherit from Identifier).
     -->
     <Theme Name="Light" GUID="{de3dbbcd-f642-433c-8353-8f1df4370aba}">
@@ -140,7 +140,7 @@
                 <Foreground Type="CT_RAW" Source="FF6464B9" />
             </Color>
             <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+                <Foreground Type="CT_RAW" Source="FF808080" />
             </Color>
             <Color Name="xml literal - comment">
                 <Foreground Type="CT_RAW" Source="FF629755" />
@@ -301,7 +301,7 @@
                 <Foreground Type="CT_RAW" Source="FF6464B9" />
             </Color>
             <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+                <Foreground Type="CT_RAW" Source="FF808080" />
             </Color>
             <Color Name="xml literal - comment">
                 <Foreground Type="CT_RAW" Source="FF629755" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44406 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1139744

Before:
![image](https://user-images.githubusercontent.com/611219/91782558-47d3f280-ebb2-11ea-8380-65cec7f10af4.png)

After:
![image](https://user-images.githubusercontent.com/611219/91782467-04798400-ebb2-11ea-9e4e-c4d4ae3887bd.png)



/CC: @Cosifne 