### PR TITLE
Implement UnmanagedCallersOnly conversions support

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static void ReportDiagnosticsIfUnmanagedCallersOnly(DiagnosticBag diagnostics, MethodSymbol symbol, Location location, bool isDelegateConversion)
         {
-            var unmanagedCallersOnlyAttributeData = symbol.UnmanagedCallersOnlyAttributeData;
+            var unmanagedCallersOnlyAttributeData = symbol.GetUnmanagedCallersOnlyAttributeData(forceComplete: false);
             if (unmanagedCallersOnlyAttributeData != null)
             {
                 // Either we haven't yet bound the attributes of this method, or there is an UnmanagedCallersOnly present.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4327,7 +4327,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(!conv.IsExtensionMethod);
                         Debug.Assert(conv.IsValid); // i.e. if it exists, then it is valid.
 
-                        if (!this.MethodGroupConversionHasErrors(argument.Syntax, conv, argument, conv.IsExtensionMethod, type, diagnostics))
+                        if (!this.MethodGroupConversionHasErrors(argument.Syntax, conv, argument, conv.IsExtensionMethod, isAddressOf: false, type, diagnostics))
                         {
                             // we do not place the "Invoke" method in the node, indicating that it did not appear in source.
                             return new BoundDelegateCreationExpression(node, argument, methodOpt: null, isExtensionMethod: false, type: type);
@@ -8061,12 +8061,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind returnRefKind = default,
             TypeSymbol returnType = null,
             bool isFunctionPointerResolution = false,
-            Cci.CallingConvention callingConvention = Cci.CallingConvention.Default)
+            in CallingConventionInfo callingConventionInfo = default)
         {
             return ResolveMethodGroup(
                 node, node.Syntax, node.Name, analyzedArguments, isMethodGroupConversion, ref useSiteDiagnostics,
                 inferWithDynamic: inferWithDynamic, returnRefKind: returnRefKind, returnType: returnType,
-                isFunctionPointerResolution: isFunctionPointerResolution, callingConvention: callingConvention);
+                isFunctionPointerResolution: isFunctionPointerResolution, callingConventionInfo: callingConventionInfo);
         }
 
         internal MethodGroupResolution ResolveMethodGroup(
@@ -8081,13 +8081,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind returnRefKind = default,
             TypeSymbol returnType = null,
             bool isFunctionPointerResolution = false,
-            Cci.CallingConvention callingConvention = Cci.CallingConvention.Default)
+            in CallingConventionInfo callingConventionInfo = default)
         {
             var methodResolution = ResolveMethodGroupInternal(
                 node, expression, methodName, analyzedArguments, isMethodGroupConversion, ref useSiteDiagnostics,
                 inferWithDynamic: inferWithDynamic, allowUnexpandedForm: allowUnexpandedForm,
                 returnRefKind: returnRefKind, returnType: returnType,
-                isFunctionPointerResolution: isFunctionPointerResolution, callingConvention: callingConvention);
+                isFunctionPointerResolution: isFunctionPointerResolution, callingConvention: callingConventionInfo);
             if (methodResolution.IsEmpty && !methodResolution.HasAnyErrors)
             {
                 Debug.Assert(node.LookupError == null);
@@ -8107,7 +8107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AnalyzedArguments analyzedArguments,
             TypeSymbol returnType,
             RefKind returnRefKind,
-            Cci.CallingConvention callingConvention,
+            in CallingConventionInfo callingConventionInfo,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             return ResolveDefaultMethodGroup(
@@ -8120,7 +8120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 returnRefKind,
                 returnType,
                 isFunctionPointerResolution: true,
-                callingConvention);
+                callingConventionInfo);
         }
 
         private MethodGroupResolution ResolveMethodGroupInternal(
@@ -8135,7 +8135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind returnRefKind = default,
             TypeSymbol returnType = null,
             bool isFunctionPointerResolution = false,
-            Cci.CallingConvention callingConvention = Cci.CallingConvention.Default)
+            in CallingConventionInfo callingConvention = default)
         {
             var methodResolution = ResolveDefaultMethodGroup(
                 methodGroup, analyzedArguments, isMethodGroupConversion, ref useSiteDiagnostics,
@@ -8207,7 +8207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind returnRefKind = default,
             TypeSymbol returnType = null,
             bool isFunctionPointerResolution = false,
-            Cci.CallingConvention callingConvention = Cci.CallingConvention.Default)
+            in CallingConventionInfo callingConvention = default)
         {
             var methods = node.Methods;
             if (methods.Length == 0)
@@ -8250,6 +8250,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                // If we're performing function pointer overload resolution and we're not in an attribute
+                // argument, then we force complete UnmanagedCallersOnly data for all methods to ensure
+                // they are loaded to be considered for calling convention comparison. If we're in an
+                // attribute argument, then it's an error case and overload resolution will treat it as
+                // matching to suppress potentially spurious diagnostics
+                if (!InAttributeArgument && isFunctionPointerResolution)
+                {
+                    foreach (var method in methodGroup.Methods)
+                    {
+                        method.ForceCompleteUnmanagedCallersOnlyAttribute();
+                    }
+                }
+
                 var result = OverloadResolutionResult<MethodSymbol>.GetInstance();
                 bool allowRefOmittedArguments = methodGroup.Receiver.IsExpressionOfComImportType();
                 OverloadResolution.MethodInvocationOverloadResolution(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8250,19 +8250,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                // If we're performing function pointer overload resolution and we're not in an attribute
-                // argument, then we force complete UnmanagedCallersOnly data for all methods to ensure
-                // they are loaded to be considered for calling convention comparison. If we're in an
-                // attribute argument, then it's an error case and overload resolution will treat it as
-                // matching to suppress potentially spurious diagnostics
-                if (!InAttributeArgument && isFunctionPointerResolution)
-                {
-                    foreach (var method in methodGroup.Methods)
-                    {
-                        method.ForceCompleteUnmanagedCallersOnlyAttribute();
-                    }
-                }
-
                 var result = OverloadResolutionResult<MethodSymbol>.GetInstance();
                 bool allowRefOmittedArguments = methodGroup.Receiver.IsExpressionOfComImportType();
                 OverloadResolution.MethodInvocationOverloadResolution(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -46,13 +46,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Conversion.NoConversion;
             }
 
-            var (methodSymbol, isFunctionPointer) = GetDelegateInvokeOrFunctionPointerMethodIfAvailable(destination);
+            var (methodSymbol, isFunctionPointer, callingConventionInfo) = GetDelegateInvokeOrFunctionPointerMethodIfAvailable(destination);
             if ((object)methodSymbol == null)
             {
                 return Conversion.NoConversion;
             }
 
-            var resolution = ResolveDelegateOrFunctionPointerMethodGroup(_binder, source, methodSymbol, isFunctionPointer, ref useSiteDiagnostics);
+            var resolution = ResolveDelegateOrFunctionPointerMethodGroup(_binder, source, methodSymbol, isFunctionPointer, callingConventionInfo, ref useSiteDiagnostics);
             var conversion = (resolution.IsEmpty || resolution.HasAnyErrors) ?
                 Conversion.NoConversion :
                 ToConversion(resolution.OverloadResolutionResult, resolution.MethodGroup, ((NamedTypeSymbol)destination).DelegateInvokeMethod.ParameterCount);
@@ -62,7 +62,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override Conversion GetMethodGroupFunctionPointerConversion(BoundMethodGroup source, FunctionPointerTypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            var resolution = ResolveDelegateOrFunctionPointerMethodGroup(_binder, source, destination.Signature, isFunctionPointer: true, ref useSiteDiagnostics);
+            var resolution = ResolveDelegateOrFunctionPointerMethodGroup(
+                _binder,
+                source,
+                destination.Signature,
+                isFunctionPointer: true,
+                new CallingConventionInfo(destination.Signature.CallingConvention, destination.Signature.GetCallingConventionModifiers()),
+                ref useSiteDiagnostics);
             var conversion = (resolution.IsEmpty || resolution.HasAnyErrors) ?
                 Conversion.NoConversion :
                 ToConversion(resolution.OverloadResolutionResult, resolution.MethodGroup, destination.Signature.ParameterCount);
@@ -83,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Resolve method group based on the optional delegate invoke method.
         /// If the invoke method is null, ignore arguments in resolution.
         /// </summary>
-        private static MethodGroupResolution ResolveDelegateOrFunctionPointerMethodGroup(Binder binder, BoundMethodGroup source, MethodSymbol delegateInvokeMethodOpt, bool isFunctionPointer, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private static MethodGroupResolution ResolveDelegateOrFunctionPointerMethodGroup(Binder binder, BoundMethodGroup source, MethodSymbol delegateInvokeMethodOpt, bool isFunctionPointer, in CallingConventionInfo callingConventionInfo, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             if ((object)delegateInvokeMethodOpt != null)
             {
@@ -91,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 GetDelegateArguments(source.Syntax, analyzedArguments, delegateInvokeMethodOpt.Parameters, binder.Compilation);
                 var resolution = binder.ResolveMethodGroup(source, analyzedArguments, useSiteDiagnostics: ref useSiteDiagnostics, inferWithDynamic: true,
                     isMethodGroupConversion: true, returnRefKind: delegateInvokeMethodOpt.RefKind, returnType: delegateInvokeMethodOpt.ReturnType,
-                    isFunctionPointerResolution: isFunctionPointer, callingConvention: delegateInvokeMethodOpt.CallingConvention);
+                    isFunctionPointerResolution: isFunctionPointer, callingConventionInfo: callingConventionInfo);
                 analyzedArguments.Free();
                 return resolution;
             }
@@ -105,33 +111,33 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Return the Invoke method symbol if the type is a delegate
         /// type and the Invoke method is available, otherwise null.
         /// </summary>
-        private static (MethodSymbol, bool isFunctionPointer) GetDelegateInvokeOrFunctionPointerMethodIfAvailable(TypeSymbol type)
+        private static (MethodSymbol, bool isFunctionPointer, CallingConventionInfo callingConventionInfo) GetDelegateInvokeOrFunctionPointerMethodIfAvailable(TypeSymbol type)
         {
             if (type is FunctionPointerTypeSymbol { Signature: { } signature })
             {
-                return (signature, true);
+                return (signature, true, new CallingConventionInfo(signature.CallingConvention, signature.GetCallingConventionModifiers()));
             }
 
             var delegateType = type.GetDelegateType();
             if ((object)delegateType == null)
             {
-                return (null, false);
+                return (null, false, default);
             }
 
             MethodSymbol methodSymbol = delegateType.DelegateInvokeMethod;
             if ((object)methodSymbol == null || methodSymbol.HasUseSiteError)
             {
-                return (null, false);
+                return (null, false, default);
             }
 
-            return (methodSymbol, false);
+            return (methodSymbol, false, default);
         }
 
         public static bool ReportDelegateOrFunctionPointerMethodGroupDiagnostics(Binder binder, BoundMethodGroup expr, TypeSymbol targetType, DiagnosticBag diagnostics)
         {
-            var (invokeMethodOpt, isFunctionPointer) = GetDelegateInvokeOrFunctionPointerMethodIfAvailable(targetType);
+            var (invokeMethodOpt, isFunctionPointer, callingConventionInfo) = GetDelegateInvokeOrFunctionPointerMethodIfAvailable(targetType);
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            var resolution = ResolveDelegateOrFunctionPointerMethodGroup(binder, expr, invokeMethodOpt, isFunctionPointer, ref useSiteDiagnostics);
+            var resolution = ResolveDelegateOrFunctionPointerMethodGroup(binder, expr, invokeMethodOpt, isFunctionPointer, callingConventionInfo, ref useSiteDiagnostics);
             diagnostics.Add(expr.Syntax, useSiteDiagnostics);
 
             bool hasErrors = resolution.HasAnyErrors;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/CallingConventionInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/CallingConventionInfo.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal readonly struct CallingConventionInfo
+    {
+        internal Cci.CallingConvention CallKind { get; }
+        internal ImmutableHashSet<CustomModifier>? CallingConventionTypes { get; }
+
+        public CallingConventionInfo(Cci.CallingConvention callKind, ImmutableHashSet<CustomModifier> callingConventionTypes)
+        {
+            Debug.Assert(callingConventionTypes.IsEmpty || callKind == Cci.CallingConvention.Unmanaged);
+            CallKind = callKind;
+            CallingConventionTypes = callingConventionTypes;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/CallingConventionInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/CallingConventionInfo.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 #nullable enable
 
 using System.Collections.Immutable;
@@ -7,14 +11,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal readonly struct CallingConventionInfo
     {
-        internal Cci.CallingConvention CallKind { get; }
-        internal ImmutableHashSet<CustomModifier>? CallingConventionTypes { get; }
+        internal readonly Cci.CallingConvention CallKind;
+        internal readonly ImmutableHashSet<CustomModifier>? UnmanagedCallingConventionTypes;
 
-        public CallingConventionInfo(Cci.CallingConvention callKind, ImmutableHashSet<CustomModifier> callingConventionTypes)
+        public CallingConventionInfo(Cci.CallingConvention callKind, ImmutableHashSet<CustomModifier> unmanagedCallingConventionTypes)
         {
-            Debug.Assert(callingConventionTypes.IsEmpty || callKind == Cci.CallingConvention.Unmanaged);
+            Debug.Assert(unmanagedCallingConventionTypes.IsEmpty || callKind == Cci.CallingConvention.Unmanaged);
             CallKind = callKind;
-            CallingConventionTypes = callingConventionTypes;
+            UnmanagedCallingConventionTypes = unmanagedCallingConventionTypes;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -530,7 +530,7 @@ outerDefault:
                     //    and duplicates. We already have both sets in a HashSet, so we can just ensure they're the same length and
                     //    that everything from one set is in the other set.
 
-                    if (actualCallKind != expectedConvention.CallKind)
+                    if (actualCallKind.HasUnknownCallingConventionAttributeBits() || !actualCallKind.IsCallingConvention(expectedConvention.CallKind))
                     {
                         results[i] = makeWrongCallingConvention(result);
                         continue;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -439,6 +439,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            Debug.Assert(!expectedConvention.CallKind.HasUnknownCallingConventionAttributeBits());
             Debug.Assert(expectedConvention.UnmanagedCallingConventionTypes is not null);
             Debug.Assert(expectedConvention.UnmanagedCallingConventionTypes.IsEmpty || expectedConvention.CallKind == Cci.CallingConvention.Unmanaged);
 
@@ -457,12 +458,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var member = (MethodSymbol)(Symbol)result.Member;
                 if (result.Result.IsValid)
                 {
-                    if (member.CallingConvention.HasUnknownCallingConventionAttributeBits())
-                    {
-                        results[i] = makeWrongCallingConvention(result);
-                        continue;
-                    }
-
                     // We're not in an attribute, so cycles shouldn't be possible
                     var unmanagedCallersOnlyData = member.GetUnmanagedCallersOnlyAttributeData(forceComplete: true);
 
@@ -479,7 +474,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        // There's data from an UnmanagedCallersOnlyAttribute present, with takes precedence over the
+                        // There's data from an UnmanagedCallersOnlyAttribute present, which takes precedence over the
                         // CallKind bit in the method definition. We use the following rules to decode the attribute:
                         // * If no types are specified, the CallKind is treated as Unmanaged, with no unmanaged calling convention types
                         // * If there is one type specified, and that type is named CallConvCdecl, CallConvThiscall, CallConvStdcall, or 
@@ -535,7 +530,7 @@ outerDefault:
                     //    and duplicates. We already have both sets in a HashSet, so we can just ensure they're the same length and
                     //    that everything from one set is in the other set.
 
-                    if (!actualCallKind.IsCallingConvention(expectedConvention.CallKind))
+                    if (actualCallKind != expectedConvention.CallKind)
                     {
                         results[i] = makeWrongCallingConvention(result);
                         continue;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1824,7 +1824,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     foreach (var viableEntryPoint in viableEntryPoints)
                     {
-                        if (viableEntryPoint.UnmanagedCallersOnlyAttributeData is { } data)
+                        if (viableEntryPoint.GetUnmanagedCallersOnlyAttributeData(forceComplete: true) is { } data)
                         {
                             Debug.Assert(!ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.Uninitialized));
                             Debug.Assert(!ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));

--- a/src/Compilers/CSharp/Portable/Errors/LazyUnmanagedCallersOnlyMethodCalledDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyUnmanagedCallersOnlyMethodCalledDiagnosticInfo.cs
@@ -29,8 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (_lazyActualUnmanagedCallersOnlyDiagnostic is null)
             {
-                _method.ForceCompleteUnmanagedCallersOnlyAttribute();
-                UnmanagedCallersOnlyAttributeData? unmanagedCallersOnlyAttributeData = _method.UnmanagedCallersOnlyAttributeData;
+                UnmanagedCallersOnlyAttributeData? unmanagedCallersOnlyAttributeData = _method.GetUnmanagedCallersOnlyAttributeData(forceComplete: true);
                 Debug.Assert(!ReferenceEquals(unmanagedCallersOnlyAttributeData, UnmanagedCallersOnlyAttributeData.Uninitialized));
                 Debug.Assert(!ReferenceEquals(unmanagedCallersOnlyAttributeData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));
 

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodEarlyWellKnownAttributeData.cs
@@ -1,0 +1,31 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Information decoded from well-known custom attributes applied on a method.
+    /// </summary>
+    internal sealed class MethodEarlyWellKnownAttributeData : CommonMethodEarlyWellKnownAttributeData
+    {
+        private bool _unmanagedCallersOnlyAttributePresent;
+        public bool UnmanagedCallersOnlyAttributePresent
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _unmanagedCallersOnlyAttributePresent;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _unmanagedCallersOnlyAttributePresent = value;
+                SetDataStored();
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         public override Accessibility DeclaredAccessibility
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override FlowAnalysisAnnotations FlowAnalysisAnnotations => FlowAnalysisAnnotations.None;
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
         internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => false;
-        internal sealed override UnmanagedCallersOnlyAttributeData? UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal override bool GenerateDebugInfo => throw ExceptionUtilities.Unreachable;
         internal override ObsoleteAttributeData? ObsoleteAttributeData => throw ExceptionUtilities.Unreachable;

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -104,30 +104,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         /// <summary>
-        /// Returns the UnmanagedCallersOnlyAttribute data for this method, if there is any. If there is no data, <see langword="null"/>
-        /// will be returned. If the data has not yet been loaded (because attributes have not yet been parsed),
-        /// <see cref="UnmanagedCallersOnlyAttributeData.Uninitialized"/> will be returned. If early attribute binding has occurred, but
-        /// fully attribute binding has not, <see cref="UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound"/> will be returned.
-        /// To force data to load, call <see cref="ForceCompleteUnmanagedCallersOnlyAttribute()"/>, but be sure to ensure that cycles will
-        /// not occur.
+        /// Returns the UnmanagedCallersOnlyAttribute data for this method, if there is any. If the data has not yet been
+        /// loaded or only early attribute binding has occurred, and forceComplete is false, then either
+        /// <see cref="UnmanagedCallersOnlyAttributeData.Uninitialized"/> or
+        /// <see cref="UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound"/> will be returned, respectively.
+        /// If passing true for forceComplete, ensure that cycles will not occur by not calling in the process of binding
+        /// an attribute argument.
         /// </summary>
-        internal abstract UnmanagedCallersOnlyAttributeData? UnmanagedCallersOnlyAttributeData { get; }
-
-        /// <summary>
-        /// Forces <see cref="UnmanagedCallersOnlyAttributeData"/> to be loaded. This can cause cycles if called in the process of attribute
-        /// binding, so be sure that attribute binding is not currently occuring when calling.
-        /// </summary>
-        internal void ForceCompleteUnmanagedCallersOnlyAttribute()
-        {
-            if (ReferenceEquals(UnmanagedCallersOnlyAttributeData, UnmanagedCallersOnlyAttributeData.Uninitialized)
-                || ReferenceEquals(UnmanagedCallersOnlyAttributeData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound))
-            {
-                this.GetAttributes();
-            }
-
-            Debug.Assert(!ReferenceEquals(UnmanagedCallersOnlyAttributeData, UnmanagedCallersOnlyAttributeData.Uninitialized));
-            Debug.Assert(!ReferenceEquals(UnmanagedCallersOnlyAttributeData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));
-        }
+        internal abstract UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete);
 #nullable restore
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -104,8 +104,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         /// <summary>
-        /// Returns the UnmanagedCallersOnlyAttribute data for this method, if there is any. If the data has not yet been
-        /// loaded or only early attribute binding has occurred, and forceComplete is false, then either
+        /// Returns the <see cref="UnmanagedCallersOnlyAttributeData"/> data for this method, if there is any. If forceComplete
+        /// is false and the data has not yet been loaded or only early attribute binding has occurred, then either
         /// <see cref="UnmanagedCallersOnlyAttributeData.Uninitialized"/> or
         /// <see cref="UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound"/> will be returned, respectively.
         /// If passing true for forceComplete, ensure that cycles will not occur by not calling in the process of binding

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers => UnderlyingMethod.RefCustomModifiers;
 
-        internal override UnmanagedCallersOnlyAttributeData? UnmanagedCallersOnlyAttributeData => UnderlyingMethod.UnmanagedCallersOnlyAttributeData;
+        internal override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => UnderlyingMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
 
         public override Symbol? AssociatedSymbol => _associatedSymbol;
 

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -437,7 +437,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _reducedFrom.ObsoleteAttributeData; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => _reducedFrom.UnmanagedCallersOnlyAttributeData;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete)
+            => _reducedFrom.GetUnmanagedCallersOnlyAttributeData(forceComplete);
 
         public override Accessibility DeclaredAccessibility
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -223,38 +223,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         }
 
 #nullable enable
-        internal override UnmanagedCallersOnlyAttributeData? UnmanagedCallersOnlyAttributeData
+        internal override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete)
         {
-            get
+            if (ReferenceEquals(_lazyUnmanagedAttributeData, UnmanagedCallersOnlyAttributeData.Uninitialized))
             {
-                if (ReferenceEquals(_lazyUnmanagedAttributeData, UnmanagedCallersOnlyAttributeData.Uninitialized))
+                var data = _underlyingMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+                if (ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.Uninitialized)
+                    || ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound))
                 {
-                    var data = _underlyingMethod.UnmanagedCallersOnlyAttributeData;
-                    if (ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.Uninitialized)
-                        || ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound))
-                    {
-                        // Underlying hasn't been found yet either, just return it. We'll check again the next
-                        // time this is called
-                        return data;
-                    }
-
-                    if (data?.CallingConventionTypes.IsEmpty == false)
-                    {
-                        var builder = PooledHashSet<INamedTypeSymbolInternal>.GetInstance();
-                        foreach (var identifier in data.CallingConventionTypes)
-                        {
-                            builder.Add((INamedTypeSymbolInternal)RetargetingTranslator.Retarget((NamedTypeSymbol)identifier));
-                        }
-
-                        data = UnmanagedCallersOnlyAttributeData.Create(builder.ToImmutableHashSet(), data.IsValid);
-                        builder.Free();
-                    }
-
-                    Interlocked.CompareExchange(ref _lazyUnmanagedAttributeData, data, UnmanagedCallersOnlyAttributeData.Uninitialized);
+                    // Underlying hasn't been found yet either, just return it. We'll check again the next
+                    // time this is called
+                    return data;
                 }
 
-                return _lazyUnmanagedAttributeData;
+                if (data?.CallingConventionTypes.IsEmpty == false)
+                {
+                    var builder = PooledHashSet<INamedTypeSymbolInternal>.GetInstance();
+                    foreach (var identifier in data.CallingConventionTypes)
+                    {
+                        builder.Add((INamedTypeSymbolInternal)RetargetingTranslator.Retarget((NamedTypeSymbol)identifier));
+                    }
+
+                    data = UnmanagedCallersOnlyAttributeData.Create(builder.ToImmutableHashSet(), data.IsValid);
+                    builder.Free();
+                }
+
+                Interlocked.CompareExchange(ref _lazyUnmanagedAttributeData, data, UnmanagedCallersOnlyAttributeData.Uninitialized);
             }
+
+            return _lazyUnmanagedAttributeData;
         }
 #nullable restore
 

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ObsoleteAttributeData ObsoleteAttributeData { get { throw ExceptionUtilities.Unreachable; } }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => throw ExceptionUtilities.Unreachable;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => throw ExceptionUtilities.Unreachable;
 
         internal override ImmutableArray<string> GetAppliedConditionalSymbols() { throw ExceptionUtilities.Unreachable; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -438,7 +438,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (lateData is { UnmanagedCallersOnlyAttributeData: not null })
                 {
                     // We can't verify the symmetric case here. Error conditions (such as if a bad expression was provided to the array initializer)
-                    // can cause the attribute to be skipped regular attribute binding. Early binding doesn't know that though, so
+                    // can cause the attribute to be skipped during regular attribute binding. Early binding doesn't know that though, so
                     // it still gets marked as present.
                     Debug.Assert(earlyData is { UnmanagedCallersOnlyAttributePresent: true });
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -210,7 +210,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this.OriginalDefinition.GetReturnTypeAttributes();
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => this.OriginalDefinition.UnmanagedCallersOnlyAttributeData;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete)
+            => this.OriginalDefinition.GetUnmanagedCallersOnlyAttributeData(forceComplete);
 
         public sealed override Symbol AssociatedSymbol
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal override Cci.CallingConvention CallingConvention
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal sealed override ImmutableArray<string> GetAppliedConditionalSymbols()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceMethodSymbol.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return null; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData? UnmanagedCallersOnlyAttributeData => null;
+        internal sealed override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
 
         internal override ImmutableArray<string> GetAppliedConditionalSymbols()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -9873,7 +9873,7 @@ unsafe class C
 using System;
 using System.Runtime.InteropServices;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-unsafe class Attr : Attribute
+class Attr : Attribute
 {
     public Attr(int i) {}
 }
@@ -9883,6 +9883,7 @@ unsafe class C
     [Attr(F())]
     static int F()
     {
+        return 0;
     }
 }
 ", UnmanagedCallersOnlyAttribute });
@@ -9893,10 +9894,7 @@ unsafe class C
                 Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "F()", isSuppressed: false).WithArguments("C.F()").WithLocation(12, 11),
                 // (12,11): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
                 //     [Attr(F())]
-                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "F()", isSuppressed: false).WithLocation(12, 11),
-                // (13,16): error CS0161: 'C.F()': not all code paths return a value
-                //     static int F()
-                Diagnostic(ErrorCode.ERR_ReturnExpected, "F", isSuppressed: false).WithArguments("C.F()").WithLocation(13, 16)
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "F()", isSuppressed: false).WithLocation(12, 11)
             );
         }
 
@@ -9916,7 +9914,7 @@ unsafe class C
 using System;
 using System.Runtime.InteropServices;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-unsafe class Attr : Attribute
+class Attr : Attribute
 {
     public Attr(int i) {}
 }
@@ -9926,6 +9924,7 @@ unsafe class C
     [Attr(F())]
     static int F()
     {
+        return 0;
     }
 }
 ", UnmanagedCallersOnlyAttribute });
