### PR TITLE
Track completion of ProjectCacheService operations

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -34,12 +33,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
     [Trait(Traits.Feature, Traits.Features.Classification)]
     public class SemanticClassifierTests : AbstractCSharpClassifierTests
     {
-        protected override Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions options, TestHost testHost)
+        protected override async Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions options, TestHost testHost)
         {
             using var workspace = CreateWorkspace(code, options, testHost);
             var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
 
-            return GetSemanticClassificationsAsync(document, span);
+            return await GetSemanticClassificationsAsync(document, span);
         }
 
         [Theory]

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -8,9 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Remote.Testing;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -20,12 +18,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 {
     public partial class SyntacticClassifierTests : AbstractCSharpClassifierTests
     {
-        protected override Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions options, TestHost testHost)
+        protected override async Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions options, TestHost testHost)
         {
             using var workspace = CreateWorkspace(code, options, testHost);
             var document = workspace.CurrentSolution.Projects.First().Documents.First();
 
-            return GetSyntacticClassificationsAsync(document, span);
+            return await GetSyntacticClassificationsAsync(document, span);
         }
 
         [Theory]

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -19,12 +19,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
     [Trait(Traits.Feature, Traits.Features.Classification)]
     public partial class TotalClassifierTests : AbstractCSharpClassifierTests
     {
-        protected override Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions options, TestHost testHost)
+        protected override async Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions options, TestHost testHost)
         {
             using var workspace = CreateWorkspace(code, options, testHost);
             var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
 
-            return GetAllClassificationsAsync(document, span);
+            return await GetAllClassificationsAsync(document, span);
         }
 
         [Theory]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -18,8 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public abstract class AbstractCSharpCompletionProviderTests : AbstractCSharpCompletionProviderTests<CSharpTestWorkspaceFixture>
     {
-        protected AbstractCSharpCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture)
-            : base(workspaceFixture)
+        protected AbstractCSharpCompletionProviderTests()
         {
         }
     }
