### PR TITLE
Add preview indicator

### DIFF
--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -150,7 +150,7 @@
   <data name="Gathering_Suggestions_Waiting_for_the_solution_to_fully_load" xml:space="preserve">
     <value>Gathering Suggestions - Waiting for the solution to fully load</value>
   </data>
-  <data name="LinesIndicator" xml:space="preserve">
+  <data name="Lines_0_to_1" xml:space="preserve">
     <value>Lines {0} to {1}</value>
   </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -150,4 +150,7 @@
   <data name="Gathering_Suggestions_Waiting_for_the_solution_to_fully_load" xml:space="preserve">
     <value>Gathering Suggestions - Waiting for the solution to fully load</value>
   </data>
+  <data name="LinesIndicator" xml:space="preserve">
+    <value>Lines {0} to {1}</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/Preview/LinesIndicator.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/LinesIndicator.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Differencing;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Formatting;
+using Microsoft.VisualStudio.Text.Projection;
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
+{
+    internal sealed class LinesIndicator
+    {
+        private readonly IAdornmentLayer _layer;
+        private readonly IWpfTextView _view;
+        private readonly IDifferenceViewer _viewer;
+        private readonly IClassificationFormatMap _classificationFormatMap;
+        private readonly IEditorFormatMap _editorFormatMap;
+        private readonly IClassificationType _lineNumberClassificaiton;
+        private readonly LinesIndicatorTextViewCreationListener _factory;
+
+        public LinesIndicator(IWpfTextView view, IDifferenceTextViewModel model, LinesIndicatorTextViewCreationListener factory)
+        {
+            _layer = view.GetAdornmentLayer(nameof(LinesIndicator));
+            _view = view;
+            _viewer = model.Viewer;
+            _factory = factory;
+            _classificationFormatMap = factory.ClassificationFormatMapService.GetClassificationFormatMap(view);
+            _editorFormatMap = factory.EditorFormatMapService.GetEditorFormatMap(view);
+            _lineNumberClassificaiton = factory.ClassificationTypeRegistryService.GetClassificationType("line number");
+
+            view.Closed += this.OnClosed;
+            view.LayoutChanged += this.OnLayoutChanged;
+        }
+
+        private void OnClosed(object sender, EventArgs e)
+        {
+            _view.Closed -= this.OnClosed;
+            _view.LayoutChanged -= this.OnLayoutChanged;
+        }
+
+        private void OnLayoutChanged(object sender, TextViewLayoutChangedEventArgs e)
+        {
+            foreach (var line in e.NewOrReformattedLines)
+            {
+                this.CreateVisuals(line);
+            }
+        }
+
+        private void CreateVisuals(ITextViewLine line)
+        {
+            if ((line.Extent.Length == PreviewFactoryService.Ellipsis.Length) && (line.Extent.GetText() == PreviewFactoryService.Ellipsis))
+            {
+                var snapshot = _viewer.DifferenceBuffer.CurrentSnapshotDifference;
+                if ((snapshot != null) && (snapshot.InlineBufferSnapshot == _view.TextSnapshot))
+                {
+                    var leftProjectionSnapshot = (IProjectionSnapshot)snapshot.LeftBufferSnapshot;
+                    var leftSourceSnapshot = this.GetSourceSnapshot(leftProjectionSnapshot);
+
+                    var leftSnapshotLine = snapshot.MapToSnapshot(line.Extent.Start, leftProjectionSnapshot).GetContainingLine();
+
+                    // Find the first line in the left snapshot after the ellipsis that corresponds to a real line in the source of the left snapshot
+                    // (it might be more than one before the ellipsis since empty lines in the left buffer are represented entirely as lines from the inert buffer).
+                    var startLine = int.MaxValue;
+                    var endLine = int.MaxValue;
+                    var skipped = 0;
+                    for (var i = leftSnapshotLine.LineNumber + 1; i < leftSnapshotLine.Snapshot.LineCount; ++i)
+                    {
+                        leftSnapshotLine = leftSnapshotLine.Snapshot.GetLineFromLineNumber(i);
+                        var source = _view.BufferGraph.MapDownToSnapshot(leftSnapshotLine.Start, PointTrackingMode.Negative, leftSourceSnapshot, PositionAffinity.Successor);
+                        if (source.HasValue)
+                        {
+                            endLine = source.Value.GetContainingLine().LineNumber;
+                            startLine = endLine - skipped;                              // Account for the skipped lines;
+                            break;
+                        }
+                        else
+                        {
+                            ++skipped;
+                        }
+                    }
+
+                    // No subsequent line means we are on the last ellipsis (and do not need to do anything)
+                    UIElement adornment;
+                    if (startLine != int.MaxValue)
+                    {
+                        // Find the last line in the left source snapshot before the next ellipsis.
+                        //  Between ellipsis, there's a 1:1 correspondance between lines in the leftProjectionSnapshot and the leftSourceSnapshot so simply count lines.
+                        for (var i = leftSnapshotLine.LineNumber + 1; i < leftSnapshotLine.Snapshot.LineCount; ++i)
+                        {
+                            var nextExtent = leftSnapshotLine.Snapshot.GetLineFromLineNumber(i).Extent;
+                            if ((nextExtent.Length == PreviewFactoryService.Ellipsis.Length) && (nextExtent.GetText() == PreviewFactoryService.Ellipsis))
+                            {
+                                break;
+                            }
+
+                            ++endLine;
+                        }
+
+                        var properties = _classificationFormatMap.GetTextProperties(_lineNumberClassificaiton);
+                        var block = new TextBlock
+                        {
+                            Text = string.Format(EditorFeaturesWpfResources.LinesIndicator, startLine + 1, endLine + 1), // Displayed line numbers are 1-based.
+                            FontSize = properties.FontRenderingEmSize,
+                            FontFamily = properties.Typeface.FontFamily,
+                            Foreground = properties.ForegroundBrush,
+                            Background = _view.Background,
+                            Height = _view.LineHeight,
+                        };
+
+                        var separatorProperties = _editorFormatMap.GetProperties("outlining.verticalrule");
+                        var separatorBrush = (separatorProperties[EditorFormatDefinition.ForegroundBrushId] as Brush) ?? Brushes.Gray;
+                        var separatorY = Math.Floor(block.Height * 0.5) + 0.5;
+                        var separator = new Line()
+                        {
+                            X1 = 5.0,
+                            Y1 = separatorY,
+                            X2 = _view.ViewportWidth,
+                            Y2 = separatorY,
+                            StrokeThickness = 1.0,
+                            Stroke = separatorBrush,
+                        };
+
+                        var panel = new StackPanel() { Orientation = Orientation.Horizontal };
+                        panel.Children.Add(block);
+                        panel.Children.Add(separator);
+
+                        adornment = panel;
+                    }
+                    else
+                    {
+                        // We are on the last ellipsis and need to hide it.
+                        adornment = new Rectangle()
+                        {
+                            Width = line.Width,
+                            Height = line.TextHeight,
+                            Fill = _view.Background,
+                        };
+                    }
+
+                    Canvas.SetTop(adornment, line.TextTop);
+                    Canvas.SetLeft(adornment, 0.0);
+
+                    _layer.AddAdornment(AdornmentPositioningBehavior.TextRelative, line.Extent, null, adornment, null);
+                }
+            }
+        }
+
+        private ITextSnapshot GetSourceSnapshot(ITextSnapshot snapshot)
+        {
+            if (snapshot is IProjectionSnapshot projection)
+            {
+                foreach (var s in projection.SourceSnapshots)
+                {
+                    if (s.ContentType != _factory.TextBufferFactoryService.InertContentType)
+                    {
+                        return this.GetSourceSnapshot(s);
+                    }
+                }
+            }
+
+            return snapshot;
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/Preview/LinesIndicatorTextViewCreationListener.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/LinesIndicatorTextViewCreationListener.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Differencing;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
+{
+    [Export(typeof(IWpfTextViewCreationListener))]
+    [ContentType(StandardContentTypeNames.Any)]
+    [TextViewRole(TextViewRoles.PreviewRole)]
+    internal sealed class LinesIndicatorTextViewCreationListener : IWpfTextViewCreationListener
+    {
+#pragma warning disable 649, 169
+        [Export(typeof(AdornmentLayerDefinition))]
+        [Name(nameof(LinesIndicator))]
+        [Order(After = PredefinedAdornmentLayers.Text, Before = PredefinedAdornmentLayers.Caret)]
+        private readonly AdornmentLayerDefinition? _editorAdornmentLayer;
+#pragma warning restore 649, 169
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public LinesIndicatorTextViewCreationListener(
+                                                      [Import] ITextBufferFactoryService textBufferFactoryService,
+                                                      [Import] IClassificationFormatMapService classificationFormatMapService,
+                                                      [Import] IEditorFormatMapService editorFormatMapService,
+                                                      [Import] IClassificationTypeRegistryService classificationTypeRegistryService)
+        {
+            this.TextBufferFactoryService = textBufferFactoryService;
+            this.ClassificationFormatMapService = classificationFormatMapService;
+            this.EditorFormatMapService = editorFormatMapService;
+            this.ClassificationTypeRegistryService = classificationTypeRegistryService;
+        }
+
+        internal ITextBufferFactoryService TextBufferFactoryService { get; }
+
+        internal IClassificationFormatMapService ClassificationFormatMapService { get; }
+
+        internal IEditorFormatMapService EditorFormatMapService { get; }
+
+        internal IClassificationTypeRegistryService ClassificationTypeRegistryService { get; }
+
+        public void TextViewCreated(IWpfTextView textView)
+        {
+            if (textView.TextViewModel is IDifferenceTextViewModel model)
+            {
+                _ = new LinesIndicator(textView, model, this);
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewFactoryService.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewFactoryService.cs
@@ -33,6 +33,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
     [Export(typeof(IPreviewFactoryService)), Shared]
     internal class PreviewFactoryService : ForegroundThreadAffinitizedObject, IPreviewFactoryService
     {
+        public const string Ellipsis = "...";
+
         private const double DefaultZoomLevel = 0.75;
         private readonly ITextViewRoleSet _previewRoleSet;
 
@@ -642,7 +644,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 _contentTypeRegistryService,
                 _editorOptionsFactoryService.GlobalOptions,
                 oldBuffer.CurrentSnapshot,
-                "...",
+                Ellipsis,
                 description,
                 originalSpans.ToArray());
 
@@ -650,7 +652,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 _contentTypeRegistryService,
                 _editorOptionsFactoryService.GlobalOptions,
                 newBuffer.CurrentSnapshot,
-                "...",
+                Ellipsis,
                 description,
                 changedSpans.ToArray());
 

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Shromažďují se návrhy – čeká se na úplné načtení řešení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regulární výrazy – komentář</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Vorschläge werden gesammelt. Es wird darauf gewartet, dass die Lösung vollständig geladen wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">RegEx - Kommentar</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Recopilando sugerencias: esperando a que la solución se cargue por completo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex - comentario</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Collecte des suggestions - Attente du chargement complet de la solution</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex - commentaire</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Raccolta dei suggerimenti - In attesa del completamento del caricamento della soluzione</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex - Commento</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">提案を収集しています - ソリューションが完全に読み込まれるのを待機しています</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">正規表現 - コメント</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">제안을 수집하는 중 - 솔루션이 완전히 로드될 때까지 기다리는 중</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex - 주석</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Zbieranie sugestii — oczekiwanie na pełne załadowanie rozwiązania</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Wyrażenie regularne — komentarz</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Obtendo Sugestões – aguardando a solução carregar totalmente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex – Comentário</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Сбор предложений — ожидается полная загрузка решения</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Регулярные выражения — комментарий</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Öneriler Toplanıyor - Çözümün tam olarak yüklenmesi bekleniyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex - yorum</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">正在收集建议 - 正在等待解决方案完全加载</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">正则表达式 - 注释</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">正在蒐集建議 - 正在等候解決方案完整載入</target>
         <note />
       </trans-unit>
+      <trans-unit id="Lines_0_to_1">
+        <source>Lines {0} to {1}</source>
+        <target state="new">Lines {0} to {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Regex_Comment">
         <source>Regex - Comment</source>
         <target state="translated">Regex - 註解</target>


### PR DESCRIPTION
Updates the preview of code changes to include line numbers of changed blocks of code.

Before changes:
![image](https://user-images.githubusercontent.com/11394666/92793676-76e12580-f363-11ea-88f5-e59fb30306ff.png)
After changes:
![image](https://user-images.githubusercontent.com/11394666/92793870-ad1ea500-f363-11ea-9039-7b9a0e21286b.png)
