### PR TITLE
Fix regression in SuppressMessageAttributeState.TargetSymbolResolver

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageTargetSymbolResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageTargetSymbolResolverTests.cs
@@ -366,6 +366,20 @@ End Class
                 "C.s");
         }
 
+        [Fact, WorkItem(1141257, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1141257")]
+        public void TestResolveEnumFieldWithoutName()
+        {
+            var source = @"
+enum E
+{
+    $$,
+}
+";
+            var syntaxTree = CreateSyntaxTree(source, LanguageNames.CSharp);
+            var compilation = CreateCompilation(syntaxTree, LanguageNames.CSharp, "");
+            _ = SuppressMessageAttributeState.ResolveTargetSymbols(compilation, "E.", SuppressMessageAttributeState.TargetScope.Member);
+        }
+
         [Fact]
         public void TestResolveProperty1()
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.TargetSymbolResolver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.TargetSymbolResolver.cs
@@ -230,6 +230,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         results.Add(singleResult);
                     }
+
+                    break;
                 }
 
                 return results.ToImmutableAndFree();


### PR DESCRIPTION
Fixes VSO Watson [#1141257](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1141257)

Regression was introduced in https://github.com/dotnet/roslyn/commit/3c3750158b620cfdeca45891245468cf423a1597#diff-464dab23fb56bf98bfcf831dd11f4288L228-L229. I forgot to add a break statement during some refactoring from PR feedback.

Verified that added unit test hangs prior to the fix.