### PR TITLE
Preserve CustomObsoleteDiagnosticInfo when changing severity

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -8697,7 +8697,7 @@ class C2 : C1
                 );
 
             verify(TestOptions.DebugDll.WithGeneralDiagnosticOption(ReportDiagnostic.Hidden),
-                // (6,9): warning TEST1: 'C1.M1()' is obsolete
+                // (6,9): hidden TEST1: 'C1.M1()' is obsolete
                 //         M1(); // 1
                 Diagnostic("TEST1", "M1()", isSuppressed: false).WithArguments("C1.M1()").WithLocation(6, 9));
 

--- a/src/Compilers/Core/Portable/Diagnostic/CustomObsoleteDiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CustomObsoleteDiagnosticInfo.cs
@@ -23,6 +23,12 @@ namespace Microsoft.CodeAnalysis
             Data = data;
         }
 
+        private CustomObsoleteDiagnosticInfo(CustomObsoleteDiagnosticInfo baseInfo, DiagnosticSeverity effectiveSeverity)
+            : base(baseInfo, effectiveSeverity)
+        {
+            Data = baseInfo.Data;
+        }
+
         public override string MessageIdentifier
         {
             get
@@ -48,6 +54,11 @@ namespace Microsoft.CodeAnalysis
 
                 return _descriptor;
             }
+        }
+
+        internal override DiagnosticInfo GetInstanceWithSeverity(DiagnosticSeverity severity)
+        {
+            return new CustomObsoleteDiagnosticInfo(this, severity);
         }
 
         private DiagnosticDescriptor CreateDescriptor()

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis
             _arguments = arguments;
         }
 
-        private DiagnosticInfo(DiagnosticInfo original, DiagnosticSeverity overriddenSeverity)
+        protected DiagnosticInfo(DiagnosticInfo original, DiagnosticSeverity overriddenSeverity)
         {
             _messageProvider = original.MessageProvider;
             _errorCode = original._errorCode;
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // Create a copy of this instance with a explicit overridden severity
-        internal DiagnosticInfo GetInstanceWithSeverity(DiagnosticSeverity severity)
+        internal virtual DiagnosticInfo GetInstanceWithSeverity(DiagnosticSeverity severity)
         {
             return new DiagnosticInfo(this, severity);
         }


### PR DESCRIPTION
Closes #47736

Need to make a pass to add tests, but I think this fixes the problem.