@@ -27,8 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> : AbstractCompletionProviderTests<TWorkspaceFixture>
         where TWorkspaceFixture : TestWorkspaceFixture, new()
     {
-        protected AbstractCSharpCompletionProviderTests(TWorkspaceFixture workspaceFixture)
-            : base(workspaceFixture)
+        protected AbstractCSharpCompletionProviderTests()
         {
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractInteractiveCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractInteractiveCSharpCompletionProviderTests.cs
@@ -8,8 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public abstract class AbstractInteractiveCSharpCompletionProviderTests : AbstractCSharpCompletionProviderTests<InteractiveCSharpTestWorkspaceFixture>
     {
-        protected AbstractInteractiveCSharpCompletionProviderTests(InteractiveCSharpTestWorkspaceFixture workspaceFixture)
-            : base(workspaceFixture)
+        protected AbstractInteractiveCSharpCompletionProviderTests()
         {
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AttributeNamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AttributeNamedParameterCompletionProviderTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
 {
     public class AttributeNamedParameterCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public AttributeNamedParameterCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(AttributeNamedParameterCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -23,10 +23,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class CrefCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public CrefCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(CrefCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.NamingStyles;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
@@ -24,10 +23,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
 {
     public class DeclarationNameCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public DeclarationNameCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(DeclarationNameCompletionProvider);
 
@@ -1439,7 +1434,9 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task DisabledByOption()
         {
-            var workspace = WorkspaceFixture.GetWorkspace(ExportProvider);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.
                 WithChangedOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp, false)));
 
@@ -1624,7 +1621,9 @@ public class Class1
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CustomNamingStyleInsideClass()
         {
-            var workspace = WorkspaceFixture.GetWorkspace(ExportProvider);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                 new OptionKey2(NamingStyleOptions.NamingPreferences, LanguageNames.CSharp),
                 NamesEndWithSuffixPreferences())));
@@ -1648,7 +1647,9 @@ class Configuration
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CustomNamingStyleInsideMethod()
         {
-            var workspace = WorkspaceFixture.GetWorkspace(ExportProvider);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                 new OptionKey2(NamingStyleOptions.NamingPreferences, LanguageNames.CSharp),
                 NamesEndWithSuffixPreferences())));
@@ -2064,7 +2065,9 @@ class ClassA
         [WorkItem(43816, "https://github.com/dotnet/roslyn/pull/43816")]
         public async Task ConflictingLocalVariable()
         {
-            var workspace = WorkspaceFixture.GetWorkspace(ExportProvider);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                 new OptionKey2(NamingStyleOptions.NamingPreferences, LanguageNames.CSharp),
                 MultipleCamelCaseLocalRules())));

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -14,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class EnumAndCompletionListTagCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public EnumAndCompletionListTagCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(EnumAndCompletionListTagCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -14,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class ExplicitInterfaceMemberCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public ExplicitInterfaceMemberCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(ExplicitInterfaceMemberCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -14,11 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class ExplicitInterfaceTypeCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public ExplicitInterfaceTypeCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture)
-            : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(ExplicitInterfaceTypeCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -21,10 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [UseExportProvider]
     public class ExtensionMethodImportCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public ExtensionMethodImportCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         private const string NonBreakingSpaceString = "\x00A0";
 
         private bool? ShowImportCompletionItemsOptionValue { get; set; } = true;

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExternAliasCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExternAliasCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -14,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class ExternAliasCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public ExternAliasCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(ExternAliasCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/FunctionPointerUnmanagedCallingConventionCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/FunctionPointerUnmanagedCallingConventionCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -14,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [Trait(Traits.Feature, Traits.Features.Completion)]
     public class FunctionPointerUnmanagedCallingConventionCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public FunctionPointerUnmanagedCallingConventionCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType() => typeof(FunctionPointerUnmanagedCallingConventionCompletionProvider);
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.Completion
 {
     public class KeywordCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public KeywordCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(KeywordCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/LoadDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/LoadDirectiveCompletionProviderTests.cs
@@ -17,10 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [Trait(Traits.Feature, Traits.Features.Completion)]
     public class LoadDirectiveCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public LoadDirectiveCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(LoadDirectiveCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
 {
     public class NamedParameterCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public NamedParameterCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(NamedParameterCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -15,10 +14,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class ObjectCreationCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public ObjectCreationCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(ObjectCreationCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -17,10 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class ObjectInitializerCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public ObjectInitializerCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(ObjectAndWithInitializerCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -23,10 +23,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class OverrideCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public OverrideCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(OverrideCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
@@ -6,7 +6,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -18,10 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     // expression-body members. This class does the opposite.
     public class OverrideCompletionProviderTests_ExpressionBody : AbstractCSharpCompletionProviderTests
     {
-        public OverrideCompletionProviderTests_ExpressionBody(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(OverrideCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class PartialMethodCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public PartialMethodCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(PartialMethodCompletionProvider);
 
@@ -780,7 +775,9 @@ partial class Bar
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task ExpressionBodyMethod()
         {
-            var workspace = WorkspaceFixture.GetWorkspace(ExportProvider);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                 CSharpCodeStyleOptions.PreferExpressionBodiedMethods,
                 new CodeStyleOption2<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption2.Silent))));
@@ -809,7 +806,9 @@ partial class Bar
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task ExpressionBodyMethodExtended()
         {
-            var workspace = WorkspaceFixture.GetWorkspace(ExportProvider);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                 CSharpCodeStyleOptions.PreferExpressionBodiedMethods,
                 new CodeStyleOption2<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption2.Silent))));

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialTypeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialTypeCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -13,10 +12,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class PartialTypeCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public PartialTypeCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(PartialTypeCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -15,10 +14,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [Trait(Traits.Feature, Traits.Features.Completion)]
     public class PropertySubpatternCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public PropertySubpatternCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(PropertySubpatternCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ReferenceDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ReferenceDirectiveCompletionProviderTests.cs
@@ -21,11 +21,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [Trait(Traits.Feature, Traits.Features.Completion)]
     public class ReferenceDirectiveCompletionProviderTests : AbstractInteractiveCSharpCompletionProviderTests
     {
-        public ReferenceDirectiveCompletionProviderTests(InteractiveCSharpTestWorkspaceFixture workspaceFixture)
-            : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(ReferenceDirectiveCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
@@ -8,11 +8,9 @@ using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Composition;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -20,10 +18,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class SnippetCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public SnippetCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(SnippetCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SpeculativeTCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SpeculativeTCompletionProviderTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -15,10 +14,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class SpeculativeTCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public SpeculativeTCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(SpeculativeTCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -18,11 +18,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class SuggestionModeCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public SuggestionModeCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture)
-            : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(CSharpSuggestionModeCompletionProvider);
 
@@ -1359,8 +1354,7 @@ class C
         {
             MarkupTestFile.GetPosition(markup, out var code, out int position);
 
-            using var workspaceFixture = new CSharpTestWorkspaceFixture();
-            try
+            using (var workspaceFixture = new CSharpTestWorkspaceFixture())
             {
                 workspaceFixture.GetWorkspace(ExportProvider);
                 var document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular);
@@ -1371,10 +1365,6 @@ class C
                     var document2 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular, cleanBeforeUpdate: false);
                     await CheckResultsAsync(document2, position, isBuilder);
                 }
-            }
-            finally
-            {
-                workspaceFixture.DisposeAfterTest();
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10,10 +10,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -24,10 +22,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
     [UseExportProvider]
     public partial class SymbolCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public SymbolCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(SymbolCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
@@ -20,10 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
 {
     public class SymbolCompletionProviderTests_NoInteractive : AbstractCSharpCompletionProviderTests
     {
-        public SymbolCompletionProviderTests_NoInteractive(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(SymbolCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TupleNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TupleNameCompletionProviderTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -14,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
 {
     public class TupleNameCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public TupleNameCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType() => typeof(TupleNameCompletionProvider);
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -9,11 +9,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Composition;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -22,10 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [UseExportProvider]
     public class TypeImportCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public TypeImportCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(TypeImportCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -17,10 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public class XmlDocumentationCommentCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public XmlDocumentationCommentCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetCompletionProviderType()
             => typeof(XmlDocCommentCompletionProvider);
 

--- a/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
@@ -13,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RefactoringHelpers
 {
     public partial class RefactoringHelpersTests : RefactoringHelpersTestBase<CSharpTestWorkspaceFixture>
     {
-        public RefactoringHelpersTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         #region Locations
         [Fact]
         [WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")]

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AbstractCSharpSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AbstractCSharpSignatureHelpProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public abstract class AbstractCSharpSignatureHelpProviderTests : AbstractSignatureHelpProviderTests<CSharpTestWorkspaceFixture>
     {
-        protected AbstractCSharpSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        protected AbstractCSharpSignatureHelpProviderTests()
         {
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -17,10 +16,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class AttributeSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public AttributeSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(AttributeSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class ConstructorInitializerSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public ConstructorInitializerSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(ConstructorInitializerSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class ElementAccessExpressionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public ElementAccessExpressionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(ElementAccessExpressionSignatureHelpProvider);
 
@@ -801,10 +796,6 @@ class C
 
         public class IncompleteElementAccessExpressionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
         {
-            public IncompleteElementAccessExpressionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-            {
-            }
-
             internal override Type GetSignatureHelpProviderType()
                 => typeof(ElementAccessExpressionSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -17,10 +16,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class GenericNamePartiallyWrittenSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public GenericNamePartiallyWrittenSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(GenericNamePartiallyWrittenSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -17,10 +16,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class GenericNameSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public GenericNameSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(GenericNameSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InitializerExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InitializerExpressionSignatureHelpProviderTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class InitializerExpressionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public InitializerExpressionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(InitializerExpressionSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -18,10 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class InvocationExpressionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public InvocationExpressionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(InvocationExpressionSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class ObjectCreationExpressionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public ObjectCreationExpressionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(ObjectCreationExpressionSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/PrimaryConstructorBaseTypeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/PrimaryConstructorBaseTypeSignatureHelpProviderTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -15,10 +14,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class PrimaryConstructorBaseTypeSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public PrimaryConstructorBaseTypeSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(PrimaryConstructorBaseTypeSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,10 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
 {
     public class TupleConstructionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
     {
-        public TupleConstructionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         internal override Type GetSignatureHelpProviderType()
             => typeof(TupleConstructionSignatureHelpProvider);
 

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.Delegate.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.Delegate.cs
@@ -16,9 +16,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TypeInferrer
     {
         private async Task TestDelegateAsync(string text, string expectedType)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             MarkupTestFile.GetSpan(text, out text, out var textSpan);
 
-            var document = fixture.UpdateDocument(text, SourceCodeKind.Regular);
+            var document = workspaceFixture.Target.UpdateDocument(text, SourceCodeKind.Regular);
 
             var root = await document.GetSyntaxRootAsync();
             var node = FindExpressionSyntaxFromSpan(root, textSpan);

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -19,10 +19,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TypeInferrer
 {
     public partial class TypeInferrerTests : TypeInferrerTestBase<CSharpTestWorkspaceFixture>
     {
-        public TypeInferrerTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
-        {
-        }
-
         protected override async Task TestWorkerAsync(Document document, TextSpan textSpan, string expectedType, TestMode mode)
         {
             var root = await document.GetSyntaxRootAsync();

--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheServiceFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
@@ -15,10 +16,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
     {
         private const int ImplicitCacheTimeoutInMS = 10000;
 
+        private readonly IAsynchronousOperationListenerProvider _listenerProvider;
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public ProjectCacheHostServiceFactory()
+        public ProjectCacheHostServiceFactory(IAsynchronousOperationListenerProvider listenerProvider)
         {
+            _listenerProvider = listenerProvider;
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
@@ -28,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
                 return new ProjectCacheService(workspaceServices.Workspace);
             }
 
-            var service = new ProjectCacheService(workspaceServices.Workspace, ImplicitCacheTimeoutInMS);
+            var service = new ProjectCacheService(workspaceServices.Workspace, _listenerProvider, ImplicitCacheTimeoutInMS);
 
             // Also clear the cache when the solution is cleared or removed.
             workspaceServices.Workspace.WorkspaceChanged += (s, e) =>

--- a/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             // Putting cacheService.CreateStrongReference in a using statement
             // creates a temporary local that isn't collected in Debug builds
             // Wrapping it in a lambda allows it to get collected.
-            var cacheService = new ProjectCacheService(null, int.MaxValue);
+            var cacheService = new ProjectCacheService(workspace: null, AsynchronousOperationListenerProvider.NullProvider, int.MaxValue);
             var projectId = ProjectId.CreateNewId();
             var owner = new Owner();
             var instance = ObjectReference.CreateFromFactory(() => new object());
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public void TestImplicitCacheKeepsObjectAlive1()
         {
             var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
-            var cacheService = new ProjectCacheService(workspace, int.MaxValue);
+            var cacheService = new ProjectCacheService(workspace, AsynchronousOperationListenerProvider.NullProvider, int.MaxValue);
             var reference = ObjectReference.CreateFromFactory(() => new object());
             reference.UseReference(r => cacheService.CacheObjectIfCachingEnabledForKey(ProjectId.CreateNewId(), (object)null, r));
             reference.AssertHeld();
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public void TestImplicitCacheMonitoring()
         {
             var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
-            var cacheService = new ProjectCacheService(workspace, 10);
+            var cacheService = new ProjectCacheService(workspace, AsynchronousOperationListenerProvider.NullProvider, 10);
             var weak = PutObjectInImplicitCache(cacheService);
 
             weak.AssertReleased();
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             var instanceTracker = ObjectReference.CreateFromFactory(() => new object());
 
-            var cacheService = new ProjectCacheService(workspace, int.MaxValue);
+            var cacheService = new ProjectCacheService(workspace, AsynchronousOperationListenerProvider.NullProvider, int.MaxValue);
             using (var cache = cacheService.EnableCaching(project2.Id))
             {
                 instanceTracker.UseReference(r => cacheService.CacheObjectIfCachingEnabledForKey(project1.Id, (object)null, r));
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var weakLast = ObjectReference.Create(compilations[compilations.Count - 1]);
 
             var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
-            var cache = new ProjectCacheService(workspace, int.MaxValue);
+            var cache = new ProjectCacheService(workspace, AsynchronousOperationListenerProvider.NullProvider, int.MaxValue);
             for (var i = 0; i < ProjectCacheService.ImplicitCacheSize + 1; i++)
             {
                 cache.CacheObjectIfCachingEnabledForKey(ProjectId.CreateNewId(), (object)null, compilations[i]);
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var weak1 = ObjectReference.Create(comp1);
 
             var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
-            var cache = new ProjectCacheService(workspace, int.MaxValue);
+            var cache = new ProjectCacheService(workspace, AsynchronousOperationListenerProvider.NullProvider, int.MaxValue);
             var key = ProjectId.CreateNewId();
             var owner = new object();
             cache.CacheObjectIfCachingEnabledForKey(key, owner, comp1);

--- a/src/EditorFeatures/TestUtilities/RefactoringHelpers/RefactoringHelpersTestBase.cs
+++ b/src/EditorFeatures/TestUtilities/RefactoringHelpers/RefactoringHelpersTestBase.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -20,18 +19,27 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.RefactoringHelpers
 {
     [UseExportProvider]
-    public abstract class RefactoringHelpersTestBase<TWorkspaceFixture> : TestBase, IClassFixture<TWorkspaceFixture>, IDisposable
+    public abstract class RefactoringHelpersTestBase<TWorkspaceFixture> : TestBase
         where TWorkspaceFixture : TestWorkspaceFixture, new()
     {
-        protected readonly TWorkspaceFixture fixture;
+        private readonly object _workspaceFixtureGate = new();
+        private ReferenceCountedDisposable<TWorkspaceFixture>.WeakReference _weakWorkspaceFixture;
 
-        protected RefactoringHelpersTestBase(TWorkspaceFixture workspaceFixture)
-            => this.fixture = workspaceFixture;
-
-        public override void Dispose()
+        protected RefactoringHelpersTestBase()
         {
-            this.fixture.DisposeAfterTest();
-            base.Dispose();
+        }
+
+        private protected ReferenceCountedDisposable<TWorkspaceFixture> GetOrCreateWorkspaceFixture()
+        {
+            lock (_workspaceFixtureGate)
+            {
+                if (_weakWorkspaceFixture.TryAddReference() is { } workspaceFixture)
+                    return workspaceFixture;
+
+                var result = new ReferenceCountedDisposable<TWorkspaceFixture>(new TWorkspaceFixture());
+                _weakWorkspaceFixture = new ReferenceCountedDisposable<TWorkspaceFixture>.WeakReference(result);
+                return result;
+            }
         }
 
         protected Task TestAsync<TNode>(string text) where TNode : SyntaxNode => TestAsync<TNode>(text, Functions<TNode>.True);
@@ -105,7 +113,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RefactoringHelpers
 
         private async Task<TNode> GetNodeForSelectionAsync<TNode>(string text, TextSpan selection, Func<TNode, bool> predicate) where TNode : SyntaxNode
         {
-            var document = fixture.UpdateDocument(text, SourceCodeKind.Regular);
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var document = workspaceFixture.Target.UpdateDocument(text, SourceCodeKind.Regular);
             var relevantNodes = await document.GetRelevantNodesAsync<TNode>(selection, CancellationToken.None).ConfigureAwait(false);
 
             return relevantNodes.FirstOrDefault(predicate);

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -25,20 +25,29 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 {
     [UseExportProvider]
-    public abstract class AbstractSignatureHelpProviderTests<TWorkspaceFixture> : TestBase, IClassFixture<TWorkspaceFixture>
+    public abstract class AbstractSignatureHelpProviderTests<TWorkspaceFixture> : TestBase
         where TWorkspaceFixture : TestWorkspaceFixture, new()
     {
-        protected TWorkspaceFixture workspaceFixture;
+        private readonly object _workspaceFixtureGate = new();
+        private ReferenceCountedDisposable<TWorkspaceFixture>.WeakReference _weakWorkspaceFixture;
 
         internal abstract Type GetSignatureHelpProviderType();
 
-        protected AbstractSignatureHelpProviderTests(TWorkspaceFixture workspaceFixture)
-            => this.workspaceFixture = workspaceFixture;
-
-        public override void Dispose()
+        protected AbstractSignatureHelpProviderTests()
         {
-            this.workspaceFixture.DisposeAfterTest();
-            base.Dispose();
+        }
+
+        private protected ReferenceCountedDisposable<TWorkspaceFixture> GetOrCreateWorkspaceFixture()
+        {
+            lock (_workspaceFixtureGate)
+            {
+                if (_weakWorkspaceFixture.TryAddReference() is { } workspaceFixture)
+                    return workspaceFixture;
+
+                var result = new ReferenceCountedDisposable<TWorkspaceFixture>(new TWorkspaceFixture());
+                _weakWorkspaceFixture = new ReferenceCountedDisposable<TWorkspaceFixture>.WeakReference(result);
+                return result;
+            }
         }
 
         /// <summary>
@@ -57,6 +66,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             SourceCodeKind? sourceCodeKind = null,
             bool experimental = false)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             if (sourceCodeKind.HasValue)
             {
                 await TestSignatureHelpWorkerAsync(markup, sourceCodeKind.Value, experimental, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
@@ -75,6 +86,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             IEnumerable<SignatureHelpTestItem> expectedOrderedItemsOrNull = null,
             bool usePreviousCharAsTrigger = false)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             markupWithPositionAndOptSpan = markupWithPositionAndOptSpan.NormalizeLineEndings();
 
             TextSpan? textSpan = null;
@@ -92,24 +105,24 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             var parseOptions = CreateExperimentalParseOptions();
 
             // regular
-            var document1 = workspaceFixture.UpdateDocument(code, sourceCodeKind);
+            var document1 = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind);
             if (experimental)
             {
                 document1 = document1.Project.WithParseOptions(parseOptions).GetDocument(document1.Id);
             }
 
-            await TestSignatureHelpWorkerSharedAsync(workspaceFixture.GetWorkspace(), code, cursorPosition, document1, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
+            await TestSignatureHelpWorkerSharedAsync(workspaceFixture.Target.GetWorkspace(), code, cursorPosition, document1, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
 
             // speculative semantic model
             if (await CanUseSpeculativeSemanticModelAsync(document1, cursorPosition))
             {
-                var document2 = workspaceFixture.UpdateDocument(code, sourceCodeKind, cleanBeforeUpdate: false);
+                var document2 = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind, cleanBeforeUpdate: false);
                 if (experimental)
                 {
                     document2 = document2.Project.WithParseOptions(parseOptions).GetDocument(document2.Id);
                 }
 
-                await TestSignatureHelpWorkerSharedAsync(workspaceFixture.GetWorkspace(), code, cursorPosition, document2, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
+                await TestSignatureHelpWorkerSharedAsync(workspaceFixture.Target.GetWorkspace(), code, cursorPosition, document2, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
             }
         }
 
@@ -125,8 +138,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 
         protected void VerifyTriggerCharacters(char[] expectedTriggerCharacters, char[] unexpectedTriggerCharacters)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             var signatureHelpProviderType = GetSignatureHelpProviderType();
-            var signatureHelpProvider = workspaceFixture.GetWorkspace().ExportProvider.GetExportedValues<ISignatureHelpProvider>().Single(provider => provider.GetType() == signatureHelpProviderType);
+            var signatureHelpProvider = workspaceFixture.Target.GetWorkspace().ExportProvider.GetExportedValues<ISignatureHelpProvider>().Single(provider => provider.GetType() == signatureHelpProviderType);
 
             foreach (var expectedTriggerCharacter in expectedTriggerCharacters)
             {
@@ -141,6 +156,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 
         protected virtual async Task VerifyCurrentParameterNameAsync(string markup, string expectedParameterName, SourceCodeKind? sourceCodeKind = null)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             if (sourceCodeKind.HasValue)
             {
                 await VerifyCurrentParameterNameWorkerAsync(markup, expectedParameterName, sourceCodeKind.Value);
@@ -160,12 +177,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 
         private async Task VerifyCurrentParameterNameWorkerAsync(string markup, string expectedParameterName, SourceCodeKind sourceCodeKind)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out var code, out int cursorPosition);
 
-            var document = workspaceFixture.UpdateDocument(code, sourceCodeKind);
+            var document = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind);
 
             var signatureHelpProviderType = GetSignatureHelpProviderType();
-            var signatureHelpProvider = workspaceFixture.GetWorkspace().ExportProvider.GetExportedValues<ISignatureHelpProvider>().Single(provider => provider.GetType() == signatureHelpProviderType);
+            var signatureHelpProvider = workspaceFixture.Target.GetWorkspace().ExportProvider.GetExportedValues<ISignatureHelpProvider>().Single(provider => provider.GetType() == signatureHelpProviderType);
             var triggerInfo = new SignatureHelpTriggerInfo(SignatureHelpTriggerReason.InvokeSignatureHelpCommand);
             _ = await signatureHelpProvider.GetItemsAsync(document, cursorPosition, triggerInfo, CancellationToken.None);
             Assert.Equal(expectedParameterName, (await GetArgumentStateAsync(cursorPosition, document, signatureHelpProvider, triggerInfo)).ArgumentName);

--- a/src/EditorFeatures/TestUtilities/TypeInferrer/TypeInferrerTestBase.cs
+++ b/src/EditorFeatures/TestUtilities/TypeInferrer/TypeInferrerTestBase.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -10,23 +9,32 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
-using Xunit;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.TypeInferrer
 {
     [UseExportProvider]
-    public abstract class TypeInferrerTestBase<TWorkspaceFixture> : TestBase, IClassFixture<TWorkspaceFixture>, IDisposable
+    public abstract class TypeInferrerTestBase<TWorkspaceFixture> : TestBase
         where TWorkspaceFixture : TestWorkspaceFixture, new()
     {
-        protected readonly TWorkspaceFixture fixture;
+        private readonly object _workspaceFixtureGate = new();
+        private ReferenceCountedDisposable<TWorkspaceFixture>.WeakReference _weakWorkspaceFixture;
 
-        protected TypeInferrerTestBase(TWorkspaceFixture workspaceFixture)
-            => this.fixture = workspaceFixture;
-
-        public override void Dispose()
+        protected TypeInferrerTestBase()
         {
-            this.fixture.DisposeAfterTest();
-            base.Dispose();
+        }
+
+        private protected ReferenceCountedDisposable<TWorkspaceFixture> GetOrCreateWorkspaceFixture()
+        {
+            lock (_workspaceFixtureGate)
+            {
+                if (_weakWorkspaceFixture.TryAddReference() is { } workspaceFixture)
+                    return workspaceFixture;
+
+                var result = new ReferenceCountedDisposable<TWorkspaceFixture>(new TWorkspaceFixture());
+                _weakWorkspaceFixture = new ReferenceCountedDisposable<TWorkspaceFixture>.WeakReference(result);
+                return result;
+            }
         }
 
         private static async Task<bool> CanUseSpeculativeSemanticModelAsync(Document document, int position)
@@ -56,14 +64,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.TypeInferrer
         protected async Task TestAsync(string text, string expectedType, TestMode mode,
             SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
+            using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
             MarkupTestFile.GetSpan(text.NormalizeLineEndings(), out text, out var textSpan);
 
-            var document = fixture.UpdateDocument(text, sourceCodeKind);
+            var document = workspaceFixture.Target.UpdateDocument(text, sourceCodeKind);
             await TestWorkerAsync(document, textSpan, expectedType, mode);
 
             if (await CanUseSpeculativeSemanticModelAsync(document, textSpan.Start))
             {
-                var document2 = fixture.UpdateDocument(text, sourceCodeKind, cleanBeforeUpdate: false);
+                var document2 = workspaceFixture.Target.UpdateDocument(text, sourceCodeKind, cleanBeforeUpdate: false);
                 await TestWorkerAsync(document2, textSpan, expectedType, mode);
             }
         }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -62,9 +62,20 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public void Dispose()
         {
-            if (_workspace != null)
+            if (_workspace is null)
+                return;
+
+            try
             {
-                throw new InvalidOperationException($"Tests which use {nameof(TestWorkspaceFixture)}.{nameof(GetWorkspace)} must call {nameof(DisposeAfterTest)} after each test.");
+                CloseTextView();
+                _currentDocument = null;
+                Code = null;
+                Position = 0;
+                _workspace?.Dispose();
+            }
+            finally
+            {
+                _workspace = null;
             }
         }
 
@@ -92,22 +103,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             {
                 edit.Replace(0, textBuffer.CurrentSnapshot.Length, text);
                 edit.Apply();
-            }
-        }
-
-        public void DisposeAfterTest()
-        {
-            try
-            {
-                CloseTextView();
-                _currentDocument = null;
-                Code = null;
-                Position = 0;
-                _workspace?.Dispose();
-            }
-            finally
-            {
-                _workspace = null;
             }
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
@@ -5,7 +5,6 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifications
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Remote.Testing
 Imports Microsoft.CodeAnalysis.Text
 
@@ -14,11 +13,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
     Public Class SemanticClassifierTests
         Inherits AbstractVisualBasicClassifierTests
 
-        Protected Overrides Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableArray(Of ClassifiedSpan))
+        Protected Overrides Async Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableArray(Of ClassifiedSpan))
             Using workspace = CreateWorkspace(code, testHost)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
 
-                Return GetSemanticClassificationsAsync(document, span)
+                Return Await GetSemanticClassificationsAsync(document, span)
             End Using
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -13,10 +13,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
     Public Class SyntacticClassifierTests
         Inherits AbstractVisualBasicClassifierTests
 
-        Protected Overrides Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableArray(Of ClassifiedSpan))
+        Protected Overrides Async Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableArray(Of ClassifiedSpan))
             Using workspace = CreateWorkspace(code, testHost)
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
-                Return GetSyntacticClassificationsAsync(document, span)
+                Return Await GetSyntacticClassificationsAsync(document, span)
             End Using
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -15,8 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
     Public MustInherit Class AbstractVisualBasicCompletionProviderTests
         Inherits AbstractCompletionProviderTests(Of VisualBasicTestWorkspaceFixture)
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
+        Protected Sub New()
         End Sub
 
         Protected Overrides Function CreateWorkspace(fileContents As String) As TestWorkspace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class CompletionListTagCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestEditorBrowsable_EnumTypeDotMemberAlways() As Task

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -12,10 +12,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
     Public Class CrefCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
-
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(CrefCompletionProvider)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/EnumCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/EnumCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class EnumCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(EnumCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ExtensionMethodImportCompletionProviderTests.vb
@@ -3,20 +3,14 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
-Imports Microsoft.VisualStudio.Composition
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
 
     <UseExportProvider>
     Public Class ExtensionMethodImportCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Private Property IsExpandedCompletion As Boolean = True
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/HandlesClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/HandlesClauseCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class HandlesClauseCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(HandlesClauseCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
@@ -10,10 +10,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
     Public Class ImplementsClauseCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
-
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(ImplementsClauseCompletionProvider)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class KeywordCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(KeywordCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class NamedParameterCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(NamedParameterCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class ObjectCreationCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(ObjectCreationCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
@@ -12,10 +12,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
     Public Class ObjectInitializerCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
-
         Private Protected Overrides Async Function VerifyWorkerAsync(
                 code As String, position As Integer,
                 expectedItemOrNull As String, expectedDescriptionOrNull As String,

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -12,10 +12,6 @@ Namespace Tests
     Public Class OverrideCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
-
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(OverrideCompletionProvider)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/PartialTypeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/PartialTypeCompletionProviderTests.vb
@@ -2,16 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class PartialTypeCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(PartialTypeCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -5,7 +5,6 @@
 Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
@@ -14,10 +13,6 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Completion.SuggestionMode
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     Public Class SuggestionModeCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestFieldDeclaration1() As Task
@@ -377,26 +372,22 @@ End Class</a>
             MarkupTestFile.GetPosition(markup.NormalizedValue, code, position)
 
             Using workspaceFixture = New VisualBasicTestWorkspaceFixture()
-                Try
-                    Dim options = workspaceFixture.GetWorkspace(ExportProvider).Options
+                Dim options = workspaceFixture.GetWorkspace(ExportProvider).Options
 
-                    If useDebuggerOptions Then
-                        options = options.
-                            WithChangedOption(CompletionControllerOptions.FilterOutOfScopeLocals, False).
-                            WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, False).
-                            WithChangedOption(CompletionServiceOptions.DisallowAddingImports, True)
-                    End If
+                If useDebuggerOptions Then
+                    options = options.
+                        WithChangedOption(CompletionControllerOptions.FilterOutOfScopeLocals, False).
+                        WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, False).
+                        WithChangedOption(CompletionServiceOptions.DisallowAddingImports, True)
+                End If
 
-                    Dim document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular)
-                    Await CheckResultsAsync(document1, position, isBuilder, triggerInfo, options)
+                Dim document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular)
+                Await CheckResultsAsync(document1, position, isBuilder, triggerInfo, options)
 
-                    If Await CanUseSpeculativeSemanticModelAsync(document1, position) Then
-                        Dim document2 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular, cleanBeforeUpdate:=False)
-                        Await CheckResultsAsync(document2, position, isBuilder, triggerInfo, options)
-                    End If
-                Finally
-                    workspaceFixture.DisposeAfterTest()
-                End Try
+                If Await CanUseSpeculativeSemanticModelAsync(document1, position) Then
+                    Dim document2 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular, cleanBeforeUpdate:=False)
+                    Await CheckResultsAsync(document2, position, isBuilder, triggerInfo, options)
+                End If
             End Using
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -15,10 +15,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Private Const s_unicodeEllipsis = ChrW(&H2026)
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
-
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(SymbolCompletionProvider)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.vb
@@ -3,20 +3,14 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
-Imports Microsoft.VisualStudio.Composition
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
 
     <UseExportProvider>
     Public Class TypeImportCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Private Property ShowImportCompletionItemsOptionValue As Boolean = True
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -4,7 +4,6 @@
 
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data
@@ -12,10 +11,6 @@ Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data
 Namespace Tests
     Public Class XmlDocCommentCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetCompletionProviderType() As Type
             Return GetType(XmlDocCommentCompletionProvider)

--- a/src/EditorFeatures/VisualBasicTest/RefactoringHelpers/RefactoringHelpersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RefactoringHelpers/RefactoringHelpersTests.vb
@@ -2,17 +2,13 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.RefactoringHelpers
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.RefactoringHelpers
     Partial Public Class RefactoringHelpersTests
         Inherits RefactoringHelpersTestBase(Of VisualBasicTestWorkspaceFixture)
-
-        Public Sub New(ByVal workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         <Fact>
         <WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")>

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/AbstractVisualBasicSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/AbstractVisualBasicSignatureHelpProviderTests.vb
@@ -11,8 +11,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
 
         ' We want to skip script testing in all VB stuff for now.
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
+        Protected Sub New()
         End Sub
 
         Protected Overrides Function TestAsync(markupWithPositionAndOptSpan As String, Optional expectedOrderedItemsOrNull As IEnumerable(Of SignatureHelpTestItem) = Nothing, Optional usePreviousCharAsTrigger As Boolean = False, Optional sourceCodeKind As Microsoft.CodeAnalysis.SourceCodeKind? = Nothing, Optional experimental As Boolean = False) As Threading.Tasks.Task

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/AddRemoveHandlerSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/AddRemoveHandlerSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class AddRemoveHandlerSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(AddRemoveHandlerSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/AttributeSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/AttributeSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class AttributeSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(AttributeSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/CastExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/CastExpressionSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class CastExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(CastExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/CollectionInitializerSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/CollectionInitializerSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class CollectionInitializerSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(CollectionInitializerSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/ConditionalExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/ConditionalExpressionSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class BinaryConditionalExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(BinaryConditionalExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/FunctionAggregationSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/FunctionAggregationSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class FunctionAggregationSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(FunctionAggregationSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/GenericNameSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/GenericNameSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class GenericNameSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(GenericNameSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetTypeExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetTypeExpressionSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class GetTypeExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(GetTypeExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetXmlNamespaceExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/GetXmlNamespaceExpressionSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class GetXmlNamespaceExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(GetXmlNamespaceExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class InvocationExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(InvocationExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/MidAssignmentSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/MidAssignmentSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class MidAssignmentSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(MidAssignmentSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.vb
@@ -3,17 +3,12 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
 
     Public Class ObjectCreationExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(ObjectCreationExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/PredefinedCastExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/PredefinedCastExpressionSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class PredefinedCastExpressionSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(PredefinedCastExpressionSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/RaiseEventStatementSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/RaiseEventStatementSignatureHelpProviderTests.vb
@@ -3,16 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SignatureHelp
     Public Class RaiseEventStatementSignatureHelpProviderTests
         Inherits AbstractVisualBasicSignatureHelpProviderTests
-
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
 
         Friend Overrides Function GetSignatureHelpProviderType() As Type
             Return GetType(RaiseEventStatementSignatureHelpProvider)

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -15,10 +15,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TypeInferrer
     Partial Public Class TypeInferrerTests
         Inherits TypeInferrerTestBase(Of VisualBasicTestWorkspaceFixture)
 
-        Public Sub New(workspaceFixture As VisualBasicTestWorkspaceFixture)
-            MyBase.New(workspaceFixture)
-        End Sub
-
         Protected Overrides Async Function TestWorkerAsync(document As Document, textSpan As TextSpan, expectedType As String, testMode As TestMode) As Task
             Dim root = Await document.GetSyntaxRootAsync()
             Dim node = FindExpressionSyntaxFromSpan(root, textSpan)

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
@@ -91,10 +91,8 @@ namespace Microsoft.CodeAnalysis.Host
             private readonly ProjectCacheService _owner;
             private readonly SemaphoreSlim _gate;
 
-            public ImplicitCacheMonitor(ProjectCacheService owner, int backOffTimeSpanInMS)
-                : base(AsynchronousOperationListenerProvider.NullListener,
-                       backOffTimeSpanInMS,
-                       CancellationToken.None)
+            public ImplicitCacheMonitor(ProjectCacheService owner, IAsynchronousOperationListener listener, int backOffTimeSpanInMS, CancellationToken cancellationToken)
+                : base(listener, backOffTimeSpanInMS, cancellationToken)
             {
                 _owner = owner;
                 _gate = new SemaphoreSlim(0);

--- a/src/VisualStudio/CSharp/Test/CodeModel/AbstractFileCodeElementTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/AbstractFileCodeElementTests.cs
@@ -21,29 +21,34 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
     public abstract class AbstractFileCodeElementTests : IDisposable
     {
         private readonly string _contents;
-        private Tuple<TestWorkspace, FileCodeModel> _workspaceAndCodeModel;
+        private (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, FileCodeModel fileCodeModel)? _workspaceAndCodeModel;
 
         public AbstractFileCodeElementTests(string contents)
         {
             _contents = contents;
         }
 
-        public Tuple<TestWorkspace, FileCodeModel> WorkspaceAndCodeModel
+        public (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, FileCodeModel fileCodeModel) WorkspaceAndCodeModel
         {
             get
             {
-                return _workspaceAndCodeModel ?? (_workspaceAndCodeModel = CreateWorkspaceAndFileCodeModelAsync(_contents));
+                return _workspaceAndCodeModel ??= CreateWorkspaceAndFileCodeModelAsync(_contents);
             }
         }
 
         protected TestWorkspace GetWorkspace()
         {
-            return WorkspaceAndCodeModel.Item1;
+            return WorkspaceAndCodeModel.workspace;
+        }
+
+        private VisualStudioWorkspace GetExtraWorkspaceToDisposeButNotUse()
+        {
+            return WorkspaceAndCodeModel.extraWorkspaceToDisposeButNotUse;
         }
 
         protected FileCodeModel GetCodeModel()
         {
-            return WorkspaceAndCodeModel.Item2;
+            return WorkspaceAndCodeModel.fileCodeModel;
         }
 
         protected Microsoft.CodeAnalysis.Solution GetCurrentSolution()
@@ -55,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
         protected Microsoft.CodeAnalysis.Document GetCurrentDocument()
             => GetCurrentProject().Documents.Single();
 
-        protected static Tuple<TestWorkspace, EnvDTE.FileCodeModel> CreateWorkspaceAndFileCodeModelAsync(string file)
+        protected static (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, FileCodeModel fileCodeModel) CreateWorkspaceAndFileCodeModelAsync(string file)
             => FileCodeModelTestHelpers.CreateWorkspaceAndFileCodeModel(file);
 
         protected CodeElement GetCodeElement(params object[] path)
@@ -79,6 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
 
         public void Dispose()
         {
+            GetExtraWorkspaceToDisposeButNotUse().Dispose();
             GetWorkspace().Dispose();
         }
 

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeModelTestHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeModelTestHelpers.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.UnitTests;
@@ -27,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
         // finalizer complaining we didn't clean it up. Catching AVs is of course not safe, but this is balancing
         // "probably not crash" as an improvement over "will crash when the finalizer throws."
         [HandleProcessCorruptedStateExceptions]
-        public static Tuple<TestWorkspace, EnvDTE.FileCodeModel> CreateWorkspaceAndFileCodeModel(string file)
+        public static (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, EnvDTE.FileCodeModel fileCodeModel) CreateWorkspaceAndFileCodeModel(string file)
         {
             var workspace = TestWorkspace.CreateCSharp(file, composition: VisualStudioTestCompositions.LanguageServices);
 
@@ -59,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
 
                 var codeModel = FileCodeModel.Create(state, null, document, new MockTextManagerAdapter()).Handle;
 
-                return Tuple.Create(workspace, (EnvDTE.FileCodeModel)codeModel);
+                return (workspace, visualStudioWorkspaceMock, codeModel);
             }
             catch
             {

--- a/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
                 Dim mockServiceProvider = New MockServiceProvider(mockComponentModel)
                 Dim libraryManager = CreateLibraryManager(mockServiceProvider, mockComponentModel, vsWorkspace)
 
-                result = New TestState(workspace, libraryManager)
+                result = New TestState(workspace, vsWorkspace, libraryManager)
             Finally
                 If result Is Nothing Then
                     workspace.Dispose()

--- a/src/VisualStudio/Core/Test/ObjectBrowser/Helpers.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/Helpers.vb
@@ -15,15 +15,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
             Implements IDisposable
 
             Private ReadOnly _workspace As TestWorkspace
+            Private ReadOnly _visualStudioWorkspace As VisualStudioWorkspace
             Private ReadOnly _libraryManager As AbstractObjectBrowserLibraryManager
 
-            Public Sub New(workspace As TestWorkspace, libraryManager As AbstractObjectBrowserLibraryManager)
+            Public Sub New(workspace As TestWorkspace, visualStudioWorkspace As VisualStudioWorkspace, libraryManager As AbstractObjectBrowserLibraryManager)
                 _workspace = workspace
+                _visualStudioWorkspace = visualStudioWorkspace
                 _libraryManager = libraryManager
             End Sub
 
             Public Sub Dispose() Implements IDisposable.Dispose
                 _libraryManager.Dispose()
+                _visualStudioWorkspace.Dispose()
                 _workspace.Dispose()
             End Sub
 

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
@@ -86,6 +86,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
             If Not Me._disposedValue Then
                 If disposing Then
+                    VisualStudioWorkspace.Dispose()
                     Workspace.Dispose()
                 End If
             End If

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Microsoft.CodeAnalysis.Host.HostWorkspaceServices.Dispose() -> void

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute_Names.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute_Names.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public const string NavigationBar = nameof(NavigationBar);
         public const string Outlining = nameof(Outlining);
         public const string PackageInstaller = nameof(PackageInstaller);
+        public const string ProjectCache = nameof(ProjectCache);
         public const string QuickInfo = nameof(QuickInfo);
         public const string ReferenceHighlighting = nameof(ReferenceHighlighting);
         public const string Rename = nameof(Rename);

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// Per workspace services provided by the host environment.
     /// </summary>
-    public abstract class HostWorkspaceServices
+    public abstract class HostWorkspaceServices : IDisposable
     {
         /// <summary>
         /// The host services this workspace services originated from.
@@ -32,6 +33,11 @@ namespace Microsoft.CodeAnalysis.Host
         /// If the host does not provide the service, this method returns null.
         /// </summary>
         public abstract TWorkspaceService? GetService<TWorkspaceService>() where TWorkspaceService : IWorkspaceService;
+
+        [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Derived types are not allowed to include a finalizer for this pattern.")]
+        public virtual void Dispose()
+        {
+        }
 
         /// <summary>
         /// Gets a workspace specific service provided by the host identified by the service type. 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -375,6 +375,10 @@ namespace Microsoft.CodeAnalysis
 
             (_optionService as IWorkspaceOptionService)?.OnWorkspaceDisposed(this);
             _optionService.UnregisterWorkspace(this);
+
+            // Dispose per-instance services created for this workspace (direct MEF exports, including factories, will
+            // be disposed when the MEF catalog is disposed).
+            Services.Dispose();
         }
 
         #region Host API

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
@@ -15,7 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote.Testing
 {
-    internal sealed class InProcRemoteHostClientProvider : IRemoteHostClientProvider
+    internal sealed class InProcRemoteHostClientProvider : IRemoteHostClientProvider, IDisposable
     {
         [ExportWorkspaceServiceFactory(typeof(IRemoteHostClientProvider), ServiceLayer.Test), Shared, PartNotDiscoverable]
         internal sealed class Factory : IWorkspaceServiceFactory
@@ -32,20 +32,21 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
         private sealed class WorkspaceManager : RemoteWorkspaceManager
         {
-            private readonly Lazy<RemoteWorkspace> _lazyWorkspace;
-
             public WorkspaceManager(SolutionAssetCache assetStorage, Type[]? additionalRemoteParts)
                 : base(assetStorage)
             {
-                _lazyWorkspace = new Lazy<RemoteWorkspace>(
+                LazyWorkspace = new Lazy<RemoteWorkspace>(
                     () => new RemoteWorkspace(FeaturesTestCompositions.RemoteHost.AddParts(additionalRemoteParts).GetHostServices(), WorkspaceKind.RemoteWorkspace));
             }
 
+            public Lazy<RemoteWorkspace> LazyWorkspace { get; }
+
             public override RemoteWorkspace GetWorkspace()
-                => _lazyWorkspace.Value;
+                => LazyWorkspace.Value;
         }
 
         private readonly HostWorkspaceServices _services;
+        private readonly Lazy<WorkspaceManager> _lazyManager;
         private readonly AsyncLazy<RemoteHostClient> _lazyClient;
 
         public SolutionAssetCache? RemoteAssetStorage { get; }
@@ -55,13 +56,25 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         {
             _services = services;
 
+            _lazyManager = new Lazy<WorkspaceManager>(() => new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts));
             _lazyClient = new AsyncLazy<RemoteHostClient>(
                 cancellationToken => InProcRemoteHostClient.CreateAsync(
                     _services,
-                    new RemoteHostTestData(
-                        new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts),
-                        isInProc: true)),
+                    new RemoteHostTestData(_lazyManager.Value, isInProc: true)),
                 cacheResult: true);
+        }
+
+        public void Dispose()
+        {
+            // Dispose the remote workspace when the owning host workspace is disposed
+            if (_lazyManager.IsValueCreated)
+            {
+                var manager = _lazyManager.Value;
+                if (manager.LazyWorkspace.IsValueCreated)
+                {
+                    manager.LazyWorkspace.Value.Dispose();
+                }
+            }
         }
 
         public Task<RemoteHostClient?> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Host/ProjectCacheHostServiceFactory.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ProjectCacheHostServiceFactory.cs
@@ -8,6 +8,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -17,13 +18,16 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         private const int ImplicitCacheTimeoutInMS = 10000;
 
+        private readonly IAsynchronousOperationListenerProvider _listenerProvider;
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public ProjectCacheHostServiceFactory()
+        public ProjectCacheHostServiceFactory(IAsynchronousOperationListenerProvider listenerProvider)
         {
+            _listenerProvider = listenerProvider;
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-            => new ProjectCacheService(workspaceServices.Workspace, ImplicitCacheTimeoutInMS);
+            => new ProjectCacheService(workspaceServices.Workspace, _listenerProvider, ImplicitCacheTimeoutInMS);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
@@ -282,4 +282,7 @@
   <data name="NotSupported_FixedSizeCollection" xml:space="preserve">
     <value>Collection was of a fixed size.</value>
   </data>
+  <data name="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose" xml:space="preserve">
+    <value>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</value>
+  </data>
 </root>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Předvolby polí</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Einstellungen für Felder</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferencias de campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Préférences de champ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferenze per campi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">フィールド設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">필드 기본 설정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferencje pól</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferências de campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Предпочтения для полей</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Alan tercihleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">字段首选项</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">欄位喜好設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
@@ -8,8 +8,10 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 [assembly: DebuggerTypeProxy(typeof(MefWorkspaceServices.LazyServiceMetadataDebuggerProxy), Target = typeof(ImmutableArray<Lazy<IWorkspaceService, WorkspaceServiceMetadata>>))]
 
@@ -20,11 +22,14 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         private readonly IMefHostExportProvider _exportProvider;
         private readonly Workspace _workspace;
 
-        private readonly ImmutableArray<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> _services;
+        private readonly ImmutableArray<(Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory)> _services;
 
         // map of type name to workspace service
-        private ImmutableDictionary<Type, Lazy<IWorkspaceService, WorkspaceServiceMetadata>> _serviceMap
-            = ImmutableDictionary<Type, Lazy<IWorkspaceService, WorkspaceServiceMetadata>>.Empty;
+        private ImmutableDictionary<Type, (Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory)> _serviceMap
+            = ImmutableDictionary<Type, (Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory)>.Empty;
+
+        private readonly object _gate = new();
+        private readonly HashSet<IDisposable> _ownedDisposableServices = new(ReferenceEqualityComparer.Instance);
 
         // accumulated cache for language services
         private ImmutableDictionary<string, MefLanguageServices> _languageServicesMap
@@ -35,9 +40,10 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             _exportProvider = host;
             _workspace = workspace;
 
-            var services = host.GetExports<IWorkspaceService, WorkspaceServiceMetadata>();
+            var services = host.GetExports<IWorkspaceService, WorkspaceServiceMetadata>()
+                .Select(lz => (lz, usesFactory: false));
             var factories = host.GetExports<IWorkspaceServiceFactory, WorkspaceServiceMetadata>()
-                .Select(lz => new Lazy<IWorkspaceService, WorkspaceServiceMetadata>(() => lz.Value.CreateService(this), lz.Metadata));
+                .Select(lz => (new Lazy<IWorkspaceService, WorkspaceServiceMetadata>(() => lz.Value.CreateService(this), lz.Metadata), usesFactory: true));
 
             _services = services.Concat(factories).ToImmutableArray();
         }
@@ -51,11 +57,56 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 
         public override Workspace Workspace => _workspace;
 
+        public override void Dispose()
+        {
+            ImmutableArray<IDisposable> disposableServices;
+            lock (_gate)
+            {
+                disposableServices = _ownedDisposableServices.ToImmutableArray();
+                _ownedDisposableServices.Clear();
+            }
+
+            foreach (var service in disposableServices)
+            {
+                try
+                {
+                    service.Dispose();
+                }
+                catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceled(ex))
+                {
+                    // Ignored
+                }
+            }
+
+            base.Dispose();
+        }
+
         public override TWorkspaceService GetService<TWorkspaceService>()
         {
             if (TryGetService(typeof(TWorkspaceService), out var service))
             {
-                return (TWorkspaceService)service.Value;
+                // MEF workspace service instances created by a factory are not owned by the MEF catalog or disposed
+                // when the MEF catalog is disposed. Whenever we are potentially going to create an instance of a
+                // service provided by a factory, we need to check if the resulting service implements IDisposable. The
+                // specific conditions here are:
+                //
+                // * usesFactory: This is true when the workspace service is provided by a factory. Services provided
+                //   directly are owned by the MEF catalog so they do not need to be tracked by the workspace.
+                // * IsValueCreated: This will be false at least once prior to accessing the lazy value. Once the value
+                //   is known to be created, we no longer need to try adding it to _ownedDisposableServices, so we use a
+                //   lock-free fast path.
+                var checkAddDisposable = service.usesFactory && !service.lazyService.IsValueCreated;
+
+                var serviceInstance = (TWorkspaceService)service.lazyService.Value;
+                if (checkAddDisposable && serviceInstance is IDisposable disposable)
+                {
+                    lock (_gate)
+                    {
+                        _ownedDisposableServices.Add(disposable);
+                    }
+                }
+
+                return serviceInstance;
             }
             else
             {
@@ -63,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             }
         }
 
-        private bool TryGetService(Type serviceType, out Lazy<IWorkspaceService, WorkspaceServiceMetadata> service)
+        private bool TryGetService(Type serviceType, out (Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory) service)
         {
             if (!_serviceMap.TryGetValue(serviceType, out service))
             {
@@ -72,16 +123,16 @@ namespace Microsoft.CodeAnalysis.Host.Mef
                     // Pick from list of exported factories and instances
                     // PERF: Hoist AssemblyQualifiedName out of inner lambda to avoid repeated string allocations.
                     var assemblyQualifiedName = svctype.AssemblyQualifiedName;
-                    return PickWorkspaceService(_services.Where(lz => lz.Metadata.ServiceType == assemblyQualifiedName));
+                    return PickWorkspaceService(_services.Where(lz => lz.lazyService.Metadata.ServiceType == assemblyQualifiedName));
                 });
             }
 
-            return service != null;
+            return service.lazyService != null;
         }
 
-        private Lazy<IWorkspaceService, WorkspaceServiceMetadata> PickWorkspaceService(IEnumerable<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> services)
+        private (Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory) PickWorkspaceService(IEnumerable<(Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory)> services)
         {
-            Lazy<IWorkspaceService, WorkspaceServiceMetadata> service;
+            (Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory) service;
 #if !CODE_STYLE
             // test layer overrides all other layers and workspace kind:
             if (TryGetServiceByLayer(ServiceLayer.Test, services, out service))
@@ -120,13 +171,13 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             }
 
             // no service.
-            return null;
+            return default;
         }
 
-        private static bool TryGetServiceByLayer(string layer, IEnumerable<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> services, out Lazy<IWorkspaceService, WorkspaceServiceMetadata> service)
+        private static bool TryGetServiceByLayer(string layer, IEnumerable<(Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory)> services, out (Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory) service)
         {
-            service = services.SingleOrDefault(lz => lz.Metadata.Layer == layer);
-            return service != null;
+            service = services.SingleOrDefault(lz => lz.lazyService.Metadata.Layer == layer);
+            return service.lazyService != null;
         }
 
         private IEnumerable<string> _languages;


### PR DESCRIPTION
* Dispose per-instance services created by workspace service factories
* Track completion of `ProjectCacheService` operations
* Make sure to dispose of `RemoteWorkspace` for in-process testing when the owning host `Workspace` is disposed

Fixes #47890