### PR TITLE
Enable default mapped span results for Razor.

### DIFF
--- a/src/Tools/ExternalAccess/Razor/RazorSpanMappingServiceWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorSpanMappingServiceWrapper.cs
@@ -28,7 +28,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             for (var i = 0; i < razorSpans.Length; i++)
             {
                 var razorSpan = razorSpans[i];
-                roslynSpans[i] = new MappedSpanResult(razorSpan.FilePath, razorSpan.LinePositionSpan, razorSpan.Span);
+                if (razorSpan.FilePath == null)
+                {
+                    // Unmapped location
+                    roslynSpans[i] = default;
+                }
+                else
+                {
+                    roslynSpans[i] = new MappedSpanResult(razorSpan.FilePath, razorSpan.LinePositionSpan, razorSpan.Span);
+                }
             }
 
             return roslynSpans.ToImmutableArray();

--- a/src/Tools/ExternalAccess/Razor/RazorSpanMappingServiceWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorSpanMappingServiceWrapper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             for (var i = 0; i < razorSpans.Length; i++)
             {
                 var razorSpan = razorSpans[i];
-                if (razorSpan.FilePath == null)
+                if (razorSpan.IsDefault)
                 {
                     // Unmapped location
                     roslynSpans[i] = default;


### PR DESCRIPTION
- Default mapped span results are used to indicate that a dynamic file could not map a particular location. Prior to this change we'd always reconstruct the span mapping full-sale which would explode during mapping construction because null filepaths weren't allowed. Therefore, we needed to understand that an "unmapped" location was being handed off from Razor's runtime and in turn needed to generate a "default" unmapped span for it.

**Before:**
![YoGdBObHxs](https://user-images.githubusercontent.com/2008729/92049529-8fd45000-ed3f-11ea-8adc-ab0b958a3e22.gif)

**After:**
![AFn504HDpr](https://user-images.githubusercontent.com/2008729/92049064-30c20b80-ed3e-11ea-8de3-30287bcc9220.gif)

Fixes dotnet/aspnetcore#24351