### PR TITLE
Use static lambdas to better express intent concisely

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -271,7 +271,9 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                     new DeclarationInfo(
                             declaredSymbolInfos.ToImmutable()),
                     new ExtensionMethodInfo(
-                        extensionMethodInfoBuilder.ToImmutableDictionary(s_getKey, s_getValuesAsImmutableArray)));
+                        extensionMethodInfoBuilder.ToImmutableDictionary(
+                            static kvp => kvp.Key,
+                            static kvp => kvp.Value.ToImmutable())));
             }
             finally
             {
@@ -288,9 +290,6 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                 declaredSymbolInfos.Free();
             }
         }
-
-        private static readonly Func<KeyValuePair<string, ArrayBuilder<int>>, string> s_getKey = kvp => kvp.Key;
-        private static readonly Func<KeyValuePair<string, ArrayBuilder<int>>, ImmutableArray<int>> s_getValuesAsImmutableArray = kvp => kvp.Value.ToImmutable();
 
         private static void AddExtensionMethodInfo(
             IDeclaredSymbolInfoFactoryService infoFactory,

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -64,10 +64,9 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             public Task<Checksum> ReadChecksumAsync(TKey key, CancellationToken cancellationToken)
-                => Storage.PerformReadAsync(s_readChecksum, (self: this, key, cancellationToken), cancellationToken);
-
-            private static readonly Func<(Accessor<TKey, TWriteQueueKey, TDatabaseId> self, TKey key, CancellationToken cancellationToken), Checksum> s_readChecksum =
-                t => t.self.ReadChecksum(t.key, t.cancellationToken);
+                => Storage.PerformReadAsync(
+                    static t => t.self.ReadChecksum(t.key, t.cancellationToken),
+                    (self: this, key, cancellationToken), cancellationToken);
 
             private Checksum ReadChecksum(TKey key, CancellationToken cancellationToken)
             {
@@ -85,10 +84,9 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             public Task<Stream> ReadStreamAsync(TKey key, Checksum checksum, CancellationToken cancellationToken)
-                => Storage.PerformReadAsync(s_readStream, (self: this, key, checksum, cancellationToken), cancellationToken);
-
-            private static readonly Func<(Accessor<TKey, TWriteQueueKey, TDatabaseId> self, TKey key, Checksum checksum, CancellationToken cancellationToken), Stream> s_readStream =
-                t => t.self.ReadStream(t.key, t.checksum, t.cancellationToken);
+                => Storage.PerformReadAsync(
+                    static t => t.self.ReadStream(t.key, t.checksum, t.cancellationToken),
+                    (self: this, key, checksum, cancellationToken), cancellationToken);
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             private Stream ReadStream(TKey key, Checksum checksum, CancellationToken cancellationToken)
@@ -122,10 +120,9 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             }
 
             public Task<bool> WriteStreamAsync(TKey key, Stream stream, Checksum checksumOpt, CancellationToken cancellationToken)
-                => Storage.PerformWriteAsync(s_writeStream, (self: this, key, stream, checksumOpt, cancellationToken), cancellationToken);
-
-            private static readonly Func<(Accessor<TKey, TWriteQueueKey, TDatabaseId> self, TKey key, Stream stream, Checksum checksumOpt, CancellationToken cancellationToken), bool> s_writeStream =
-                t => t.self.WriteStream(t.key, t.stream, t.checksumOpt, t.cancellationToken);
+                => Storage.PerformWriteAsync(
+                    static t => t.self.WriteStream(t.key, t.stream, t.checksumOpt, t.cancellationToken),
+                    (self: this, key, stream, checksumOpt, cancellationToken), cancellationToken);
 
             private bool WriteStream(TKey key, Stream stream, Checksum checksumOpt, CancellationToken cancellationToken)
             {
@@ -187,25 +184,21 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                 // only safe if we are in a transaction and no-one else can race with
                 // us.
                 return connection.RunInTransaction(
-                    s_validateChecksumAndReadBlock,
+                    static t =>
+                    {
+                        // If we were passed a checksum, make sure it matches what we have
+                        // stored in the table already.  If they don't match, don't read
+                        // out the data value at all.
+                        if (t.checksumOpt != null &&
+                            !t.self.ChecksumsMatch_MustRunInTransaction(t.connection, t.database, t.rowId, t.checksumOpt, t.cancellationToken))
+                        {
+                            return null;
+                        }
+
+                        return t.connection.ReadBlob_MustRunInTransaction(t.database, t.self.DataTableName, t.columnName, t.rowId);
+                    },
                     (self: this, connection, database, columnName, checksumOpt, rowId, cancellationToken));
             }
-
-            private static readonly Func<(Accessor<TKey, TWriteQueueKey, TDatabaseId> self, SqlConnection connection, Database database,
-                 string columnName, Checksum checksumOpt, long rowId, CancellationToken cancellationToken), Stream> s_validateChecksumAndReadBlock =
-                t =>
-                {
-                    // If we were passed a checksum, make sure it matches what we have
-                    // stored in the table already.  If they don't match, don't read
-                    // out the data value at all.
-                    if (t.checksumOpt != null &&
-                        !t.self.ChecksumsMatch_MustRunInTransaction(t.connection, t.database, t.rowId, t.checksumOpt, t.cancellationToken))
-                    {
-                        return null;
-                    }
-
-                    return t.connection.ReadBlob_MustRunInTransaction(t.database, t.self.DataTableName, t.columnName, t.rowId);
-                };
 
             private bool ChecksumsMatch_MustRunInTransaction(
                 SqlConnection connection, Database database, long rowId, Checksum checksum, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
@@ -88,7 +88,9 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // values.
             try
             {
-                stringId = connection.RunInTransaction(s_insertStringIntoDataBase, (self: this, connection, value));
+                stringId = connection.RunInTransaction(
+                    static t => t.self.InsertStringIntoDatabase_MustRunInTransaction(t.connection, t.value),
+                    (self: this, connection, value));
 
                 Contract.ThrowIfTrue(stringId == null);
                 return stringId;
@@ -108,9 +110,6 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             return null;
         }
-
-        private static readonly Func<(SQLitePersistentStorage self, SqlConnection connection, string value), int> s_insertStringIntoDataBase =
-            t => t.self.InsertStringIntoDatabase_MustRunInTransaction(t.connection, t.value);
 
         private int InsertStringIntoDatabase_MustRunInTransaction(SqlConnection connection, string value)
         {


### PR DESCRIPTION
These are a couple of areas where we switched, in the past, from a normal lambda to a static delegate to ensure we didn't accidentally capture something.  The original changes were done because the captures ended up causing perf issues, and we wanted to make sure we didn't accidentally regress this.

We can now state this simply in the source by explicitly using a static-lambda.  These lambdas now convey explicitly that they shoudl not capture, and it's no longer possible to accidentally cause them to do so (without a very obvious textual change on the declaration). 