### PR TITLE
Generate unsafe constructors

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -5410,5 +5410,36 @@ internal class SampleType : Exception
 }",
 index: 1);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        public async Task TestGenerateUnsafe()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    unsafe void M(int* x)
+    {
+        new [|D|](x);
+    }
+}",
+@"class C
+{
+    unsafe void M(int* x)
+    {
+        new D(x);
+    }
+}
+
+internal class D
+{
+    private unsafe int* x;
+
+    public unsafe D(int* x)
+    {
+        this.x = x;
+    }
+}", index: 1);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -4053,5 +4053,169 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        public async Task TestWithUnsafe_Field()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    unsafe void M(int* x)
+    {
+        new [|C|](x);
+    }
+}",
+@"class C
+{
+    private unsafe int* x;
+
+    public unsafe C(int* x)
+    {
+        this.x = x;
+    }
+
+    unsafe void M(int* x)
+    {
+        new C(x);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        public async Task TestWithUnsafe_Property()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    unsafe void M(int* x)
+    {
+        new [|C|](x);
+    }
+}",
+@"class C
+{
+    public unsafe C(int* x)
+    {
+        X = x;
+    }
+
+    public unsafe int* X { get; }
+
+    unsafe void M(int* x)
+    {
+        new C(x);
+    }
+}", index: 1);
+        }
+
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestWithUnsafeInUnsafeClass_Field()
+        {
+            await TestInRegularAndScriptAsync(
+@"unsafe class C
+{
+    void M(int* x)
+    {
+        new [|C|](x);
+    }
+}",
+@"unsafe class C
+{
+    private int* x;
+
+    public C(int* x)
+    {
+        this.x = x;
+    }
+
+    void M(int* x)
+    {
+        new C(x);
+    }
+}");
+        }
+
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestWithUnsafeInUnsafeClass_Property()
+        {
+            await TestInRegularAndScriptAsync(
+    @"unsafe class C
+{
+    void M(int* x)
+    {
+        new [|C|](x);
+    }
+}",
+    @"unsafe class C
+{
+    public C(int* x)
+    {
+        X = x;
+    }
+
+    public int* X { get; }
+
+    void M(int* x)
+    {
+        new C(x);
+    }
+}", index: 1);
+        }
+
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestUnsafeDelegateConstructor()
+        {
+            await TestInRegularAndScriptAsync(
+@"class A
+{
+    public unsafe A(int* a) { }
+
+    public unsafe A(int* a, int b, int c) : [|this(a, b)|] { }
+}",
+@"class A
+{
+    private int b;
+
+    public unsafe A(int* a) { }
+
+    public unsafe A(int* a, int b) : this(a)
+    {
+        this.b = b;
+    }
+
+    public unsafe A(int* a, int b, int c) : this(a, b) { }
+}");
+        }
+
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestUnsafeDelegateConstructorInUnsafeClass()
+        {
+            await TestInRegularAndScriptAsync(
+ @"unsafe class A
+{
+    public A(int* a) { }
+
+    public A(int* a, int b, int c) : [|this(a, b)|] { }
+}",
+ @"unsafe class A
+{
+    private int b;
+
+    public A(int* a) { }
+
+    public A(int* a, int b) : this(a)
+    {
+        this.b = b;
+    }
+
+    public A(int* a, int b, int c) : this(a, b) { }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -1718,5 +1718,49 @@ chosenSymbols: null);
     }
 }", options: options.MergeStyles(options.FieldNamesAreCamelCaseWithFieldUnderscorePrefixAndUnderscoreEndSuffix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefix));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        public async Task TestUnsafeField()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class Z
+{
+    [|unsafe int* a;|]
+}",
+@"
+class Z
+{
+    unsafe int* a;
+
+    public unsafe Z(int* a{|Navigation:)|}
+    {
+        this.a = a;
+    }
+}", compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(45808, "https://github.com/dotnet/roslyn/issues/45808")]
+        public async Task TestUnsafeFieldInUnsafeClass()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+unsafe class Z
+{
+    [|int* a;|]
+}",
+@"
+unsafe class Z
+{
+    int* a;
+
+    public Z(int* a{|Navigation:)|}
+    {
+        this.a = a;
+    }
+}", compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -30,6 +30,9 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
         {
         }
 
+        protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
+           => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
+
         protected override bool IsSimpleNameGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken)
             => node is SimpleNameSyntax;
 

--- a/src/Features/CSharp/Portable/GenerateConstructorFromMembers/CSharpGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructorFromMembers/CSharpGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.GenerateConstructorFromMembers;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
@@ -33,6 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructorFromMembers
             : base(pickMembersService_forTesting)
         {
         }
+
+        protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
+            => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
 
         protected override string ToDisplayString(IParameterSymbol parameter, SymbolDisplayFormat format)
             => SymbolDisplay.ToDisplayString(parameter, format);

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
@@ -62,7 +62,8 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                     parameterToNewMemberMap: null,
                     addNullChecks: _addNullChecks,
                     preferThrowExpression: preferThrowExpression,
-                    generateProperties: false);
+                    generateProperties: false,
+                    _state.IsContainedInUnsafeType);
 
                 // If the user has selected a set of members (i.e. TextSpan is not empty), then we will
                 // choose the right location (i.e. null) to insert the constructor.  However, if they're 

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
                 var addNullChecks = (addNullChecksOption?.Value).GetValueOrDefault();
                 var state = await State.TryGenerateAsync(
-                    _document, _textSpan, _containingType,
+                    _service, _document, _textSpan, _containingType,
                     result.Members, cancellationToken).ConfigureAwait(false);
 
                 if (state == null)

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 {
                     return false;
                 }
