### PR TITLE
Fix MemberNotNull attributes on substituted methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
@@ -323,6 +323,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override FlowAnalysisAnnotations FlowAnalysisAnnotations => UnderlyingMethod.FlowAnalysisAnnotations;
 
+        internal sealed override ImmutableArray<string> NotNullMembers => UnderlyingMethod.NotNullMembers;
+
+        internal sealed override ImmutableArray<string> NotNullWhenTrueMembers => UnderlyingMethod.NotNullWhenTrueMembers;
+
+        internal sealed override ImmutableArray<string> NotNullWhenFalseMembers => UnderlyingMethod.NotNullWhenFalseMembers;
+
         internal override bool ReturnValueIsMarshalledExplicitly
         {
             get


### PR DESCRIPTION
Closes #47667

We forgot to override some methods in WrappedMethodSymbol, so substituted methods were showing as never having any NotNullMembers, NotNullWhenTrueMembers, or NotNullWhenFalseMembers.