### PR TITLE
PrintMembers should exclude indexers and setter-only properties

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (m.Kind is SymbolKind.Property)
                 {
                     var property = (PropertySymbol)m;
-                    return !property.IsIndexer && property.GetMethod is not null;
+                    return !property.IsIndexer && !property.IsOverride && property.GetMethod is not null;
                 }
 
                 return false;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -4419,9 +4419,9 @@ record C1(int I1)
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             CompileAndVerify(comp, expectedOutput: "C1 { I1 = 42, P2 = 43, P3 = 44 }", verify: Verification.Skipped /* init-only */);
             comp.VerifyEmitDiagnostics(
-                // (10,32): warning CS0067: The event 'C1.a' is never used
+                // (12,32): warning CS0067: The event 'C1.a' is never used
                 //     public event System.Action a;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "a", isSuppressed: false).WithArguments("C1.a").WithLocation(10, 32)
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "a", isSuppressed: false).WithArguments("C1.a").WithLocation(12, 32)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -4413,6 +4413,18 @@ record C1(int I1)
     public int P2 { get => 43; }
     public ref int P3 { get => ref field; }
     public event System.Action a;
+
+    private int field1 = 100;
+    internal int field2 = 100;
+    protected int field3 = 100;
+    private protected int field4 = 100;
+    internal protected int field5 = 100;
+
+    private int Property1 { get; set; } = 100;
+    internal int Property2 { get; set; } = 100;
+    protected int Property3 { get; set; } = 100;
+    private protected int Property4 { get; set; } = 100;
+    internal protected int Property5 { get; set; } = 100;
 }
 ";
 
@@ -4421,7 +4433,10 @@ record C1(int I1)
             comp.VerifyEmitDiagnostics(
                 // (12,32): warning CS0067: The event 'C1.a' is never used
                 //     public event System.Action a;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "a", isSuppressed: false).WithArguments("C1.a").WithLocation(12, 32)
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "a", isSuppressed: false).WithArguments("C1.a").WithLocation(12, 32),
+                // (14,17): warning CS0414: The field 'C1.field1' is assigned but its value is never used
+                //     private int field1 = 100;
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "field1", isSuppressed: false).WithArguments("C1.field1").WithLocation(14, 17)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -4459,7 +4459,7 @@ record C1
         }
 
         [Fact, WorkItem(47797, "https://github.com/dotnet/roslyn/issues/47797")]
-        public void ToString_OverridenProperty_NoRepetition()
+        public void ToString_OverriddenProperty_NoRepetition()
         {
             var src = @"
 System.Console.WriteLine(new B() { P = 2 }.ToString());
@@ -4473,7 +4473,7 @@ record B : A
     public override int P { get; set; }
 }
 ";
-            var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, options: TestOptions.DebugExe);
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
             CompileAndVerify(comp, expectedOutput: "B { P = 2 }");
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47672
Fixes https://github.com/dotnet/roslyn/issues/47797 (incorporated fix and test from @Youssef1313's PR, thx)