### PR TITLE
Indent braces on 'with' expression relative to starting line

### DIFF
--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -406,6 +406,47 @@ $$
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        [WorkItem(47438, "https://github.com/dotnet/roslyn/issues/47438")]
+        public void WithExpression()
+        {
+            var code = @"
+record C
+{
+    void M()
+    {
+        _ = this with $$
+    }
+}";
+
+            var expectedBeforeReturn = @"
+record C
+{
+    void M()
+    {
+        _ = this with { }
+    }
+}";
+
+            var expectedAfterReturn = @"
+record C
+{
+    void M()
+    {
+        _ = this with
+        {
+
+        }
+    }
+}";
+            using var session = CreateSession(code);
+            Assert.NotNull(session);
+
+            CheckStart(session.Session);
+            CheckText(session.Session, expectedBeforeReturn);
+            CheckReturn(session.Session, 12, expectedAfterReturn);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void RecursivePattern()
         {
             var code = @"

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9565,6 +9565,58 @@ class C
 }".Replace("&nbsp;", "\u00A0"));
         }
 
+        [Fact, WorkItem(47438, "https://github.com/dotnet/roslyn/issues/47438")]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task IndentationForMultilineWith()
+        {
+            var code = @"record C(int X)
+{
+    C M()
+    {
+        return this with
+{
+X = 1
+};
+    }
+}";
+            var expectedCode = @"record C(int X)
+{
+    C M()
+    {
+        return this with
+        {
+            X = 1
+        };
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact, WorkItem(47438, "https://github.com/dotnet/roslyn/issues/47438")]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task IndentationForMultilineWith_ArrowBody()
+        {
+            var code = @"record C(int X)
+{
+    C M()
+        => this with
+{
+X = 1
+};
+}";
+            var expectedCode = @"record C(int X)
+{
+    C M()
+        => this with
+        {
+            X = 1
+        };
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
         [Fact, WorkItem(41022, "https://github.com/dotnet/roslyn/issues/41022")]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingAfterAttribute()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -178,6 +178,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case SwitchExpressionSyntax switchExpression:
                     SetAlignmentBlockOperation(list, switchExpression.GetFirstToken(), switchExpression.OpenBraceToken, switchExpression.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;
+                case WithExpressionSyntax withExpression:
+                    SetAlignmentBlockOperation(list, withExpression.GetFirstToken(), withExpression.Initializer.OpenBraceToken, withExpression.Initializer.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+                    return;
                 case PropertyPatternClauseSyntax propertyPatternClause:
                     if (propertyPatternClause.Parent is RecursivePatternSyntax { Parent: { } recursivePatternParent })
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47438

I tried deploying locally for further validation, but failed to build/deploy. The following 3 commands produces errors like the one below.

```
git clean -xdf
Restore.cmd
.\Build.cmd -Configuration Release -deployExtensions -launch
```
 
```
D:\repos\roslyn\.dotnet\sdk\5.0.100-preview.7.20366.6\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(241,5): error NETSDK1005: Assets file 'D:\repos\roslyn\artifacts\obj\Roslyn.Services.UnitTests.Utilities\project.assets.json' doesn't have a target for '.NETCoreApp,Version=v5.0'. Ensure that restore has run and th
at you have included 'net5.0' in the TargetFrameworks for your project. [D:\repos\roslyn\src\Workspaces\CoreTestUtilities\Roslyn.Services.UnitTests.Utilities.csproj]
```