### PR TITLE
Fix Introduce local formatting

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -3064,6 +3064,97 @@ options: ImplicitTypingEverywhere());
 
             await TestInRegularAndScriptAsync(code, expected, options: ImplicitTypingEverywhere());
         }
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceLocalInBlockBodiedLambda()
+        {
+            var code =
+@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    void M()
+    {
+        new List<Action>
+        {
+            () =>
+            {
+                [|Array.Empty<string>()|].Count();
+            }
+        };
+    }
+}
+";
+
+            var expected =
+@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    void M()
+    {
+        new List<Action>
+        {
+            () =>
+            {
+                var {|Rename:vs|} = Array.Empty<string>();
+                vs.Count();
+            }
+        };
+    }
+}
+";
+            await TestInRegularAndScriptAsync(code, expected, options: ImplicitTypingEverywhere());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceLocalInBlockBodiedLambdaWithPropertyAccess()
+        {
+            var code =
+@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    void M()
+    {
+        new List<Action>
+        {
+            () =>
+            {
+                var x = [|Array.Empty<string>()|].Length;
+            }
+        };
+    }
+}
+";
+
+            var expected =
+@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    void M()
+    {
+        new List<Action>
+        {
+            () =>
+            {
+                var {|Rename:vs|} = Array.Empty<string>();
+                var x = vs.Length;
+            }
+        };
+    }
+}
+";
+            await TestInRegularAndScriptAsync(code, expected, options: ImplicitTypingEverywhere());
+        }
 
         [WorkItem(1037057, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1037057")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -421,7 +421,11 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             if (precedingEndOfLine == default)
             {
                 return oldStatements.ReplaceRange(
-                    nextStatement, new[] { newStatement, nextStatement });
+                    nextStatement, new[]
+                    {
+                        newStatement.WithLeadingTrivia(nextStatementLeading),
+                        nextStatement
+                    });
             }
 
             var endOfLineIndex = nextStatementLeading.IndexOf(precedingEndOfLine) + 1;

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             var text = await document.Document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             if (!text.AreOnSameLine(containerToGenerateInto.GetFirstToken(), containerToGenerateInto.GetLastToken()))
             {
-                declarationStatement = declarationStatement.WithAppendedTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+                declarationStatement = declarationStatement.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
             }
 
             switch (containerToGenerateInto)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/47277.
Explanation (See the above issue for the expected and actual):
When `.Count()` (or anything else) is called on `Array.Empty<string>()` the `declarationStatement` generated has the leading trivia from `.Count()` instead of `Array.Empty<string>()` resulting in it appearing on the same line as the opening brace.
Additionally the generated `vs.Count()` would not appear on a new line as the `CarriageReturnLineFeed `was elastic and the declationStatement was only having it trailing trivia append to.