### PR TITLE
Inlinable and cached virtual properties

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -2169,7 +2169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             get { return false; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { throw new NotImplementedException(); }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override int GetHashCode() => _identifier.GetHashCode();
             internal override SyntaxNode ScopeDesignatorOpt => null;
-            public override Symbol ContainingSymbol => _containingSymbol;
+            protected override Symbol ContainingSymbolImpl => _containingSymbol;
             public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
             public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
             public override TypeWithAnnotations TypeWithAnnotations => _type;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
@@ -59,10 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _constructor = isIterator ? (MethodSymbol)new IteratorConstructor(this) : new AsyncConstructor(this);
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return _typeKind; }
-        }
+        protected override TypeKind TypeKindImpl => _typeKind;
 
         internal override MethodSymbol Constructor
         {

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed class SynthesizedClosureEnvironment : SynthesizedContainer, ISynthesizedMethodBodyImplementationSymbol
     {
         private readonly MethodSymbol _topLevelMethod;
+        private readonly TypeKind _typeKind;
         internal readonly SyntaxNode ScopeSyntaxOpt;
         internal readonly int ClosureOrdinal;
         /// <summary>
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ArrayBuilder<Symbol> _membersBuilder = ArrayBuilder<Symbol>.GetInstance();
         private ImmutableArray<Symbol> _members;
 
-        public override TypeKind TypeKind { get; }
+        protected override TypeKind TypeKindImpl => _typeKind;
         internal override MethodSymbol Constructor { get; }
 
         internal SynthesizedClosureEnvironment(
@@ -45,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DebugId closureId)
             : base(MakeName(scopeSyntaxOpt, methodId, closureId), containingMethod)
         {
-            TypeKind = isStruct ? TypeKind.Struct : TypeKind.Class;
+            _typeKind = isStruct ? TypeKind.Struct : TypeKind.Class;
             _topLevelMethod = topLevelMethod;
             OriginalContainingMethodOpt = containingMethod;
             Constructor = isStruct ? null : new SynthesizedClosureEnvironmentConstructor(this);

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // display classes for static lambdas do not have any data and can be serialized.
         public override bool IsSerializable => (object)SingletonCache != null;
 
-        public override Symbol ContainingSymbol => _topLevelMethod.ContainingSymbol;
+        protected override Symbol ContainingSymbolImpl => _topLevelMethod.ContainingSymbol;
 
         // Closures in the same method share the same SynthesizedClosureEnvironment. We must
         // always return true because two closures in the same method might have different

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorFinallyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorFinallyMethodSymbol.cs
@@ -194,10 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return true; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _stateMachineType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _stateMachineType;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
@@ -41,10 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _constructor = new IteratorConstructor(this);
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return TypeKind.Class; }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Class;
 
         internal override MethodSymbol Constructor
         {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _topLevelMethod = topLevelMethod;
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _topLevelMethod.ContainingSymbol; }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
@@ -28,10 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return _topLevelMethod.ContainingSymbol; }
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return TypeKind.Class; }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Class;
 
         public sealed override bool AreLocalsZeroed
         {

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return count;
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return KickoffMethod.ContainingType; }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineProperty.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineProperty.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray.Create(ImplementedProperty); }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _getter.ContainingSymbol; }
         }

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -13,6 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
+    using System.Runtime.CompilerServices;
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
     internal abstract partial class SyntaxParser : IDisposable
@@ -285,10 +286,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         protected SyntaxToken CurrentToken
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                return _currentToken ?? (_currentToken = this.FetchCurrentToken());
+                return _currentToken ?? GetAndSetCurrentToken();
+
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        SyntaxToken GetAndSetCurrentToken()
+        {
+            return (_currentToken = this.FetchCurrentToken());
         }
 
         private SyntaxToken FetchCurrentToken()

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -131,13 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Alias;
-            }
-        }
+        protected override SymbolKind KindImpl => SymbolKind.Alias;
 
         /// <summary>
         /// Gets the <see cref="NamespaceOrTypeSymbol"/> for the

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// return that as the "containing" symbol, even though the alias isn't a member of the
         /// namespace as such.
         /// </summary>
-        public override Symbol? ContainingSymbol
+        protected override Symbol? ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -214,10 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => this.Manager.System_Object;
 
-            public override TypeKind TypeKind
-            {
-                get { return TypeKind.Class; }
-            }
+            protected override TypeKind TypeKindImpl => TypeKind.Class;
 
             internal override bool IsInterface
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return _nameToSymbols.Keys; }
             }
 
-            public override Symbol ContainingSymbol
+            protected override Symbol ContainingSymbolImpl
             {
                 get { return this.Manager.Compilation.SourceModule.GlobalNamespace; }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.FieldSymbol.cs
@@ -96,10 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get { return _property.ContainingType; }
-            }
+            protected override Symbol ContainingSymbolImpl => _property.ContainingType;
 
             public override NamedTypeSymbol ContainingType
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.PropertySymbol.cs
@@ -157,10 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return ImmutableArray<PropertySymbol>.Empty; }
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get { return _containingType; }
-            }
+            protected override Symbol ContainingSymbolImpl => _containingType;
 
             public override NamedTypeSymbol ContainingType
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
@@ -36,10 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return 0; }
             }
 
