### PR TITLE
Enter suggestion mode for potential lambda expression

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -1349,6 +1349,58 @@ class C
             await VerifyNotBuilderAsync(markup);
         }
 
+        [WorkItem(46927, "https://github.com/dotnet/roslyn/issues/46927")]
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task FirstArgumentOfInvocation_NoParameter(bool hasTypedChar)
+        {
+            var markup = $@"
+using System;
+interface Foo
+{{
+    bool Bar() => true;
+}}
+class P
+{{
+    void M(Foo f)
+    {{
+        f.Bar({(hasTypedChar ? "s" : "")}$$
+    }}
+}}";
+            await VerifyNotBuilderAsync(markup);
+        }
+
+        [WorkItem(46927, "https://github.com/dotnet/roslyn/issues/46927")]
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task FirstArgumentOfInvocation_PossibleLambdaExpression(bool isLambda, bool hasTypedChar)
+        {
+            var overload = isLambda
+                ? "bool Bar(Func<int, bool> predicate) => true;"
+                : "bool Bar(int x) => true;";
+
+            var markup = $@"
+using System;
+interface Foo
+{{
+    bool Bar() => true;
+    {overload}
+}}
+class P
+{{
+    void M(Foo f)
+    {{
+        f.Bar({(hasTypedChar ? "s" : "")}$$
+    }}
+}}";
+            if (isLambda)
+            {
+                await VerifyBuilderAsync(markup);
+            }
+            else
+            {
+                await VerifyNotBuilderAsync(markup);
+            }
+        }
+
         private async Task VerifyNotBuilderAsync(string markup)
             => await VerifyWorkerAsync(markup, isBuilder: false);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -458,10 +458,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var info = SemanticModel.GetSymbolInfo(invocation, CancellationToken);
                 var methods = info.GetBestOrAllSymbols().OfType<IMethodSymbol>();
 
-                // Overload resolution (see DevDiv 611477) in certain extension method cases
-                // can result in GetSymbolInfo returning nothing. In this case, get the 
-                // method group info, which is what signature help already does.
-                if (info.Symbol == null)
+                // 1. Overload resolution (see DevDiv 611477) in certain extension method cases
+                // can result in GetSymbolInfo returning nothing. 
+                // 2. when trying to infer the type of the first argument, it's possible that nothing correspinding to
+                // the argument is typed and there exists an overload with 0 parameter as a viable match.
+                // In one of these cases, get the method group info, which is what signature help already does.
+                if (info.Symbol == null ||
+                    info.Symbol is IMethodSymbol method && method.Parameters.Length == 0)
                 {
                     var memberGroupMethods =
                         SemanticModel.GetMemberGroup(invocation.Expression, CancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // the argument is typed and there exists an overload with 0 parameter as a viable match.
                 // In one of these cases, get the method group info, which is what signature help already does.
                 if (info.Symbol == null ||
-                    info.Symbol is IMethodSymbol method && method.Parameters.Length == 0)
+                    argumentOpt == null && info.Symbol is IMethodSymbol method && method.Parameters.Length == 0)
                 {
                     var memberGroupMethods =
                         SemanticModel.GetMemberGroup(invocation.Expression, CancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // 1. Overload resolution (see DevDiv 611477) in certain extension method cases
                 // can result in GetSymbolInfo returning nothing. 
-                // 2. when trying to infer the type of the first argument, it's possible that nothing correspinding to
+                // 2. when trying to infer the type of the first argument, it's possible that nothing corresponding to
                 // the argument is typed and there exists an overload with 0 parameter as a viable match.
                 // In one of these cases, get the method group info, which is what signature help already does.
                 if (info.Symbol == null ||


### PR DESCRIPTION
Fix #46927 

In the example below (i.e. multiple overloads, has one with no parameter and user hasn't typed any argument at invocation), `SemanticModel.GetSymbolInfo` would return the symbol for `bool Bar()` as the viable match for the invocation. In this case , we still want to get all the overloads back to check for possibility of typing a lambda expression.

```cs
    interface Foo
    {
        bool Bar() => true;
        bool Bar(Func<int, bool> predicate) => true;
    }
    class P
    {
        void M(Foo f)
        {
            f.Bar($$
        }
    }
```