-                
+
                 IsContainedInUnsafeType = service.ContainingTypesOrSelfHasUnsafeKeyword(containingType);
 
                 var rules = await document.GetNamingRulesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
@@ -22,8 +22,10 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             public INamedTypeSymbol ContainingType { get; private set; }
             public ImmutableArray<ISymbol> SelectedMembers { get; private set; }
             public ImmutableArray<IParameterSymbol> Parameters { get; private set; }
+            public bool IsContainedInUnsafeType { get; private set; }
 
             public static async Task<State> TryGenerateAsync(
+                AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
                 Document document,
                 TextSpan textSpan,
                 INamedTypeSymbol containingType,
@@ -31,7 +33,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 CancellationToken cancellationToken)
             {
                 var state = new State();
-                if (!await state.TryInitializeAsync(document, textSpan, containingType, selectedMembers, cancellationToken).ConfigureAwait(false))
+                if (!await state.TryInitializeAsync(service, document, textSpan, containingType, selectedMembers, cancellationToken).ConfigureAwait(false))
                 {
                     return null;
                 }
@@ -40,6 +42,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             }
 
             private async Task<bool> TryInitializeAsync(
+                AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
                 Document document,
                 TextSpan textSpan,
                 INamedTypeSymbol containingType,
@@ -58,6 +61,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 {
                     return false;
                 }
+                IsContainedInUnsafeType = service.ContainingTypesOrSelfHasUnsafeKeyword(containingType);
 
                 var rules = await document.GetNamingRulesAsync(cancellationToken).ConfigureAwait(false);
                 Parameters = DetermineParameters(selectedMembers, rules);

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 {
                     return false;
                 }
+                
                 IsContainedInUnsafeType = service.ContainingTypesOrSelfHasUnsafeKeyword(containingType);
 
                 var rules = await document.GetNamingRulesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
         protected AbstractGenerateConstructorFromMembersCodeRefactoringProvider(IPickMembersService pickMembersService_forTesting)
             => _pickMembersService_forTesting = pickMembersService_forTesting;
 
+        protected abstract bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType);
         protected abstract string ToDisplayString(IParameterSymbol parameter, SymbolDisplayFormat format);
         protected abstract bool PrefersThrowExpression(DocumentOptionSet options);
 
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 var info = await GetSelectedMemberInfoAsync(document, textSpan, allowPartialSelection: true, cancellationToken).ConfigureAwait(false);
                 if (info != null)
                 {
-                    var state = await State.TryGenerateAsync(document, textSpan, info.ContainingType, info.SelectedMembers, cancellationToken).ConfigureAwait(false);
+                    var state = await State.TryGenerateAsync(this, document, textSpan, info.ContainingType, info.SelectedMembers, cancellationToken).ConfigureAwait(false);
                     if (state != null && state.MatchingConstructor == null)
                     {
                         return GetCodeActions(document, state, addNullChecks);

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
         where TArgumentSyntax : SyntaxNode
         where TAttributeArgumentSyntax : SyntaxNode
     {
+        protected abstract bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType);
         protected abstract bool IsSimpleNameGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract bool IsConstructorInitializerGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -242,7 +242,8 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         parameterToNewFieldMap.ToImmutable(),
                         addNullChecks: false,
                         preferThrowExpression: false,
-                        generateProperties: false));
+                        generateProperties: false,
+                        isContainedInUnsafeType: false)); // Since we generated the type, we know its not unsafe
                 }
             }
 

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -25,6 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
         Protected Overrides Function ContainingTypesOrSelfHasUnsafeKeyword(containingType As INamedTypeSymbol) As Boolean
             Return False
         End Function
