### PR TITLE
Ensure IServiceBroker is used on a background thread

### DIFF
--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -163,6 +163,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var descriptor = ServiceDescriptors.GetServiceDescriptor(typeof(T), RemoteHostOptions.IsServiceHubProcess64Bit(_services));
 
+                // Make sure we are on the thread pool to avoid UI thread dependencies if external code uses ConfigureAwait(true)
+                await TaskScheduler.Default;
+
 #pragma warning disable ISB001 // Dispose of proxies - BrokeredServiceConnection takes care of disposal
                 var proxy = await _serviceBroker.GetProxyAsync<T>(descriptor, options, cancellationToken).ConfigureAwait(false);
 #pragma warning restore


### PR DESCRIPTION
Some `IServiceBroker` asynchronous operations do not explicitly use `ConfigureAwait(false)`. This change ensures we call `GetProxyAsync<T>` from a background thread to avoid accidentally introducing a UI thread dependency in code that should not have one.

/cc @AArnott 