-            public sealed override Symbol ContainingSymbol
-            {
-                get { return _containingType; }
-            }
+            protected sealed override Symbol ContainingSymbolImpl => _containingType;
 
             public override NamedTypeSymbol ContainingType
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -337,10 +337,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => this.Manager.System_Object;
 
-            public override TypeKind TypeKind
-            {
-                get { return TypeKind.Class; }
-            }
+            protected override TypeKind TypeKindImpl => TypeKind.Class;
 
             internal override bool IsInterface
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return _nameToSymbols.Keys; }
             }
 
-            public override Symbol ContainingSymbol
+            protected override Symbol ContainingSymbolImpl
             {
                 get { return this.Manager.Compilation.SourceModule.GlobalNamespace; }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -108,10 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray<TypeWithAnnotations>.Empty;
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get { return _container; }
-            }
+            protected override Symbol ContainingSymbolImpl => _container;
 
             internal override ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -288,13 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override TypeKind TypeKindImpl => TypeKind.Array;
 
-        public override Symbol? ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected override Symbol? ContainingSymbolImpl => null;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -286,13 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override SymbolKind KindImpl => SymbolKind.ArrayType;
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Array;
-            }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Array;
 
         public override Symbol? ContainingSymbol
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -284,13 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.ArrayType;
-            }
-        }
+        protected override SymbolKind KindImpl => SymbolKind.ArrayType;
 
         public override TypeKind TypeKind
         {

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -186,13 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitAssembly(this);
         }
 
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Assembly;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Assembly;
 
         public sealed override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -293,13 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => null;
 
         /// <summary>
         /// Lookup a top level type referenced from metadata, names should be

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public TypeWithAnnotations TypeWithAnnotations { get; }
 
-        public override Symbol? ContainingSymbol => null;
+        protected override Symbol? ContainingSymbolImpl => null;
         public override Accessibility DeclaredAccessibility => Accessibility.NotApplicable;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
         public override bool IsAbstract => false;

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool IsSealed => false;
         public override bool IsStatic => false;
         public override bool IsVirtual => false;
-        public override SymbolKind Kind => SymbolKind.Discard;
+        protected override SymbolKind KindImpl => SymbolKind.Discard;
         public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
         internal override ObsoleteAttributeData? ObsoleteAttributeData => null;
         internal override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument a) => visitor.VisitDiscard(this, a);

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -56,13 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override SymbolKind KindImpl => SymbolKind.DynamicType;
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Dynamic;
-            }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Dynamic;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -54,13 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.DynamicType;
-            }
-        }
+        protected override SymbolKind KindImpl => SymbolKind.DynamicType;
 
         public override TypeKind TypeKind
         {

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -155,13 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitDynamicType(this);
         }
 
-        public override Symbol? ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected override Symbol? ContainingSymbolImpl => null;
 
         public override Accessibility DeclaredAccessibility
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
@@ -98,10 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         internal override Microsoft.Cci.CallingConvention CallingConvention
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorPropertySymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _isIndexedProperty = isIndexedProperty;
         }
 
-        public override Symbol ContainingSymbol { get { return _containingSymbol; } }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override RefKind RefKind { get { return RefKind.None; } }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -44,13 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get
-                {
-                    return _container;
-                }
-            }
+            protected override Symbol? ContainingSymbolImpl => _container;
 
             public override bool HasConstructorConstraint
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -215,13 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this type.
         /// </summary>
-        public sealed override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Error;
-            }
-        }
+        protected sealed override TypeKind TypeKindImpl => TypeKind.Error;
 
         internal sealed override bool IsInterface
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -225,13 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Get the symbol that logically contains this symbol. 
         /// </summary>
-        public override Symbol? ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected override Symbol? ContainingSymbolImpl => null;
 
         /// <summary>
         /// Gets the locations where this symbol was originally defined, either in source or
@@ -632,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _constructedFrom; }
         }
 
-        public override Symbol? ContainingSymbol
+        protected override Symbol? ContainingSymbolImpl
         {
             get { return _constructedFrom.ContainingSymbol; }
         }
@@ -671,10 +665,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return this; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         internal override TypeMap TypeSubstitution
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -546,10 +546,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _originalDefinition = originalDefinition;
         }
 
-        public override NamedTypeSymbol OriginalDefinition
-        {
-            get { return _originalDefinition; }
-        }
+        protected override NamedTypeSymbol OriginalDefinitionImpl => _originalDefinition;
 
         internal override bool MangleName
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -210,13 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.ErrorType;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.ErrorType;
 
         /// <summary>
         /// Gets the kind of this type.

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override sealed Symbol OriginalSymbolDefinition
+        protected override sealed Symbol OriginalSymbolDefinitionImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -233,13 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Event;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Event;
 
         /// <summary>
         /// Implements visitor pattern.

--- a/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
@@ -147,13 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol? ContainingSymbol
-        {
-            get
-            {
-                return _containingSymbol;
-            }
-        }
+        protected override Symbol? ContainingSymbolImpl => _containingSymbol;
 
         public override string Name
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
@@ -163,14 +163,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override NamedTypeSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
-
         // public override SymbolKind Kind { get { return SymbolKind.Error; } }
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override sealed Symbol OriginalSymbolDefinition
+        protected override sealed Symbol OriginalSymbolDefinitionImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -175,13 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Field;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Field;
 
         internal override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument argument)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -791,7 +791,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol? ContainingSymbol => null;
