### PR TITLE
Correctly get binder when a local function is the first thing in top level statements

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1980,7 +1980,7 @@ done:
                     // Top level statements are unique among our nodes: if there are no syntax nodes before local functions,
                     // then that means the start of the span of the top-level statement is the same as the start as the local
                     // function. Therefore, GetEnclosingBinder can't tell the difference, and it will get the binder for the
-                    // local function, not for the CompilationUnitSyntax. This is desirable in almost call cases but this one:
+                    // local function, not for the CompilationUnitSyntax. This is desirable in almost all cases but this one:
                     // There are no locals or invocations before this, meaning there's nothing to call GetDeclaredSymbol,
                     // GetTypeInfo, or GetSymbolInfo on. GetDeclaredSymbol(CompilationUnitSyntax) goes down another path that
                     // does not need to do any binding whatsoever, so it also doesn't care about this behavior. The only place

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1978,7 +1978,7 @@ done:
                 if (root is CompilationUnitSyntax)
                 {
                     // Top level statements are unique among our nodes: if there are no syntax nodes before local functions,
-                    // then that means the start of the span of the top-level statement is the same as the start as the local
+                    // then that means the start of the span of the top-level statement is the same as the start of the local
                     // function. Therefore, GetEnclosingBinder can't tell the difference, and it will get the binder for the
                     // local function, not for the CompilationUnitSyntax. This is desirable in almost all cases but this one:
                     // There are no locals or invocations before this, meaning there's nothing to call GetDeclaredSymbol,

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1975,7 +1975,24 @@ done:
 
             BoundNode bind(CSharpSyntaxNode root, DiagnosticBag diagnosticBag, out Binder binder)
             {
-                binder = GetEnclosingBinder(GetAdjustedNodePosition(root));
+                if (root is CompilationUnitSyntax)
+                {
+                    // Top level statements are unique among our nodes: if there are no syntax nodes before local functions,
+                    // then that means the start of the span of the top-level statement is the same as the start as the local
+                    // function. Therefore, GetEnclosingBinder can't tell the difference, and it will get the binder for the
+                    // local function, not for the CompilationUnitSyntax. This is desirable in almost call cases but this one:
+                    // There are no locals or invocations before this, meaning there's nothing to call GetDeclaredSymbol,
+                    // GetTypeInfo, or GetSymbolInfo on. GetDeclaredSymbol(CompilationUnitSyntax) goes down another path that
+                    // does not need to do any binding whatsoever, so it also doesn't care about this behavior. The only place
+                    // that actually needs to get the enclosing binding for a CompilationUnitSyntax in such a scenario is this
+                    // method. So, if our root is the CompilationUnitSyntax, directly get the binder for it.
+                    binder = RootBinder.GetBinder(root);
+                    Debug.Assert(binder is SimpleProgramBinder);
+                }
+                else
+                {
+                    binder = GetEnclosingBinder(GetAdjustedNodePosition(root));
+                }
                 return Bind(binder, root, diagnosticBag);
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -4713,40 +4713,17 @@ class C
             Assert.Equal(PublicNullableFlowState.NotNull, typeInfo.Nullability.FlowState);
         }
 
-        [Fact, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
-        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst_1()
-        {
-            var comp = CreateCompilation(@"void M() {}", options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
-
-            var tree = comp.SyntaxTrees[0];
-            var localFunction = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
-            var model = comp.GetSemanticModel(tree);
-
-            AssertEx.Equal("void M()", model.GetDeclaredSymbol(localFunction).ToTestDisplayString());
-        }
-
-        [Fact, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
-        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst_2()
-        {
-            var comp = CreateCompilation(@"void M() {}
-M();
-", options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
-
-            var tree = comp.SyntaxTrees[0];
-            var localFunction = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
-            var model = comp.GetSemanticModel(tree);
-
-            AssertEx.Equal("void M()", model.GetDeclaredSymbol(localFunction).ToTestDisplayString());
-        }
-
-        [Fact, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
-        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst_3()
-        {
-            var comp = CreateCompilation(@"
+        [Theory, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
+        [InlineData("void M() {}")]
+        [InlineData(@"void M() {}
+M();")]
+        [InlineData(@"
 // Comment
 void M() {}
-M();
-", options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
+M();")]
+        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst(string code)
+        {
+            var comp = CreateCompilation(code, options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
 
             var tree = comp.SyntaxTrees[0];
             var localFunction = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -4712,5 +4712,47 @@ class C
             Assert.Equal(PublicNullableAnnotation.NotAnnotated, typeInfo.Type.NullableAnnotation);
             Assert.Equal(PublicNullableFlowState.NotNull, typeInfo.Nullability.FlowState);
         }
+
+        [Fact, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
+        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst_1()
+        {
+            var comp = CreateCompilation(@"void M() {}", options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
+
+            var tree = comp.SyntaxTrees[0];
+            var localFunction = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
+            var model = comp.GetSemanticModel(tree);
+
+            AssertEx.Equal("void M()", model.GetDeclaredSymbol(localFunction).ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
+        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst_2()
+        {
+            var comp = CreateCompilation(@"void M() {}
+M();
+", options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
+
+            var tree = comp.SyntaxTrees[0];
+            var localFunction = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
+            var model = comp.GetSemanticModel(tree);
+
+            AssertEx.Equal("void M()", model.GetDeclaredSymbol(localFunction).ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(47467, "https://github.com/dotnet/roslyn/issues/47467")]
+        public void GetDeclaredSymbolTopLevelStatementsWithLocalFunctionFirst_3()
+        {
+            var comp = CreateCompilation(@"
+// Comment
+void M() {}
+M();
+", options: TestOptions.ReleaseExe.WithNullableContextOptions(NullableContextOptions.Enable));
+
+            var tree = comp.SyntaxTrees[0];
+            var localFunction = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
+            var model = comp.GetSemanticModel(tree);
+
+            AssertEx.Equal("void M()", model.GetDeclaredSymbol(localFunction).ToTestDisplayString());
+        }
     }
 }


### PR DESCRIPTION
We had a bug where nullable analysis was getting the incorrect binder when attempting to populate initial information about all top-level statements if the first thing in the top level was a local function. This ensures that we use the correct binder for these cases.

I've investigated other areas where we call `GetAdjustedNodePosition`, and I do not believe that any of them have this issue. It seems like this particular case is unique in that preferring the innermost binder was actually not what we wanted to do here, or the usage wasn't possible to hit with this scenario.

Fixes https://github.com/dotnet/roslyn/issues/47467