### PR TITLE
Don't warn on unused record primary constructor parameters

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
         {
         }
 
+        protected override bool IsRecordDeclaration(SyntaxNode node)
+            => node is RecordDeclarationSyntax;
+
         protected override bool SupportsDiscard(SyntaxTree tree)
             => ((CSharpParseOptions)tree.Options).LanguageVersion >= LanguageVersion.CSharp7;
 

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1530,5 +1530,49 @@ class C
 }",
     Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId));
         }
+
+        [WorkItem(47142, "https://github.com/dotnet/roslyn/issues/47142")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task Record_PrimaryConstructorParameter()
+        {
+            await TestMissingAsync(
+@"record A(int [|X|]);"
+);
+        }
+
+        [WorkItem(47142, "https://github.com/dotnet/roslyn/issues/47142")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task Record_NonPrimaryConstructorParameter()
+        {
+            await TestDiagnosticsAsync(
+@"record A
+{
+    public A(int [|X|])
+    {
+    }
+}
+",
+    Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId));
+        }
+
+        [WorkItem(47142, "https://github.com/dotnet/roslyn/issues/47142")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task Record_DelegatingPrimaryConstructorParameter()
+        {
+            await TestDiagnosticMissingAsync(
+@"record A(int X);
+record B(int X, int [|Y|]) : A(X);
+");
+        }
+
+        [WorkItem(47174, "https://github.com/dotnet/roslyn/issues/47174")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task RecordPrimaryConstructorParameter_PublicRecord()
+        {
+            await TestDiagnosticMissingAsync(
+@"public record Base(int I) { }
+public record Derived(string [|S|]) : Base(42) { }
+");
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -219,6 +219,14 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     return false;
                 }
 
+                // Ignore parameters of record primary constructors since they map to public properties
+                // TODO: Remove this when implicit operations are synthesised: https://github.com/dotnet/roslyn/issues/47829 
+                if (method.IsConstructor() &&
+                    _compilationAnalyzer.IsRecordDeclaration(method.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()))
+                {
+                    return false;
+                }
+
                 // Ignore event handler methods "Handler(object, MyEventArgs)"
                 // as event handlers are required to match this signature
                 // regardless of whether or not the parameters are used.

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -99,6 +99,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
             UnusedValueAssignmentOption = unusedValueAssignmentOption;
         }
 
+        protected abstract bool IsRecordDeclaration(SyntaxNode node);
         protected abstract Location GetDefinitionLocationToFade(IOperation unusedDefinition);
         protected abstract bool SupportsDiscard(SyntaxTree tree);
         protected abstract bool MethodHasHandlesClause(IMethodSymbol method);

--- a/src/Analyzers/VisualBasic/Analyzers/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedParametersAndValuesDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedParametersAndValuesDiagnosticAnalyzer.vb
@@ -20,6 +20,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedParametersAndValues
                        LanguageNames.VisualBasic)
         End Sub
 
+        Protected Overrides Function IsRecordDeclaration(node As SyntaxNode) As Boolean
+            Return False
+        End Function
+
         Protected Overrides Function SupportsDiscard(tree As SyntaxTree) As Boolean
             Return False
         End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47142
Fixes https://github.com/dotnet/roslyn/issues/47174

Until we synthesize operation blocks for implicit code this analyzer can't reason about records much, so just opt them out and don't confuse/annoy people.

FYI @jcouv 