@@ -9936,10 +9935,7 @@ unsafe class C
                 Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "F()", isSuppressed: false).WithArguments("C.F()").WithLocation(12, 11),
                 // (12,11): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
                 //     [Attr(F())]
-                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "F()", isSuppressed: false).WithLocation(12, 11),
-                // (13,16): error CS0161: 'C.F()': not all code paths return a value
-                //     static int F()
-                Diagnostic(ErrorCode.ERR_ReturnExpected, "F", isSuppressed: false).WithArguments("C.F()").WithLocation(13, 16)
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "F()", isSuppressed: false).WithLocation(12, 11)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -8614,7 +8614,7 @@ class D
 
             var c = comp.GetTypeByMetadataName("C");
             var m1 = c.GetMethod("M1");
-            var unmanagedData = m1.UnmanagedCallersOnlyAttributeData;
+            var unmanagedData = m1.GetUnmanagedCallersOnlyAttributeData(forceComplete: true);
             Assert.NotSame(unmanagedData, UnmanagedCallersOnlyAttributeData.Uninitialized);
             Assert.NotSame(unmanagedData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound);
             Assert.False(unmanagedData!.IsValid);
@@ -9882,14 +9882,15 @@ class A
                 // (5,69): error CS1003: Syntax error, ',' expected
                 //     [UnmanagedCallersOnly(CallConvs = new[] { typeof(Bad, Expression) })]
                 Diagnostic(ErrorCode.ERR_SyntaxError, ")", isSuppressed: false).WithArguments(",", ")").WithLocation(5, 69),
