### PR TITLE
Fix incorrect mapping of body-level-symbols (i.e. locals) between VS and OOP.

### DIFF
--- a/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyTests.cs
@@ -68,6 +68,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
         }
 
         [Fact]
+        [WorkItem(1178861, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1178861")]
+        [WorkItem(1192188, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1192188")]
+        [WorkItem(1192486, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1192486")]
         public async Task ResolveBodySymbolsInMultiProjectReferencesToOriginalProjectAsync()
         {
             var random = new Random(Seed: 0);
@@ -116,6 +119,7 @@ class Program
         </Document>
     </Project>";
 
+                // Randomize the order of the projects in the workspace.
                 if (random.Next() % 2 == 0)
                 {
                     return TestWorkspace.CreateWorkspace(XElement.Parse($@"
@@ -138,6 +142,7 @@ class Program
 
             async Task<(Compilation bodyCompilation, Compilation referenceCompilation)> GetCompilationsAsync(Project bodyProject, Project referenceProject)
             {
+                // Randomize the order that we get compilations (and thus populate our internal caches).
                 Compilation bodyCompilation, referenceCompilation;
                 if (random.Next() % 2 == 0)
                 {
@@ -155,6 +160,7 @@ class Program
 
             async Task<(ISymbol bodyLocalSymbol, ISymbol referenceAssemblySymbol)> GetSymbolsAsync(Compilation bodyCompilation, Compilation referenceCompilation)
             {
+                // Randomize the order that we get symbols from each project.
                 ISymbol bodyLocalSymbol, referenceAssemblySymbol;
                 if (random.Next() % 2 == 0)
                 {
@@ -186,6 +192,7 @@ class Program
 
             (ProjectId bodyLocalProjectId, ProjectId referenceAssemblyProjectId) GetOriginatingProjectIds(Solution solution, ISymbol bodyLocalSymbol, ISymbol referenceAssemblySymbol)
             {
+                // Randomize the order that we get try to get the originating project for the symbol.
                 ProjectId bodyLocalProjectId, referenceAssemblyProjectId;
                 if (random.Next() % 2 == 0)
                 {

--- a/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -62,6 +65,141 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
             var resolved = symbolKey.Resolve(compilation).Symbol;
 
             Assert.Equal(method, resolved);
+        }
+
+        [Fact]
+        public async Task ResolveBodySymbolsInMultiProjectReferencesToOriginalProjectAsync()
+        {
+            var random = new Random(Seed: 0);
+
+            // try to trigger race caused by ability to find reference in multiple potential projects depending on what
+            // order things are in in internal collections.  This test was always able to hit the issue prior to the fix
+            // going in, but does not hit it with the fix.  While this doesn't prove the race is gone, it strongly
+            // implies it.
+            for (var i = 0; i < 100; i++)
+            {
+                using var workspace = GetWorkspace();
+                var solution = workspace.CurrentSolution;
+
+                var bodyProject = solution.Projects.Single(p => p.AssemblyName == "BodyProject");
+                var referenceProject = solution.Projects.Single(p => p.AssemblyName == "ReferenceProject");
+
+                var (bodyCompilation, referenceCompilation) = await GetCompilationsAsync(bodyProject, referenceProject);
+                var (bodyLocalSymbol, referenceAssemblySymbol) = await GetSymbolsAsync(bodyCompilation, referenceCompilation);
+
+                var (bodyLocalProjectId, referenceAssemblyProjectId) = GetOriginatingProjectIds(solution, bodyLocalSymbol, referenceAssemblySymbol);
+
+                Assert.True(bodyProject.Id == bodyLocalProjectId, $"Expected {bodyProject.Id} == {bodyLocalProjectId}. {i}");
+                Assert.Equal(referenceProject.Id, referenceAssemblyProjectId);
+            }
+
+            return;
+
+            TestWorkspace GetWorkspace()
+            {
+                var bodyProject = @"
+    <Project Language=""C#"" AssemblyName=""BodyProject"" CommonReferences=""true"">
+        <Document>
+class Program
+{
+    void M()
+    {
+        int local;
+    }
+}
+        </Document>
+    </Project>";
+                var referenceProject = @"
+    <Project Language=""C#"" AssemblyName=""ReferenceProject"" CommonReferences=""true"">
+        <ProjectReference>BodyProject</ProjectReference>
+        <Document>
+        </Document>
+    </Project>";
+
+                if (random.Next() % 2 == 0)
+                {
+                    return TestWorkspace.CreateWorkspace(XElement.Parse($@"
+<Workspace>
+    {bodyProject}
+    {referenceProject}
+</Workspace>
+"));
+                }
+                else
+                {
+                    return TestWorkspace.CreateWorkspace(XElement.Parse($@"
+<Workspace>
+    {referenceProject}
+    {bodyProject}
+</Workspace>
+"));
+                }
+            }
+
+            async Task<(Compilation bodyCompilation, Compilation referenceCompilation)> GetCompilationsAsync(Project bodyProject, Project referenceProject)
+            {
+                Compilation bodyCompilation, referenceCompilation;
+                if (random.Next() % 2 == 0)
+                {
+                    bodyCompilation = await bodyProject.GetCompilationAsync();
+                    referenceCompilation = await referenceProject.GetCompilationAsync();
+                }
+                else
+                {
+                    referenceCompilation = await referenceProject.GetCompilationAsync();
+                    bodyCompilation = await bodyProject.GetCompilationAsync();
+                }
+
+                return (bodyCompilation, referenceCompilation);
+            }
+
+            async Task<(ISymbol bodyLocalSymbol, ISymbol referenceAssemblySymbol)> GetSymbolsAsync(Compilation bodyCompilation, Compilation referenceCompilation)
+            {
+                ISymbol bodyLocalSymbol, referenceAssemblySymbol;
+                if (random.Next() % 2 == 0)
+                {
+                    bodyLocalSymbol = await GetBodyLocalSymbol(bodyCompilation);
+                    referenceAssemblySymbol = referenceCompilation.Assembly;
+                }
+                else
+                {
+                    referenceAssemblySymbol = referenceCompilation.Assembly;
+                    bodyLocalSymbol = await GetBodyLocalSymbol(bodyCompilation);
+                }
+
+                return (bodyLocalSymbol, referenceAssemblySymbol);
+            }
+
+            async Task<ILocalSymbol> GetBodyLocalSymbol(Compilation bodyCompilation)
+            {
+                var tree = bodyCompilation.SyntaxTrees.Single();
+                var semanticModel = bodyCompilation.GetSemanticModel(tree);
+
+                var root = await tree.GetRootAsync();
+                var varDecl = root.DescendantNodesAndSelf().OfType<VariableDeclaratorSyntax>().Single();
+
+                var local = (ILocalSymbol)semanticModel.GetDeclaredSymbol(varDecl);
+                Assert.NotNull(local);
+
+                return local;
+            }
+
+            (ProjectId bodyLocalProjectId, ProjectId referenceAssemblyProjectId) GetOriginatingProjectIds(Solution solution, ISymbol bodyLocalSymbol, ISymbol referenceAssemblySymbol)
+            {
+                ProjectId bodyLocalProjectId, referenceAssemblyProjectId;
+                if (random.Next() % 2 == 0)
+                {
+                    bodyLocalProjectId = solution.GetOriginatingProjectId(bodyLocalSymbol);
+                    referenceAssemblyProjectId = solution.GetOriginatingProjectId(referenceAssemblySymbol);
+                }
+                else
+                {
+                    referenceAssemblyProjectId = solution.GetOriginatingProjectId(referenceAssemblySymbol);
+                    bodyLocalProjectId = solution.GetOriginatingProjectId(bodyLocalSymbol);
+                }
+
+                return (bodyLocalProjectId, referenceAssemblyProjectId);
+            }
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.PositionalSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.PositionalSyntaxReference.cs
@@ -21,56 +21,42 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             private class PositionalSyntaxReference : SyntaxReference
             {
-                private readonly SyntaxTree _tree;
-                private readonly TextSpan _textSpan;
                 private readonly SyntaxKind _kind;
 
                 public PositionalSyntaxReference(SyntaxNode node)
                 {
-                    _tree = node.SyntaxTree;
-                    _textSpan = node.Span;
+                    SyntaxTree = node.SyntaxTree;
+                    Span = node.Span;
                     _kind = node.Kind();
 
-                    System.Diagnostics.Debug.Assert(_textSpan.Length > 0);
+                    System.Diagnostics.Debug.Assert(Span.Length > 0);
                 }
 
-                public override SyntaxTree SyntaxTree
-                {
-                    get
-                    {
-                        return _tree;
-                    }
-                }
+                public override SyntaxTree SyntaxTree { get; }
 
-                public override TextSpan Span
-                {
-                    get
-                    {
-                        return _textSpan;
-                    }
-                }
+                public override TextSpan Span { get; }
 
                 public override SyntaxNode GetSyntax(CancellationToken cancellationToken)
                 {
                     // Find our node going down in the tree. 
                     // Try not going deeper than needed.
-                    return this.GetNode(_tree.GetRoot(cancellationToken));
+                    return this.GetNode(SyntaxTree.GetRoot(cancellationToken));
                 }
 
                 public override async Task<SyntaxNode> GetSyntaxAsync(CancellationToken cancellationToken = default)
                 {
-                    var root = await _tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+                    var root = await SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
                     return this.GetNode(root);
                 }
 
                 private SyntaxNode GetNode(SyntaxNode root)
                 {
                     var current = root;
-                    var spanStart = _textSpan.Start;
+                    var spanStart = Span.Start;
 
                     while (current.FullSpan.Contains(spanStart))
                     {
-                        if (current.Kind() == _kind && current.Span == _textSpan)
+                        if (current.Kind() == _kind && current.Span == Span)
                         {
                             return current;
                         }
@@ -93,8 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Syntax references to nonterminals in structured trivia should be uncommon.
                     // Provide more efficient implementation if that is not true
-                    var descendantsIntersectingSpan = parent.DescendantNodes(_textSpan, descendIntoTrivia: true);
-                    return descendantsIntersectingSpan.First(node => node.IsKind(_kind) && node.Span == _textSpan);
+                    var descendantsIntersectingSpan = parent.DescendantNodes(Span, descendIntoTrivia: true);
+                    return descendantsIntersectingSpan.First(node => node.IsKind(_kind) && node.Span == Span);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -18,16 +18,6 @@ namespace Microsoft.CodeAnalysis
     {
         private static class BodyLevelSymbolKey
         {
-            public static bool IsBodyLevelSymbol(ISymbol symbol)
-                => symbol switch
-                {
-                    ILabelSymbol _ => true,
-                    IRangeVariableSymbol _ => true,
-                    ILocalSymbol _ => true,
-                    IMethodSymbol { MethodKind: MethodKind.LocalFunction } _ => true,
-                    _ => false,
-                };
-
             public static ImmutableArray<Location> GetBodyLevelSourceLocations(ISymbol symbol, CancellationToken cancellationToken)
             {
                 Contract.ThrowIfFalse(IsBodyLevelSymbol(symbol));

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis
                 _nextId++;
 
                 StartKey();
-                if (BodyLevelSymbolKey.IsBodyLevelSymbol(symbol))
+                if (IsBodyLevelSymbol(symbol))
                 {
                     WriteType(SymbolKeyType.BodyLevel);
                     BodyLevelSymbolKey.Create(symbol, this);

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis
 
         public static bool CanCreate(ISymbol symbol, CancellationToken cancellationToken)
         {
-            if (BodyLevelSymbolKey.IsBodyLevelSymbol(symbol))
+            if (IsBodyLevelSymbol(symbol))
             {
                 var locations = BodyLevelSymbolKey.GetBodyLevelSourceLocations(symbol, cancellationToken);
                 if (locations.Length == 0)
@@ -307,5 +307,15 @@ namespace Microsoft.CodeAnalysis
 
             return result;
         }
+
+        public static bool IsBodyLevelSymbol(ISymbol symbol)
+            => symbol switch
+            {
+                ILabelSymbol _ => true,
+                IRangeVariableSymbol _ => true,
+                ILocalSymbol _ => true,
+                IMethodSymbol { MethodKind: MethodKind.LocalFunction } _ => true,
+                _ => false,
+            };
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -120,9 +120,14 @@ namespace Microsoft.CodeAnalysis
                              symbol.Kind == SymbolKind.NetModule ||
                              symbol.Kind == SymbolKind.DynamicType);
                 var state = this.ReadState();
+
                 var unrootedSymbolSet = state.UnrootedSymbolSet;
                 if (unrootedSymbolSet == null)
+                {
+                    // this was not a tracker that hands out symbols (for example, it's a 'declaration table only'
+                    // tracker).  So we have nothing to check this symbol against.
                     return false;
+                }
 
                 if (primary)
                 {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SymbolToProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SymbolToProjectId.cs
@@ -98,7 +98,9 @@ namespace Microsoft.CodeAnalysis
                 // projects, but which have the same syntax-tree (which is only in one project).  We need to actually
                 // check it's assembly symbol so that we get the actual project it is from (the original project, or the
                 // retargetted project).
-                var syntaxTree = symbol.DeclaringSyntaxReferences[0].SyntaxTree;
+                var syntaxTree = symbol.Locations[0].SourceTree;
+                Contract.ThrowIfNull(syntaxTree);
+
                 var documentId = DocumentState.GetDocumentIdForTree(syntaxTree);
                 if (documentId == null)
                 {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SymbolToProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SymbolToProjectId.cs
@@ -61,8 +61,8 @@ namespace Microsoft.CodeAnalysis
                     // references) for that project.  This is the case for metadata symbols.  A metadata symbol might be
                     // found in many projects, so we just return the first result as that's just as good for finding the
                     // metadata symbol as any other project.
-                    var id = TryGetProjectId(symbol, primary: true) ??
-                             TryGetProjectId(symbol, primary: false);
+                    projectId = TryGetProjectId(symbol, primary: true) ??
+                                TryGetProjectId(symbol, primary: false);
 
                     // Have to lock as there's no atomic AddOrUpdate in netstandard2.0 and we could throw if two
                     // threads tried to add the same item.
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis
             {
                 foreach (var (id, tracker) in _projectIdToTrackerMap)
                 {
-                    if (tracker.ContainsAssemblyOrModuleOrDynamic(symbol, primary: true))
+                    if (tracker.ContainsAssemblyOrModuleOrDynamic(symbol, primary))
                         return id;
                 }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
@@ -19,17 +19,17 @@ namespace Microsoft.CodeAnalysis
         /// contained a <see cref="Compilation"/> that could have produced that symbol.  This is especially needed with
         /// OOP scenarios where we have to communicate to OOP from VS (And vice versa) what symbol we are referring to.
         /// To do this, we pass along a project where this symbol could be found, and enough information (a <see
-        /// cref="SymbolKey"/>) to resolve that symbol back in that that <see cref="Project"/>.</para>
-        ///
-        /// <para>This is challenging
-        /// however as symbols do not necessarily have back-pointers to <see cref="Compilation"/>s, and as such, we
-        /// can't just see which Project produced the <see cref="Compilation"/> that produced that <see
+        /// cref="SymbolKey"/>) to resolve that symbol back in that that <see cref="Project"/>.
+        /// <para>
+        /// This is challenging however as symbols do not necessarily have back-pointers to <see cref="Compilation"/>s,
+        /// and as such, we can't just see which Project produced the <see cref="Compilation"/> that produced that <see
         /// cref="ISymbol"/>.  In other words, the <see cref="ISymbol"/> doesn't <c>root</c> the compilation.  Because
-        /// of that we keep track of those symbols per project in a <c>weak</c> fashion.  Then, we can later see if a
+        /// of that we keep track of those symbols per project in a <em>weak</em> fashion.  Then, we can later see if a
         /// symbol came from a particular project by checking if it is one of those weak symbols.  We use weakly held
         /// symbols to that a <see cref="ProjectState"/> instance doesn't hold symbols alive.  But, we know if we are
         /// holding the symbol itself, then the weak-ref will stay alive such that we can do this containment check.
-        /// </summary>
+        /// </para>
+        /// </remarks>
         private readonly struct UnrootedSymbolSet
         {
             /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal partial class SolutionState
+    {
+        private readonly struct UnrootedSymbolSet
+        {
+            public readonly WeakReference<IAssemblySymbol> PrimaryAssemblySymbol;
+            public readonly WeakReference<ITypeSymbol?> PrimaryDynamicSymbol;
+            public readonly WeakSet<ISymbol> SecondaryReferencedSymbols;
+
+            public UnrootedSymbolSet(WeakReference<IAssemblySymbol> primaryAssemblySymbol, WeakReference<ITypeSymbol?> primaryDynamicSymbol, WeakSet<ISymbol> secondaryReferencedSymbols)
+            {
+                PrimaryAssemblySymbol = primaryAssemblySymbol;
+                PrimaryDynamicSymbol = primaryDynamicSymbol;
+                SecondaryReferencedSymbols = secondaryReferencedSymbols;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CodeAnalysis
     internal partial class SolutionState
     {
         /// <summary>
+        /// A helper type for mapping <see cref="ISymbol"/> back to an originating <see cref="Project"/>.
+        /// </summary>
+        /// <remarks>
         /// In IDE scenarios we have the need to map from an <see cref="ISymbol"/> to the <see cref="Project"/> that
         /// contained a <see cref="Compilation"/> that could have produced that symbol.  This is especially needed with
         /// OOP scenarios where we have to communicate to OOP from VS (And vice versa) what symbol we are referring to.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
@@ -11,10 +11,38 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial class SolutionState
     {
+        /// <summary>
+        /// In IDE scenarios we have the need to map from an <see cref="ISymbol"/> to the <see cref="Project"/> that
+        /// contained a <see cref="Compilation"/> that could have produced that symbol.  This is especially needed with
+        /// OOP scenarios where we have to communicate to OOP from VS (And vice versa) what symbol we are referring to.
+        /// To do this, we pass along a project where this symbol could be found, and enough information (a <see
+        /// cref="SymbolKey"/>) to resolve that symbol back in that that <see cref="Project"/>.  This is challenging
+        /// however as symbols do not necessarily have back-pointers to <see cref="Compilation"/>s, and as such, we
+        /// can't just see which Project produced the <see cref="Compilation"/> that produced that <see
+        /// cref="ISymbol"/>.  In other words, the <see cref="ISymbol"/> doesn't <c>root</c> the compilation.  Because
+        /// of that we keep track of those symbols per project in a <c>weak</c> fashion.  Then, we can later see if a
+        /// symbol came from a particular project by checking if it is one of those weak symbols.  We use weakly held
+        /// symbols to that a <see cref="ProjectState"/> instance doesn't hold symbols alive.  But, we know if we are
+        /// holding the symbol itself, then the weak-ref will stay alive such that we can do this containment check.
+        /// </summary>
         private readonly struct UnrootedSymbolSet
         {
+            /// <summary>
+            /// The <see cref="IAssemblySymbol"/> produced directly by <see cref="Compilation.Assembly"/>.
+            /// </summary>
             public readonly WeakReference<IAssemblySymbol> PrimaryAssemblySymbol;
+
+            /// <summary>
+            /// The <see cref="IDynamicTypeSymbol"/> produced directly by <see cref="Compilation.DynamicType"/>.  Only
+            /// valid for <see cref="LanguageNames.CSharp"/>.
+            /// </summary>
             public readonly WeakReference<ITypeSymbol?> PrimaryDynamicSymbol;
+
+            /// <summary>
+            /// The <see cref="IAssemblySymbol"/>s or <see cref="IModuleSymbol"/>s produced through <see
+            /// cref="Compilation.GetAssemblyOrModuleSymbol(MetadataReference)"/> for all the references exposed by <see
+            /// cref="Compilation.References"/>/
+            /// </summary>
             public readonly WeakSet<ISymbol> SecondaryReferencedSymbols;
 
             public UnrootedSymbolSet(WeakReference<IAssemblySymbol> primaryAssemblySymbol, WeakReference<ITypeSymbol?> primaryDynamicSymbol, WeakSet<ISymbol> secondaryReferencedSymbols)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
@@ -19,7 +19,9 @@ namespace Microsoft.CodeAnalysis
         /// contained a <see cref="Compilation"/> that could have produced that symbol.  This is especially needed with
         /// OOP scenarios where we have to communicate to OOP from VS (And vice versa) what symbol we are referring to.
         /// To do this, we pass along a project where this symbol could be found, and enough information (a <see
-        /// cref="SymbolKey"/>) to resolve that symbol back in that that <see cref="Project"/>.  This is challenging
+        /// cref="SymbolKey"/>) to resolve that symbol back in that that <see cref="Project"/>.</para>
+        ///
+        /// <para>This is challenging
         /// however as symbols do not necessarily have back-pointers to <see cref="Compilation"/>s, and as such, we
         /// can't just see which Project produced the <see cref="Compilation"/> that produced that <see
         /// cref="ISymbol"/>.  In other words, the <see cref="ISymbol"/> doesn't <c>root</c> the compilation.  Because


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1178861
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1192486
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1192188

This has been an issue causing a lot of flakeyness between VS and OOP.  

We knew we had an issue here and we logged a an NFE containing useful information to try to help track this down.  From that NFE data I found that *all* the hits were for 'body level' symbols (i.e. locals/local-functions/range-variables/labels).  I was able to find an NFE from a roslyn user and saw something very surprising.  Namely that we had started with a local varaible from CSharpCompiler project, but thought it was from CSharpFeatures project.

With this information in mind i audited our code for mapping symbols back to projects and found a very core issue there that i've addressed (in a few ways).  The PR will cover what the fix is here.

--

Note: due to the mitigation in https://github.com/dotnet/roslyn/pull/47339, we will not take this for preview3.  