### PR TITLE
Decision dag: union the set of values when there are two predecessor states.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -645,7 +645,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Build the state machine underlying the decision dag
             DecisionDag decisionDag = MakeDecisionDag(cases);
 
-            // Note: It is useful for debugging the dag state table construction to view `decisionDag.Dump()` here.
+            // Note: It is useful for debugging the dag state table construction to set a breakpoint
+            // here and view `decisionDag.Dump()`.
+            ;
 
             // Compute the bound decision dag corresponding to each node of decisionDag, and store
             // it in node.Dag.
@@ -679,32 +681,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var state = new DagState(cases, remainingValues);
                 if (uniqueState.TryGetValue(state, out DagState? existingState))
                 {
-                    var newRemainingValues = existingState.RemainingValues;
-                    bool changed = false;
+                    // We found an existing state that matches.  Update its set of possible remaining values
+                    // of each temp by taking the union of the sets on each incoming edge.
+                    var newRemainingValues = ImmutableDictionary<BoundDagTemp, IValueSet>.Empty;
                     foreach (var (dagTemp, valuesForTemp) in remainingValues)
                     {
-                        if (newRemainingValues.TryGetValue(dagTemp, out var existingValuesForTemp))
+                        // If one incoming edge does not have a set of possible values for the temp,
+                        // that means the temp can take on any value of its type.
+                        if (existingState.RemainingValues.TryGetValue(dagTemp, out var existingValuesForTemp))
                         {
                             var newExistingValuesForTemp = existingValuesForTemp.Union(valuesForTemp);
-                            if (!newExistingValuesForTemp.Equals(existingValuesForTemp))
-                            {
-                                newRemainingValues = newRemainingValues.SetItem(dagTemp, newExistingValuesForTemp);
-                                changed = true;
-                            }
-                        }
-                        else
-                        {
-                            newRemainingValues = newRemainingValues.Add(dagTemp, valuesForTemp);
-                            changed = true;
+                            newRemainingValues = newRemainingValues.SetItem(dagTemp, newExistingValuesForTemp);
                         }
                     }
 
-                    if (changed)
-                    {
-                        existingState.UpdateRemainingValues(newRemainingValues);
-                        if (!workList.Contains(existingState))
-                            workList.Push(existingState);
-                    }
+                    existingState.UpdateRemainingValues(newRemainingValues);
+                    if (!workList.Contains(existingState))
+                        workList.Push(existingState);
 
                     return existingState;
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -3243,5 +3243,32 @@ static class Ex
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen, "switch").WithArguments("0").WithLocation(5, 15)
                 );
         }
+
+        [Fact]
+        public void MultiplePathsToState_01()
+        {
+            var source =
+@"class Sample
+{
+    void M(int a, int b)
+    {
+        _ = (a, b) switch
+        {
+            (0, 0) => 0,
+            (0, 1) => 1,
+            (0, 2) => 2,
+
+            (1, 0) => 5,
+            (1, 1) => 6,
+            (1, 2) => 7,
+
+            _ => 10,
+        };
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyEmitDiagnostics(
+                );
+        }
     }
 }


### PR DESCRIPTION
If a state has no set of values for a temp on one of the edges, that means it is unrestricted.
This fixes a bug in decision dag construction.  I was not able to construct a test that is
affected, but the change makes a visible difference in an internal dump of the decision dag
for the newly added test `MultiplePathsToState_01`, which we walked through in a compiler
team meeting on 2020-09-09.