### PR TITLE
Implement ImmutableArrayDictionary<TKey, TValue>

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    internal static class ImmutableArrayDictionary
+    {
+        public static ImmutableArrayDictionary<TKey, TValue> Create<TKey, TValue>()
+            where TKey : notnull
+            => ImmutableArrayDictionary<TKey, TValue>.Empty;
+
+        public static ImmutableArrayDictionary<TKey, TValue> Create<TKey, TValue>(IEqualityComparer<TKey>? keyComparer)
+            where TKey : notnull
+            => ImmutableArrayDictionary<TKey, TValue>.Empty.WithComparers(keyComparer);
+
+        public static ImmutableArrayDictionary<TKey, TValue> Create<TKey, TValue>(IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+            where TKey : notnull
+            => ImmutableArrayDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer);
+
+        public static ImmutableArrayDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>()
+            where TKey : notnull
+            => Create<TKey, TValue>().ToBuilder();
+
+        public static ImmutableArrayDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(IEqualityComparer<TKey>? keyComparer)
+            where TKey : notnull
+            => Create<TKey, TValue>(keyComparer).ToBuilder();
+
+        public static ImmutableArrayDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+            where TKey : notnull
+            => Create<TKey, TValue>(keyComparer, valueComparer).ToBuilder();
+
+        public static ImmutableArrayDictionary<TKey, TValue> CreateRange<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> items)
+            where TKey : notnull
+            => ImmutableArrayDictionary<TKey, TValue>.Empty.AddRange(items);
+
+        public static ImmutableArrayDictionary<TKey, TValue> CreateRange<TKey, TValue>(IEqualityComparer<TKey>? keyComparer, IEnumerable<KeyValuePair<TKey, TValue>> items)
+            where TKey : notnull
+            => ImmutableArrayDictionary<TKey, TValue>.Empty.WithComparers(keyComparer).AddRange(items);
+
+        public static ImmutableArrayDictionary<TKey, TValue> CreateRange<TKey, TValue>(IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer, IEnumerable<KeyValuePair<TKey, TValue>> items)
+            where TKey : notnull
+            => ImmutableArrayDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer).AddRange(items);
+
+        public static ImmutableArrayDictionary<TKey, TValue> ToImmutableArrayDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> items)
+            where TKey : notnull
+            => ToImmutableArrayDictionary(items, keyComparer: null, valueComparer: null);
+
+        public static ImmutableArrayDictionary<TKey, TValue> ToImmutableArrayDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> items, IEqualityComparer<TKey>? keyComparer)
+            where TKey : notnull
+            => ToImmutableArrayDictionary(items, keyComparer, valueComparer: null);
+
+        public static ImmutableArrayDictionary<TKey, TValue> ToImmutableArrayDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> items, IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+            where TKey : notnull
+        {
+            if (items is null)
+                throw new ArgumentNullException(nameof(items));
+
+            if (items is ImmutableArrayDictionary<TKey, TValue> existingDictionary)
+                return existingDictionary.WithComparers(keyComparer, valueComparer);
+
+            return ImmutableArrayDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer).AddRange(items);
+        }
+
+        public static ImmutableArrayDictionary<TKey, TValue> ToImmutableArrayDictionary<TSource, TKey, TValue>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector)
+            where TKey : notnull
+            => ToImmutableArrayDictionary(source, keySelector, elementSelector, keyComparer: null, valueComparer: null);
+
+        public static ImmutableArrayDictionary<TKey, TValue> ToImmutableArrayDictionary<TSource, TKey, TValue>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, IEqualityComparer<TKey>? keyComparer)
+            where TKey : notnull
+            => ToImmutableArrayDictionary(source, keySelector, elementSelector, keyComparer, valueComparer: null);
+
+        public static ImmutableArrayDictionary<TKey, TValue> ToImmutableArrayDictionary<TSource, TKey, TValue>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+            where TKey : notnull
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+            if (keySelector is null)
+                throw new ArgumentNullException(nameof(keySelector));
+            if (elementSelector is null)
+                throw new ArgumentNullException(nameof(elementSelector));
+
+            return ImmutableArrayDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer)
+                .AddRange(source.Select(element => new KeyValuePair<TKey, TValue>(keySelector(element), elementSelector(element))));
+        }
+
+        public static ImmutableArrayDictionary<TKey, TSource> ToImmutableArrayDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+            where TKey : notnull
+            => ToImmutableArrayDictionary(source, keySelector, elementSelector: Functions<TSource>.Identity, keyComparer: null, valueComparer: null);
+
+        public static ImmutableArrayDictionary<TKey, TSource> ToImmutableArrayDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer)
+            where TKey : notnull
+            => ToImmutableArrayDictionary(source, keySelector, elementSelector: Functions<TSource>.Identity, keyComparer, valueComparer: null);
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Builder+KeyCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Builder+KeyCollection.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        partial class Builder
+        {
+            public struct KeyCollection : ICollection<TKey>, IReadOnlyCollection<TKey>, ICollection
+            {
+                private readonly ImmutableArrayDictionary<TKey, TValue>.Builder _dictionary;
+
+                internal KeyCollection(ImmutableArrayDictionary<TKey, TValue>.Builder dictionary)
+                {
+                    RoslynDebug.AssertNotNull(dictionary);
+                    _dictionary = dictionary;
+                }
+
+                public int Count => _dictionary.Count;
+
+                bool ICollection<TKey>.IsReadOnly => false;
+
+                bool ICollection.IsSynchronized => false;
+
+                object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+                void ICollection<TKey>.Add(TKey item)
+                    => throw new NotSupportedException();
+
+                public void Clear()
+                    => _dictionary.Clear();
+
+                public bool Contains(TKey item)
+                    => _dictionary.ContainsKey(item);
+
+                public void CopyTo(TKey[] array, int arrayIndex)
+                    => ((ICollection<TKey>)_dictionary.ReadOnlyDictionary.Keys).CopyTo(array, arrayIndex);
+
+                public ImmutableArrayDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator()
+                    => new ImmutableArrayDictionary<TKey, TValue>.KeyCollection.Enumerator(_dictionary.GetEnumerator());
+
+                public bool Remove(TKey item)
+                    => _dictionary.Remove(item);
+
+                void ICollection.CopyTo(Array array, int index)
+                    => ((ICollection)_dictionary.ReadOnlyDictionary.Keys).CopyTo(array, index);
+
+                IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+                    => GetEnumerator();
+
+                IEnumerator IEnumerable.GetEnumerator()
+                    => GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Builder+ValueCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Builder+ValueCollection.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        partial class Builder
+        {
+            public struct ValueCollection : ICollection<TValue>, IReadOnlyCollection<TValue>, ICollection
+            {
+                private readonly ImmutableArrayDictionary<TKey, TValue>.Builder _dictionary;
+
+                internal ValueCollection(ImmutableArrayDictionary<TKey, TValue>.Builder dictionary)
+                {
+                    RoslynDebug.AssertNotNull(dictionary);
+                    _dictionary = dictionary;
+                }
+
+                public int Count => _dictionary.Count;
+
+                bool ICollection<TValue>.IsReadOnly => false;
+
+                bool ICollection.IsSynchronized => false;
+
+                object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+                void ICollection<TValue>.Add(TValue item)
+                    => throw new NotSupportedException();
+
+                public void Clear()
+                    => _dictionary.Clear();
+
+                public bool Contains(TValue item)
+                    => _dictionary.ContainsValue(item);
+
+                public void CopyTo(TValue[] array, int arrayIndex)
+                    => ((ICollection<TValue>)_dictionary.ReadOnlyDictionary.Values).CopyTo(array, arrayIndex);
+
+                public ImmutableArrayDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator()
+                    => new ImmutableArrayDictionary<TKey, TValue>.ValueCollection.Enumerator(_dictionary.GetEnumerator());
+
+                bool ICollection<TValue>.Remove(TValue item)
+                    => throw new NotSupportedException();
+
+                void ICollection.CopyTo(Array array, int index)
+                    => ((ICollection)_dictionary.ReadOnlyDictionary.Values).CopyTo(array, index);
+
+                IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+                    => GetEnumerator();
+
+                IEnumerator IEnumerable.GetEnumerator()
+                    => GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Builder.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Builder.cs
@@ -1,0 +1,230 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        public sealed partial class Builder : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, IDictionary
+        {
+            private readonly ImmutableArrayDictionary<TKey, TValue> _dictionary;
+            private Dictionary<TKey, TValue>? _mutableDictionary;
+
+            internal Builder(ImmutableArrayDictionary<TKey, TValue> dictionary)
+            {
+                _dictionary = dictionary;
+            }
+
+            public IEqualityComparer<TKey> KeyComparer => _dictionary.KeyComparer;
+
+            public IEqualityComparer<TValue> ValueComparer => _dictionary.ValueComparer;
+
+            public int Count => ReadOnlyDictionary.Count;
+
+            public KeyCollection Keys => new KeyCollection(this);
+
+            public ValueCollection Values => new ValueCollection(this);
+
+            private Dictionary<TKey, TValue> ReadOnlyDictionary => _mutableDictionary ?? _dictionary._dictionary;
+
+            IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+            IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+            ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+
+            ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+
+            bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+            ICollection IDictionary.Keys => Keys;
+
+            ICollection IDictionary.Values => Values;
+
+            bool IDictionary.IsReadOnly => false;
+
+            bool IDictionary.IsFixedSize => false;
+
+            object ICollection.SyncRoot => this;
+
+            bool ICollection.IsSynchronized => false;
+
+            public TValue this[TKey key]
+            {
+                get => ReadOnlyDictionary[key];
+                set => GetOrCreateMutableDictionary()[key] = value;
+            }
+
+            object? IDictionary.this[object key]
+            {
+                get => ((IDictionary)ReadOnlyDictionary)[key];
+                set => ((IDictionary)GetOrCreateMutableDictionary())[key] = value;
+            }
+
+            private Dictionary<TKey, TValue> GetOrCreateMutableDictionary()
+            {
+                return _mutableDictionary ??= new Dictionary<TKey, TValue>(_dictionary._dictionary, _dictionary.KeyComparer);
+            }
+
+            public void Add(TKey key, TValue value)
+                => GetOrCreateMutableDictionary().Add(key, value);
+
+            public void Add(KeyValuePair<TKey, TValue> item)
+                => Add(item.Key, item.Value);
+
+            public void AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items)
+            {
+                if (items == null)
+                    throw new ArgumentNullException(nameof(items));
+
+                foreach (KeyValuePair<TKey, TValue> pair in items)
+                    Add(pair.Key, pair.Value);
+            }
+
+            public void Clear()
+            {
+                if (ReadOnlyDictionary.Count != 0)
+                {
+                    if (_mutableDictionary is null)
+                        _mutableDictionary = new Dictionary<TKey, TValue>(KeyComparer);
+                    else
+                        _mutableDictionary.Clear();
+                }
+            }
+
+            public bool Contains(KeyValuePair<TKey, TValue> item)
+            {
+                return TryGetValue(item.Key, out TValue value)
+                    && ValueComparer.Equals(value, item.Value);
+            }
+
+            public bool ContainsKey(TKey key)
+                => ReadOnlyDictionary.ContainsKey(key);
+
+            public bool ContainsValue(TValue value)
+            {
+                if (ValueComparer == EqualityComparer<TValue>.Default)
+                {
+                    return _dictionary.ContainsValue(value);
+                }
+                else
+                {
+                    foreach (var pair in ReadOnlyDictionary)
+                    {
+                        if (ValueComparer.Equals(pair.Value, value))
+                            return true;
+                    }
+
+                    return false;
+                }
+            }
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(GetOrCreateMutableDictionary(), Enumerator.ReturnType.KeyValuePair);
+
+            [return: MaybeNull]
+            public TValue GetValueOrDefault(TKey key)
+            {
+                if (TryGetValue(key, out TValue value))
+                    return value;
+
+                return default;
+            }
+
+            public TValue GetValueOrDefault(TKey key, TValue defaultValue)
+            {
+                if (TryGetValue(key, out TValue value))
+                    return value;
+
+                return defaultValue;
+            }
+
+            public bool Remove(TKey key)
+            {
+                if (_mutableDictionary is null && !ContainsKey(key))
+                    return false;
+
+                return GetOrCreateMutableDictionary().Remove(key);
+            }
+
+            public bool Remove(KeyValuePair<TKey, TValue> item)
+            {
+                if (!Contains(item))
+                {
+                    return false;
+                }
+
+                GetOrCreateMutableDictionary().Remove(item.Key);
+                return true;
+            }
+
+            public void RemoveRange(IEnumerable<TKey> keys)
+            {
+                if (keys is null)
+                    throw new ArgumentNullException(nameof(keys));
+
+                foreach (var key in keys)
+                {
+                    Remove(key);
+                }
+            }
+
+            public bool TryGetKey(TKey equalKey, [NotNullWhen(true)] out TKey? actualKey)
+            {
+                foreach (var key in Keys)
+                {
+                    if (KeyComparer.Equals(key, equalKey))
+                    {
+                        actualKey = key;
+                        return true;
+                    }
+                }
+
+                actualKey = default;
+                return false;
+            }
+
+            public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+                => ReadOnlyDictionary.TryGetValue(key, out value);
+
+            public ImmutableArrayDictionary<TKey, TValue> ToImmutable()
+            {
+                var dictionary = ReadOnlyDictionary;
+                _mutableDictionary = null;
+                return new ImmutableArrayDictionary<TKey, TValue>(dictionary, ValueComparer);
+            }
+
+            void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+                => ((ICollection<KeyValuePair<TKey, TValue>>)ReadOnlyDictionary).CopyTo(array, arrayIndex);
+
+            IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+                => new Enumerator(GetOrCreateMutableDictionary(), Enumerator.ReturnType.KeyValuePair);
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => new Enumerator(GetOrCreateMutableDictionary(), Enumerator.ReturnType.KeyValuePair);
+
+            bool IDictionary.Contains(object key)
+                => ((IDictionary)ReadOnlyDictionary).Contains(key);
+
+            void IDictionary.Add(object key, object? value)
+                => ((IDictionary)GetOrCreateMutableDictionary()).Add(key, value);
+
+            IDictionaryEnumerator IDictionary.GetEnumerator()
+                => new Enumerator(GetOrCreateMutableDictionary(), Enumerator.ReturnType.DictionaryEntry);
+
+            void IDictionary.Remove(object key)
+                => ((IDictionary)GetOrCreateMutableDictionary()).Remove(key);
+
+            void ICollection.CopyTo(Array array, int index)
+                => ((ICollection)ReadOnlyDictionary).CopyTo(array, index);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Enumerator.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+Enumerator.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
+        {
+            private readonly Dictionary<TKey, TValue> _dictionary;
+            private readonly ReturnType _returnType;
+            private Dictionary<TKey, TValue>.Enumerator _enumerator;
+
+            internal Enumerator(Dictionary<TKey, TValue> dictionary, ReturnType returnType)
+            {
+                _dictionary = dictionary;
+                _returnType = returnType;
+                _enumerator = dictionary.GetEnumerator();
+            }
+
+            internal enum ReturnType
+            {
+                /// <summary>
+                /// The return value from the implementation of <see cref="IEnumerable.GetEnumerator"/> is
+                /// <see cref="KeyValuePair{TKey, TValue}"/>. This is the return value for most instances of this
+                /// enumerator.
+                /// </summary>
+                KeyValuePair,
+
+                /// <summary>
+                /// The return value from the implementation of <see cref="IEnumerable.GetEnumerator"/> is
+                /// <see cref="System.Collections.DictionaryEntry"/>. This is the return value for instances of this
+                /// enumerator created by the <see cref="IDictionary.GetEnumerator"/> implementation in
+                /// <see cref="ImmutableArrayDictionary{TKey, TValue}"/>.
+                /// </summary>
+                DictionaryEntry,
+            }
+
+            public KeyValuePair<TKey, TValue> Current => _enumerator.Current;
+
+            object IEnumerator.Current => _returnType == ReturnType.DictionaryEntry ? (object)((IDictionaryEnumerator)this).Entry : Current;
+
+            DictionaryEntry IDictionaryEnumerator.Entry => new DictionaryEntry(Current.Key, Current.Value);
+
+            object IDictionaryEnumerator.Key => Current.Key;
+
+            object? IDictionaryEnumerator.Value => Current.Value;
+
+            public void Dispose()
+                => _enumerator.Dispose();
+
+            public bool MoveNext()
+                => _enumerator.MoveNext();
+
+            public void Reset()
+            {
+                _enumerator = _dictionary.GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+KeyCollection+Enumerator.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+KeyCollection+Enumerator.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        partial struct KeyCollection
+        {
+            public struct Enumerator : IEnumerator<TKey>
+            {
+                private ImmutableArrayDictionary<TKey, TValue>.Enumerator _enumerator;
+
+                internal Enumerator(ImmutableArrayDictionary<TKey, TValue>.Enumerator enumerator)
+                {
+                    _enumerator = enumerator;
+                }
+
+                public TKey Current => _enumerator.Current.Key;
+
+                object IEnumerator.Current => Current;
+
+                public void Dispose()
+                    => _enumerator.Dispose();
+
+                public bool MoveNext()
+                    => _enumerator.MoveNext();
+
+                public void Reset()
+                    => _enumerator.Reset();
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+KeyCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+KeyCollection.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        public readonly partial struct KeyCollection : IReadOnlyCollection<TKey>, ICollection<TKey>, ICollection
+        {
+            private readonly ImmutableArrayDictionary<TKey, TValue> _dictionary;
+
+            internal KeyCollection(ImmutableArrayDictionary<TKey, TValue> dictionary)
+            {
+                _dictionary = dictionary;
+            }
+
+            public int Count => _dictionary.Count;
+
+            bool ICollection<TKey>.IsReadOnly => true;
+
+            bool ICollection.IsSynchronized => true;
+
+            object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(_dictionary.GetEnumerator());
+
+            public bool Contains(TKey item)
+                => _dictionary.ContainsKey(item);
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+                => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => GetEnumerator();
+
+            void ICollection<TKey>.CopyTo(TKey[] array, int arrayIndex)
+                => ((ICollection<TKey>)_dictionary.Keys).CopyTo(array, arrayIndex);
+
+            void ICollection.CopyTo(Array array, int index)
+                => ((ICollection)_dictionary.Keys).CopyTo(array, index);
+
+            void ICollection<TKey>.Add(TKey item)
+                => throw new NotSupportedException();
+
+            void ICollection<TKey>.Clear()
+                => throw new NotSupportedException();
+
+            bool ICollection<TKey>.Remove(TKey item)
+                => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+ValueCollection+Enumerator.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+ValueCollection+Enumerator.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        partial struct ValueCollection
+        {
+            public struct Enumerator : IEnumerator<TValue>
+            {
+                private ImmutableArrayDictionary<TKey, TValue>.Enumerator _enumerator;
+
+                internal Enumerator(ImmutableArrayDictionary<TKey, TValue>.Enumerator enumerator)
+                {
+                    _enumerator = enumerator;
+                }
+
+                public TValue Current => _enumerator.Current.Value;
+
+                object? IEnumerator.Current => Current;
+
+                public void Dispose()
+                    => _enumerator.Dispose();
+
+                public bool MoveNext()
+                    => _enumerator.MoveNext();
+
+                public void Reset()
+                    => _enumerator.Reset();
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+ValueCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2+ValueCollection.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    partial struct ImmutableArrayDictionary<TKey, TValue>
+    {
+        public readonly partial struct ValueCollection : IReadOnlyCollection<TValue>, ICollection<TValue>, ICollection
+        {
+            private readonly ImmutableArrayDictionary<TKey, TValue> _dictionary;
+
+            internal ValueCollection(ImmutableArrayDictionary<TKey, TValue> dictionary)
+            {
+                _dictionary = dictionary;
+            }
+
+            public int Count => _dictionary.Count;
+
+            bool ICollection<TValue>.IsReadOnly => true;
+
+            bool ICollection.IsSynchronized => true;
+
+            object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(_dictionary.GetEnumerator());
+
+            public bool Contains(TValue item)
+                => _dictionary.ContainsValue(item);
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+                => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => GetEnumerator();
+
+            void ICollection<TValue>.CopyTo(TValue[] array, int arrayIndex)
+                => ((ICollection<TValue>)_dictionary.Values).CopyTo(array, arrayIndex);
+
+            void ICollection.CopyTo(Array array, int index)
+                => ((ICollection)_dictionary.Values).CopyTo(array, index);
+
+            void ICollection<TValue>.Add(TValue item)
+                => throw new NotSupportedException();
+
+            void ICollection<TValue>.Clear()
+                => throw new NotSupportedException();
+
+            bool ICollection<TValue>.Remove(TValue item)
+                => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayDictionary`2.cs
@@ -1,0 +1,292 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    internal readonly partial struct ImmutableArrayDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, IDictionary
+        where TKey : notnull
+    {
+        public static readonly ImmutableArrayDictionary<TKey, TValue> Empty = new ImmutableArrayDictionary<TKey, TValue>(new Dictionary<TKey, TValue>(), valueComparer: null);
+
+        private readonly Dictionary<TKey, TValue> _dictionary;
+        private readonly IEqualityComparer<TValue> _valueComparer;
+
+        private ImmutableArrayDictionary(Dictionary<TKey, TValue> dictionary, IEqualityComparer<TValue>? valueComparer)
+        {
+            _dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+            _valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+        }
+
+        public IEqualityComparer<TKey> KeyComparer => _dictionary.Comparer;
+
+        public IEqualityComparer<TValue> ValueComparer => _valueComparer;
+
+        public int Count => _dictionary.Count;
+
+        public bool IsEmpty => _dictionary.Count == 0;
+
+        public KeyCollection Keys => new KeyCollection(this);
+
+        public ValueCollection Values => new ValueCollection(this);
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => true;
+
+        ICollection IDictionary.Keys => Keys;
+
+        ICollection IDictionary.Values => Values;
+
+        bool IDictionary.IsReadOnly => true;
+
+        bool IDictionary.IsFixedSize => true;
+
+        object ICollection.SyncRoot => this;
+
+        bool ICollection.IsSynchronized => true;
+
+        public TValue this[TKey key] => _dictionary[key];
+
+        TValue IDictionary<TKey, TValue>.this[TKey key]
+        {
+            get => this[key];
+            set => throw new NotSupportedException();
+        }
+
+        object? IDictionary.this[object key]
+        {
+            get => ((IDictionary)_dictionary)[key];
+            set => throw new NotSupportedException();
+        }
+
+        public ImmutableArrayDictionary<TKey, TValue> Add(TKey key, TValue value)
+        {
+            var dictionary = new Dictionary<TKey, TValue>(_dictionary, _dictionary.Comparer);
+            dictionary.Add(key, value);
+            return new ImmutableArrayDictionary<TKey, TValue>(dictionary, _valueComparer);
+        }
+
+        public ImmutableArrayDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
+        {
+            var dictionary = new Dictionary<TKey, TValue>(_dictionary, _dictionary.Comparer);
+            foreach (var (key, value) in pairs)
+            {
+                dictionary.Add(key, value);
+            }
+
+            return new ImmutableArrayDictionary<TKey, TValue>(dictionary, _valueComparer);
+        }
+
+        public ImmutableArrayDictionary<TKey, TValue> Clear()
+        {
+            if (IsEmpty)
+            {
+                return this;
+            }
+
+            return Empty.WithComparers(KeyComparer, ValueComparer);
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> pair)
+        {
+            return TryGetValue(pair.Key, out TValue value)
+                && ValueComparer.Equals(value, pair.Value);
+        }
+
+        public bool ContainsKey(TKey key)
+            => _dictionary.ContainsKey(key);
+
+        public bool ContainsValue(TValue value)
+        {
+            if (ValueComparer == EqualityComparer<TValue>.Default)
+            {
+                return _dictionary.ContainsValue(value);
+            }
+            else
+            {
+                foreach (var pair in this)
+                {
+                    if (ValueComparer.Equals(pair.Value, value))
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
+        public Enumerator GetEnumerator()
+            => new Enumerator(_dictionary, Enumerator.ReturnType.KeyValuePair);
+
+        public ImmutableArrayDictionary<TKey, TValue> Remove(TKey key)
+        {
+            if (!_dictionary.ContainsKey(key))
+                return this;
+
+            var dictionary = new Dictionary<TKey, TValue>(_dictionary, _dictionary.Comparer);
+            dictionary.Remove(key);
+            return new ImmutableArrayDictionary<TKey, TValue>(dictionary, _valueComparer);
+        }
+
+        public ImmutableArrayDictionary<TKey, TValue> RemoveRange(IEnumerable<TKey> keys)
+        {
+            if (keys is null)
+                throw new ArgumentNullException(nameof(keys));
+
+            var result = ToBuilder();
+            result.RemoveRange(keys);
+            return result.ToImmutable();
+        }
+
+        public ImmutableArrayDictionary<TKey, TValue> SetItem(TKey key, TValue value)
+        {
+            var dictionary = new Dictionary<TKey, TValue>(_dictionary, _dictionary.Comparer);
+            dictionary[key] = value;
+            return new ImmutableArrayDictionary<TKey, TValue>(dictionary, _valueComparer);
+        }
+
+        public ImmutableArrayDictionary<TKey, TValue> SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
+        {
+            if (items is null)
+                throw new ArgumentNullException(nameof(items));
+
+            Builder result = ToBuilder();
+            foreach (var item in items)
+            {
+                result[item.Key] = item.Value;
+            }
+
+            return result.ToImmutable();
+        }
+
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        public bool TryGetKey(TKey equalKey, [NotNullWhen(true)] out TKey? actualKey)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        {
+            foreach (var key in Keys)
+            {
+                if (KeyComparer.Equals(key, equalKey))
+                {
+                    actualKey = key;
+                    return true;
+                }
+            }
+
+            actualKey = default;
+            return false;
+        }
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+            => _dictionary.TryGetValue(key, out value);
+
+        public ImmutableArrayDictionary<TKey, TValue> WithComparers(IEqualityComparer<TKey>? keyComparer)
+            => WithComparers(keyComparer, valueComparer: null);
+
+        public ImmutableArrayDictionary<TKey, TValue> WithComparers(IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+        {
+            keyComparer ??= EqualityComparer<TKey>.Default;
+            valueComparer ??= EqualityComparer<TValue>.Default;
+
+            if (IsEmpty)
+            {
+                if (keyComparer == Empty.KeyComparer)
+                {
+                    return new ImmutableArrayDictionary<TKey, TValue>(Empty._dictionary, valueComparer);
+                }
+                else
+                {
+                    return new ImmutableArrayDictionary<TKey, TValue>(new Dictionary<TKey, TValue>(keyComparer), _valueComparer);
+                }
+            }
+            else if (KeyComparer == keyComparer)
+            {
+                // Don't need to reconstruct the dictionary because the key comparer is the same
+                return new ImmutableArrayDictionary<TKey, TValue>(_dictionary, valueComparer);
+            }
+            else
+            {
+                return ImmutableArrayDictionary.CreateRange(keyComparer, valueComparer, this);
+            }
+        }
+
+        public Builder ToBuilder()
+            => new Builder(this);
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear()
+            => Clear();
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value)
+            => Add(key, value);
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
+            => AddRange(pairs);
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value)
+            => SetItem(key, value);
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
+            => SetItems(items);
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(IEnumerable<TKey> keys)
+            => RemoveRange(keys);
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) => Remove(key);
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+            => new Enumerator(_dictionary, Enumerator.ReturnType.KeyValuePair);
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+            => new Enumerator(_dictionary, Enumerator.ReturnType.DictionaryEntry);
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => new Enumerator(_dictionary, Enumerator.ReturnType.KeyValuePair);
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+            => ((ICollection<KeyValuePair<TKey, TValue>>)_dictionary).CopyTo(array, arrayIndex);
+
+        bool IDictionary.Contains(object key)
+            => ((IDictionary)_dictionary).Contains(key);
+
+        void ICollection.CopyTo(Array array, int index)
+            => ((ICollection)_dictionary).CopyTo(array, index);
+
+        void IDictionary<TKey, TValue>.Add(TKey key, TValue value)
+            => throw new NotSupportedException();
+
+        bool IDictionary<TKey, TValue>.Remove(TKey key)
+            => throw new NotSupportedException();
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+            => throw new NotSupportedException();
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Clear()
+            => throw new NotSupportedException();
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+            => throw new NotSupportedException();
+
+        void IDictionary.Add(object key, object? value)
+            => throw new NotSupportedException();
+
+        void IDictionary.Clear()
+            => throw new NotSupportedException();
+
+        void IDictionary.Remove(object key)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
This is a full-featured replacement for `ImmutableDictionary<TKey, TValue>` backed by `Dictionary<TKey, TValue>` instead of an AVL trees. See #47637.