### PR TITLE
Avoid trying to boost on non-supported platforms

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/ProcessExtensions.cs
+++ b/src/Workspaces/Remote/ServiceHub/ProcessExtensions.cs
@@ -13,8 +13,15 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal static class ProcessExtensions
     {
+        private static bool s_settingPrioritySupported = true;
+
         public static bool TrySetPriorityClass(this Process process, ProcessPriorityClass priorityClass)
         {
+            if (!s_settingPrioritySupported)
+            {
+                return false;
+            }
+
             try
             {
                 process.PriorityClass = priorityClass;
@@ -23,6 +30,8 @@ namespace Microsoft.CodeAnalysis.Remote
             catch (Exception e) when (e is PlatformNotSupportedException || e is Win32Exception)
             {
                 // the runtime does not support changing process priority
+                s_settingPrioritySupported = false;
+
                 return false;
             }
         }

--- a/src/Workspaces/Remote/ServiceHub/ProcessExtensions.cs
+++ b/src/Workspaces/Remote/ServiceHub/ProcessExtensions.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    /// <summary>
+    /// Boost performance of any servicehub service which is invoked by user explicit actions
+    /// </summary>
+    internal static class ProcessExtensions
+    {
+        public static bool TrySetPriorityClass(this Process process, ProcessPriorityClass priorityClass)
+        {
+            try
+            {
+                process.PriorityClass = priorityClass;
+                return true;
+            }
+            catch (Exception e) when (e is PlatformNotSupportedException || e is Win32Exception)
+            {
+                // the runtime does not support changing process priority
+                return false;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
@@ -64,10 +64,17 @@ namespace Microsoft.CodeAnalysis.Remote
 
             if (TestData == null || !TestData.IsInProc)
             {
-                // Set this process's priority BelowNormal.
-                // this should let us to freely try to use all resources possible without worrying about affecting
-                // host's work such as responsiveness or build.
-                Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+                try
+                {
+                    // Set this process's priority BelowNormal.
+                    // this should let us to freely try to use all resources possible without worrying about affecting
+                    // host's work such as responsiveness or build.
+                    Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+                }
+                catch (Exception e) when (e is PlatformNotSupportedException || e is Win32Exception)
+                {
+                    // the runtime does not support changing process priority, so just ignore this
+                }
             }
 
             // this service provide a way for client to make sure remote host is alive

--- a/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
@@ -64,17 +64,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
             if (TestData == null || !TestData.IsInProc)
             {
-                try
-                {
-                    // Set this process's priority BelowNormal.
-                    // this should let us to freely try to use all resources possible without worrying about affecting
-                    // host's work such as responsiveness or build.
-                    Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
-                }
-                catch (Exception e) when (e is PlatformNotSupportedException || e is Win32Exception)
-                {
-                    // the runtime does not support changing process priority, so just ignore this
-                }
+                // Try setting this process's priority BelowNormal.
+                // this should let us to freely try to use all resources possible without worrying about affecting
+                // host's work such as responsiveness or build.
+                Process.GetCurrentProcess().TrySetPriorityClass(ProcessPriorityClass.BelowNormal);
             }
 
             // this service provide a way for client to make sure remote host is alive

--- a/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs
+++ b/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal struct UserOperationBooster : IDisposable
     {
-        private static bool s_settingPrioritySupported = true;
         private static int s_count = 0;
         private static readonly object s_gate = new object();
 
@@ -36,11 +35,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (s_count == 1)
                 {
                     // try boosting to normal priority
-                    if (!s_settingPrioritySupported || !Process.GetCurrentProcess().TrySetPriorityClass(ProcessPriorityClass.Normal))
+                    if (!Process.GetCurrentProcess().TrySetPriorityClass(ProcessPriorityClass.Normal))
                     {
                         // The runtime does not support changing process priority, so just return a NOP booster.
-                        s_settingPrioritySupported = false;
-
                         return new UserOperationBooster();
                     }
                 }

--- a/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs
+++ b/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal struct UserOperationBooster : IDisposable
     {
-        private static bool settingPrioritySupported = true;
+        private static bool s_settingPrioritySupported = true;
         private static int s_count = 0;
         private static readonly object s_gate = new object();
 
@@ -36,10 +36,10 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (s_count == 1)
                 {
                     // try boosting to normal priority
-                    if (settingPrioritySupported && !Process.GetCurrentProcess().TrySetPriorityClass(ProcessPriorityClass.Normal))
+                    if (!s_settingPrioritySupported || !Process.GetCurrentProcess().TrySetPriorityClass(ProcessPriorityClass.Normal))
                     {
                         // The runtime does not support changing process priority, so just return a NOP booster.
-                        settingPrioritySupported = false;
+                        s_settingPrioritySupported = false;
 
                         return new UserOperationBooster();
                     }

--- a/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs
+++ b/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -33,8 +34,16 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 if (s_count == 1)
                 {
-                    // boost to normal priority
-                    Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal;
+                    try
+                    {
+                        // boost to normal priority
+                        Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal;
+                    }
+                    catch (Exception e) when (e is PlatformNotSupportedException || e is Win32Exception)
+                    {
+                        // The runtime does not support changing process priority, so just return a NOP booster.
+                        return new UserOperationBooster();
+                    }
                 }
 
                 return new UserOperationBooster(isBoosted: true);


### PR DESCRIPTION
On Mono, this throws an exception every time you try to query it, and it is documented that setting PriorityClass can throw, so adapt to that.

```
StreamJsonRpc.RemoteInvocationException: Success
  at StreamJsonRpc.JsonRpc.InvokeCoreAsync[TResult] (StreamJsonRpc.RequestId id, System.String targetName, System.Collections.Generic.IReadOnlyList`1[T] arguments, System.Threading.CancellationToken cancellationToken, System.Boolean isParameterObject) [0x00184] in C:\A\_work\164\s\src\StreamJsonRpc\JsonRpc.cs:1350
  at Microsoft.CodeAnalysis.Remote.RemoteEndPoint.InvokeAsync[T] (System.String targetName, System.Collections.Generic.IReadOnlyList`1[T] arguments, System.Threading.CancellationToken cancellationToken) [0x0005c] in /_/src/Workspaces/Remote/Core/RemoteEndPoint.cs:153
RPC server exception:
System.ComponentModel.Win32Exception: Success
     at System.Diagnostics.Process.set_PriorityClass (System.Diagnostics.ProcessPriorityClass value) [0x00049] in <3b74eb7e72ba49d0adf622008aa5cb32>:0
     at (wrapper remoting-invoke-with-check) System.Diagnostics.Process.set_PriorityClass(System.Diagnostics.ProcessPriorityClass)
     at Microsoft.CodeAnalysis.Remote.UserOperationBooster.Boost () [0x00029] in <8b79db78374649648c6dc65f376ad81c>:0
     at Microsoft.CodeAnalysis.Remote.CodeAnalysisService+<>c__DisplayClass33_0.<GetSemanticClassificationsAsync>b__0 () [0x00012] in <8b79db78374649648c6dc65f376ad81c>:0
     at Microsoft.CodeAnalysis.Remote.ServiceBase.RunServiceAsync[T] (System.Func`1[TResult] callAsync, System.Threading.CancellationToken cancellationToken) [0x00085] in <8b79db78374649648c6dc65f376ad81c>:0
```