### PR TITLE
always nuget restore in graph mode

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -230,11 +230,6 @@ function BuildSolution() {
   # Set DotNetBuildFromSource to 'true' if we're simulating building for source-build.
   $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildFromSource=true" } else { "" }
 
-  # If we are using msbuild.exe restore using static graph
-  # This check can be removed and turned on for all builds once roslyn depends on a .NET Core SDK
-  # that has a new enough msbuild for the -graph switch to be present
-  $restoreUseStaticGraphEvaluation = if ($msbuildEngine -ne 'dotnet') { "/p:RestoreUseStaticGraphEvaluation=true" } else { "" }
-  
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -256,7 +251,7 @@ function BuildSolution() {
       /p:TreatWarningsAsErrors=$warnAsError `
       /p:EnableNgenOptimization=$applyOptimizationData `
       /p:IbcOptimizationDataDir=$ibcDir `
-      $restoreUseStaticGraphEvaluation `
+      /p:RestoreUseStaticGraphEvaluation=true `
       /p:VisualStudioIbcDrop=$ibcDropName `
       $suppressExtensionDeployment `
       $msbuildWarnAsError `


### PR DESCRIPTION
This change moves restore to always be in graph mode (see commit [here](https://github.com/dotnet/roslyn/pull/47665/commits/6e4dd9f4a74510f56800542b87c0c3307772c57b)). This has two benefits:

1. better incremental restore performance
2. more deterministic restore behavior

This change also passes `-graph` to msbuild which changes MSBuilds evaluaton mode from being stack-based to being graph-based (see commit [here](https://github.com/dotnet/roslyn/pull/47665/commits/14b79203f46e1d50c41c8da612ca7c68dcee0d0a)). This is the msbuild description of this option:

> Causes MSBuild to construct and build a project graph.
>
> Constructing a graph involves identifying project references to form dependencies. Building that graphinvolves attempting to build project references prior to the projects that reference them, differing from traditional MSBuild scheduling. (Short form: -graph)
>
> This flag is experimental and may not work as intended.

This has the same benefits of using graph restore:

1. better incremental build performance
2. more deterministic build behavior

An _additional_ improvement would be to pass `-isolate` so that the build fails if it cannot be statically evaluated (i.e. dependencies are deterministic). However that is blocked by these bugs so that will need to be done when we consume a new SDK that has fixes for these:

- [ ] [Microsoft.Net.Sdk fails with /isolate constraints](https://github.com/dotnet/msbuild/issues/5687)
- [ ] [Static graph incorrectly represents multitargeting agnostic projects that depend on multitargeting projects](https://github.com/dotnet/msbuild/issues/4344)