### PR TITLE
Use 'deadlock' instead of 'blocking'

### DIFF
--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -138,8 +138,8 @@ namespace Microsoft.CodeAnalysis.Remote
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
 
             // Create new tasks that both start executing, rather than invoking the delegates directly.
-            // If the reader started synchronously reading before the writer task started it would be blocking, and vice versa
-            // if the writer synchronously filled the buffer before the reader task started it would also be blocking.
+            // If the reader started synchronously reading before the writer task started it would hang, and vice versa
+            // if the writer synchronously filled the buffer before the reader task started it would also hang.
             var writerTask = Task.Run(async () => await invocation(service, serverStream, cancellationToken).ConfigureAwait(false), cancellationToken);
             var readerTask = Task.Run(async () => await reader(clientStream, cancellationToken).ConfigureAwait(false), cancellationToken);
             await Task.WhenAll(writerTask, readerTask).ConfigureAwait(false);

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -138,8 +138,8 @@ namespace Microsoft.CodeAnalysis.Remote
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
 
             // Create new tasks that both start executing, rather than invoking the delegates directly.
-            // If the reader started synchronously reading before the writer task started it would hang, and vice versa
-            // if the writer synchronously filled the buffer before the reader task started it would also hang.
+            // If the reader started synchronously reading before the writer task started it would deadlock, and vice versa
+            // if the writer synchronously filled the buffer before the reader task started it would also deadlock.
             var writerTask = Task.Run(async () => await invocation(service, serverStream, cancellationToken).ConfigureAwait(false), cancellationToken);
             var readerTask = Task.Run(async () => await reader(clientStream, cancellationToken).ConfigureAwait(false), cancellationToken);
             await Task.WhenAll(writerTask, readerTask).ConfigureAwait(false);


### PR DESCRIPTION
Builds on dotnet/roslyn#47863 to use 'deadlock' instead of 'blocking'.

Blocking has a different meaning from the original text, and is not accurate in this context. This revert PR will allow us to find a more appropriate alternative, if necessary.

A 'hang' in a generic term for a deadlock, livelock, or UI delay long enough that it cannot be distinguished from the first two by a user. I am not aware of a recommended replacement term for this usage, so the term used for this meaning does not currently need to change. If it is changed, it should be changed either by clarifying the specific case that applies (i.e. one of these three conditions applies, but the others do not), or by using a more correct term (i.e. 'hang' was not the correct term in the first place). 

On reviewing the comment in question for this change, 'hang' appears to be the term most readily understandable to a reader, but deadlock would likely suffice. I'm marking this change ready for review on the basis that 'hang' is arguably the current best term available for this comment.