### PR TITLE
Typeless expressions should contribute nullability to lambda return

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -505,8 +505,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _ => throw ExceptionUtilities.UnexpectedValue(source),
             };
             BoundMethodGroup group = FixMethodGroupWithTypeOrValue(originalGroup, conversion, diagnostics);
-            BoundExpression? receiverOpt = group.ReceiverOpt;
-            MethodSymbol? method = conversion.Method;
             bool hasErrors = false;
 
             if (MethodGroupConversionHasErrors(syntax, conversion, group.ReceiverOpt, conversion.IsExtensionMethod, destination, diagnostics))

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -16,14 +16,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static NullableAnnotation GetNullableAnnotation(ArrayBuilder<TypeWithAnnotations> types)
         {
 #if DEBUG
-            var example = types.Where(t => t.HasType).FirstOrDefault();
+            var example = types.FirstOrDefault(t => t.HasType);
 #endif
 
             var result = NullableAnnotation.NotAnnotated;
             foreach (var type in types)
             {
 #if DEBUG
-                Debug.Assert(!type.HasType || (example.HasType && type.Equals(example, TypeCompareKind.AllIgnoreOptions)));
+                Debug.Assert(!type.HasType || type.Equals(example, TypeCompareKind.AllIgnoreOptions));
 #endif
 
                 // This uses the covariant merging rules.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -14,11 +15,17 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public static NullableAnnotation GetNullableAnnotation(ArrayBuilder<TypeWithAnnotations> types)
         {
+#if DEBUG
+            var example = types.Where(t => t.HasType).FirstOrDefault();
+#endif
+
             var result = NullableAnnotation.NotAnnotated;
             foreach (var type in types)
             {
-                Debug.Assert(type.HasType);
-                Debug.Assert(type.Equals(types[0], TypeCompareKind.AllIgnoreOptions));
+#if DEBUG
+                Debug.Assert(!type.HasType || !example.HasType || type.Equals(example, TypeCompareKind.AllIgnoreOptions));
+#endif
+
                 // This uses the covariant merging rules.
                 result = result.Join(type.NullableAnnotation);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var type in types)
             {
 #if DEBUG
-                Debug.Assert(!type.HasType || !example.HasType || type.Equals(example, TypeCompareKind.AllIgnoreOptions));
+                Debug.Assert(!type.HasType || (example.HasType && type.Equals(example, TypeCompareKind.AllIgnoreOptions)));
 #endif
 
                 // This uses the covariant merging rules.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6473,8 +6473,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultState = NullableFlowState.NotNull;
                     break;
 
-                case ConversionKind.SwitchExpression:
                 case ConversionKind.ObjectCreation:
+                case ConversionKind.SwitchExpression:
                 case ConversionKind.ConditionalExpression:
                     return operandType;
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2795,11 +2795,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitUnconvertedObjectCreationExpression(BoundUnconvertedObjectCreationExpression node)
         {
-            var discardedDiagnostics = new DiagnosticBag();
-            var expr = _binder!.BindObjectCreationForErrorRecovery(node, discardedDiagnostics);
-            discardedDiagnostics.Free();
-            Visit(expr);
-            SetResultType(node, TypeWithState.Create(expr.Type, NullableFlowState.NotNull));
+            // This method is only involved in method inference with unbound lambdas.
+            // The diagnostics on arguments are reported by VisitObjectCreationExpression.
+            SetResultType(node, TypeWithState.Create(null, NullableFlowState.NotNull));
             return null;
         }
 
@@ -4061,8 +4059,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression originalConsequence,
             BoundExpression originalAlternative)
         {
-            Debug.Assert(node.Type is object);
-
             VisitCondition(condition);
             var consequenceState = this.StateWhenTrue;
             var alternativeState = this.StateWhenFalse;
@@ -4080,7 +4076,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (alternativeLValue, alternativeRValue) = visitConditionalRefOperand(alternativeState, originalAlternative);
                 Join(ref this.State, ref consequenceState);
 
-                TypeSymbol refResultType = node.Type.SetUnknownNullabilityForReferenceTypes();
+                TypeSymbol? refResultType = node.Type?.SetUnknownNullabilityForReferenceTypes();
                 if (IsNullabilityMismatch(consequenceLValue, alternativeLValue))
                 {
                     // l-value types must match
@@ -4157,8 +4153,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             NullableFlowState resultState;
             if (resultType is null)
             {
-                resultType = node.Type.SetUnknownNullabilityForReferenceTypes();
-                resultState = NullableFlowState.NotNull;
+                resultType = node.Type?.SetUnknownNullabilityForReferenceTypes();
+                resultState = consequenceRValue.State.Join(alternativeRValue.State);
 
                 var resultTypeWithState = TypeWithState.Create(resultType, resultState);
 
@@ -6477,12 +6473,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultState = NullableFlowState.NotNull;
                     break;
 
-                case ConversionKind.ObjectCreation:
                 case ConversionKind.SwitchExpression:
+                case ConversionKind.ObjectCreation:
                 case ConversionKind.ConditionalExpression:
-                    // These are not represented as a separate conversion in the bound tree.
-                    // Instead they are folded into the operand.
-                    throw ExceptionUtilities.UnexpectedValue(conversion.Kind);
+                    return operandType;
 
                 case ConversionKind.ExplicitUserDefined:
                 case ConversionKind.ImplicitUserDefined:
@@ -8719,9 +8713,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitDefaultLiteral(BoundDefaultLiteral node)
         {
-            // Can occur in error scenarios
+            // Can occur in error scenarios and lambda scenarios
             var result = base.VisitDefaultLiteral(node);
-            SetUnknownResultNullability(node);
+            SetResultType(node, TypeWithState.Create(node.Type, NullableFlowState.MaybeDefault));
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -782,7 +782,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (type is null)
                 {
-                    return annotation.IsAnnotated() ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
+                    return annotation.IsAnnotated() ? NullableFlowState.MaybeDefault : NullableFlowState.NotNull;
                 }
                 if (type.IsPossiblyNullableReferenceTypeTypeParameter())
                 {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -1268,7 +1268,7 @@ class C
             Assert.Equal(notNull, leftInfo.Nullability);
             Assert.Equal(notNull, leftInfo.ConvertedNullability);
             Assert.Equal(@null, rightInfo.Nullability);
-            Assert.Equal(notNull, rightInfo.ConvertedNullability);
+            Assert.Equal(@null, rightInfo.ConvertedNullability);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/46954
Fixes https://github.com/dotnet/roslyn/issues/44339

NullableWalker assumed that we would not encounter unconverted conditional or switch expressions. This resulted in a crash because such expressions can lack type.
We can encounter such expressions when those expressions are target-typed and we're in a lambda while trying to figure out the return type of the lambda (which will then become the target-type).

So we need to analyze such typeless expressions before they become target-typed (switch, conditional, null, default, lambdas, ...). They should contribute nullability information, but no type (so we should avoid giving them an error type for this purpose).