### PR TITLE
Ensure that warnaserror works identically for warnings configured in …

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -196,6 +196,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // 4. Global analyzer config level
                 isSpecified = true;
+
+                // '/warnaserror' should promote warnings configured in global analyzer config to error.
+                if (report == ReportDiagnostic.Warn && generalDiagnosticOption == ReportDiagnostic.Error)
+                {
+                    report = ReportDiagnostic.Error;
+                }
             }
             else
             {

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
@@ -145,6 +145,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ElseIf syntaxTreeOptions IsNot Nothing AndAlso syntaxTreeOptions.TryGetGlobalDiagnosticValue(id, cancellationToken, report) Then
                 ' 4. Global analyzer config level
                 isSpecified = True
+
+                ' '/warnaserror' should promote warnings configured in global analyzer config to error.
+                If report = ReportDiagnostic.Warn AndAlso generalDiagnosticOption = ReportDiagnostic.Error Then
+                    report = ReportDiagnostic.Error
+                End If
             Else
                 report = If(isEnabledByDefault, ReportDiagnostic.Default, ReportDiagnostic.Suppress)
             End If


### PR DESCRIPTION
…ruleset and global config

1. Fixes #43051
2. Ensures consistent behavior between ruleset and global config. Before the product change in this PR, the added unit tests pass for ruleset scenario, but fails for global config, confirming the inconsistency.

This change enables users to migrate away from rulesets when they desire to have rules configured as warnings by default and bump it to errors in CI with warnaserror. They cannot do this via editorconfig as diagnostic severity settings in editorconfig always override command line options (nowarn and warnaserror).