### PR TITLE
Supply completions for negative regex categories as well.

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Regex.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Regex.vb
@@ -272,6 +272,30 @@ class c
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNegativeCategory(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.Text.RegularExpressions;
+class c
+{
+    void goo()
+    {
+        var r = new Regex(@"\P$$");
+    }
+}
+]]></Document>, showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("{")
+                Await state.AssertCompletionSession()
+
+                Assert.True(state.GetCompletionItems().Any(Function(i) i.DisplayText = "IsGreek"))
+
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function NotInInterpolatedString(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document><![CDATA[

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedCompletionProvider.cs
@@ -258,17 +258,13 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
             // we're providing the set of unicode categories that are legal there.
 
             var index = tree.Text.IndexOf(previousVirtualChar);
-            if (index >= 2 &&
-                tree.Text[index - 2] == '\\')
+            if (index >= 2 && tree.Text[index - 2] == '\\')
             {
                 var escapeChar = tree.Text[index - 1];
                 if (escapeChar == 'p' || escapeChar == 'P')
                 {
-                    var result = FindToken(tree.Root, escapeChar);
-                    if (result == null)
-                        return;
-
-                    if (result.Value.parent is RegexEscapeNode)
+                    var token = FindToken(tree.Root, escapeChar);
+                    if (token?.parent is RegexEscapeNode)
                         ProvideEscapeCategoryCompletions(context);
                 }
             }

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedCompletionProvider.cs
@@ -259,20 +259,17 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
 
             var index = tree.Text.IndexOf(previousVirtualChar);
             if (index >= 2 &&
-                tree.Text[index - 2] == '\\' &&
-                tree.Text[index - 1] == 'p')
+                tree.Text[index - 2] == '\\')
             {
-                var slashChar = tree.Text[index - 1];
-                var result = FindToken(tree.Root, slashChar);
-                if (result == null)
+                var escapeChar = tree.Text[index - 1];
+                if (escapeChar == 'p' || escapeChar == 'P')
                 {
-                    return;
-                }
+                    var result = FindToken(tree.Root, escapeChar);
+                    if (result == null)
+                        return;
 
-                var (parent, _) = result.Value;
-                if (parent is RegexEscapeNode)
-                {
-                    ProvideEscapeCategoryCompletions(context);
+                    if (result.Value.parent is RegexEscapeNode)
+                        ProvideEscapeCategoryCompletions(context);
                 }
             }
         }


### PR DESCRIPTION
View with whitespace off.  this is a trivial change.