### PR TITLE
Dont crash generate variable

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1187,8 +1187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property INamedTypeSymbol_IsImplicitClass As Boolean Implements INamedTypeSymbol.IsImplicitClass
             Get
-                ' TODO (tomat):
-                Return False
+                Return Me.IsImplicitClass
             End Get
         End Property
 

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -9312,5 +9312,27 @@ class C
     string.Format(FeaturesResources.Generate_field_1_0, "Field", "C"),
 });
         }
+
+        [WorkItem(45367, "https://github.com/dotnet/roslyn/issues/45367")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task DontOfferPropertyOrFieldInNamespace()
+        {
+            await TestExactActionSetOfferedAsync(
+@"using System;
+
+namespace ConsoleApp5
+{
+    class MyException: Exception
+    
+    internal MyException(int error, int offset, string message) : base(message)
+    {
+        [|Error|] = error;
+        Offset = offset;
+    }", new[]
+{
+    string.Format(FeaturesResources.Generate_local_0, "Error", "MyException"),
+    string.Format(FeaturesResources.Generate_parameter_0, "Error", "MyException"),
+});
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -2977,5 +2977,18 @@ Class Program
 End Class",
 count:=5)
         End Function
+
+        <WorkItem(45367, "https://github.com/dotnet/roslyn/issues/45367")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TestCrashInNamespace() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Namespace ConsoleApp5
+    Friend Sub New(errNum As Integer, offset As Integer, message As String)
+        MyBase.New(message)
+
+        Me.[|Error|] = errNum
+    End Sub
+End Namespace")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -132,6 +132,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 return CanGenerateLocal() || CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, cancellationToken);
             }
 
+            internal bool CanGeneratePropertyOrField()
+            {
+                return !ContainingType.IsImplicitClass;
+            }
+
             internal bool CanGenerateLocal()
             {
                 // !this.IsInMemberContext prevents us offering this fix for `x.goo` where `goo` does not exist

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -64,7 +64,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                     }
                     else
                     {
-
                         AddFieldCodeActions(actions, semanticDocument, state);
                         AddPropertyCodeActions(actions, semanticDocument, state);
                     }
@@ -107,6 +106,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 return;
             }
 
+            if (!state.CanGeneratePropertyOrField())
+            {
+                return;
+            }
+
             var isOnlyReadAndIsInInterface = state.TypeToGenerateIn.TypeKind == TypeKind.Interface && !state.IsWrittenTo;
 
             if (isOnlyReadAndIsInInterface || state.IsInConstructor)
@@ -130,6 +134,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
         {
             if (state.TypeToGenerateIn.TypeKind != TypeKind.Interface)
             {
+                if (!state.CanGeneratePropertyOrField())
+                {
+                    return;
+                }
+
                 if (state.IsConstant)
                 {
                     result.Add(new GenerateVariableCodeAction(

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, cancellationToken);
 
-                if (canGenerateMember)
+                if (canGenerateMember && state.CanGeneratePropertyOrField())
                 {
                     // prefer fields over properties (and vice versa) depending on the casing of the member.
                     // lowercase -> fields.  title case -> properties.
@@ -106,11 +106,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 return;
             }
 
-            if (!state.CanGeneratePropertyOrField())
-            {
-                return;
-            }
-
             var isOnlyReadAndIsInInterface = state.TypeToGenerateIn.TypeKind == TypeKind.Interface && !state.IsWrittenTo;
 
             if (isOnlyReadAndIsInInterface || state.IsInConstructor)
@@ -134,11 +129,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
         {
             if (state.TypeToGenerateIn.TypeKind != TypeKind.Interface)
             {
-                if (!state.CanGeneratePropertyOrField())
-                {
-                    return;
-                }
-
                 if (state.IsConstant)
                 {
                     result.Add(new GenerateVariableCodeAction(


### PR DESCRIPTION
Fixes #45367

The field and property code generation functions throw if the requirements aren't met, so check for the same requirements before offering them.