### PR TITLE
bugfix/msbuildworkspace duplicate analyzer references

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.AnalyzerReferencePathComparer.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.AnalyzerReferencePathComparer.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+# nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.MSBuild
+{
+    public partial class MSBuildProjectLoader
+    {
+        private partial class Worker
+        {
+            private class AnalyzerReferencePathComparer : IEqualityComparer<AnalyzerReference?>
+            {
+                public static AnalyzerReferencePathComparer Instance = new AnalyzerReferencePathComparer();
+
+                private AnalyzerReferencePathComparer() { }
+
+                public bool Equals(AnalyzerReference? x, AnalyzerReference? y)
+                    => string.Equals(x?.FullPath, y?.FullPath, StringComparison.OrdinalIgnoreCase);
+
+                public int GetHashCode(AnalyzerReference? obj)
+                    => obj?.FullPath?.GetHashCode() ?? 0;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     }
                 }
 
-                return commandLineArgs.ResolveAnalyzerReferences(analyzerLoader);
+                return commandLineArgs.ResolveAnalyzerReferences(analyzerLoader).Distinct(AnalyzerReferencePathComparer.Instance);
             }
 
             private static ImmutableArray<DocumentInfo> CreateDocumentInfos(IReadOnlyList<DocumentFileInfo> documentFileInfos, ProjectId projectId, Encoding? encoding)


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn/issues/47078

Do not pass duplicate analyzer references to ProjectInfo