+        protected override Symbol? ContainingSymbolImpl => null;
         // Function pointers cannot have type parameters
         public override int Arity => 0;
         public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override TypeWithAnnotations TypeWithAnnotations { get; }
         public override RefKind RefKind { get; }
         public override int Ordinal { get; }
-        public override Symbol ContainingSymbol => _containingSymbol;
+        protected override Symbol? ContainingSymbolImpl => _containingSymbol;
         public override ImmutableArray<CustomModifier> RefCustomModifiers { get; }
 
         public override bool Equals(Symbol other, TypeCompareKind compareKind)

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsReferenceType => false;
         public override bool IsValueType => true;
-        public override TypeKind TypeKind => TypeKind.FunctionPointer;
+        protected override TypeKind TypeKindImpl => TypeKind.FunctionPointer;
         public override bool IsRefLikeType => false;
         public override bool IsReadOnly => false;
         protected override SymbolKind KindImpl => SymbolKind.FunctionPointerType;

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override TypeKind TypeKind => TypeKind.FunctionPointer;
         public override bool IsRefLikeType => false;
         public override bool IsReadOnly => false;
-        public override SymbolKind Kind => SymbolKind.FunctionPointerType;
+        protected override SymbolKind KindImpl => SymbolKind.FunctionPointerType;
         public override Symbol? ContainingSymbol => null;
         public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool IsRefLikeType => false;
         public override bool IsReadOnly => false;
         protected override SymbolKind KindImpl => SymbolKind.FunctionPointerType;
-        public override Symbol? ContainingSymbol => null;
+        protected override Symbol? ContainingSymbolImpl => null;
         public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
         public override Accessibility DeclaredAccessibility => Accessibility.NotApplicable;

--- a/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
@@ -152,13 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Gets the immediately containing symbol of the <see cref="LabelSymbol"/>.
         /// It should be the <see cref="MethodSymbol"/> containing the label in its body.
         /// </summary>
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                throw new NotSupportedException();
-            }
-        }
+        protected override Symbol? ContainingSymbolImpl => throw new NotSupportedException();
 
         /// <summary>
         /// Returns value 'Label' of the <see cref="SymbolKind"/>

--- a/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
@@ -163,13 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns value 'Label' of the <see cref="SymbolKind"/>
         /// </summary>
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Label;
-            }
-        }
+        protected override SymbolKind KindImpl => SymbolKind.Label;
 
         protected sealed override ISymbol CreateISymbol()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -166,13 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns value 'Local' of the <see cref="SymbolKind"/>
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Local;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Local;
 
         internal sealed override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument argument)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -237,13 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray.CreateRange<NamedTypeSymbol>(_cachedLookup[name].OfType<NamedTypeSymbol>());
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingNamespace;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingNamespace;
 
         public override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -215,13 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol? ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -112,13 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEGlobalNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEGlobalNamespaceSymbol.cs
@@ -29,13 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             _moduleSymbol = moduleSymbol;
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _moduleSymbol;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _moduleSymbol;
 
         internal override PEModuleSymbol ContainingPEModule
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEGlobalNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEGlobalNamespaceSymbol.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return true;
         }
 
-        public override Symbol ContainingSymbol => _containingType;
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType => _containingType;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -193,13 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _assemblySymbol;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _assemblySymbol;
 
         public override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -328,13 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override SpecialType SpecialType
-        {
-            get
-            {
-                return _corTypeId;
-            }
-        }
+        protected override SpecialType SpecialTypeImpl => _corTypeId;
 
         internal PEModuleSymbol ContainingPEModule
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -532,13 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _container;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _container;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -1636,7 +1636,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override TypeKind TypeKind
+        protected override TypeKind TypeKindImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
@@ -79,10 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             _typesByNS = typesByNS;
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingNamespaceSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingNamespaceSymbol;
 
         internal override PEModuleSymbol ContainingPEModule
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -425,13 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingSymbol;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         internal override bool HasMetadataConstantValue
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -247,13 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -126,10 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override sealed Symbol OriginalSymbolDefinition
+        protected override sealed Symbol OriginalSymbolDefinitionImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -635,13 +635,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns value 'Method' of the <see cref="SymbolKind"/>
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Method;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Method;
 
         /// <summary>
         /// Returns true if this symbol represents a constructor of a script class.

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return _namespaceName; }
             }
 