-                // (8,33): error CS8786: Calling convention of 'A.F()' is not compatible with 'Default'.
-                //         delegate*<void> ptr1 = &F;
-                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "F", isSuppressed: false).WithArguments("A.F()", "Default").WithLocation(8, 33)
+                // (9,43): error CS8786: Calling convention of 'A.F()' is not compatible with 'Unmanaged'.
+                //         delegate* unmanaged<void> ptr2 = &F;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "F", isSuppressed: false).WithArguments("A.F()", "Unmanaged").WithLocation(9, 43)
             );
         }
 
         [Theory]
         [InlineData("", 1)]
+        [InlineData("CallConvs = null", 1)]
         [InlineData("CallConvs = new System.Type[0]", 1)]
         [InlineData("CallConvs = new[] { typeof(CallConvCdecl) }", 2)]
         [InlineData("CallConvs = new[] { typeof(CallConvCdecl), typeof(CallConvCdecl) }", 2)]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -27,17 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenFunctionPointersTests : CSharpTestBase
     {
         private CompilationVerifier CompileAndVerifyFunctionPointers(
-            string source,
-            MetadataReference[]? references = null,
-            Action<ModuleSymbol>? symbolValidator = null,
-            string? expectedOutput = null,
-            TargetFramework targetFramework = TargetFramework.Standard,
-            CSharpCompilationOptions? options = null,
-            bool overrideUnmanagedSupport = false)
-            => CompileAndVerifyFunctionPointers(new[] { source }, references, symbolValidator, expectedOutput, targetFramework, options, overrideUnmanagedSupport);
-
-        private CompilationVerifier CompileAndVerifyFunctionPointers(
-                string[] sources,
+                CSharpTestSource sources,
                 MetadataReference[]? references = null,
                 Action<ModuleSymbol>? symbolValidator = null,
                 string? expectedOutput = null,
@@ -57,20 +47,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             return CompileAndVerify(comp, symbolValidator: symbolValidator, expectedOutput: expectedOutput, verify: Verification.Skipped);
         }
 
+        private static CSharpCompilation CreateCompilationWithFunctionPointers(CSharpTestSource source, IEnumerable<MetadataReference>? references = null, CSharpCompilationOptions? options = null)
+        {
+            return CreateCompilation(source, references: references, options: options ?? TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular9);
+        }
+
         private CompilationVerifier CompileAndVerifyFunctionPointersWithIl(string source, string ilStub, Action<ModuleSymbol>? symbolValidator = null, string? expectedOutput = null)
         {
             var comp = CreateCompilationWithIL(source, ilStub, parseOptions: TestOptions.Regular9, options: expectedOutput is null ? TestOptions.UnsafeReleaseDll : TestOptions.UnsafeReleaseExe);
             return CompileAndVerify(comp, expectedOutput: expectedOutput, symbolValidator: symbolValidator, verify: Verification.Skipped);
-        }
-
-        private static CSharpCompilation CreateCompilationWithFunctionPointers(string source, IEnumerable<MetadataReference>? references = null, CSharpCompilationOptions? options = null)
-        {
-            return CreateCompilation(source, references: references, options: options ?? TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular9);
-        }
-
-        private static CSharpCompilation CreateCompilationWithFunctionPointers(string[] source, IEnumerable<MetadataReference>? references = null, CSharpCompilationOptions? options = null)
-        {
-            return CreateCompilation(source, references: references, options: options ?? TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular9);
         }
 
         private static CSharpCompilation CreateCompilationWithFunctionPointersAndIl(string source, string ilStub, IEnumerable<MetadataReference>? references = null)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -8105,9 +8105,9 @@ class D
 
             comp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
             comp.VerifyDiagnostics(
-                // (7,42): error CS0570: 'C.M()' is not supported by the language
+                // (6,42): error CS0570: 'C.M()' is not supported by the language
                 //         delegate* unmanaged<void> ptr = &C.M;
-                Diagnostic(ErrorCode.ERR_BindToBogus, "C.M", isSuppressed: false).WithArguments("C.M()").WithLocation(7, 42)
+                Diagnostic(ErrorCode.ERR_BindToBogus, "C.M", isSuppressed: false).WithArguments("C.M()").WithLocation(6, 42)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -1077,7 +1077,7 @@ public class C
             );
 
             var m = finalComp.GetTypeByMetadataName("C").GetMethod("M");
-            var unmanagedCallersOnlyData = m.UnmanagedCallersOnlyAttributeData;
+            var unmanagedCallersOnlyData = m.GetUnmanagedCallersOnlyAttributeData(forceComplete: true);
             Assert.IsType<RetargetingMethodSymbol>(m);
             var containingAssembly = unmanagedCallersOnlyData.CallingConventionTypes.Single().ContainingAssembly;
             Assert.NotSame(containingAssembly, beforeRetargeting.Assembly);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodEarlyWellKnownAttributeData.cs
@@ -54,21 +54,5 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
-
-        private bool _unmanagedCallersOnlyAttributePresent;
-        public bool UnmanagedCallersOnlyAttributePresent
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _unmanagedCallersOnlyAttributePresent;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _unmanagedCallersOnlyAttributePresent = value;
-                SetDataStored();
-            }
-        }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
@@ -170,7 +170,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool IsEarlyDecodedWellKnownAttributeDataComputed
         {
-            get { return IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData); }
+            get
+            {
+                bool earlyComplete = IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData);
+                // If late attributes are complete, early attributes must also be complete
+                Debug.Assert(!IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData) || earlyComplete);
+                return earlyComplete;
+            }
         }
 
         /// <summary>
