### PR TITLE
Enable unused integration test parameter

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicKeywordHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicKeywordHighlighting.cs
@@ -34,7 +34,7 @@ Class C
     End Sub
 End Class");
 
-            Verify("To", 3);
+            Verify("To", 4);
             VisualStudio.ExecuteCommand("Edit.NextHighlightedReference");
             VisualStudio.Editor.Verify.CurrentLineText("For a = 0 To 1 Step$$ 1", assertCaretPosition: true, trimWhitespace: true);
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicKeywordHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicKeywordHighlighting.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -39,9 +39,7 @@ End Class");
             VisualStudio.Editor.Verify.CurrentLineText("For a = 0 To 1 Step$$ 1", assertCaretPosition: true, trimWhitespace: true);
         }
 
-#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/46169
         private void Verify(string marker, int expectedCount)
-#pragma warning restore IDE0060 // Remove unused parameter
         {
             VisualStudio.Editor.PlaceCaret(marker, charsOffset: -1);
             VisualStudio.Workspace.WaitForAllAsyncOperations(
@@ -52,7 +50,7 @@ End Class");
                 FeatureAttribute.Classification,
                 FeatureAttribute.KeywordHighlighting);
 
-            // Assert.Equal(expectedCount, VisualStudio.Editor.GetKeywordHighlightTagCount());
+            Assert.Equal(expectedCount, VisualStudio.Editor.GetKeywordHighlightTags().Length);
         }
     }
 }


### PR DESCRIPTION
Fixes #46169 
The existing test had an unused parameter, which is now enabled. Also fixed up the test's highlight count (testing in actual VS has 4 highlights instead of 3).