-            internal override ModuleSymbol ContainingModule
+            internal override ModuleSymbol ContainingModuleImpl
             {
                 get
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            public override Symbol ContainingSymbol
+            protected override Symbol ContainingSymbolImpl
             {
                 get
                 {
@@ -412,14 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get
-                {
-                    return _containingType;
-                }
-            }
-
+            protected override Symbol ContainingSymbolImpl => _containingType;
 
             protected override SpecialType SpecialTypeImpl
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            public override SpecialType SpecialType
+            protected override SpecialType SpecialTypeImpl
             {
                 get
                 {
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
 
-            public override SpecialType SpecialType
+            protected override SpecialType SpecialTypeImpl
             {
                 get
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -84,13 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return assembly;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => assembly;
 
         public override NamespaceSymbol GlobalNamespace
         {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingNamespaceSymbol.cs
@@ -46,13 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingSymbol;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override ModuleSymbol ContainingModule
+        internal sealed override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -53,13 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns value 'NetModule' of the <see cref="SymbolKind"/>
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.NetModule;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.NetModule;
 
         internal override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument argument)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal abstract partial class NamedTypeSymbol : TypeSymbol, INamedTypeSymbolInternal
     {
+        private NamedTypeSymbol _originalDefinition = null;
         private bool _hasNoBaseCycles;
 
         // Only the compiler can create NamedTypeSymbols.
@@ -1159,20 +1160,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// symbol by type substitution then OriginalDefinition gets the original symbol as it was defined in
         /// source or metadata.
         /// </summary>
-        public new virtual NamedTypeSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new NamedTypeSymbol OriginalDefinition => _originalDefinition ?? GetAndSetOriginalDefinition();
 
-        protected override sealed TypeSymbol OriginalTypeSymbolDefinition
+        protected virtual NamedTypeSymbol OriginalDefinitionImpl => this;
+
+        protected override sealed TypeSymbol OriginalTypeSymbolDefinitionImpl => this.OriginalDefinition;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private NamedTypeSymbol GetAndSetOriginalDefinition()
         {
-            get
-            {
-                return this.OriginalDefinition;
-            }
+            // Look up from derived NamedTypeSymbol on first call.
+            var originalDefinition = OriginalDefinitionImpl;
+            _originalDefinition = originalDefinition;
+            return originalDefinition;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -605,13 +605,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public override SymbolKind Kind // Cannot seal this method because of the ErrorSymbol.
-        {
-            get
-            {
-                return SymbolKind.NamedType;
-            }
-        }
+        // Cannot seal this method because of the ErrorSymbol.
+        protected override SymbolKind KindImpl => SymbolKind.NamedType;
 
         internal abstract NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved);
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -114,13 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Namespace;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Namespace;
 
         public override sealed bool IsImplicitlyDeclared
         {

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract override AssemblySymbol ContainingAssembly { get; }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override NamedTypeSymbol ConstructedFrom => this;
 
-        public override Symbol ContainingSymbol => _underlyingType.ContainingSymbol;
+        protected override Symbol ContainingSymbolImpl => _underlyingType.ContainingSymbol;
 
         internal override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotationsNoUseSiteDiagnostics => ImmutableArray<TypeWithAnnotations>.Empty;
 
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             NativeIntegerTypeSymbol.VerifyEquality(this, underlyingMethod);
         }
 
-        public override Symbol ContainingSymbol => _container;
+        protected override Symbol ContainingSymbolImpl => _container;
 
         public override MethodSymbol UnderlyingMethod { get; }
 
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             NativeIntegerTypeSymbol.VerifyEquality(this, underlyingParameter);
         }
 
-        public override Symbol ContainingSymbol => _container;
+        protected override Symbol ContainingSymbolImpl => _container;
 
         public override TypeWithAnnotations TypeWithAnnotations => _containingType.SubstituteUnderlyingType(_underlyingParameter.TypeWithAnnotations);
 
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             NativeIntegerTypeSymbol.VerifyEquality(this, underlyingProperty);
         }
 
-        public override Symbol ContainingSymbol => _container;
+        protected override Symbol ContainingSymbolImpl => _container;
 
         public override TypeWithAnnotations TypeWithAnnotations => _container.SubstituteUnderlyingType(_underlyingProperty.TypeWithAnnotations);
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _underlyingType.BaseTypeNoUseSiteDiagnostics;
 
-        public override SpecialType SpecialType => _underlyingType.SpecialType;
+        protected override SpecialType SpecialTypeImpl => _underlyingType.SpecialType;
 
         public override IEnumerable<string> MemberNames => GetMembers().Select(m => m.Name);
 

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -246,13 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Parameter;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Parameter;
 
         /// <summary>
         /// Implements visitor pattern. 

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override sealed Symbol OriginalSymbolDefinition
+        protected override sealed Symbol OriginalSymbolDefinitionImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -154,13 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.PointerType;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.PointerType;
 
         public override TypeKind TypeKind
         {

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -156,13 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override SymbolKind KindImpl => SymbolKind.PointerType;
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Pointer;
-            }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Pointer;
 
         public override Symbol ContainingSymbol
         {

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -158,13 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override TypeKind TypeKindImpl => TypeKind.Pointer;
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => null;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -315,13 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Property;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.Property;
 
         /// <summary>
         /// Implements visitor pattern.

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override sealed Symbol OriginalSymbolDefinition
+        protected override sealed Symbol OriginalSymbolDefinitionImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
@@ -39,13 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.RangeVariable;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.RangeVariable;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
@@ -126,13 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingSymbol;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         internal override TResult Accept<TArg, TResult>(CSharpSymbolVisitor<TArg, TResult> visitor, TArg a)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -444,10 +444,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _reducedFrom.DeclaredAccessibility; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _reducedFrom.ContainingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _reducedFrom.ContainingSymbol;
 
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
@@ -599,10 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _containingMethod = containingMethod;
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get { return _containingMethod; }
-            }
+            protected override Symbol ContainingSymbolImpl => _containingMethod;
 
             public override int Ordinal
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return builder.ToImmutableAndFree();
         }
 
-        public override Symbol? ContainingSymbol
+        protected override Symbol? ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return this.RetargetingTranslator.Retarget(_underlyingField.GetFieldType(fieldsBeingBound), RetargetOptions.RetargetPrimitiveTypesByTypeCode);
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return _underlyingModule.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return this.RetargetingTranslator.Retarget(_underlyingType.GetTypeMembers(name, arity));
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return RetargetTypeMembers(_underlyingNamespace.GetTypeMembers(name, arity));
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingParameterSymbol.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal sealed override ModuleSymbol ContainingModule
+        internal sealed override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingParameterSymbol.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        public sealed override Symbol ContainingSymbol
+        protected sealed override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return builder.ToImmutableAndFree();
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations { get { return _explicitInterfaceImplementations; } }
 
-        public override Symbol ContainingSymbol { get { return _containingType; } }
+        protected override Symbol ContainingSymbolImpl { get { return _containingType; } }
 
         public override MethodKind MethodKind { get { return _methodKind; } }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override AssemblySymbol ContainingAssembly { get { throw ExceptionUtilities.Unreachable; } }
 
-        internal override ModuleSymbol ContainingModule { get { throw ExceptionUtilities.Unreachable; } }
+        internal override ModuleSymbol ContainingModuleImpl { get { throw ExceptionUtilities.Unreachable; } }
 
         internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) { throw ExceptionUtilities.Unreachable; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override AssemblySymbol ContainingAssembly { get { throw ExceptionUtilities.Unreachable; } }
 
-        internal override ModuleSymbol ContainingModule { get { throw ExceptionUtilities.Unreachable; } }
+        internal override ModuleSymbol ContainingModuleImpl { get { throw ExceptionUtilities.Unreachable; } }
 
         #endregion Not used by MethodSignatureComparer
 

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableHashSet<string> NotNullIfParameterNotNull { get { throw ExceptionUtilities.Unreachable; } }
 
-        public override Symbol ContainingSymbol { get { throw ExceptionUtilities.Unreachable; } }
+        protected override Symbol ContainingSymbolImpl { get { throw ExceptionUtilities.Unreachable; } }
 
         public override ImmutableArray<Location> Locations { get { throw ExceptionUtilities.Unreachable; } }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyPropertySymbol.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<PropertySymbol> ExplicitInterfaceImplementations { get { return _explicitInterfaceImplementations; } }
 
-        public override Symbol ContainingSymbol { get { return _containingType; } }
+        protected override Symbol ContainingSymbolImpl { get { return _containingType; } }
 
         public override string Name { get { return _name; } }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyPropertySymbol.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override AssemblySymbol ContainingAssembly { get { throw ExceptionUtilities.Unreachable; } }
 
-        internal override ModuleSymbol ContainingModule { get { throw ExceptionUtilities.Unreachable; } }
+        internal override ModuleSymbol ContainingModuleImpl { get { throw ExceptionUtilities.Unreachable; } }
 
         internal override bool MustCallMethodsDirectly { get { throw ExceptionUtilities.Unreachable; } }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -151,13 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => null;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -147,13 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => null;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -294,10 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         internal override Microsoft.Cci.CallingConvention CallingConvention
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override MethodKind MethodKind => MethodKind.LocalFunction;
 
-        public sealed override Symbol ContainingSymbol => _containingSymbol;
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override string Name => Syntax.Identifier.ValueText ?? "";
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -86,13 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override abstract TypeWithAnnotations TypeWithAnnotations { get; }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return containingType;
-            }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -92,13 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return containingType;
-            }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -163,10 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _field.ContainingType; }
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return TypeKind.Struct; }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Struct;
 
         internal override MethodSymbol Constructor
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -158,10 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _internalField = new SynthesizedFieldSymbol(this, ((PointerTypeSymbol)field.Type).PointedAtType, FixedElementFieldName, isPublic: true);
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _field.ContainingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _field.ContainingType;
 
         protected override TypeKind TypeKindImpl => TypeKind.Struct;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLabelSymbol.cs