@@ -179,7 +185,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool IsDecodedWellKnownAttributeDataComputed
         {
-            get { return IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData); }
+            get
+            {
+                bool attributesComplete = IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData);
+                // If late attributes are complete, early attributes must also be complete
+                Debug.Assert(!attributesComplete || IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData));
+                return attributesComplete;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly UnmanagedCallersOnlyAttributeData Uninitialized = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
         internal static readonly UnmanagedCallersOnlyAttributeData AttributePresentDataNotBound = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
         private static readonly UnmanagedCallersOnlyAttributeData PlatformDefault = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: true);
+        internal static readonly UnmanagedCallersOnlyAttributeData Invalid = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
 
         internal static UnmanagedCallersOnlyAttributeData Create(ImmutableHashSet<INamedTypeSymbolInternal>? callingConventionTypes, bool isValid)
             => (callingConventionTypes, isValid) switch

--- a/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly UnmanagedCallersOnlyAttributeData Uninitialized = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
         internal static readonly UnmanagedCallersOnlyAttributeData AttributePresentDataNotBound = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
         private static readonly UnmanagedCallersOnlyAttributeData PlatformDefault = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: true);
-        internal static readonly UnmanagedCallersOnlyAttributeData Invalid = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
 
         internal static UnmanagedCallersOnlyAttributeData Create(ImmutableHashSet<INamedTypeSymbolInternal>? callingConventionTypes, bool isValid)
             => (callingConventionTypes, isValid) switch
@@ -38,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         {
             return key == "CallConvs"
                    && value.Kind == TypedConstantKind.Array
-                   && value.Values.All(v => v.Kind == TypedConstantKind.Type);
+                   && (value.Values.IsDefaultOrEmpty || value.Values.All(v => v.Kind == TypedConstantKind.Type));
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -425,7 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => throw ExceptionUtilities.Unreachable;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => throw ExceptionUtilities.Unreachable;
 
         internal ResultProperties ResultProperties
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
-        internal sealed override UnmanagedCallersOnlyAttributeData UnmanagedCallersOnlyAttributeData => throw ExceptionUtilities.Unreachable;
+        internal sealed override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => throw ExceptionUtilities.Unreachable;
 
         internal override bool RequiresSecurityObject
         {


### PR DESCRIPTION
We now support understanding the calling convention types specified in UnmanagedCallersOnlyAttribute when performing overload resolution on an address of a method group. For the purposes of such resolution, we use the rules from the function pointers spec https://github.com/dotnet/csharplang/blob/master/proposals/csharp-9.0/function-pointers.md#systemruntimeinteropservicesunmanagedcallersonlyattribute.

Fixes https://github.com/dotnet/roslyn/issues/47858.