### PR TITLE
Mitigation for IOperation threading issue

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1934,7 +1934,7 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 if (part.Kind == BoundKind.StringInsert)
                 {
-                    builder.Add((IInterpolatedStringContentOperation)Create(part));
+                    builder.Add((IInterpolatedStringContentOperation)CreateInternal(part));
                 }
                 else
                 {

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -184,19 +184,20 @@ namespace Microsoft.CodeAnalysis
                 return operations;
             }
 
-            // race is okay. penalty is going through a loop one more time or
-            // .Parent going through slower path of SearchParentOperation()
-            // explicit cast is not allowed, so using "as" instead
-            // invalid expression can have null element in the array
-            if ((operations[0] as Operation)?._parentDoNotAccessDirectly != s_unset)
-            {
-                // most likely already initialized. if not, due to a race or invalid expression,
-                // operation.Parent will take slower path but still return correct Parent.
-                return operations;
-            }
-
             foreach (var operation in operations)
             {
+                // Due to lazy construction of nodes, it's very possible that two threads might see lists where
+                // the first operation in an array is reference equal between the arrays, but the second operation
+                // is not reference equal. This difference is generally not observable from a user perspective (unless
+                // they're doing their own reference equality), and fixing it by removing laziness from IOperation
+                // entirely is tracked by https://github.com/dotnet/roslyn/issues/35818. Until then, however, we've
+                // seen real world examples where bailing out of the entire set operation causes infinite loops when
+                // searching for a parent operation, so we only skip setting the parent for a single node at a time.
+                if ((operations[0] as Operation)?._parentDoNotAccessDirectly != s_unset)
+                {
+                    continue;
+                }
+
                 // go through slowest path
                 SetParentOperation(operation, parent);
             }

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis
                 // entirely is tracked by https://github.com/dotnet/roslyn/issues/35818. Until then, however, we've
                 // seen real world examples where bailing out of the entire set operation causes infinite loops when
                 // searching for a parent operation, so we only skip setting the parent for a single node at a time.
-                if ((operations[0] as Operation)?._parentDoNotAccessDirectly != s_unset)
+                if ((operation as Operation)?._parentDoNotAccessDirectly != s_unset)
                 {
                     continue;
                 }


### PR DESCRIPTION
This is a mitigation for the threading issue discussed in https://github.com/dotnet/roslyn/issues/35818. When building VS, there is a flaky threading issue where an interpolation with multiple parts can end up with different nodes on different threads, causing an optimization in `SetParentOperation(ImmutableArray)` to be invalid. This makes the optimization much narrower, ensuring that it is actually valid for this case.

The specific scenario here is an interplotated string with multiple parts. The steps are:
1. 2 threads attempt to get the children of an interpolated string operation at the same time.
2. Thread 1 gets the child for the first part of the string and caches it.
3. Thread 2 gets the child for the first part of the string and gets that same cached element.
4. Both threads attempt to get child 2. Neither hits the cache, so they get different nodes.
5. Both threads construct the array of interpolated string parts.
6. Thread 1 sets the parent of the interpolated string parts to be itself.
7. Thread 2 attempts to set the parent of the interpolated string parts to be itself. This returns early, because part 1 already has a parent, leaving part 2 with an unset parent.
8. Later, thread 2 asks for the parent of part 2. It is unset, violating the invariants, and we infinite loop.

As an additional mitigation step, we also ensure that the process of constructing an interpolated string's inserts does not hit the cache.  Since we never ask for an operation within a single expression, this will prevent 2 threads from seeing the same first element and differing subsequent elements.
