### PR TITLE
Issue a warning when a global analyzer config contains an invalid section name.

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12664,12 +12664,12 @@ option1 = def");
 
             analyzerConfig = analyzerConfigFile.WriteAllText(@"
 is_global = true
-[file.cs]
+[/file.cs]
 option1 = abc");
 
             analyzerConfig2 = analyzerConfigFile2.WriteAllText(@"
 is_global = true
-[file.cs]
+[/file.cs]
 option1 = def");
 
             output = VerifyOutput(dir, src, additionalFlags: new[] { "/analyzerconfig:" + analyzerConfig.Path + "," + analyzerConfig2.Path }, expectedWarningCount: 1, includeCurrentAssemblyAsAnalyzerReference: false);
@@ -12677,7 +12677,7 @@ option1 = def");
             // warning MultipleGlobalAnalyzerKeys: Multiple global analyzer config files set the same key 'option1' in section 'file.cs'. It has been unset. Key was set by the following files: ...
             Assert.Contains("MultipleGlobalAnalyzerKeys:", output, StringComparison.Ordinal);
             Assert.Contains("'option1'", output, StringComparison.Ordinal);
-            Assert.Contains("'file.cs'", output, StringComparison.Ordinal);
+            Assert.Contains("'/file.cs'", output, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2121,7 +2121,7 @@ option2 = config3
         [InlineData("\\", false)] //editorconfig sees a single backslash
         [InlineData("\\\\", false)] //editorconfig sees an escaped backslash, which is not a valid absolute path
         [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
-        [InlineData("c:\\my\\file.cs", false)] // s: editorconfig sees a single file called 'c:\my\file.cs' 
+        [InlineData("c:\\my\\file.cs", false)] // invalid: editorconfig sees a single file called 'c:\my\file.cs' 
         [InlineData("\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' 
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2114,15 +2114,18 @@ option2 = config3
         [InlineData("/path?", false)]
         [InlineData("/path,", false)]
         [InlineData("/path\"", true)]
-        [InlineData("/path\\", false)] //editorconfig sees a single backslash
+        [InlineData("/path\\", false)] //editorconfig sees a single escape character (special)
         [InlineData("/path\\\\", true)] //editorconfig sees an escaped backslash
         [InlineData("//path", true)]
         [InlineData("//", true)]
-        [InlineData("\\", false)] //editorconfig sees a single backslash
-        [InlineData("\\\\", false)] //editorconfig sees an escaped backslash, which is not a valid absolute path
+        [InlineData("\\", false)] //invalid: editorconfig sees a single escape character
+        [InlineData("\\\\", false)] //invalid: editorconfig sees an escaped, literal backslash
         [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
-        [InlineData("c:\\my\\file.cs", false)] // invalid: editorconfig sees a single file called 'c:\my\file.cs' 
-        [InlineData("\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' 
+        [InlineData("c:\\my\\file.cs", false)] // invalid: editorconfig sees a single file called 'c:(\m)y(\f)ile.cs' (i.e. \m and \f are escape chars)
+        [InlineData("\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '(\m)y(\f)ile.cs' 
+        [InlineData("\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' with literal backslashes
+        [InlineData("\\\\\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\\my\file.cs' not a UNC path
+        [InlineData("//server/file.cs", true)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2127,6 +2127,7 @@ option2 = config3
         [InlineData("\\\\\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\\my\file.cs' not a UNC path
         [InlineData("//server/file.cs", true)]
         [InlineData("//server\\file.cs", true)]
+        [InlineData("\\/file.cs", false)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2114,9 +2114,12 @@ option2 = config3
         [InlineData("/path?", false)]
         [InlineData("/path,", false)]
         [InlineData("/path\"", true)]
-        [InlineData("/path\\", false)]
+        [InlineData("/path\\", false)] //editorconfig sees a single backslash
+        [InlineData("/path\\\\", true)] //editorconfig sees an escaped backslash
         [InlineData("//path", true)]
         [InlineData("//", true)]
+        [InlineData("\\", false)] //editorconfig sees a single backslash
+        [InlineData("\\\\", true)] //editorconifg sees an escaped backslash
         [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -1552,20 +1552,20 @@ option2 = value2", "/.globalconfig2"));
             configs.Add(Parse(@"is_global = true
 option1 = value1
 
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 
-[c:/path/to/file2.cs]
+[/path/to/file2.cs]
 option1 = value1
 ", "/.globalconfig1"));
 
             configs.Add(Parse(@"is_global = true
 option2 = value2
 
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option2 = value2
 
-[c:/path/to/file3.cs]
+[/path/to/file3.cs]
 option1 = value1",
 "/.globalconfig2"));
 
@@ -1581,16 +1581,16 @@ option1 = value1",
             var file2Section = globalConfig.NamedSections[1];
             var file3Section = globalConfig.NamedSections[2];
 
-            Assert.Equal(@"c:/path/to/file1.cs", file1Section.Name);
+            Assert.Equal(@"/path/to/file1.cs", file1Section.Name);
             Assert.Equal(2, file1Section.Properties.Count);
             Assert.Equal("value1", file1Section.Properties["option1"]);
             Assert.Equal("value2", file1Section.Properties["option2"]);
 
-            Assert.Equal(@"c:/path/to/file2.cs", file2Section.Name);
+            Assert.Equal(@"/path/to/file2.cs", file2Section.Name);
             Assert.Equal(1, file2Section.Properties.Count);
             Assert.Equal("value1", file2Section.Properties["option1"]);
 
-            Assert.Equal(@"c:/path/to/file3.cs", file3Section.Name);
+            Assert.Equal(@"/path/to/file3.cs", file3Section.Name);
             Assert.Equal(1, file3Section.Properties.Count);
             Assert.Equal("value1", file3Section.Properties["option1"]);
             configs.Free();
@@ -1618,19 +1618,19 @@ option1 = value2", "/.globalconfig2"));
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 ", "/.globalconfig1"));
 
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value2",
 "/.globalconfig2"));
 
             var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out var diagnostics);
 
             diagnostics.Verify(
-                Diagnostic("MultipleGlobalAnalyzerKeys").WithArguments("option1", "c:/path/to/file1.cs", "/.globalconfig1, /.globalconfig2").WithLocation(1, 1)
+                Diagnostic("MultipleGlobalAnalyzerKeys").WithArguments("option1", "/path/to/file1.cs", "/.globalconfig1, /.globalconfig2").WithLocation(1, 1)
                 );
         }
 
@@ -1653,12 +1653,12 @@ option1 = value2", "/.globalconfig2"));
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 ", "/.globalconfig1"));
 
             configs.Add(Parse(@"
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value2",
 "/.globalconfig2"));
 
@@ -1675,14 +1675,13 @@ option1 = value1
 ", "/.globalconfig1"));
 
             var options = GetAnalyzerConfigOptions(
-                 new[] { "/file1.cs", "/path/to/file1.cs", "c:/path/to/file1.cs", "/file1.vb" },
+                 new[] { "/file1.cs", "/path/to/file1.cs", "/file1.vb" },
                  configs);
             configs.Free();
 
             VerifyAnalyzerOptions(
               new[]
               {
-                    new[] { ("option1", "value1") },
                     new[] { ("option1", "value1") },
                     new[] { ("option1", "value1") },
                     new[] { ("option1", "value1") }
@@ -1695,7 +1694,7 @@ option1 = value1
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 
 [*.cs]
@@ -1704,12 +1703,12 @@ option2 = value2
 [.*/path/*.cs]
 option3 = value3
 
-[c:/.*/*.cs]
+[/.*/*.cs]
 option4 = value4
 ", "/.globalconfig1"));
 
             var options = GetAnalyzerConfigOptions(
-                 new[] { "/file1.cs", "/path/to/file1.cs", "c:/path/to/file1.cs", "/file1.vb" },
+                 new[] { "/file1.cs", "/path/to/file2.cs", "/path/to/file1.cs", "/file1.vb" },
                  configs);
             configs.Free();
 
@@ -1789,12 +1788,12 @@ option2 = config3
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 ", "/.globalconfig1"));
 
             configs.Add(Parse(@"is_global = true
-[c:/pAth/To/fiLe1.cs]
+[/pAth/To/fiLe1.cs]
 option1 = value2",
 "/.globalconfig2"));
 
@@ -1810,18 +1809,18 @@ option1 = value2",
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 ", "/.globalconfig1"));
 
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 opTioN1 = value2",
 "/.globalconfig2"));
 
             var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("MultipleGlobalAnalyzerKeys").WithArguments("option1", "c:/path/to/file1.cs", "/.globalconfig1, /.globalconfig2").WithLocation(1, 1)
+                Diagnostic("MultipleGlobalAnalyzerKeys").WithArguments("option1", "/path/to/file1.cs", "/.globalconfig1, /.globalconfig2").WithLocation(1, 1)
                 );
             configs.Free();
         }
@@ -1850,16 +1849,16 @@ opTioN1 = value2",
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"is_global = true
-[c:/path/to/file1.cs]
+[/path/to/file1.cs]
 option1 = value1
 
-[c:\path\to\file2.cs]
+[\path\to\file2.cs]
 option1 = value1
 
 ", "/.globalconfig1"));
 
             var options = GetAnalyzerConfigOptions(
-                 new[] { "c:/path/to/file1.cs", "c:/path/to/file2.cs" },
+                 new[] { "/path/to/file1.cs", "/path/to/file2.cs" },
                  configs);
             configs.Free();
 
@@ -1900,12 +1899,12 @@ dotnet_diagnostic.cs001.severity = error
             configs.Add(Parse(@"
 is_global = true
 
-[c:/path/to/file.cs]
+[/path/to/file.cs]
 dotnet_diagnostic.cs000.severity = error
 ", "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
-                new[] { "/test.cs", "c:/path/to/file.cs" },
+                new[] { "/test.cs", "/path/to/file.cs" },
                 configs);
             configs.Free();
 
@@ -1924,12 +1923,12 @@ dotnet_diagnostic.cs000.severity = error
 is_global = true
 dotnet_diagnostic.cs000.severity = foo
 
-[c:/path/to/file.cs]
+[/path/to/file.cs]
 dotnet_diagnostic.cs001.severity = bar
 ", "/.editorconfig"));
 
             var set = AnalyzerConfigSet.Create(configs);
-            var options = new[] { "/test.cs", "c:/path/to/file.cs" }.Select(f => set.GetOptionsForSourcePath(f)).ToArray();
+            var options = new[] { "/test.cs", "/path/to/file.cs" }.Select(f => set.GetOptionsForSourcePath(f)).ToArray();
             configs.Free();
 
             set.GlobalConfigOptions.Diagnostics.Verify(
@@ -1949,12 +1948,12 @@ dotnet_diagnostic.cs001.severity = bar
 is_global = true
 dotnet_diagnostic.cs000.severity = none
 
-[c:/path/to/file.cs]
+[/path/to/file.cs]
 dotnet_diagnostic.cs000.severity = error
 ", "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
-                new[] { "c:/path/to/file.cs" },
+                new[] { "/path/to/file.cs" },
                 configs);
             configs.Free();
 
@@ -2102,7 +2101,6 @@ option2 = config3
         }
 
         [Theory]
-        [InlineData("c:/path/to/file.cs", true)]
         [InlineData("/path/to/file.cs", true)]
         [InlineData("file.cs", false)]
         [InlineData("../file.cs", false)]

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2109,6 +2109,15 @@ option2 = config3
         [InlineData("?abc.cs", false)]
         [InlineData("/path/to/**", false)]
         [InlineData("/path/[a]/to/*.cs", false)]
+        [InlineData("/path{", false)]
+        [InlineData("/path}", false)]
+        [InlineData("/path?", false)]
+        [InlineData("/path,", false)]
+        [InlineData("/path\"", true)]
+        [InlineData("/path\\", false)]
+        [InlineData("//path", true)]
+        [InlineData("//", true)]
+        [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2126,6 +2126,7 @@ option2 = config3
         [InlineData("\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' with literal backslashes
         [InlineData("\\\\\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\\my\file.cs' not a UNC path
         [InlineData("//server/file.cs", true)]
+        [InlineData("//server\\file.cs", true)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2121,6 +2121,8 @@ option2 = config3
         [InlineData("\\", false)] //editorconfig sees a single backslash
         [InlineData("\\\\", false)] //editorconfig sees an escaped backslash, which is not a valid absolute path
         [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
+        [InlineData("c:\\my\\file.cs", false)] // s: editorconfig sees a single file called 'c:\my\file.cs' 
+        [InlineData("\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' 
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2168,6 +2168,8 @@ is_global = true
         [InlineData(@"c:", false, false)]
         [InlineData(@"c\", false, false)]
         [InlineData(@"\c\:", false, false)]
+        [InlineData("c:/", true, false)]
+        [InlineData("c:/*.cs", false, false)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames_PlatformSpecific(string sectionName, bool isValidWindows, bool isValidOther)
             => GlobalConfigIssuesWarningWithInvalidSectionNames(sectionName, ExecutionConditionUtil.IsWindows ? isValidWindows : isValidOther);
 

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2119,7 +2119,7 @@ option2 = config3
         [InlineData("//path", true)]
         [InlineData("//", true)]
         [InlineData("\\", false)] //editorconfig sees a single backslash
-        [InlineData("\\\\", true)] //editorconifg sees an escaped backslash
+        [InlineData("\\\\", false)] //editorconfig sees an escaped backslash, which is not a valid absolute path
         [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2127,7 +2127,11 @@ option2 = config3
         [InlineData("\\\\\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\\my\file.cs' not a UNC path
         [InlineData("//server/file.cs", true)]
         [InlineData("//server\\file.cs", true)]
-        [InlineData("\\/file.cs", false)]
+        [InlineData("\\/file.cs", true)] // allow escaped chars
+        [InlineData("<>a??/b.cs", false)]
+        [InlineData(".", false)]
+        [InlineData("/", true)]
+        [InlineData("", true)] // only true becuase [] isn't a valid editorconfig section name either and thus never gets parsed
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
@@ -2150,6 +2154,21 @@ is_global = true
                     );
             }
         }
+
+        [ConditionalTheoryAttribute(typeof(WindowsOnly))]
+        [InlineData("c:/myfile.cs", true)]
+        [InlineData("cd:/myfile.cs", false)] // windows only allows a single character as a drive specifier
+        [InlineData("\\c\\:\\/myfile.cs", true)] // allow escaped characters
+        [InlineData("/myfile.cs", true)] //absolute, with a relative drive root
+        [InlineData("c:myfile.cs", false)] //relative, with an absolute drive root
+        [InlineData("c:\\myfile.cs", false)] //not a valid editorconfig path
+        [InlineData("//?/C:/Test/Foo.txt", false)] // ? is a special char in editorconfig
+        [InlineData("//\\?/C:/Test/Foo.txt", true)]
+        [InlineData("\\\\?\\C:\\Test\\Foo.txt", false)]
+        [InlineData("c:", false)]
+        [InlineData("c\\", false)]
+        [InlineData("\\c\\:", false)]
+        public void GlobalConfigIssuesWarningWithInvalidSectionNames_WindowsOnly(string sectionName, bool isValid) => GlobalConfigIssuesWarningWithInvalidSectionNames(sectionName, isValid);
 
         #endregion
     }

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2114,24 +2114,24 @@ option2 = config3
         [InlineData("/path?", false)]
         [InlineData("/path,", false)]
         [InlineData("/path\"", true)]
-        [InlineData("/path\\", false)] //editorconfig sees a single escape character (special)
-        [InlineData("/path\\\\", true)] //editorconfig sees an escaped backslash
+        [InlineData(@"/path\", false)] //editorconfig sees a single escape character (special)
+        [InlineData(@"/path\\", true)] //editorconfig sees an escaped backslash
         [InlineData("//path", true)]
         [InlineData("//", true)]
-        [InlineData("\\", false)] //invalid: editorconfig sees a single escape character
-        [InlineData("\\\\", false)] //invalid: editorconfig sees an escaped, literal backslash
-        [InlineData("/\\{\\}\\,\\[\\]\\*", true)]
-        [InlineData("c:\\my\\file.cs", false)] // invalid: editorconfig sees a single file called 'c:(\m)y(\f)ile.cs' (i.e. \m and \f are escape chars)
-        [InlineData("\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '(\m)y(\f)ile.cs' 
-        [InlineData("\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' with literal backslashes
-        [InlineData("\\\\\\\\my\\\\file.cs", false)] // invalid: editorconfig sees a single file called '\\my\file.cs' not a UNC path
+        [InlineData(@"\", false)] //invalid: editorconfig sees a single escape character
+        [InlineData(@"\\", false)] //invalid: editorconfig sees an escaped, literal backslash
+        [InlineData(@"/\{\}\,\[\]\*", true)]
+        [InlineData(@"c:\my\file.cs", false)] // invalid: editorconfig sees a single file called 'c:(\m)y(\f)ile.cs' (i.e. \m and \f are escape chars)
+        [InlineData(@"\my\file.cs", false)] // invalid: editorconfig sees a single file called '(\m)y(\f)ile.cs' 
+        [InlineData(@"\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '\my\file.cs' with literal backslashes
+        [InlineData(@"\\\\my\\file.cs", false)] // invalid: editorconfig sees a single file called '\\my\file.cs' not a UNC path
         [InlineData("//server/file.cs", true)]
-        [InlineData("//server\\file.cs", true)]
-        [InlineData("\\/file.cs", true)] // allow escaped chars
+        [InlineData(@"//server\file.cs", true)]
+        [InlineData(@"\/file.cs", true)] // allow escaped chars
         [InlineData("<>a??/b.cs", false)]
         [InlineData(".", false)]
         [InlineData("/", true)]
-        [InlineData("", true)] // only true becuase [] isn't a valid editorconfig section name either and thus never gets parsed
+        [InlineData("", true)] // only true because [] isn't a valid editorconfig section name either and thus never gets parsed
         public void GlobalConfigIssuesWarningWithInvalidSectionNames(string sectionName, bool isValid)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
@@ -2155,20 +2155,21 @@ is_global = true
             }
         }
 
-        [ConditionalTheoryAttribute(typeof(WindowsOnly))]
-        [InlineData("c:/myfile.cs", true)]
-        [InlineData("cd:/myfile.cs", false)] // windows only allows a single character as a drive specifier
-        [InlineData("\\c\\:\\/myfile.cs", true)] // allow escaped characters
-        [InlineData("/myfile.cs", true)] //absolute, with a relative drive root
-        [InlineData("c:myfile.cs", false)] //relative, with an absolute drive root
-        [InlineData("c:\\myfile.cs", false)] //not a valid editorconfig path
-        [InlineData("//?/C:/Test/Foo.txt", false)] // ? is a special char in editorconfig
-        [InlineData("//\\?/C:/Test/Foo.txt", true)]
-        [InlineData("\\\\?\\C:\\Test\\Foo.txt", false)]
-        [InlineData("c:", false)]
-        [InlineData("c\\", false)]
-        [InlineData("\\c\\:", false)]
-        public void GlobalConfigIssuesWarningWithInvalidSectionNames_WindowsOnly(string sectionName, bool isValid) => GlobalConfigIssuesWarningWithInvalidSectionNames(sectionName, isValid);
+        [Theory]
+        [InlineData("c:/myfile.cs", true, false)]
+        [InlineData("cd:/myfile.cs", false, false)] // windows only allows a single character as a drive specifier
+        [InlineData(@"\c\:\/myfile.cs", true, false)] // allow escaped characters
+        [InlineData("/myfile.cs", true, true)] //absolute, with a relative drive root
+        [InlineData("c:myfile.cs", false, false)] //relative, wit2h an absolute drive root
+        [InlineData(@"c:\myfile.cs", false, false)] //not a valid editorconfig path
+        [InlineData("//?/C:/Test/Foo.txt", false, false)] // ? is a special char in editorconfig
+        [InlineData(@"//\?/C:/Test/Foo.txt", true, true)]
+        [InlineData(@"\\?\C:\Test\Foo.txt", false, false)]
+        [InlineData(@"c:", false, false)]
+        [InlineData(@"c\", false, false)]
+        [InlineData(@"\c\:", false, false)]
+        public void GlobalConfigIssuesWarningWithInvalidSectionNames_PlatformSpecific(string sectionName, bool isValidWindows, bool isValidOther)
+            => GlobalConfigIssuesWarningWithInvalidSectionNames(sectionName, ExecutionConditionUtil.IsWindows ? isValidWindows : isValidOther);
 
         #endregion
     }

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -714,4 +714,11 @@
   <data name="AssemblyReferencesNetFramework" xml:space="preserve">
     <value>The assembly containing type '{0}' references .NET Framework, which is not supported.</value>
   </data>
+  <data name="WRN_InvalidGlobalSectionName" xml:space="preserve">
+    <value>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</value>
+    <comment>{0}: invalid section name, {1} path to global config</comment>
+  </data>
+  <data name="WRN_InvalidGlobalSectionName_Title" xml:space="preserve">
+    <value>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</value>
+  </data>
 </root>

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -113,6 +113,20 @@ namespace Microsoft.CodeAnalysis
                 numberRangePairs.ToImmutableAndFree());
         }
 
+        internal static bool ContainsSpecialCharacters(string sectionName)
+        {
+            SectionNameLexer nameLexer = new SectionNameLexer(sectionName);
+            while (!nameLexer.IsDone)
+            {
+                if (nameLexer.Lex() != TokenKind.SimpleCharacter)
+                {
+                    return true;
+                }
+                nameLexer.EatCurrentCharacter();
+            }
+            return false;
+        }
+
         /// <summary>
         /// <![CDATA[
         /// <path-list> ::= <path-item> | <path-item> <path-list>

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -113,19 +114,79 @@ namespace Microsoft.CodeAnalysis
                 numberRangePairs.ToImmutableAndFree());
         }
 
-        internal static bool ContainsSpecialCharacters(string sectionName, out bool sawPathSeparator)
+        /// <summary>
+        /// Test if a section name is an abosulte path with no special chars
+        /// </summary>
+        internal static bool IsAbsoluteEditorConfigPath(string sectionName)
         {
+            // NOTE: editorconfig paths must use '/' as a directory separator character on all OS.
+
+            // on all unix systems this is thus a simple test: does the path start with '/'
+            // and contain no special chars?
+
+            // on windows, a path can be either drive rooted or not (e.g. start with 'c:' or just '')
+            // in addition to being absolute or relative.
+            // for example c:myfile.cs is a relative path, but rooted on drive c:
+            // /myfile2.cs is an absolute path but rooted to the current drive.
+
+            // in addition there are UNC paths and volume guids (see https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats)
+            // but these start with \\ (and thus '/' in editor config terminology)
+
+            // in this implementation we choose to ignore the drive root for the purposes of
+            // determining validity. On windows c:/file.cs and /file.cs are both assumed to be
+            // valid absolute paths, even though the second one is technically relative to
+            // the current drive of the compiler working directory. 
+
+            // Note that this check has no impact on config correctness. Files on windows
+            // will still be compared using their full path (including drive root) so it's
+            // not possible to target the wrong file. It's just possible that the user won't
+            // recevive a warning that this section is ignored on windows in this edge case.
+
             SectionNameLexer nameLexer = new SectionNameLexer(sectionName);
-            sawPathSeparator = false;
+            bool sawStartChar = false;
+            int logicalIndex = 0;
             while (!nameLexer.IsDone)
             {
                 if (nameLexer.Lex() != TokenKind.SimpleCharacter)
                 {
-                    return true;
+                    return false;
                 }
-                sawPathSeparator |= nameLexer.EatCurrentCharacter() == '/';
+                var simpleChar = nameLexer.EatCurrentCharacter();
+
+                // check the path starts with '/'
+                if (logicalIndex == 0)
+                {
+                    if (simpleChar == '/')
+                    {
+                        sawStartChar = true;
+                    }
+                    else if (Path.DirectorySeparatorChar == '/')
+                    {
+                        return false;
+                    }
+                }
+                // on windows we get a second chance to find the start char
+                else if (!sawStartChar && Path.DirectorySeparatorChar == '\\')
+                {
+                    if (logicalIndex == 1 && simpleChar != ':')
+                    {
+                        return false;
+                    }
+                    else if (logicalIndex == 2)
+                    {
+                        if (simpleChar != '/')
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            sawStartChar = true;
+                        }
+                    }
+                }
+                logicalIndex++;
             }
-            return false;
+            return sawStartChar;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Test if a section name is an abosulte path with no special chars
+        /// Test if a section name is an absolute path with no special chars
         /// </summary>
         internal static bool IsAbsoluteEditorConfigPath(string sectionName)
         {
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
             // Note that this check has no impact on config correctness. Files on windows
             // will still be compared using their full path (including drive root) so it's
             // not possible to target the wrong file. It's just possible that the user won't
-            // recevive a warning that this section is ignored on windows in this edge case.
+            // receive a warning that this section is ignored on windows in this edge case.
 
             SectionNameLexer nameLexer = new SectionNameLexer(sectionName);
             bool sawStartChar = false;

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -113,16 +113,17 @@ namespace Microsoft.CodeAnalysis
                 numberRangePairs.ToImmutableAndFree());
         }
 
-        internal static bool ContainsSpecialCharacters(string sectionName)
+        internal static bool ContainsSpecialCharacters(string sectionName, out bool sawPathSeparator)
         {
             SectionNameLexer nameLexer = new SectionNameLexer(sectionName);
+            sawPathSeparator = false;
             while (!nameLexer.IsDone)
             {
                 if (nameLexer.Lex() != TokenKind.SimpleCharacter)
                 {
                     return true;
                 }
-                nameLexer.EatCurrentCharacter();
+                sawPathSeparator |= nameLexer.EatCurrentCharacter() == '/';
             }
             return false;
         }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -104,6 +105,15 @@ namespace Microsoft.CodeAnalysis
                 "MultipleGlobalAnalyzerKeys",
                 CodeAnalysisResources.WRN_MultipleGlobalAnalyzerKeys_Title,
                 CodeAnalysisResources.WRN_MultipleGlobalAnalyzerKeys,
+                "AnalyzerConfig",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor InvalidGlobalAnalyzerSectionDescriptor
+            = new DiagnosticDescriptor(
+                "InvalidGlobalSectionName",
+                CodeAnalysisResources.WRN_InvalidGlobalSectionName_Title,
+                CodeAnalysisResources.WRN_InvalidGlobalSectionName,
                 "AnalyzerConfig",
                 DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
@@ -452,17 +462,17 @@ namespace Microsoft.CodeAnalysis
         internal static GlobalAnalyzerConfig MergeGlobalConfigs(ArrayBuilder<AnalyzerConfig> analyzerConfigs, out ImmutableArray<Diagnostic> diagnostics)
         {
             GlobalAnalyzerConfigBuilder globalAnalyzerConfigBuilder = new GlobalAnalyzerConfigBuilder();
+            DiagnosticBag diagnosticBag = DiagnosticBag.GetInstance();
             for (int i = 0; i < analyzerConfigs.Count; i++)
             {
                 if (analyzerConfigs[i].IsGlobal)
                 {
-                    globalAnalyzerConfigBuilder.MergeIntoGlobalConfig(analyzerConfigs[i]);
+                    globalAnalyzerConfigBuilder.MergeIntoGlobalConfig(analyzerConfigs[i], diagnosticBag);
                     analyzerConfigs.RemoveAt(i);
                     i--;
                 }
             }
 
-            DiagnosticBag diagnosticBag = DiagnosticBag.GetInstance();
             var globalConfig = globalAnalyzerConfigBuilder.Build(diagnosticBag);
             diagnostics = diagnosticBag.ToReadOnlyAndFree();
             return globalConfig;
@@ -479,7 +489,7 @@ namespace Microsoft.CodeAnalysis
             internal const string GlobalConfigPath = "<Global Config>";
             internal const string GlobalSectionName = "Global Section";
 
-            internal void MergeIntoGlobalConfig(AnalyzerConfig config)
+            internal void MergeIntoGlobalConfig(AnalyzerConfig config, DiagnosticBag diagnostics)
             {
                 if (_values is null)
                 {
@@ -490,7 +500,18 @@ namespace Microsoft.CodeAnalysis
                 MergeSection(config.PathToFile, config.GlobalSection, isGlobalSection: true);
                 foreach (var section in config.NamedSections)
                 {
-                    MergeSection(config.PathToFile, section, isGlobalSection: false);
+                    if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name))
+                    {
+                        MergeSection(config.PathToFile, section, isGlobalSection: false);
+                    }
+                    else
+                    {
+                        diagnostics.Add(Diagnostic.Create(
+                            InvalidGlobalAnalyzerSectionDescriptor,
+                            Location.None,
+                            section.Name,
+                            config.PathToFile));
+                    }
                 }
             }
 

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -500,8 +500,7 @@ namespace Microsoft.CodeAnalysis
                 MergeSection(config.PathToFile, config.GlobalSection, isGlobalSection: true);
                 foreach (var section in config.NamedSections)
                 {
-                    // Check that the path is rooted according to the OS we're on, doesn't contain any glob characters, and has an .editorconfig path separator in it
-                    if (isEditorConfigPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name, out bool sawPathSeparator) && sawPathSeparator)
+                    if (IsAbsoluteEditorConfigPath(section.Name))
                     {
                         MergeSection(config.PathToFile, section, isGlobalSection: false);
                     }
@@ -513,13 +512,6 @@ namespace Microsoft.CodeAnalysis
                             section.Name,
                             config.PathToFile));
                     }
-                }
-
-                static bool isEditorConfigPathRooted(string name)
-                {
-                    return Path.IsPathRooted(name) &&
-                        // on windows '\' is a valid path root, but editor configs must use forward slashes, so we disallow it
-                        !name.StartsWith("\\");
                 }
             }
 

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -500,7 +500,11 @@ namespace Microsoft.CodeAnalysis
                 MergeSection(config.PathToFile, config.GlobalSection, isGlobalSection: true);
                 foreach (var section in config.NamedSections)
                 {
-                    if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name))
+                    if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name)
+                        // all paths in editorconfig are converted to forward slash, 
+                        // but on windows a literal backslash is still a valid rooted path,
+                        // so we explicitly ignore any sections that start with it
+                        && !section.Name.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
                     {
                         MergeSection(config.PathToFile, section, isGlobalSection: false);
                     }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis
                 MergeSection(config.PathToFile, config.GlobalSection, isGlobalSection: true);
                 foreach (var section in config.NamedSections)
                 {
-                    // Check that the path is rooted according to the OS we're on, doesn't contain any glob characters, and has an .editorconfig path seperator in it
+                    // Check that the path is rooted according to the OS we're on, doesn't contain any glob characters, and has an .editorconfig path separator in it
                     if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name, out bool sawPathSeparator) && sawPathSeparator)
                     {
                         MergeSection(config.PathToFile, section, isGlobalSection: false);

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -500,11 +500,8 @@ namespace Microsoft.CodeAnalysis
                 MergeSection(config.PathToFile, config.GlobalSection, isGlobalSection: true);
                 foreach (var section in config.NamedSections)
                 {
-                    if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name)
-                        // all paths in editorconfig are converted to forward slash, 
-                        // but on windows a literal backslash is still a valid rooted path,
-                        // so we explicitly ignore any sections that start with it
-                        && !section.Name.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+                    // Check that the path is rooted according to the OS we're on, doesn't contain any glob characters, and has an .editorconfig path seperator in it
+                    if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name, out bool sawPathSeparator) && sawPathSeparator)
                     {
                         MergeSection(config.PathToFile, section, isGlobalSection: false);
                     }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis
                 foreach (var section in config.NamedSections)
                 {
                     // Check that the path is rooted according to the OS we're on, doesn't contain any glob characters, and has an .editorconfig path separator in it
-                    if (Path.IsPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name, out bool sawPathSeparator) && sawPathSeparator)
+                    if (isEditorConfigPathRooted(section.Name) && !ContainsSpecialCharacters(section.Name, out bool sawPathSeparator) && sawPathSeparator)
                     {
                         MergeSection(config.PathToFile, section, isGlobalSection: false);
                     }
@@ -513,6 +513,13 @@ namespace Microsoft.CodeAnalysis
                             section.Name,
                             config.PathToFile));
                     }
+                }
+
+                static bool isEditorConfigPathRooted(string name)
+                {
+                    return Path.IsPathRooted(name) &&
+                        // on windows '\' is a valid path root, but editor configs must use forward slashes, so we disallow it
+                        !name.StartsWith("\\");
                 }
             }
 

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Neplatný název jazykové verze: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Při diagnostice {0} byla v konfiguračním souboru analyzátoru v {2} předána neplatná závažnost {1}.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Ungültiger Kulturname: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Der Diagnose "{0}" wurde ein ungültiger Schweregrad "{1}" in der Konfigurationsdatei des Analysetools unter "{2}" zugewiesen.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Nombre de referencia cultural no válido: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Se proporcionó al diagnóstico "{0}" una gravedad no válida "{1}" en el archivo de configuración del analizador en "{2}".</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Nom de culture non valide : '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Le diagnostic '{0}' a reçu un niveau de gravité non valide '{1}' dans le fichier config de l'analyseur sur '{2}'.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Il nome delle impostazioni cultura '{0}' non è valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Alla diagnostica ' {0}' è stato assegnato un livello di gravità non valido '{1}' nel file di configurazione dell'analizzatore alla posizione '{2}'.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -569,6 +569,16 @@
         <target state="translated">無効なカルチャ名: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">アナライザー構成ファイルの '{2}' で、診断 '{0}' に無効な重要度 '{1}' が指定されました。</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -569,6 +569,16 @@
         <target state="translated">잘못된 문화권 이름입니다('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">'{2}'의 분석기 구성 파일에 있는 진단 '{0}'에 잘못된 심각도 '{1}'이(가) 지정되었습니다.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Nieprawidłowa nazwa kultury: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Dla elementu diagnostyki „{0}” określono nieprawidłową ważność „{1}” w pliku konfiguracji analizatora — „{2}”.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Nome de cultura inválido: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">O diagnóstico '{0}' recebeu uma gravidade inválida '{1}' no arquivo de configuração do analisador em '{2}'.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Недопустимое название языка и региональных параметров: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">Для диагностики "{0}" указана недопустимая серьезность "{1}" в файле конфигурации анализатора в "{2}".</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -569,6 +569,16 @@
         <target state="translated">Geçersiz kültür adı: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">'{0}' tanılamasına '{2}' konumundaki çözümleyici yapılandırma dosyasında geçersiz bir önem derecesi ('{1}') verildi.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -569,6 +569,16 @@
         <target state="translated">无效的区域性名称:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">在 "{2}" 的分析器配置文件中为诊断 "{0}" 给定了无效的严重性 "{1}"。</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -569,6 +569,16 @@
         <target state="translated">文化特性名稱無效: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName">
+        <source>Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</source>
+        <target state="new">Global analyzer config section name '{0}' is invalid as it is not an absolute path. Section will be ignored. Section was declared in file: '{1}'</target>
+        <note>{0}: invalid section name, {1} path to global config</note>
+      </trans-unit>
+      <trans-unit id="WRN_InvalidGlobalSectionName_Title">
+        <source>Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</source>
+        <target state="new">Global analyzer config section name is invalid as it is not an absolute path. Section will be ignored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InvalidSeverityInAnalyzerConfig">
         <source>The diagnostic '{0}' was given an invalid severity '{1}' in the analyzer config file at '{2}'.</source>
         <target state="translated">在分析器組態檔的 '{2}' 處，為診斷 '{0}' 提供了無效的嚴重性 '{1}'。</target>


### PR DESCRIPTION
Check that a section name in a global config is an absolute path, and contains no glob/special chars.