### PR TITLE
Keep track of the trigger location for async completion

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
-            if (!Helpers.TryGetInitialTriggerLocation(item, out var triggerLocation))
+            if (!Helpers.TryGetInitialTriggerLocation(session, out var triggerLocation))
             {
                 // Need the trigger snapshot to calculate the span when the commit changes to be applied.
                 // They should always be available from VS. Just to be defensive, if it's not found here, Roslyn should not make a commit.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 foreach (var roslynItem in completionList.Items)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var item = Convert(document, roslynItem, filterSet, triggerLocation);
+                    var item = Convert(document, roslynItem, filterSet);
                     itemsBuilder.Add(item);
                 }
 
@@ -436,8 +436,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         private VSCompletionItem Convert(
             Document document,
             RoslynCompletionItem roslynItem,
-            FilterSet filterSet,
-            SnapshotPoint triggerLocation)
+            FilterSet filterSet)
         {
             VSCompletionItemData itemData;
 
@@ -491,7 +490,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 attributeIcons: itemData.AttributeIcons);
 
             item.Properties.AddProperty(RoslynItem, roslynItem);
-            item.Properties.AddProperty(TriggerLocation, triggerLocation);
 
             return item;
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -220,6 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             SnapshotSpan applicableToSpan,
             CancellationToken cancellationToken)
         {
+            session.Properties[TriggerLocation] = triggerLocation;
             return GetCompletionContextWorkerAsync(session, trigger, triggerLocation, isExpanded: false, cancellationToken);
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -142,17 +142,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         internal static bool TryGetInitialTriggerLocation(EditorAsyncCompletion.IAsyncCompletionSession session, out SnapshotPoint initialTriggerLocation)
             => session.Properties.TryGetProperty(CompletionSource.TriggerLocation, out initialTriggerLocation);
 
-        internal static bool TryGetInitialTriggerLocation(VSCompletionItem item, out SnapshotPoint initialTriggerLocation)
-        {
-            if (item.Properties.TryGetProperty(CompletionSource.TriggerLocation, out initialTriggerLocation))
-            {
-                return true;
-            }
-
-            initialTriggerLocation = default;
-            return false;
-        }
-
         // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will introduce this support and we will get rid of relying on the "★" then.
         // We check both the display text and the display text prefix to account for IntelliCode item providers

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -140,16 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             => c == '\t' || c == '\n' || c == '\0';
 
         internal static bool TryGetInitialTriggerLocation(EditorAsyncCompletion.IAsyncCompletionSession session, out SnapshotPoint initialTriggerLocation)
-        {
-            if (session is EditorAsyncCompletion.IAsyncCompletionSessionOperations sessionOperations)
-            {
-                initialTriggerLocation = sessionOperations.InitialTriggerLocation;
-                return true;
-            }
-
-            initialTriggerLocation = default;
-            return false;
-        }
+            => session.Properties.TryGetProperty(CompletionSource.TriggerLocation, out initialTriggerLocation);
 
         internal static bool TryGetInitialTriggerLocation(VSCompletionItem item, out SnapshotPoint initialTriggerLocation)
         {

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -730,5 +730,31 @@ $$</Document>
                 Assert.False(state.HasSuggestedItem())
             End Using
         End Function
+
+        <WorkItem(1163608, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1163608")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
+        Public Async Function TestItemDescription() As Task
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>class Program
+{
+    static void Main(string[] args)
+    [|{|]
+    }
+}</Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, True)
+                state.SendTypeChars("arg")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("args")
+                Dim description = Await state.GetSelectedItemDescriptionAsync()
+                Assert.Contains("args", description.Text)
+                state.SendTab()
+                Assert.Contains("args", state.GetCurrentViewLineText())
+            End Using
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
So in debugging context, we can get the actual document triggered for completion.
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1163608

FYI @AmadeusW 
