### PR TITLE
Handle NotNullIfNotNull in delegate creation and overrides

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1261,13 +1261,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             TypeWithAnnotations getNotNullIfNotNullOutputType(TypeWithAnnotations outputType, ImmutableHashSet<string> notNullIfParameterNotNull)
             {
-                for (var i = 0; i < overriddenParameters.Length; i++)
+                if (!notNullIfParameterNotNull.IsEmpty)
                 {
-                    var overridingParam = overridingParameters[i + overridingMethodOffset];
-                    var overriddenParam = overriddenParameters[i];
-                    if (notNullIfParameterNotNull.Contains(overridingParam.Name) && !overriddenParam.TypeWithAnnotations.NullableAnnotation.IsAnnotated())
+                    for (var i = 0; i < overriddenParameters.Length; i++)
                     {
-                        return outputType.AsNotAnnotated();
+                        var overridingParam = overridingParameters[i + overridingMethodOffset];
+                        if (notNullIfParameterNotNull.Contains(overridingParam.Name) && !overriddenParameters[i].TypeWithAnnotations.NullableAnnotation.IsAnnotated())
+                        {
+                            return outputType.AsNotAnnotated();
+                        }
                     }
                 }
 


### PR DESCRIPTION
Closes #44174

Implements the fix described in https://github.com/dotnet/roslyn/issues/44735#issuecomment-675768560