### PR TITLE
Short-circuit constant expressions when checking for mutating expressions.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
@@ -117,10 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 public bool MightAssignSomething(BoundExpression expr)
                 {
-                    if (expr == null || expr.ConstantValue != null)
-                    {
+                    if (expr == null)
                         return false;
-                    }
 
                     this._mightAssignSomething = false;
                     this.Visit(expr);
@@ -129,6 +127,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 public override BoundNode Visit(BoundNode node)
                 {
+                    // A constant expression cannot mutate anything
+                    if (node is BoundExpression { ConstantValue: { } })
+                        return null;
+
                     // Stop visiting once we determine something might get assigned
                     return this._mightAssignSomething ? null : base.Visit(node);
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -3037,6 +3037,37 @@ static class Ex
             Assert.Equal(SpecialType.System_Boolean, type.ConvertedType.SpecialType);
         }
 
+        [Fact]
+        [WorkItem(46593, "https://github.com/dotnet/roslyn/issues/46593")]
+        public void NameofInWhenClause()
+        {
+            var source =
+@"struct Outer
+{
+    struct S
+    {
+        static void M(string q)
+        {
+            S s = new S();
+            System.Console.Write(s switch
+            {
+                { P: 1 } when nameof(Q) == q => 1,
+                { P: 2 } => 2,
+                _ => 3,
+            });
+        }
+
+        int P => 1;
+    }
+
+    public int Q => 1;
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyEmitDiagnostics(
+                );
+        }
+
         [Fact, WorkItem(20210, "https://github.com/dotnet/roslyn/issues/20210")]
         public void SwitchOnNull_20210()
         {


### PR DESCRIPTION
Nameof's subexpressions do not require receivers, so this prevents us from having to handle that.
Fixes #46593