### PR TITLE
Error list improvements

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -360,7 +360,8 @@ dotnet_diagnostic.{DisabledByDefaultAnalyzer.s_compilationRule.Id}.severity = wa
                 workspace,
                 ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>>.Empty.Add(
                     document.Project.Id,
-                    ImmutableArray.Create(DiagnosticData.Create(Diagnostic.Create(NoNameAnalyzer.s_syntaxRule, location), document.Project))));
+                    ImmutableArray.Create(DiagnosticData.Create(Diagnostic.Create(NoNameAnalyzer.s_syntaxRule, location), document.Project))),
+                onBuildCompleted: true);
 
             // wait for all events to raised
             await ((AsynchronousOperationListener)service.Listener).ExpeditedWaitAsync().ConfigureAwait(false);

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 _projectId = projectId;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (!(obj is HostArgsId other))
                 {

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerUpdateArgsId.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerUpdateArgsId.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     internal class AnalyzerUpdateArgsId : BuildToolId.Base<DiagnosticAnalyzer>, ISupportLiveUpdate
     {
-        public DiagnosticAnalyzer Analyzer => _Field1;
+        public DiagnosticAnalyzer Analyzer => _Field1!;
 
         protected AnalyzerUpdateArgsId(DiagnosticAnalyzer analyzer)
             : base(analyzer)

--- a/src/Features/Core/Portable/Diagnostics/BuildToolId.cs
+++ b/src/Features/Core/Portable/Diagnostics/BuildToolId.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -15,12 +17,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal abstract class Base<T> : BuildToolId
         {
-            protected readonly T _Field1;
+            protected readonly T? _Field1;
 
-            public Base(T field)
+            public Base(T? field)
                 => _Field1 = field;
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (!(obj is Base<T> other))
                 {
@@ -36,12 +38,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal abstract class Base<T1, T2> : Base<T2>
         {
-            private readonly T1 _Field2;
+            private readonly T1? _Field2;
 
-            public Base(T1 field1, T2 field2) : base(field2)
+            public Base(T1? field1, T2? field2) : base(field2)
                 => _Field2 = field1;
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (!(obj is Base<T1, T2> other))
                 {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -171,11 +171,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return SpecializedTasks.EmptyImmutableArray<DiagnosticData>();
         }
 
-        public bool IsCompilationEndAnalyzer(DiagnosticAnalyzer diagnosticAnalyzer, Project project, Compilation compilation)
+        public async Task<bool> IsCompilationEndAnalyzerAsync(DiagnosticAnalyzer diagnosticAnalyzer, Project project, CancellationToken cancellationToken)
         {
             if (_map.TryGetValue(project.Solution.Workspace, out var analyzer))
             {
-                return analyzer.IsCompilationEndAnalyzer(diagnosticAnalyzer, project, compilation);
+                return await analyzer.IsCompilationEndAnalyzerAsync(diagnosticAnalyzer, project, cancellationToken).ConfigureAwait(false);
             }
 
             return false;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
@@ -14,11 +14,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// 
         /// no cancellationToken since this can't be cancelled
         /// </summary>
-        public Task SynchronizeWithBuildAsync(Workspace workspace, ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> diagnostics)
+        public Task SynchronizeWithBuildAsync(Workspace workspace, ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> diagnostics, bool onBuildCompleted)
         {
             if (_map.TryGetValue(workspace, out var analyzer))
             {
-                return analyzer.SynchronizeWithBuildAsync(diagnostics);
+                return analyzer.SynchronizeWithBuildAsync(diagnostics, onBuildCompleted);
             }
 
             return Task.CompletedTask;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private readonly DiagnosticAnalyzerTelemetry _telemetry;
         private readonly StateManager _stateManager;
         private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
+        private readonly IDocumentTrackingService? _documentTrackingService;
         private ConditionalWeakTable<Project, CompilationWithAnalyzers?> _projectCompilationsWithAnalyzers;
 
         internal DiagnosticAnalyzerService AnalyzerService { get; }
@@ -53,6 +54,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             AnalyzerService = analyzerService;
             Workspace = workspace;
             PersistentStorageService = workspace.Services.GetRequiredService<IPersistentStorageService>();
+            _documentTrackingService = workspace.Services.GetService<IDocumentTrackingService>();
 
             _correlationId = correlationId;
 
@@ -66,8 +68,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache => _diagnosticAnalyzerRunner.AnalyzerInfoCache;
 
-        public bool IsCompilationEndAnalyzer(DiagnosticAnalyzer diagnosticAnalyzer, Project project, Compilation compilation)
-            => DiagnosticAnalyzerInfoCache.IsCompilationEndAnalyzer(diagnosticAnalyzer, project, compilation) == true;
+        public async Task<bool> IsCompilationEndAnalyzerAsync(DiagnosticAnalyzer diagnosticAnalyzer, Project project, CancellationToken cancellationToken)
+            => await DiagnosticAnalyzerInfoCache.IsCompilationEndAnalyzerAsync(diagnosticAnalyzer, project, cancellationToken).ConfigureAwait(false) == true;
 
         public bool ContainsDiagnostics(ProjectId projectId)
         {

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -84,6 +84,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Check whether given <see cref="DiagnosticAnalyzer"/> is compilation end analyzer
         /// By compilation end analyzer, it means compilation end analysis here
         /// </summary>
-        bool IsCompilationEndAnalyzer(DiagnosticAnalyzer analyzer, Project project, Compilation compilation);
+        Task<bool> IsCompilationEndAnalyzerAsync(DiagnosticAnalyzer analyzer, Project project, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
+++ b/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public override string BuildTool => _analyzerPackageName;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is LiveDiagnosticUpdateArgsId other))
             {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractRoslynTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractRoslynTableDataSource.cs
@@ -28,6 +28,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             return solution.GetDocumentIdsWithFilePath(document.FilePath);
         }
 
+        protected bool IsSolutionCrawlerRunning { get; private set; }
+
         private void ConnectToSolutionCrawlerService(Workspace workspace)
         {
             var crawlerService = workspace.Services.GetService<ISolutionCrawlerService>();
@@ -59,8 +61,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         private void SolutionCrawlerProgressChanged(bool running)
         {
-            IsStable = !running;
-            ChangeStableState(IsStable);
+            IsSolutionCrawlerRunning = running;
+            ChangeStableStateIfRequired(newIsStable: !IsSolutionCrawlerRunning);
+        }
+
+        protected void ChangeStableStateIfRequired(bool newIsStable)
+        {
+            var oldIsStable = IsStable;
+            if (oldIsStable != newIsStable)
+            {
+                IsStable = newIsStable;
+                ChangeStableState(newIsStable);
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractRoslynTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractRoslynTableDataSource.cs
@@ -28,6 +28,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             return solution.GetDocumentIdsWithFilePath(document.FilePath);
         }
 
+        /// <summary>
+        /// Flag indicating if a solution crawler is running incremental analyzers in background.
+        /// We get build progress updates from <see cref="ISolutionCrawlerProgressReporter.ProgressChanged"/>.
+        /// Solution crawler progress events are guaranteed to be invoked in a serial fashion.
+        /// </summary>
         protected bool IsSolutionCrawlerRunning { get; private set; }
 
         private void ConnectToSolutionCrawlerService(Workspace workspace)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -37,7 +37,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             private readonly Workspace _workspace;
             private readonly OpenDocumentTracker<DiagnosticTableItem> _tracker;
 
-            private readonly ExternalErrorDiagnosticUpdateSource? _buildUpdateSource;
             private bool _isBuildRunning;
 
             public LiveTableDataSource(Workspace workspace, IDiagnosticService diagnosticService, string identifier, ExternalErrorDiagnosticUpdateSource? buildUpdateSource = null)
@@ -51,7 +50,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 _diagnosticService = diagnosticService;
                 ConnectToDiagnosticService(workspace, diagnosticService);
 
-                _buildUpdateSource = buildUpdateSource;
                 ConnectToBuildUpdateSource(buildUpdateSource);
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -8,10 +8,8 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
-using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -22,6 +20,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
     {
         internal partial class VisualStudioDiagnosticListTable : VisualStudioBaseDiagnosticListTable
         {
+            /// <summary>
+            /// Error list diagnostic source for "Build only" setting.
+            /// See <see cref="VisualStudioBaseDiagnosticListTable.LiveTableDataSource"/>
+            /// for error list diagnostic source for "Build + Intellisense" setting.
+            /// </summary>
             private class BuildTableDataSource : AbstractTableDataSource<DiagnosticTableItem>
             {
                 private readonly object _key = new object();

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             {
                 _errorList = errorList;
 
-                _liveTableSource = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);
+                _liveTableSource = new LiveTableDataSource(workspace, diagnosticService, IdentifierString, workspace.ExternalErrorDiagnosticUpdateSource);
                 _buildTableSource = new BuildTableDataSource(workspace, workspace.ExternalErrorDiagnosticUpdateSource);
 
                 AddInitialTableSource(Workspace.CurrentSolution, GetCurrentDataSource());

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -189,18 +189,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             {
                 Debug.Assert(state == null || !state.WereProjectErrorsCleared(projectId));
 
-                // Clear build-only errors for project
+                // Here, we clear the build and live errors for the project.
+                // Additionally, we mark projects as having its errors cleared.
+                // This ensures that we do not attempt to clear the diagnostics again for the same project
+                // when 'ClearErrors' is invoked for multiple dependent projects.
+                // Finally, we update build progress state so error list gets refreshed.
+
                 ClearBuildOnlyProjectErrors(solution, projectId);
 
-                // Clear live errors for project
                 await SetLiveErrorsForProjectAsync(projectId, ImmutableArray<DiagnosticData>.Empty).ConfigureAwait(false);
 
-                // Mark projects as having its error cleared.
-                // This ensures that we do not attempt to again clear the diagnostics for the same project
-                // when 'ClearErrors' is invoked for multiple dependent projects.
                 state?.MarkErrorsCleared(projectId);
 
-                // Update build progress to refresh error list
                 OnBuildProgressChanged(state, BuildProgress.Updated);
             }
         }

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -512,7 +512,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Throw New NotImplementedException()
             End Function
 
-            Public Function IsCompilationEndAnalyzer(analyzer As DiagnosticAnalyzer, project As Project, compilation As Compilation) As Boolean Implements IDiagnosticAnalyzerService.IsCompilationEndAnalyzer
+            Public Function IsCompilationEndAnalyzerAsync(analyzer As DiagnosticAnalyzer, project As Project, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDiagnosticAnalyzerService.IsCompilationEndAnalyzerAsync
                 Throw New NotImplementedException()
             End Function
 


### PR DESCRIPTION
Work towards addressing large number of recent VS Feedback requests when user invokes an explicit build:
- https://developercommunity.visualstudio.com/content/problem/1173125/error-list-sometimes-goes-empty-after-a-build.html
- https://developercommunity.visualstudio.com/content/problem/1154411/errors-persist-in-the-error-list-even-after-fixing.html
- https://developercommunity.visualstudio.com/content/problem/1149465/error-list-doesnt-show-errors-in-167x.html
- https://developercommunity.visualstudio.com/content/problem/1142347/the-error-list-cannot-be-refreshed-in-real-time-ev.html
- https://developercommunity.visualstudio.com/content/problem/1135858/error-list-errors-are-not-removed-after-successful.html
- https://developercommunity.visualstudio.com/content/problem/1134412/failed-compilation-does-not-show-errors.html
- https://developercommunity.visualstudio.com/content/problem/1126855/compile-error-view-major-bugs.html
- https://developercommunity.visualstudio.com/content/problem/1053969/error-list-not-show.html

## Changes in this PR

- **Performance**
   - Refresh error list during the build, as and when we either clear diagnostics or add diagnostics from build into our in progress build state. Current implementation defers all updates to the end of the build, which has couple of disadvantages:
       - It adds to overall computuation within devenv.exe at end of the build, so it takes a longer time for error list to reach the stable state. This confuses the user into thinking error list has updated, but just has stale data.
	   - Error list shows stale results during the build and  some time after the build completes till we complete de-duplication of build and live diagnostics.
   - Avoid pre-fetching compilation for all projects everytime we de-dupe build and live diagnostics after build completes. This causes the major compute overhead from the time build completes to error list is updated (could even be a few minutes). The only reason we need the compilation for this step is to determine if an analyzer is a compilation end analyzer or not, so we can grouo the reported analyzer diagnostics into live or build-only bucket correctly. I will work on a separate follow-up change to avoid this computation completely, so we don't need to fetch compilation to determine is compilation end analyzer.

- **Functional**
   - Update error list's "Build + Intellisense" setting to correctly show non-stable state (i.e. `Error List...`) while the build is executing and we are de-duping build and live diagnostics after build completes. Currently, the stable state for this setting only shows non-stable when solution crawler is running. This leads to error list incorrectly showing stable state when a build completes, but we are still de-duping diagnostics and solution crawler has not yet restarted. This confuses the users into thinking error list has finished all updates and has stale diagnostics.
   - Clear diagnostics for transitive projects: When we receive ClearDiagnostics(project) callback during build for projects getting re-built as part of the build, we now clear diagnostics for that project and also for all projects that transitively depend on that project. Not clearing transitively dependent project diagnostics will lead to stale diagnostics for these dependent projects in the error list, especially when user fixes errors in the core project in the dependency chain.

## Follow-up

- Try to get rid of [hacky logic](https://github.com/dotnet/roslyn/blob/master/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache_CompilationEnd.cs) to determine if an analyzer is a compilation end analyzer, which is also a performance overhead during build/live diagnostic de-duplication
- After this change, "Build only" setting in error list refreshes to show last build diagnostics almost instantly. However, "Build + Intellisense" setting still takes noticeable amount time for raised diagnostic updated events to be processed and error list to refresh. I will attempt to see if this can be further improved.