### PR TITLE
Remove bogus assert

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/SemanticClassificationCache/SemanticClassificationCacheIncrementalAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/SemanticClassificationCache/SemanticClassificationCacheIncrementalAnalyzerProvider.cs
@@ -61,11 +61,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SemanticClassif
                 }
 
                 var statusService = document.Project.Solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
+
+                // If we're not fully loaded, then we don't want to cache classifications.  The classifications we have
+                // will likely not be accurate.  And, if we shutdown after that, we'll have cached incomplete classifications.
                 var isFullyLoaded = await statusService.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
+                if (!isFullyLoaded)
+                    return;
 
                 await client.TryInvokeAsync<IRemoteSemanticClassificationCacheService>(
                     document.Project.Solution,
-                    (service, solutionInfo, cancellationToken) => service.CacheSemanticClassificationsAsync(solutionInfo, document.Id, isFullyLoaded, cancellationToken),
+                    (service, solutionInfo, cancellationToken) => service.CacheSemanticClassificationsAsync(solutionInfo, document.Id, cancellationToken),
                     callbackTarget: null,
                     cancellationToken).ConfigureAwait(false);
             }

--- a/src/VisualStudio/Core/Def/Implementation/SemanticClassificationCache/SemanticClassificationCacheIncrementalAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/SemanticClassificationCache/SemanticClassificationCacheIncrementalAnalyzerProvider.cs
@@ -62,7 +62,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SemanticClassif
 
                 var statusService = document.Project.Solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
                 var isFullyLoaded = await statusService.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
-                Debug.Assert(isFullyLoaded, "We should only be called by the incremental analyzer once the solution is fully loaded.");
 
                 await client.TryInvokeAsync<IRemoteSemanticClassificationCacheService>(
                     document.Project.Solution,

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationCacheService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationCacheService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Classification
     internal interface IRemoteSemanticClassificationCacheService
     {
         ValueTask CacheSemanticClassificationsAsync(
-            PinnedSolutionInfo solutionInfo, DocumentId documentId, bool isFullyLoaded, CancellationToken cancellationToken);
+            PinnedSolutionInfo solutionInfo, DocumentId documentId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Tries to get cached semantic classifications for the specified document and the specified <paramref

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
@@ -73,17 +73,14 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask CacheSemanticClassificationsAsync(
             PinnedSolutionInfo solutionInfo,
             DocumentId documentId,
-            bool isFullyLoaded,
             CancellationToken cancellationToken)
         {
             return RunServiceAsync(async cancellationToken =>
             {
-                // Once fully loaded, we can clear any of the cached information we stored during load.
-                if (isFullyLoaded)
-                {
-                    lock (_cachedData)
-                        _cachedData.Clear();
-                }
+                // We only get called to cache classifications once we're fully loaded.  At that point there's no need
+                // for us to keep around any of the data we cached in-memory during the time the solution was loading.
+                lock (_cachedData)
+                    _cachedData.Clear();
 
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetRequiredDocument(documentId);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47338

It turns out it is possible for analyzers to run prior to a solution being fully loaded.  This can happen if someone explicitly requests reanalysis.  Originally we thought this wasn't possible, and we put an assert to trap this in case we were wrong.  Since we're wrong, the code has been updated to match the actual expectations of the system.