### PR TITLE
Eliminate allocation on a hot path with cyclic references

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -124,24 +124,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return AssemblyIdentityComparer.CultureComparer.Equals(identity1.CultureName, identity2.CultureName);
             }
 
-            protected override AssemblySymbol?[] GetActualBoundReferencesUsedBy(AssemblySymbol assemblySymbol)
+            protected override void GetActualBoundReferencesUsedBy(AssemblySymbol assemblySymbol, List<AssemblySymbol?> referencedAssemblySymbols)
             {
-                var refs = new List<AssemblySymbol?>();
+                referencedAssemblySymbols.Clear();
 
                 foreach (var module in assemblySymbol.Modules)
                 {
-                    refs.AddRange(module.GetReferencedAssemblySymbols());
+                    referencedAssemblySymbols.AddRange(module.GetReferencedAssemblySymbols());
                 }
 
-                for (int i = 0; i < refs.Count; i++)
+                for (int i = 0; i < referencedAssemblySymbols.Count; i++)
                 {
-                    if (refs[i]!.IsMissing)
+                    if (referencedAssemblySymbols[i]!.IsMissing)
                     {
-                        refs[i] = null; // Do not expose missing assembly symbols to ReferenceManager.Binder
+                        referencedAssemblySymbols[i] = null; // Do not expose missing assembly symbols to ReferenceManager.Binder
                     }
                 }
-
-                return refs.ToArray();
             }
 
             protected override ImmutableArray<AssemblySymbol> GetNoPiaResolutionAssemblies(AssemblySymbol candidateAssembly)

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -126,8 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             protected override void GetActualBoundReferencesUsedBy(AssemblySymbol assemblySymbol, List<AssemblySymbol?> referencedAssemblySymbols)
             {
-                referencedAssemblySymbols.Clear();
-
+                Debug.Assert(referencedAssemblySymbols.IsEmpty());
                 foreach (var module in assemblySymbol.Modules)
                 {
                     referencedAssemblySymbols.AddRange(module.GetReferencedAssemblySymbols());

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -698,6 +698,9 @@ namespace Microsoft.CodeAnalysis
             Queue<AssemblyReferenceCandidate> candidatesToExamine = new Queue<AssemblyReferenceCandidate>();
             int totalAssemblies = assemblies.Length;
 
+            // A reusable buffer to contain the AssemblySymbols a candidate symbol refers to
+            List<TAssemblySymbol?> candidateReferencedSymbols = new List<TAssemblySymbol?>(1024);
+
             for (int i = 1; i < totalAssemblies; i++)
             {
                 // We could have a match already
@@ -778,12 +781,12 @@ namespace Microsoft.CodeAnalysis
                         // how we bound the candidate references for this compilation:
                         var candidateReferenceBinding = boundInputs[candidateIndex].ReferenceBinding;
 
-                        // the AssemblySymbols the candidate symbol refers to:
-                        TAssemblySymbol?[] candidateReferencedSymbols = GetActualBoundReferencesUsedBy(candidate.AssemblySymbol);
+                        // get the AssemblySymbols the candidate symbol refers to into candidateReferencedSymbols
+                        GetActualBoundReferencesUsedBy(candidate.AssemblySymbol, candidateReferencedSymbols);
 
                         Debug.Assert(candidateReferenceBinding is object);
-                        Debug.Assert(candidateReferenceBinding.Length == candidateReferencedSymbols.Length);
-                        int referencesCount = candidateReferencedSymbols.Length;
+                        Debug.Assert(candidateReferenceBinding.Length == candidateReferencedSymbols.Count);
+                        int referencesCount = candidateReferencedSymbols.Count;
 
                         for (int k = 0; k < referencesCount; k++)
                         {
@@ -1019,17 +1022,15 @@ namespace Microsoft.CodeAnalysis
 
         // https://github.com/dotnet/roslyn/issues/40751 It should not be necessary to annotate this method to annotate overrides
         /// <summary>
-        /// Return AssemblySymbols referenced by the input AssemblySymbol. The AssemblySymbols must correspond 
+        /// Compute AssemblySymbols referenced by the input AssemblySymbol and fill in <paramref name="referencedAssemblySymbols"/> with the result.
+        /// The AssemblySymbols must correspond 
         /// to the AssemblyNames returned by AssemblyData.AssemblyReferences property. If reference is not 
         /// resolved, null reference should be returned in the corresponding item. 
         /// </summary>
-        /// <param name="assemblySymbol"></param>
-        /// The target AssemblySymbol instance.
-        /// <returns>
-        /// An array of AssemblySymbols referenced by the input AssemblySymbol.
-        /// Implementers may return cached array, Binder does not mutate it.
-        /// </returns>
-        protected abstract TAssemblySymbol?[] GetActualBoundReferencesUsedBy(TAssemblySymbol assemblySymbol);
+        /// <param name="assemblySymbol">The target AssemblySymbol instance.</param>
+        /// <param name="referencedAssemblySymbols">A list which should be cleared and then filled in with AssemblySymbols referenced by the input AssemblySymbol.
+        /// Implementer may not cache the list; the caller may mutate it.</param>
+        protected abstract void GetActualBoundReferencesUsedBy(TAssemblySymbol assemblySymbol, List<TAssemblySymbol?> referencedAssemblySymbols);
 
         /// <summary>
         /// Return collection of assemblies involved in canonical type resolution of

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -782,6 +782,7 @@ namespace Microsoft.CodeAnalysis
                         var candidateReferenceBinding = boundInputs[candidateIndex].ReferenceBinding;
 
                         // get the AssemblySymbols the candidate symbol refers to into candidateReferencedSymbols
+                        candidateReferencedSymbols.Clear();
                         GetActualBoundReferencesUsedBy(candidate.AssemblySymbol, candidateReferencedSymbols);
 
                         Debug.Assert(candidateReferenceBinding is object);
@@ -1028,7 +1029,9 @@ namespace Microsoft.CodeAnalysis
         /// resolved, null reference should be returned in the corresponding item. 
         /// </summary>
         /// <param name="assemblySymbol">The target AssemblySymbol instance.</param>
-        /// <param name="referencedAssemblySymbols">A list which should be cleared and then filled in with AssemblySymbols referenced by the input AssemblySymbol.
+        /// <param name="referencedAssemblySymbols">A list which will be filled in with
+        /// AssemblySymbols referenced by the input AssemblySymbol. The caller is expected to clear
+        /// the list before calling this method.
         /// Implementer may not cache the list; the caller may mutate it.</param>
         protected abstract void GetActualBoundReferencesUsedBy(TAssemblySymbol assemblySymbol, List<TAssemblySymbol?> referencedAssemblySymbols);
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -52,21 +52,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 MyBase.New(simpleAssemblyName, identityComparer, observedMetadata)
             End Sub
 
-            Protected Overrides Function GetActualBoundReferencesUsedBy(assemblySymbol As AssemblySymbol) As AssemblySymbol()
-                Dim refs As New List(Of AssemblySymbol)
+            Protected Overrides Sub GetActualBoundReferencesUsedBy(assemblySymbol As AssemblySymbol, referencedAssemblySymbols As List(Of AssemblySymbol))
+                referencedAssemblySymbols.Clear()
 
                 For Each [module] In assemblySymbol.Modules
-                    refs.AddRange([module].GetReferencedAssemblySymbols())
+                    referencedAssemblySymbols.AddRange([module].GetReferencedAssemblySymbols())
                 Next
 
-                For i As Integer = 0 To refs.Count - 1 Step 1
-                    If refs(i).IsMissing Then
-                        refs(i) = Nothing ' Do not expose missing assembly symbols to ReferenceManager.Binder
+                For i As Integer = 0 To referencedAssemblySymbols.Count - 1 Step 1
+                    If referencedAssemblySymbols(i).IsMissing Then
+                        referencedAssemblySymbols(i) = Nothing ' Do not expose missing assembly symbols to ReferenceManager.Binder
                     End If
                 Next
-
-                Return refs.ToArray()
-            End Function
+            End Sub
 
             Protected Overrides Function GetNoPiaResolutionAssemblies(candidateAssembly As AssemblySymbol) As ImmutableArray(Of AssemblySymbol)
                 If TypeOf candidateAssembly Is SourceAssemblySymbol Then


### PR DESCRIPTION
Fixes #47471

Measurements indicate the principal problem in the reported scenario is an array allocation that
causes extreme garbage and results in GC thrashing.  That specific allocation is eliminated in this PR
by reusing a list as a buffer rather than allocating a new buffer for each call to `GetActualBoundReferencesUsedBy`.

Judging by the triply-nested loop in the caller (`ReuseAssemblySymbols`),
it is possible that some algorithmic work could further reduce any issues that remain.  However,
the customer's problem is already solved because they removed the circular reference in their
projects.  Thus this PR simply addresses the observed symptom.

There is no specific test for this as it would require a very large solution and measuring the
amount of memory allocation.