@@ -114,13 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingMethod;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingMethod;
 
         // Get the identifier node or token that defined this label symbol. This is useful for robustly
         // checking if a label symbol actually matches a particular definition, even in the presence

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -255,10 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _valEscapeScope = value;
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         /// <summary>
         /// Gets the name of the local variable.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -688,13 +688,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return _flags.TypeKind;
-            }
-        }
+        protected override TypeKind TypeKindImpl => _flags.TypeKind;
 
         internal MergedTypeDeclaration MergedDeclaration
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -668,13 +668,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingSymbol;
-            }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => _containingSymbol;
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -680,13 +680,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region Flags Encoded Properties
 
-        public override SpecialType SpecialType
-        {
-            get
-            {
-                return _flags.SpecialType;
-            }
-        }
+        protected override SpecialType SpecialTypeImpl => _flags.SpecialType;
 
         protected override TypeKind TypeKindImpl => _flags.TypeKind;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -354,13 +354,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -372,13 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _assemblySymbol;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _assemblySymbol;
 
         public override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return GetTypeMembers(name).WhereAsArray((s, arity) => s.Arity == arity, arity);
         }
 
-        internal override ModuleSymbol ContainingModule
+        internal override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal MergedNamespaceDeclaration MergedDeclaration
             => _mergedDeclaration;
 