+        
         Protected Overrides Function GenerateNameForArgument(semanticModel As SemanticModel, argument As ArgumentSyntax, cancellationToken As CancellationToken) As String
             Return semanticModel.GenerateNameForArgument(argument, cancellationToken)
         End Function

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
         Protected Overrides Function ContainingTypesOrSelfHasUnsafeKeyword(containingType As INamedTypeSymbol) As Boolean
             Return False
         End Function
-        
+
         Protected Overrides Function GenerateNameForArgument(semanticModel As SemanticModel, argument As ArgumentSyntax, cancellationToken As CancellationToken) As String
             Return semanticModel.GenerateNameForArgument(argument, cancellationToken)
         End Function

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -22,6 +22,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
         Public Sub New()
         End Sub
 
+        Protected Overrides Function ContainingTypesOrSelfHasUnsafeKeyword(containingType As INamedTypeSymbol) As Boolean
+            Return False
+        End Function
         Protected Overrides Function GenerateNameForArgument(semanticModel As SemanticModel, argument As ArgumentSyntax, cancellationToken As CancellationToken) As String
             Return semanticModel.GenerateNameForArgument(argument, cancellationToken)
         End Function

--- a/src/Features/VisualBasic/Portable/GenerateConstructorFromMembers/VisualBasicGenerateConstructorFromMembersCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructorFromMembers/VisualBasicGenerateConstructorFromMembersCodeRefactoringProvider.vb
@@ -29,6 +29,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructorFromMembers
             MyBase.New(pickMembersService_forTesting)
         End Sub
 
+        Protected Overrides Function ContainingTypesOrSelfHasUnsafeKeyword(containingType As INamedTypeSymbol) As Boolean
+            Return False
+        End Function
+
         Protected Overrides Function ToDisplayString(parameter As IParameterSymbol, format As SymbolDisplayFormat) As String
             Return SymbolDisplay.ToDisplayString(parameter, format)
         End Function

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
@@ -128,6 +128,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 AddAccessibilityModifiers(constructor.DeclaredAccessibility, tokens, options, Accessibility.Private);
             }
 
