### PR TITLE
Enable "unmapped" span results.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISpanMappingService.cs
@@ -59,11 +59,6 @@ namespace Microsoft.CodeAnalysis.Host
 
         public MappedSpanResult(string filePath, LinePositionSpan linePositionSpan, TextSpan span)
         {
-            if (string.IsNullOrEmpty(filePath))
-            {
-                throw new System.ArgumentException(nameof(filePath));
-            }
-
             FilePath = filePath;
             LinePositionSpan = linePositionSpan;
             Span = span;


### PR DESCRIPTION
- Default mapped span results are used to indicate that a dynamic file could not map a particular location. Prior to this change the `IsDefault` flag was checking if `FilePath` was `null` to indicate that it wasn't mapped; however, in the ctor of the class it'd throw if `FilePath` was `null` resulting in a red bar in VS.

**Before:**
![YoGdBObHxs](https://user-images.githubusercontent.com/2008729/92049529-8fd45000-ed3f-11ea-8adc-ab0b958a3e22.gif)

**After:**
![AFn504HDpr](https://user-images.githubusercontent.com/2008729/92049064-30c20b80-ed3e-11ea-8de3-30287bcc9220.gif)

Fixes dotnet/aspnetcore#24351