-        public override Symbol ContainingSymbol
-            => _container;
+        protected override Symbol ContainingSymbolImpl => _container;
 
         public override AssemblySymbol ContainingAssembly
             => _module.ContainingAssembly;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -53,10 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _ordinal; }
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public sealed override AssemblySymbol ContainingAssembly
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -520,13 +520,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -472,10 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _owner; }
-        }
+        protected override Symbol ContainingSymbolImpl => _owner;
 
         public override VarianceKind Variance
         {
@@ -598,10 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _owner; }
-        }
+        protected override Symbol ContainingSymbolImpl => _owner;
 
         public override bool HasConstructorConstraint
         {
@@ -838,10 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return this.Owner; }
-        }
+        protected override Symbol ContainingSymbolImpl => this.Owner;
 
         public override bool HasConstructorConstraint
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return (Symbol)_containingMethod ?? _containingType; }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedEventSymbol.cs
@@ -37,13 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override EventSymbol OriginalDefinition
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
@@ -33,13 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _lazyType.Value;
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -184,13 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -111,10 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(_lazyTypeParameters != null);
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get { return _newContainer; }
-        }
+        protected sealed override Symbol ContainingSymbolImpl => _newContainer;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -124,10 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override SymbolKind Kind
-        {
-            get { return OriginalDefinition.Kind; }
-        }
+        protected sealed override SymbolKind KindImpl => OriginalDefinition.Kind;
 
         public sealed override NamedTypeSymbol OriginalDefinition
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -126,10 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override SymbolKind KindImpl => OriginalDefinition.Kind;
 
-        public sealed override NamedTypeSymbol OriginalDefinition
-        {
-            get { return _underlyingType; }
-        }
+        protected sealed override NamedTypeSymbol OriginalDefinitionImpl => _underlyingType;
 
         internal sealed override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedParameterSymbol.cs
@@ -37,10 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _underlyingParameter.OriginalDefinition; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override TypeWithAnnotations TypeWithAnnotations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedPropertySymbol.cs
@@ -34,13 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -36,13 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #endif
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _container;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _container;
 
         public override TypeParameterSymbol OriginalDefinition
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ISymbol _lazyISymbol;
         // Cached kind
         private SymbolKind _lazyKind = (SymbolKind)(-1);
+        private Symbol _lazyOriginalSymbolDefinition = null;
 
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // Changes to the public interface of this class should remain synchronized with the VB version of Symbol.
@@ -281,20 +282,25 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// symbol by type substitution then OriginalDefinition gets the original symbol as it was defined in
         /// source or metadata.
         /// </summary>
-        public Symbol OriginalDefinition
-        {
-            get
-            {
-                return OriginalSymbolDefinition;
-            }
-        }
+        public Symbol OriginalDefinition => OriginalSymbolDefinition;
 