+            if (CodeGenerationConstructorInfo.GetIsUnsafe(constructor))
+            {
+                tokens.Add(SyntaxFactory.Token(SyntaxKind.UnsafeKeyword));
+            }
+
             return tokens.ToSyntaxTokenListAndFree();
         }
     }

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<SyntaxNode> thisConstructorArguments = default)
         {
             var result = new CodeGenerationConstructorSymbol(null, attributes, accessibility, modifiers, parameters);
-            CodeGenerationConstructorInfo.Attach(result, typeName, statements, baseConstructorArguments, thisConstructorArguments);
+            CodeGenerationConstructorInfo.Attach(result, modifiers.IsUnsafe, typeName, statements, baseConstructorArguments, thisConstructorArguments);
             return result;
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorInfo.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorInfo.cs
@@ -12,17 +12,20 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private static readonly ConditionalWeakTable<IMethodSymbol, CodeGenerationConstructorInfo> s_constructorToInfoMap =
             new ConditionalWeakTable<IMethodSymbol, CodeGenerationConstructorInfo>();
 
+        private readonly bool _isUnsafe;
         private readonly string _typeName;
         private readonly ImmutableArray<SyntaxNode> _baseConstructorArguments;
         private readonly ImmutableArray<SyntaxNode> _thisConstructorArguments;
         private readonly ImmutableArray<SyntaxNode> _statements;
 
         private CodeGenerationConstructorInfo(
+            bool isUnsafe,
             string typeName,
             ImmutableArray<SyntaxNode> statements,
             ImmutableArray<SyntaxNode> baseConstructorArguments,
             ImmutableArray<SyntaxNode> thisConstructorArguments)
         {
+            _isUnsafe = isUnsafe;
             _typeName = typeName;
             _statements = statements;
             _baseConstructorArguments = baseConstructorArguments;
@@ -31,12 +34,13 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public static void Attach(
             IMethodSymbol constructor,
+            bool isUnsafe,
             string typeName,
             ImmutableArray<SyntaxNode> statements,
             ImmutableArray<SyntaxNode> baseConstructorArguments,
             ImmutableArray<SyntaxNode> thisConstructorArguments)
         {
-            var info = new CodeGenerationConstructorInfo(typeName, statements, baseConstructorArguments, thisConstructorArguments);
+            var info = new CodeGenerationConstructorInfo(isUnsafe, typeName, statements, baseConstructorArguments, thisConstructorArguments);
             s_constructorToInfoMap.Add(constructor, info);
         }
 
@@ -58,6 +62,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public static string GetTypeName(IMethodSymbol constructor)
             => GetTypeName(GetInfo(constructor), constructor);
 
+        public static bool GetIsUnsafe(IMethodSymbol constructor)
+            => GetIsUnsafe(GetInfo(constructor));
+
         private static ImmutableArray<SyntaxNode> GetThisConstructorArgumentsOpt(CodeGenerationConstructorInfo info)
             => info?._thisConstructorArguments ?? default;
 
@@ -69,5 +76,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         private static string GetTypeName(CodeGenerationConstructorInfo info, IMethodSymbol constructor)
             => info == null ? constructor.ContainingType.Name : info._typeName;
+
+        private static bool GetIsUnsafe(CodeGenerationConstructorInfo info)
+            => info?._isUnsafe ?? false;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             var result = new CodeGenerationConstructorSymbol(this.ContainingType, this.GetAttributes(), this.DeclaredAccessibility, this.Modifiers, this.Parameters);
 
             CodeGenerationConstructorInfo.Attach(result,
+                CodeGenerationConstructorInfo.GetIsUnsafe(this),
                 CodeGenerationConstructorInfo.GetTypeName(this),
                 CodeGenerationConstructorInfo.GetStatements(this),
                 CodeGenerationConstructorInfo.GetBaseConstructorArgumentsOpt(this),

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -48,11 +48,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             ImmutableDictionary<string, string> parameterToNewMemberMap,
             bool addNullChecks,
             bool preferThrowExpression,
-            bool generateProperties)
+            bool generateProperties,
+            bool isContainedInUnsafeType)
         {
             var newMembers = generateProperties
-                ? CreatePropertiesForParameters(parameters, parameterToNewMemberMap)
-                : CreateFieldsForParameters(parameters, parameterToNewMemberMap);
+                ? CreatePropertiesForParameters(parameters, parameterToNewMemberMap, isContainedInUnsafeType)
+                : CreateFieldsForParameters(parameters, parameterToNewMemberMap, isContainedInUnsafeType);
             var statements = factory.CreateAssignmentStatements(
                 semanticModel, parameters, parameterToExistingMemberMap, parameterToNewMemberMap,
                 addNullChecks, preferThrowExpression).SelectAsArray(
@@ -61,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(
                 attributes: default,
                 accessibility: containingTypeOpt.IsAbstractClass() ? Accessibility.Protected : Accessibility.Public,
-                modifiers: new DeclarationModifiers(),
+                modifiers: new DeclarationModifiers(isUnsafe: !isContainedInUnsafeType && parameters.Any(p => p.RequiresUnsafeModifier())),
                 typeName: typeName,
                 parameters: parameters,
                 statements: statements,
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static ImmutableArray<ISymbol> CreateFieldsForParameters(
-            ImmutableArray<IParameterSymbol> parameters, ImmutableDictionary<string, string> parameterToNewFieldMap)
+            ImmutableArray<IParameterSymbol> parameters, ImmutableDictionary<string, string> parameterToNewFieldMap, bool isContainedInUnsafeType)
         {
             using var _ = ArrayBuilder<ISymbol>.GetInstance(out var result);
             foreach (var parameter in parameters)
@@ -107,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     result.Add(CodeGenerationSymbolFactory.CreateFieldSymbol(
                         attributes: default,
                         accessibility: Accessibility.Private,
-                        modifiers: default,
+                        modifiers: new DeclarationModifiers(isUnsafe: !isContainedInUnsafeType && parameter.RequiresUnsafeModifier()),
                         type: parameter.Type,
                         name: fieldName));
                 }
@@ -117,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static ImmutableArray<ISymbol> CreatePropertiesForParameters(
-            ImmutableArray<IParameterSymbol> parameters, ImmutableDictionary<string, string> parameterToNewPropertyMap)
+            ImmutableArray<IParameterSymbol> parameters, ImmutableDictionary<string, string> parameterToNewPropertyMap, bool isContainedInUnsafeType)
         {
             using var _ = ArrayBuilder<ISymbol>.GetInstance(out var result);
             foreach (var parameter in parameters)
@@ -129,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     result.Add(CodeGenerationSymbolFactory.CreatePropertySymbol(
                         attributes: default,
                         accessibility: Accessibility.Public,
-                        modifiers: default,
+                        modifiers: new DeclarationModifiers(isUnsafe: !isContainedInUnsafeType && parameter.RequiresUnsafeModifier()),
                         type: parameter.Type,
                         refKind: RefKind.None,
                         explicitInterfaceImplementations: ImmutableArray<IPropertySymbol>.Empty,


### PR DESCRIPTION
Fixes #45808

The fix got a little viral here, so this also fixes normal generate constructor, generate delegating constructor, and generating constructors when generating a type.