### PR TITLE
Exclude empty item from completion list

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10733,5 +10733,23 @@ class C
     }
 }", "Local");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(1152109, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1152109")]
+        public async Task NoItemWithEmptyDisplayName()
+        {
+            var markup = @"
+class C
+{
+    static void M()
+    {
+        int$$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(
+                markup, "",
+                matchingFilters: new List<CompletionFilter> { FilterSet.LocalAndParameterFilter });
+        }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -134,6 +134,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
             var symbolGroups = from symbol in symbols
                                let texts = GetDisplayAndSuffixAndInsertionText(symbol, contextLookup(symbol))
+                               where !string.IsNullOrWhiteSpace(texts.displayText)
                                group symbol by texts into g
                                select g;
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -132,6 +132,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             Lazy<ImmutableArray<ITypeSymbol>> inferredTypes,
             TelemetryCounter telemetryCounter)
         {
+            // We might get symbol w/o name but CanBeReferencedByName is still set to true, 
+            // need to filter them out.
+            // https://github.com/dotnet/roslyn/issues/47690
             var symbolGroups = from symbol in symbols
                                let texts = GetDisplayAndSuffixAndInsertionText(symbol, contextLookup(symbol))
                                where !string.IsNullOrWhiteSpace(texts.displayText)


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1152109

In this case, SemanticModel would return a local symbol named `` of type `int`, we want to exclude that from completion list.
```cs
static void Main()
{
    int$$
}
```

@jasonmalinowski not sure what's the reason for this compiler behavior, should the fix be in compiler instead?