### PR TITLE
Exclude constant and static fields from record's PrintMembers

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
                 }
 
-                if (m is SymbolField { IsConst: false })
+                if (m.Kind is SymbolKind.Field)
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static bool isPrintable(Symbol m)
             {
-                if (m.DeclaredAccessibility != Accessibility.Public)
+                if (m.DeclaredAccessibility != Accessibility.Public || m.IsStatic)
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
                 }
 
-                if (m.Kind is SymbolKind.Field)
+                if (m is SymbolField { IsConst: false })
                 {
                     return true;
                 }


### PR DESCRIPTION
Might fix #47867, will confirm after adding a test.

But:

1. Should constants be excluded?
2. Why constants currently cause a problem in the first place?