### PR TITLE
Enable optprof coverage for MS.CA.Workspaces.dll

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -77,6 +77,10 @@
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.CSharp.dll",
               "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
             }
           ]
         },
@@ -154,6 +158,10 @@
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
             }
           ]
         },
@@ -226,6 +234,10 @@
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             }
           ]
@@ -307,6 +319,10 @@
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+              "testCases":[ "VSPE.OptProfTests.vs_asl_cs_scenario", "VSPE.OptProfTests.vs_perf_DesignTime_solution_loadclose_cs_picasso", "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
               "testCases":[ "VSPE.OptProfTests.vs_asl_cs_scenario", "VSPE.OptProfTests.vs_perf_DesignTime_solution_loadclose_cs_picasso", "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             }
           ]


### PR DESCRIPTION
Insertion contains this change:
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/274926

Optprof run based on the insertion build above:
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=816550

2nd insertion with Roslyn build using updated ibc data from the optprof run above
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/275730