-        protected virtual Symbol OriginalSymbolDefinition
+        private Symbol OriginalSymbolDefinition => _lazyOriginalSymbolDefinition ?? GetAndSetOriginalSymbolDefinition();
+
+        protected virtual Symbol OriginalSymbolDefinitionImpl
         {
             get
             {
                 return this;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Symbol GetAndSetOriginalSymbolDefinition()
+        {
+            // Look up from derived NamedTypeSymbol on first call.
+            var originalSymbolDefinition = OriginalSymbolDefinitionImpl;
+            _lazyOriginalSymbolDefinition = originalSymbolDefinition;
+            return originalSymbolDefinition;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private SymbolKind _lazyKind = (SymbolKind)(-1);
         private Symbol _lazyOriginalSymbolDefinition = null;
         private ModuleSymbol _lazyContainingModule = null;
+        private Symbol _lazyContainingSymbol = null;
 
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // Changes to the public interface of this class should remain synchronized with the VB version of Symbol.
@@ -120,9 +121,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Get the symbol that logically contains this symbol. 
+        /// Get the symbol that logically contains this symbol.
         /// </summary>
-        public abstract Symbol ContainingSymbol { get; }
+        public Symbol ContainingSymbol => _lazyContainingSymbol ?? GetAndSetContainingSymbol();
+
+        protected abstract Symbol ContainingSymbolImpl { get; }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Symbol GetAndSetContainingSymbol()
+        {
+            // Look up from derived Symbol on first call.
+            var containingSymbol = ContainingSymbolImpl;
+            _lazyContainingSymbol = containingSymbol;
+            return containingSymbol;
+        }
+
 
         /// <summary>
         /// Returns the nearest lexically enclosing type, or null if there is none.

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Cached kind
         private SymbolKind _lazyKind = (SymbolKind)(-1);
         private Symbol _lazyOriginalSymbolDefinition = null;
+        private ModuleSymbol _lazyContainingModule = null;
 
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // Changes to the public interface of this class should remain synchronized with the VB version of Symbol.
@@ -256,7 +257,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Returns the module containing this symbol. If this symbol is shared across multiple
         /// modules, or doesn't belong to a module, returns null.
         /// </summary>
-        internal virtual ModuleSymbol ContainingModule
+        internal ModuleSymbol ContainingModule => _lazyContainingModule ?? GetAndSetContainingModule();
+
+        internal virtual ModuleSymbol ContainingModuleImpl
         {
             get
             {
@@ -265,6 +268,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var container = this.ContainingSymbol;
                 return (object)container != null ? container.ContainingModule : null;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private ModuleSymbol GetAndSetContainingModule()
+        {
+            // Look up from derived Symbol on first call.
+            var containingModule = ContainingModuleImpl;
+            _lazyContainingModule = containingModule;
+            return containingModule;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -104,8 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override ConstantValue GetConstantValue(ConstantFieldsInProgress inProgress, bool earlyDecodingWellKnownAttributes)
             => null;
 
-        public override Symbol ContainingSymbol
-            => _property.ContainingSymbol;
+        protected override Symbol ContainingSymbolImpl => _property.ContainingSymbol;
 
         public override NamedTypeSymbol ContainingType
             => _property.ContainingType;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -35,10 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _invoke = new InvokeMethod(this, byRefParameters, voidReturnTypeOpt);
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         protected override TypeKind TypeKindImpl => TypeKind.Delegate;
 
@@ -280,10 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return false; }
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get { return _containingType; }
-            }
+            protected override Symbol ContainingSymbolImpl => _containingType;
 
             public override ImmutableArray<Location> Locations
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -40,10 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _containingSymbol; }
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return TypeKind.Delegate; }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Delegate;
 
         internal override MethodSymbol Constructor
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override TypeKind TypeKindImpl => TypeKind.Class;
 
-        public override Symbol ContainingSymbol => _namespace;
+        protected override Symbol ContainingSymbolImpl => _namespace;
 
         internal override ModuleSymbol ContainingModuleImpl => _module;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override Accessibility DeclaredAccessibility => Accessibility.Internal;
 
-        public override TypeKind TypeKind => TypeKind.Class;
+        protected override TypeKind TypeKindImpl => TypeKind.Class;
 
         public override Symbol ContainingSymbol => _namespace;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override Symbol ContainingSymbol => _namespace;
 
-        internal override ModuleSymbol ContainingModule => _module;
+        internal override ModuleSymbol ContainingModuleImpl => _module;
 
         public override AssemblySymbol ContainingAssembly => _module.ContainingAssembly;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -57,10 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract BoundBlock CreateBody(DiagnosticBag diagnostics);
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public abstract override string Name
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -141,10 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal sealed override ModuleSymbol ContainingModule
+        internal sealed override ModuleSymbol ContainingModuleImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -75,10 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Synthesized methods that must be emitted in the compiler generated
         /// PrivateImplementationDetails class have null containing type symbol.
         /// </summary>
-        public sealed override Symbol ContainingSymbol
-        {
-            get { return null; }
-        }
+        protected override Symbol ContainingSymbolImpl => null;
 
         public sealed override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
@@ -110,10 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _parameters; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _implementingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _implementingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -49,10 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region Sealed
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get { return _containingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public sealed override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -47,10 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingType; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override Accessibility DeclaredAccessibility
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -316,13 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -106,10 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return default(SyntaxToken); }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingMethodOpt; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingMethodOpt;
 
         public override string Name
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -119,10 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableHashSet<string>.Empty; }
         }
 
-        public override Symbol? ContainingSymbol
-        {
-            get { return _container; }
-        }
+        protected override Symbol? ContainingSymbolImpl => _container;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSealedPropertyAccessor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSealedPropertyAccessor.cs
@@ -43,13 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _property.ContainingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _property.ContainingType;
 
         public override ImmutableArray<Location> Locations
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -21,13 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _containingType = containingType;
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingType;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -50,10 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _originalVariable.Name; }
         }
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SynthesizedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SynthesizedNamespaceSymbol.cs
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override string Name
             => _name;
 
-        public override Symbol ContainingSymbol
-            => _containingSymbol;
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
 
         public override AssemblySymbol ContainingAssembly
             => _containingSymbol.ContainingAssembly;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -194,13 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override SymbolKind KindImpl => SymbolKind.TypeParameter;
 
-        public sealed override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.TypeParameter;
-            }
-        }
+        protected sealed override TypeKind TypeKindImpl => TypeKind.TypeParameter;
 
         // Only the compiler can create TypeParameterSymbols.
         internal TypeParameterSymbol()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override sealed TypeSymbol OriginalTypeSymbolDefinition
+        protected override sealed TypeSymbol OriginalTypeSymbolDefinitionImpl
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -192,13 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitTypeParameter(this);
         }
 
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.TypeParameter;
-            }
-        }
+        protected sealed override SymbolKind KindImpl => SymbolKind.TypeParameter;
 
         public sealed override TypeKind TypeKind
         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private TypeKind _lazyTypeKind = TypeKind.Unknown;
         // Cached SpecialType
         private SpecialType _lazySpecialType = (SpecialType)(-1);
+        private TypeSymbol _lazyOriginalTypeSymbolDefinition = null;
 
         private ImmutableHashSet<Symbol> _lazyAbstractMembers;
         private InterfaceInfo _lazyInterfaceInfo;
@@ -129,29 +130,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// symbol by type substitution then OriginalDefinition gets the original symbol as it was defined in
         /// source or metadata.
         /// </summary>
-        public new TypeSymbol OriginalDefinition
+        public new TypeSymbol OriginalDefinition => OriginalTypeSymbolDefinition;
+
+        private TypeSymbol OriginalTypeSymbolDefinition
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                return OriginalTypeSymbolDefinition;
+                return _lazyOriginalTypeSymbolDefinition ?? GetAndSetOriginalTypeSymbolDefinition();
             }
         }
 
