### PR TITLE
Use verbose logging on Unix

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -266,7 +266,7 @@ function BuildSolution {
     test_runtime_args="--debug"
   elif [[ "$test_core_clr" == true ]]; then
     test=true
-    test_runtime="/p:TestRuntime=Core /p:TestTargetFrameworks=net5.0%3Bnetcoreapp3.1"
+    test_runtime="/p:TestRuntime=Core /p:TestTargetFrameworks=net5.0%3Bnetcoreapp3.1 /p:TestRunnerAdditionalArguments=-verbose"
     mono_tool=""
   fi
 


### PR DESCRIPTION
The verbose logging option causes xUnit to output starting / finished
markers for each of the tests that it is executing. This will help us
track down the test that is hanging on Mac so frequently