### PR TITLE
Do not export IDE0079 (remove unnecessary suppressions) analyzer in C…

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessarySuppressions/CSharpRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessarySuppressions/CSharpRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -12,7 +12,9 @@ using Microsoft.CodeAnalysis.RemoveUnnecessarySuppressions;
 
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessarySuppressions
 {
+#if !CODE_STYLE // Not exported in CodeStyle layer: https://github.com/dotnet/roslyn/issues/47942
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+#endif
     internal sealed class CSharpRemoveUnnecessaryInlineSuppressionsDiagnosticAnalyzer
         : AbstractRemoveUnnecessaryInlineSuppressionsDiagnosticAnalyzer
     {

--- a/src/Analyzers/Core/CodeFixes/RemoveUnnecessarySuppressions/RemoveUnnecessaryPragmaSuppressionsCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/RemoveUnnecessarySuppressions/RemoveUnnecessaryPragmaSuppressionsCodeFixProvider.cs
@@ -21,7 +21,9 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.RemoveUnnecessarySuppressions
 {
+#if !CODE_STYLE // Not exported in CodeStyle layer: https://github.com/dotnet/roslyn/issues/47942
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeFixProviderNames.RemoveUnnecessaryPragmaSuppressions), Shared]
+#endif
     internal sealed class RemoveUnnecessaryInlineSuppressionsCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         [ImportingConstructor]

--- a/src/Analyzers/VisualBasic/Analyzers/RemoveUnnecessarySuppressions/VisualBasicRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/RemoveUnnecessarySuppressions/VisualBasicRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.vb
@@ -10,8 +10,12 @@ Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessarySuppressions
 
+#If Not CODE_STYLE Then ' Not exported in CodeStyle layer: https://github.com/dotnet/roslyn/issues/47942
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Friend NotInheritable Class VisualBasicRemoveUnnecessaryInlineSuppressionsDiagnosticAnalyzer
+#Else
+    Friend NotInheritable Class VisualBasicRemoveUnnecessaryInlineSuppressionsDiagnosticAnalyzer
+#End If
         Inherits AbstractRemoveUnnecessaryInlineSuppressionsDiagnosticAnalyzer
 
         Protected Overrides ReadOnly Property CompilerErrorCodePrefix As String = "BC"


### PR DESCRIPTION
…odeStyle layer

Fixes #47942
This is a special IDE-only analyzer that should not be exported in the CodeStyle NuGet package. We still want to retain the code in the shared analyzer layer to allow different analyzer hosts to be able to explicitly instantiate it and enforce it on command line from the CodeStyle package.