### PR TITLE
Make DocumentationCommentCompiler work after NormalizeWhitespace

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -807,6 +807,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int newLineLength;
                 int end = IndexOfNewLine(text, start, out newLineLength);
                 int trimStart = GetIndexOfFirstNonWhitespaceChar(text, start, end) + substringStart;
+
+                // this happens when text ends with new line followed by whitespace
+                if (trimStart >= end)
+                {
+                    break;
+                }
+
                 WriteSubStringLine(text, trimStart, end - trimStart);
                 start = end + newLineLength;
             }

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -809,7 +809,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int trimStart = GetIndexOfFirstNonWhitespaceChar(text, start, end) + substringStart;
 
                 // this happens when text ends with new line followed by whitespace
-                if (trimStart >= end)
+                if (trimStart > end)
                 {
                     break;
                 }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -3285,10 +3285,19 @@ public class Program
 
             var tree = Parse(text);
 
+            Assert.Equal(@"/// <summary>
+    /// This is Foo.Bar
+    /// </summary>
+", getDocumentationCommentString());
+
             tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(eol: Environment.NewLine), tree.Options);
 
-            // NormalizeWhitespace doesn't change the text here (though it might change the tree structure)
+            // NormalizeWhitespace didn't change the full text, but it moved whitespace into the documentation comment
             Assert.Equal(text, tree.ToString());
+            Assert.Equal(@"/// <summary>
+    /// This is Foo.Bar
+    /// </summary>
+    ", getDocumentationCommentString());
 
             var comp = CreateCompilation(tree);
 
@@ -3297,6 +3306,9 @@ public class Program
             DocumentationCommentCompiler.WriteDocumentationCommentXml(comp, null, null, diags, default);
 
             diags.Verify();
+
+            string getDocumentationCommentString() =>
+                tree.GetRoot().DescendantTrivia().Single(n => n.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)).ToFullString();
         }
 
         #region Xml Test helpers

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -3285,7 +3285,7 @@ public class Program
 
             var tree = Parse(text);
 
-            tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(), tree.Options);
+            tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(eol: Environment.NewLine), tree.Options);
 
             // NormalizeWhitespace doesn't change the text here (though it might change the tree structure)
             Assert.Equal(text, tree.ToString());

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -3269,6 +3269,31 @@ public class Program
                 );
         }
 
+        [WorkItem(47278, "https://github.com/dotnet/roslyn/issues/47278")]
+        [Fact]
+        public void NormalizeWhitespace()
+        {
+            var text = @"
+namespace Foo
+{
+    /// <summary>
+    /// This is Foo.Bar
+    /// </summary>
+    class Bar { }
+}";
+
+            var tree = Parse(text);
+            tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(), tree.Options);
+
+            var comp = CreateCompilation(tree);
+
+            var diags = new DiagnosticBag();
+
+            DocumentationCommentCompiler.WriteDocumentationCommentXml(comp, null, null, diags, default);
+
+            diags.Verify();
+        }
+
         #region Xml Test helpers
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -3273,17 +3273,22 @@ public class Program
         [Fact]
         public void NormalizeWhitespace()
         {
-            var text = @"
-namespace Foo
+            var text = @"namespace Foo
 {
     /// <summary>
     /// This is Foo.Bar
     /// </summary>
-    class Bar { }
+    class Bar
+    {
+    }
 }";
 
             var tree = Parse(text);
+
             tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(), tree.Options);
+
+            // NormalizeWhitespace doesn't change the text here (though it might change the tree structure)
+            Assert.Equal(text, tree.ToString());
 
             var comp = CreateCompilation(tree);
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -3292,7 +3292,7 @@ public class Program
 
             tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(eol: Environment.NewLine), tree.Options);
 
-            // NormalizeWhitespace didn't change the full text, but it moved whitespace into the documentation comment
+            // NormalizeWhitespace didn't change the full text, but it moved whitespace from the following whitespace trivia to the end of the documentation comment
             Assert.Equal(text, tree.ToString());
             Assert.Equal(@"/// <summary>
     /// This is Foo.Bar


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47278.