### PR TITLE
Enable automatic discovery of global editor configs

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -79,11 +79,12 @@
     
     -->
   <ItemGroup>
-    <_AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    <_AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false' or '$(DiscoverGlobalConfigFiles)' != 'false'" />
     <!-- Work around a GetPathsOfAllDirectoriesAbove() bug where it can return multiple equivalent paths when the 
          compilation includes linked files with relative paths - https://github.com/microsoft/msbuild/issues/4392 -->
     <PotentialEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
-    <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    <PotentialEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.globalconfig'))" Condition="'$(DiscoverGlobalConfigFiles)' != 'false'" />
+    <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false' or '$(DiscoverGlobalConfigFiles)' != 'false'" />
   </ItemGroup>
 
   <!--

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -79,14 +79,14 @@
     
     -->
   <ItemGroup>
-    <_AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false' or '$(DiscoverGlobalConfigFiles)' != 'false'" />
+    <_AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false' or '$(DiscoverGlobalAnalyzerConfigFiles)' != 'false'" />
     <!-- Work around a GetPathsOfAllDirectoriesAbove() bug where it can return multiple equivalent paths when the 
          compilation includes linked files with relative paths - https://github.com/microsoft/msbuild/issues/4392 -->
     <PotentialEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
     <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
     
-    <GlobalEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.globalconfig'))" Condition="'$(DiscoverGlobalConfigFiles)' != 'false'" />
-    <EditorConfigFiles Include="@(GlobalEditorConfigFiles->Exists())" Condition="'$(DiscoverGlobalConfigFiles)' != 'false'" />
+    <GlobalAnalyzerConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.globalconfig'))" Condition="'$(DiscoverGlobalAnalyzerConfigFiles)' != 'false'" />
+    <EditorConfigFiles Include="@(GlobalAnalyzerConfigFiles->Exists())" Condition="'$(DiscoverGlobalAnalyzerConfigFiles)' != 'false'" />
   </ItemGroup>
 
   <!--

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -83,8 +83,10 @@
     <!-- Work around a GetPathsOfAllDirectoriesAbove() bug where it can return multiple equivalent paths when the 
          compilation includes linked files with relative paths - https://github.com/microsoft/msbuild/issues/4392 -->
     <PotentialEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
-    <PotentialEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.globalconfig'))" Condition="'$(DiscoverGlobalConfigFiles)' != 'false'" />
-    <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false' or '$(DiscoverGlobalConfigFiles)' != 'false'" />
+    <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    
+    <GlobalEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.globalconfig'))" Condition="'$(DiscoverGlobalConfigFiles)' != 'false'" />
+    <EditorConfigFiles Include="@(GlobalEditorConfigFiles->Exists())" Condition="'$(DiscoverGlobalConfigFiles)' != 'false'" />
   </ItemGroup>
 
   <!--

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 });
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), AlwaysSkip = "https://github.com/dotnet/roslyn/issues/34688")]
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void TestDiscoverEditorConfigFiles()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -423,6 +423,154 @@ some_prop = some_val");
                     Path.Combine(ProjectDir.Path, ".editorconfig"),
                     editorConfigFile2.Path
                 });
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void TestDiscoverEditorConfigFilesCanBeDisabled()
+        {
+            var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
+            var subdir = ProjectDir.CreateDirectory("subdir");
+            var srcFile2 = subdir.CreateFile("lib2.cs").WriteAllText("class D { }");
+            var editorConfigFile2 = subdir.CreateFile(".editorconfig").WriteAllText(@"[*.cs]
+some_prop = some_val");
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+    <DiscoverEditorConfigFiles>false</DiscoverEditorConfigFiles>
+</PropertyGroup>",
+                customTargets: null,
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(EditorConfigFiles)"
+                },
+                expectedResults: new[] { "" });
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void TestDiscoverGlobalConfigFiles()
+        {
+            var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
+            var globalConfigFile = ProjectDir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+            var subdir = ProjectDir.CreateDirectory("subdir");
+            var srcFile2 = subdir.CreateFile("lib2.cs").WriteAllText("class D { }");
+            var globalConfigFile2 = subdir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+
+            VerifyValues(
+                customProps: null,
+                customTargets: null,
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(EditorConfigFiles)"
+                },
+                expectedResults: new[]
+                {
+                    Path.Combine(ProjectDir.Path, ".editorconfig"),
+                    globalConfigFile.Path,
+                    globalConfigFile2.Path
+                });
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void TestDiscoverGlobalConfigFilesCanBeDisabled()
+        {
+            var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
+            var globalConfigFile = ProjectDir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+            var subdir = ProjectDir.CreateDirectory("subdir");
+            var srcFile2 = subdir.CreateFile("lib2.cs").WriteAllText("class D { }");
+            var globalConfigFile2 = subdir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+    <DiscoverGlobalConfigFiles>false</DiscoverGlobalConfigFiles>
+</PropertyGroup>",
+                customTargets: null,
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(EditorConfigFiles)"
+                },
+                 expectedResults: new[]
+                {
+                    Path.Combine(ProjectDir.Path, ".editorconfig"),
+                });
+        }
+
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void TestDiscoverGlobalConfigFilesWhenEditorConfigDisabled()
+        {
+            var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
+            var globalConfigFile = ProjectDir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+            var subdir = ProjectDir.CreateDirectory("subdir");
+            var srcFile2 = subdir.CreateFile("lib2.cs").WriteAllText("class D { }");
+            var globalConfigFile2 = subdir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+    <DiscoverEditorConfigFiles>false</DiscoverEditorConfigFiles>
+</PropertyGroup>",
+                customTargets: null,
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(EditorConfigFiles)"
+                },
+                 expectedResults: new[]
+                {
+                    globalConfigFile.Path,
+                    globalConfigFile2.Path
+                });
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void TestDiscoverEditorAndGlobalConfigFilesCanBeDisabled()
+        {
+            var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
+            var globalConfigFile = ProjectDir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+            var subdir = ProjectDir.CreateDirectory("subdir");
+            var globalConfigFile2 = subdir.CreateFile(".globalconfig").WriteAllText(@"is_global = true
+some_prop = some_val");
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+    <DiscoverEditorConfigFiles>false</DiscoverEditorConfigFiles>
+    <DiscoverGlobalConfigFiles>false</DiscoverGlobalConfigFiles>
+</PropertyGroup>",
+                customTargets: null,
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(EditorConfigFiles)"
+                },
+                 expectedResults: new[] { "" });
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -572,5 +572,33 @@ some_prop = some_val");
                 },
                  expectedResults: new[] { "" });
         }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void TestGlobalConfigsCanBeManuallyAdded()
+        {
+            var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
+            var globalConfigFile = ProjectDir.CreateFile("mycustom.config").WriteAllText(@"is_global = true
+some_prop = some_val");
+
+            VerifyValues(
+                customProps: @"
+<ItemGroup>
+    <GlobalEditorConfigFiles Include=""mycustom.config"" />
+</ItemGroup>",
+                customTargets: null,
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(EditorConfigFiles)"
+                },
+                 expectedResults: new[]
+                {
+                    Path.Combine(ProjectDir.Path, ".editorconfig"),
+                    "mycustom.config"
+                });
+        }
     }
 }


### PR DESCRIPTION
Automatically discover any files that end with `.globalconfig`
Allow the user to disable global config discovery
Add and enable tests.

Fixes https://github.com/dotnet/roslyn/issues/34688