-        protected virtual TypeSymbol OriginalTypeSymbolDefinition
+        protected virtual TypeSymbol OriginalTypeSymbolDefinitionImpl => this;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private TypeSymbol GetAndSetOriginalTypeSymbolDefinition()
         {
-            get
-            {
-                return this;
-            }
+            // Look up from derived TypeSymbol on first call.
+            var originalTypeSymbolDefinition = OriginalTypeSymbolDefinitionImpl;
+            _lazyOriginalTypeSymbolDefinition = originalTypeSymbolDefinition;
+            return originalTypeSymbolDefinition;
         }
 
-        protected override sealed Symbol OriginalSymbolDefinition
-        {
-            get
-            {
-                return this.OriginalTypeSymbolDefinition;
-            }
-        }
+        protected override sealed Symbol OriginalSymbolDefinitionImpl => OriginalTypeSymbolDefinition;
 
         /// <summary>
         /// Gets the BaseType of this type. If the base type could not be determined, then 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -41,6 +41,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // Cached TypeKind
         private TypeKind _lazyTypeKind = TypeKind.Unknown;
+        // Cached SpecialType
+        private SpecialType _lazySpecialType = (SpecialType)(-1);
 
         private ImmutableHashSet<Symbol> _lazyAbstractMembers;
         private InterfaceInfo _lazyInterfaceInfo;
@@ -517,12 +519,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Not preserved in types constructed from this one.
         /// </remarks>
-        public virtual SpecialType SpecialType
+        public SpecialType SpecialType
         {
             get
             {
-                return SpecialType.None;
+                // Return the cached SpecialType or get it from the derived symbol.
+                return _lazySpecialType >= 0 ? _lazySpecialType : GetAndSetSpecialType();
             }
+        }
+
+        protected virtual SpecialType SpecialTypeImpl => SpecialType.None;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private SpecialType GetAndSetSpecialType()
+        {
+            // Look up from derived symbol on first call.
+            var type = SpecialTypeImpl;
+            _lazySpecialType = type;
+            return type;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RoslynDebug.Assert(underlyingLocal is object);
             RoslynDebug.Assert(updatedContainingSymbol is object);
             Debug.Assert(!assertContaining || updatedContainingSymbol.Equals(underlyingLocal.ContainingSymbol, TypeCompareKind.AllNullableIgnoreOptions));
-            ContainingSymbol = updatedContainingSymbol;
+            _containingSymbol = updatedContainingSymbol;
             TypeWithAnnotations = updatedType;
             _underlyingLocal = underlyingLocal;
         }
@@ -36,7 +36,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private readonly SourceLocalSymbol _underlyingLocal;
-        public override Symbol ContainingSymbol { get; }
+        private readonly Symbol _containingSymbol;
+        protected override Symbol ContainingSymbolImpl => _containingSymbol;
         public override TypeWithAnnotations TypeWithAnnotations { get; }
 
         public override bool Equals(Symbol other, TypeCompareKind compareKind)

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -106,13 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return _underlyingType.TypeKind;
-            }
-        }
+        protected override TypeKind TypeKindImpl => _underlyingType.TypeKind;
 
         internal override bool IsInterface
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -135,10 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     select (NamedTypeSymbol)sym).ToArray().AsImmutableOrNull();
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return _typeKind; }
-        }
+        protected override TypeKind TypeKindImpl => _typeKind;
 
         internal override bool IsInterface
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             get { return _typeKind == TypeKind.Interface; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return null; }
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamespaceSymbol.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     select (NamedTypeSymbol)c).ToArray().AsImmutableOrNull();
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/DisplayClassVariable.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/DisplayClassVariable.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 get { throw ExceptionUtilities.Unreachable; }
             }
 
-            public override Symbol ContainingSymbol
+            protected override Symbol ContainingSymbolImpl
             {
                 get { return _container; }
             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEDisplayClassFieldLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEDisplayClassFieldLocalSymbol.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _variable.ContainingSymbol; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalConstantSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalConstantSymbol.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _method; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return _locations; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _method; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return false; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _container; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return null; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _container; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -280,10 +280,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             throw ExceptionUtilities.Unreachable;
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return TypeKind.Class; }
-        }
+        protected override TypeKind TypeKindImpl => TypeKind.Class;
 
         public override NamedTypeSymbol ContainingType
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _getTypeMap = getTypeMap;
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _container; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return RefKind.None; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _method; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return null; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _container; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return VarianceKind.None; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _container; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SynthesizedContextMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SynthesizedContextMethodSymbol.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return null; }
         }
 
-        public override Symbol ContainingSymbol
+        protected override Symbol ContainingSymbolImpl
         {
             get { return _container; }
         }


### PR DESCRIPTION
Reduces the number of method calls when compiling `Microsoft.CodeAnalysis` by ~80 Million

![image](https://user-images.githubusercontent.com/1142958/92318409-e4a7ed00-f003-11ea-9149-849e1d8e32ba.png)

This might be a breaking change; as it adjusts method inheritance and what methods are virtual/override, however I was mostly curious as the call counts for simple properties was in the millions when compiling `Microsoft.CodeAnalysis` alone.

As the properties are virtual they cannot be inlined. This changes some properties to be concrete on the defining type; then have a protected virtual `Impl` property that the defining type caches on first access to allow it to become a simple(ish) inlinable property. Since most of the derived types are essentially immutable this caching allows the calls to frequently both become direct and also evaporate.

Was mostly curious if it made a difference and it seems to have 🙂