### PR TITLE
Downgrade VS Editor packages version to last public release.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <CodeStyleLayerCodeAnalysisVersion>3.7.0</CodeStyleLayerCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20407.3</MicrosoftCodeAnalysisTestingVersion>
     <CodeStyleAnalyzerVersion>3.7.0-3.20271.4</CodeStyleAnalyzerVersion>
-    <VisualStudioEditorPackagesVersion>16.8.39</VisualStudioEditorPackagesVersion>
+    <VisualStudioEditorPackagesVersion>16.6.255</VisualStudioEditorPackagesVersion>
     <ILToolsPackageVersion>5.0.0-alpha1.19409.1</ILToolsPackageVersion>
     <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.8.52</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>16.8.30323.125</MicrosoftVisualStudioShellPackagesVersion>


### PR DESCRIPTION
Since we ship Microsoft.CodeAnalysis.EditorFeatures.Text on NuGet and it depends on Microsoft.VisualStudio.CoreUtility, Microsoft.VisualStudio.Text.Data, and Microsoft.VisualStudio.Text.Logic, we are bound to take only publicly published versions of the VS Editor packages. 