### PR TITLE
Align C# and VB preconditions for GetActualBoundReferencesUsedBy

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -53,8 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Sub
 
             Protected Overrides Sub GetActualBoundReferencesUsedBy(assemblySymbol As AssemblySymbol, referencedAssemblySymbols As List(Of AssemblySymbol))
-                referencedAssemblySymbols.Clear()
-
+                Debug.Assert(referencedAssemblySymbols.IsEmpty())
                 For Each [module] In assemblySymbol.Modules
                     referencedAssemblySymbols.AddRange([module].GetReferencedAssemblySymbols())
                 Next


### PR DESCRIPTION
Related to #47471
I missed this in the previous PR despite comments suggesting this change.
