### PR TITLE
Make tree retrieval optional, it's not required for non-C#/VB languages. 

### DIFF
--- a/src/EditorFeatures/CSharpTest/TodoComment/NoCompilationTodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/NoCompilationTodoCommentTests.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities.TodoComments;
+using Microsoft.CodeAnalysis.TodoComments;
+using Microsoft.CodeAnalysis.UnitTests;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
+{
+    [UseExportProvider]
+    public class NoCompilationTodoCommentTests : AbstractTodoCommentTests
+    {
+        protected override TestWorkspace CreateWorkspace(string codeWithMarker)
+        {
+            return TestWorkspace.CreateWorkspace(XElement.Parse(
+$@"<Workspace>
+    <Project Language=""NoCompilation"">
+        <Document>{codeWithMarker}</Document>
+    </Project>
+</Workspace>"), composition: EditorTestCompositions.EditorFeatures.AddParts(
+                typeof(NoCompilationContentTypeDefinitions),
+                typeof(NoCompilationContentTypeLanguageService),
+                typeof(NoCompilationTodoCommentService)));
+        }
+
+        [Fact, WorkItem(1192024, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1192024")]
+        public async Task TodoCommentInNoCompilationProject()
+        {
+            var code = @"(* [|Message|] *)";
+
+            await TestAsync(code);
+        }
+    }
+
+    [PartNotDiscoverable]
+    [ExportLanguageService(typeof(ITodoCommentService), language: NoCompilationConstants.LanguageName), Shared]
+    internal class NoCompilationTodoCommentService : ITodoCommentService
+    {
+        [ImportingConstructor]
+        [System.Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public NoCompilationTodoCommentService()
+        {
+        }
+
+        public Task<ImmutableArray<TodoComments.TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ImmutableArray.Create(new TodoComments.TodoComment(commentDescriptors.First(), "Message", 3)));
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
@@ -2,14 +2,65 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities.TodoComments;
+using Microsoft.CodeAnalysis.TodoComments;
+using Microsoft.CodeAnalysis.UnitTests;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
 {
+    [UseExportProvider]
+    public class NoCompilationTodoCommentTests : AbstractTodoCommentTests
+    {
+        protected override TestWorkspace CreateWorkspace(string codeWithMarker)
+        {
+            return TestWorkspace.CreateWorkspace(XElement.Parse(
+$@"<Workspace>
+    <Project Language=""NoCompilation"">
+        <Document>{codeWithMarker}</Document>
+    </Project>
+</Workspace>"), composition: EditorTestCompositions.EditorFeatures.AddParts(
+                typeof(NoCompilationContentTypeDefinitions),
+                typeof(NoCompilationContentTypeLanguageService),
+                typeof(NoCompilationTodoCommentService)));
+        }
+
+        [Fact, WorkItem(1192024, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1192024")]
+        public async Task TodoCommentInNoCompilationProject()
+        {
+            var code = @"(* [|Message|] *)";
+
+            await TestAsync(code);
+        }
+    }
+
+    [PartNotDiscoverable]
+    [ExportLanguageService(typeof(ITodoCommentService), language: NoCompilationConstants.LanguageName), Shared]
+    internal class NoCompilationTodoCommentService : ITodoCommentService
+    {
+        [ImportingConstructor]
+        [System.Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public NoCompilationTodoCommentService()
+        {
+        }
+
+        public Task<ImmutableArray<TodoComments.TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ImmutableArray.Create(new TodoComments.TodoComment(commentDescriptors.First(), "Message", 3)));
+        }
+    }
+
     [UseExportProvider]
     public class TodoCommentTests : AbstractTodoCommentTests
     {

--- a/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
@@ -2,65 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities.TodoComments;
-using Microsoft.CodeAnalysis.TodoComments;
-using Microsoft.CodeAnalysis.UnitTests;
-using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
 {
-    [UseExportProvider]
-    public class NoCompilationTodoCommentTests : AbstractTodoCommentTests
-    {
-        protected override TestWorkspace CreateWorkspace(string codeWithMarker)
-        {
-            return TestWorkspace.CreateWorkspace(XElement.Parse(
-$@"<Workspace>
-    <Project Language=""NoCompilation"">
-        <Document>{codeWithMarker}</Document>
-    </Project>
-</Workspace>"), composition: EditorTestCompositions.EditorFeatures.AddParts(
-                typeof(NoCompilationContentTypeDefinitions),
-                typeof(NoCompilationContentTypeLanguageService),
-                typeof(NoCompilationTodoCommentService)));
-        }
-
-        [Fact, WorkItem(1192024, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1192024")]
-        public async Task TodoCommentInNoCompilationProject()
-        {
-            var code = @"(* [|Message|] *)";
-
-            await TestAsync(code);
-        }
-    }
-
-    [PartNotDiscoverable]
-    [ExportLanguageService(typeof(ITodoCommentService), language: NoCompilationConstants.LanguageName), Shared]
-    internal class NoCompilationTodoCommentService : ITodoCommentService
-    {
-        [ImportingConstructor]
-        [System.Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public NoCompilationTodoCommentService()
-        {
-        }
-
-        public Task<ImmutableArray<TodoComments.TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(ImmutableArray.Create(new TodoComments.TodoComment(commentDescriptors.First(), "Message", 3)));
-        }
-    }
-
     [UseExportProvider]
     public class TodoCommentTests : AbstractTodoCommentTests
     {

--- a/src/EditorFeatures/TestUtilities/TodoComments/AbtractTodoCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/TodoComments/AbtractTodoCommentTests.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Editor.Implementation.TodoComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.TodoComments;
@@ -34,28 +35,29 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.TodoComments
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
             var service = document.GetLanguageService<ITodoCommentService>();
-            var todoLists = await service.GetTodoCommentsAsync(document,
+            var todoComments = await service.GetTodoCommentsAsync(document,
                 TodoCommentDescriptor.Parse(TodoCommentOptions.TokenList.DefaultValue),
                 CancellationToken.None);
 
+            using var _ = ArrayBuilder<TodoCommentData>.GetInstance(out var converted);
+            await TodoComment.ConvertAsync(document, todoComments, converted, CancellationToken.None);
+
             var expectedLists = hostDocument.SelectedSpans;
-            Assert.Equal(todoLists.Length, expectedLists.Count);
+            Assert.Equal(converted.Count, expectedLists.Count);
 
             var sourceText = await document.GetTextAsync();
             var tree = await document.GetSyntaxTreeAsync();
-            for (var i = 0; i < todoLists.Length; i++)
+            for (var i = 0; i < converted.Count; i++)
             {
-                var todo = todoLists[i];
+                var todo = converted[i];
                 var span = expectedLists[i];
 
                 var line = initialTextSnapshot.GetLineFromPosition(span.Start);
                 var text = initialTextSnapshot.GetText(span.ToSpan());
 
-                var converted = todo.CreateSerializableData(document, sourceText, tree);
-
-                Assert.Equal(converted.MappedLine, line.LineNumber);
-                Assert.Equal(converted.MappedColumn, span.Start - line.Start);
-                Assert.Equal(converted.Message, text);
+                Assert.Equal(todo.MappedLine, line.LineNumber);
+                Assert.Equal(todo.MappedColumn, span.Start - line.Start);
+                Assert.Equal(todo.Message, text);
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/TodoComments/AbtractTodoCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/TodoComments/AbtractTodoCommentTests.cs
@@ -2,14 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Editor.Implementation.TodoComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.TodoComments;
+using Microsoft.CodeAnalysis.UnitTests;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities.TodoComments

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentsIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentsIncrementalAnalyzer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             CancellationToken cancellationToken)
         {
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var comment in todoComments)
                 converted.Add(comment.CreateSerializableData(document, sourceText, syntaxTree));

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentsIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentsIncrementalAnalyzer.cs
@@ -66,24 +66,11 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
             // Convert the roslyn-level results to the more VS oriented line/col data.
             using var _ = ArrayBuilder<TodoCommentData>.GetInstance(out var converted);
-            await ConvertAsync(
+            await TodoComment.ConvertAsync(
                 document, todoComments, converted, cancellationToken).ConfigureAwait(false);
 
             // Now inform VS about this new information
             await ReportTodoCommentDataAsync(document.Id, converted.ToImmutable(), cancellationToken).ConfigureAwait(false);
-        }
-
-        private static async Task ConvertAsync(
-            Document document,
-            ImmutableArray<TodoComment> todoComments,
-            ArrayBuilder<TodoCommentData> converted,
-            CancellationToken cancellationToken)
-        {
-            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-
-            foreach (var comment in todoComments)
-                converted.Add(comment.CreateSerializableData(document, sourceText, syntaxTree));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -233,8 +233,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // TS doesn't have syntax trees, so just explicitly pass along null when converting the data.
-            foreach (var comment in todoComments)
-                converted.Add(comment.CreateSerializableData(document, text, tree: null));
+            await TodoComment.ConvertAsync(document, todoComments, converted, cancellationToken).ConfigureAwait(false);
 
             await ReportTodoCommentDataAsync(
                 document.Id, converted.ToImmutable(), cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -232,7 +232,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
 
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-            // TS doesn't have syntax trees, so just explicitly pass along null when converting the data.
             await TodoComment.ConvertAsync(document, todoComments, converted, cancellationToken).ConfigureAwait(false);
 
             await ReportTodoCommentDataAsync(


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1192024.