### PR TITLE
Extend the Mac Job Timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ jobs:
 - job: macOS_Test
   pool:
     vmImage: 'macOS-10.14'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
 
   steps:
     - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --testCoreClr


### PR DESCRIPTION
The Azure DevOps service is currently in the process of transitioning to
a new Mac pool. The machines in the new Mac pool are observably slower
than the ones in the old pool.

This difference in speed appears to be the cause of our recent
instability in the Mac jobs. Consider the following two jobs as a data
point:

- [Passed Build](https://dev.azure.com/dnceng/public/_build/results?buildId=818909&view=logs&j=1402d8c5-7e47-5bf4-467f-73e45e01bcce)
- [Failed Build](https://dev.azure.com/dnceng/public/_build/results?buildId=819817&view=logs&j=1402d8c5-7e47-5bf4-467f-73e45e01bcce)

At first I believed the source of the issue was a hang in the C#
semantic tests. Pretty much all our OSX failures came when executing
that test assembly. In a retent PR though I added a verbose log support
and discovered it was failing on the test
`AccessPropertyWithoutArguments`. That is a pretty basic test, no reason
I can see that it would result in a Mac only hang bug.

Decided to break down the runs into different sections and see how long
it took each build to get to that section

| Event | Passed Build Time | Failed Build Time |
| --- | --- | --- |
| Begin Real Build | 10 min | 12 min |
| Begin Running Tests | 30 min | 54 min |
| Begin C# semantic test | 39 min | 78 min |

Essentially everything is taking longer in the failed run. It seems very likely 
that the passed run ran on the old Mac pool and the failed run on the new
Mac pool. The slow down lines up with what other repositories are seeing.

As such I'm going to increase the timeout to account for this change. If
my analysis is wrong and it's a real hang it should continue to
reproduce after this change and I'll investigate further.