### PR TITLE
Refactor PEMethodSymbol loading of UnmanagedCallersOnly

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1338,9 +1338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 {
                     Debug.Assert(!ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.Uninitialized));
                     Debug.Assert(!ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));
-                    if (MethodKind is not MethodKind.Ordinary
-                        || !IsStatic
-                        || !data.IsValid)
+                    if (!data.IsValid || CheckAndReportValidUnmanagedCallersOnlyTarget(location: null, diagnostics: null))
                     {
                         result = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
                     }
@@ -1439,24 +1437,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (!_packedFlags.IsUnmanagedCallersOnlyAttributePopulated)
             {
-                var allAttributes = GetAttributes();
+                var containingModule = (PEModuleSymbol)ContainingModule;
+                var unmanagedCallersOnlyData = containingModule.Module.TryGetUnmanagedCallersOnlyAttribute(_handle, new MetadataDecoder(containingModule),
+                    static (name, value) => MethodSymbol.TryDecodeUnmanagedCallersOnlyCallConvsProperty(name, value, location: null, diagnostics: null));
 
-                CSharpAttributeData? unmanagedAttribute = null;
-                foreach (var attribute in allAttributes)
-                {
-                    if (attribute.IsTargetAttribute(this, AttributeDescription.UnmanagedCallersOnlyAttribute))
-                    {
-                        unmanagedAttribute = attribute;
-                        break;
-                    }
-                }
-
-                UnmanagedCallersOnlyAttributeData? data = unmanagedAttribute == null
-                    ? null
-                    : DecodeUnmanagedCallersOnlyAttributeData(unmanagedAttribute, location: null, diagnostics: null);
+                Debug.Assert(!ReferenceEquals(unmanagedCallersOnlyData, UnmanagedCallersOnlyAttributeData.Uninitialized)
+                             && !ReferenceEquals(unmanagedCallersOnlyData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));
 
                 var result = InterlockedOperations.Initialize(ref AccessUncommonFields()._lazyUnmanagedCallersOnlyAttributeData,
-                                                              data,
+                                                              unmanagedCallersOnlyData,
                                                               UnmanagedCallersOnlyAttributeData.Uninitialized);
 
                 _packedFlags.SetIsUnmanagedCallersOnlyAttributePopulated();

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1439,7 +1439,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 var containingModule = (PEModuleSymbol)ContainingModule;
                 var unmanagedCallersOnlyData = containingModule.Module.TryGetUnmanagedCallersOnlyAttribute(_handle, new MetadataDecoder(containingModule),
-                    static (name, value, isProperty) => MethodSymbol.TryDecodeUnmanagedCallersOnlyCallConvsField(name, value, isProperty, location: null, diagnostics: null));
+                    static (name, value, isField) => MethodSymbol.TryDecodeUnmanagedCallersOnlyCallConvsField(name, value, isField, location: null, diagnostics: null));
 
                 Debug.Assert(!ReferenceEquals(unmanagedCallersOnlyData, UnmanagedCallersOnlyAttributeData.Uninitialized)
                              && !ReferenceEquals(unmanagedCallersOnlyData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1338,7 +1338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 {
                     Debug.Assert(!ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.Uninitialized));
                     Debug.Assert(!ReferenceEquals(data, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));
-                    if (!data.IsValid || CheckAndReportValidUnmanagedCallersOnlyTarget(location: null, diagnostics: null))
+                    if (CheckAndReportValidUnmanagedCallersOnlyTarget(location: null, diagnostics: null))
                     {
                         result = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
                     }
@@ -1439,7 +1439,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 var containingModule = (PEModuleSymbol)ContainingModule;
                 var unmanagedCallersOnlyData = containingModule.Module.TryGetUnmanagedCallersOnlyAttribute(_handle, new MetadataDecoder(containingModule),
-                    static (name, value) => MethodSymbol.TryDecodeUnmanagedCallersOnlyCallConvsProperty(name, value, location: null, diagnostics: null));
+                    static (name, value, isProperty) => MethodSymbol.TryDecodeUnmanagedCallersOnlyCallConvsField(name, value, isProperty, location: null, diagnostics: null));
 
                 Debug.Assert(!ReferenceEquals(unmanagedCallersOnlyData, UnmanagedCallersOnlyAttributeData.Uninitialized)
                              && !ReferenceEquals(unmanagedCallersOnlyData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound));

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -959,31 +959,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
 #nullable enable
-        protected static UnmanagedCallersOnlyAttributeData DecodeUnmanagedCallersOnlyAttributeData(CSharpAttributeData attribute, Location location, DiagnosticBag diagnostics)
-        {
-            Debug.Assert(attribute.AttributeClass is not null);
-            ImmutableHashSet<INamedTypeSymbolInternal>? callingConventionTypes = null;
-            if (attribute.CommonNamedArguments is { IsDefaultOrEmpty: false } namedArgs)
-            {
-                foreach (var (key, value) in attribute.CommonNamedArguments)
-                {
-                    // Technically, CIL can define a field and a property with the same name. However, such a
-                    // member results in an Ambiguous Member error, and we never get to piece of code at all.
-                    // See UnmanagedCallersOnly_PropertyAndFieldNamedCallConvs for an example
-                    bool isField = attribute.AttributeClass.GetMembers(key).Any(m => m is FieldSymbol);
-
-                    var namedArgumentDecoded = TryDecodeUnmanagedCallersOnlyCallConvsField(key, value, isField, location, diagnostics);
-
-                    if (namedArgumentDecoded.IsCallConvs)
-                    {
-                        callingConventionTypes = namedArgumentDecoded.CallConvs;
-                    }
-                }
-            }
-
-            return UnmanagedCallersOnlyAttributeData.Create(callingConventionTypes);
-        }
-
         internal static (bool IsCallConvs, ImmutableHashSet<INamedTypeSymbolInternal>? CallConvs) TryDecodeUnmanagedCallersOnlyCallConvsField(
             string key,
             TypedConstant value,

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         builder.Add((INamedTypeSymbolInternal)RetargetingTranslator.Retarget((NamedTypeSymbol)identifier));
                     }
 
-                    data = UnmanagedCallersOnlyAttributeData.Create(builder.ToImmutableHashSet(), data.IsValid);
+                    data = UnmanagedCallersOnlyAttributeData.Create(builder.ToImmutableHashSet());
                     builder.Free();
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -890,14 +890,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool reportedError = CheckAndReportValidUnmanagedCallersOnlyTarget(arguments.AttributeSyntaxOpt.Name.Location, arguments.Diagnostics);
 
-            var returnTypeSyntax = SyntaxNode switch
-            {
-                MethodDeclarationSyntax m => m.ReturnType,
-                LocalFunctionStatementSyntax l => l.ReturnType,
-                _ => null
-            };
+            var returnTypeSyntax = this.ExtractReturnTypeSyntax();
 
-            if (returnTypeSyntax == null)
+            if (returnTypeSyntax is CompilationUnitSyntax && this is not SynthesizedSimpleProgramEntryPointSymbol)
             {
                 // If there's no syntax for the return type, then we already errored because this isn't a valid
                 // unmanagedcallersonly target (it's a property getter/setter or some other non-regular-method).

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -942,7 +942,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     foreach (var (key, value) in attribute.CommonNamedArguments)
                     {
                         // Technically, CIL can define a field and a property with the same name. However, such a
-                        // member results in an Ambiguous Member error, and we never get to piece of code at all.
+                        // member results in an Ambiguous Member error, and we never get to this piece of code at all.
                         // See UnmanagedCallersOnly_PropertyAndFieldNamedCallConvs for an example
                         bool isField = attribute.AttributeClass.GetMembers(key).Any(
                             static (m, systemType) => m is FieldSymbol { Type: ArrayTypeSymbol { ElementType: NamedTypeSymbol elementType } } && elementType.Equals(systemType, TypeCompareKind.ConsiderEverything),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -894,7 +894,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 MethodDeclarationSyntax m => m.ReturnType,
                 LocalFunctionStatementSyntax l => l.ReturnType,
-                _ => default
+                _ => null
             };
 
             if (returnTypeSyntax == null)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -8098,6 +8098,7 @@ class D
 {
     unsafe static void M1()
     {
+        C.M();
         delegate* unmanaged<void> ptr = &C.M;
     }
 }
@@ -8105,10 +8106,17 @@ class D
 
             comp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
             comp.VerifyDiagnostics(
-                // (6,42): error CS0570: 'C.M()' is not supported by the language
-                //         delegate* unmanaged<void> ptr = &C.M;
-                Diagnostic(ErrorCode.ERR_BindToBogus, "C.M", isSuppressed: false).WithArguments("C.M()").WithLocation(6, 42)
+                // (6,9): error CS8901: 'C.M()' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
+                //         C.M();
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "C.M()").WithArguments("C.M()").WithLocation(6, 9)
             );
+
+            var c = comp.GetTypeByMetadataName("C");
+            var m1 = c.GetMethod("M");
+            var unmanagedData = m1.GetUnmanagedCallersOnlyAttributeData(forceComplete: true);
+            Assert.NotSame(unmanagedData, UnmanagedCallersOnlyAttributeData.Uninitialized);
+            Assert.NotSame(unmanagedData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound);
+            Assert.Empty(unmanagedData!.CallingConventionTypes);
         }
 
         [Fact]
@@ -8722,20 +8730,22 @@ class D
     }
 }";
 
-            var comp = CreateCompilationWithIL(@"
+            var comp = CreateCompilationWithFunctionPointersAndIl(@"
 class D
 {
-    public static void M2()
+    public unsafe static void M2()
     {
         C.M1();
+        delegate* unmanaged<void> ptr = &C.M1;
     }
 }
 ", il);
 
+            comp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
             comp.VerifyDiagnostics(
-                // (6,11): error CS0570: 'C.M1()' is not supported by the language
+                // (6,9): error CS8901: 'C.M1()' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
                 //         C.M1();
-                Diagnostic(ErrorCode.ERR_BindToBogus, "M1").WithArguments("C.M1()").WithLocation(6, 11)
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "C.M1()").WithArguments("C.M1()").WithLocation(6, 9)
             );
 
             var c = comp.GetTypeByMetadataName("C");
@@ -8743,8 +8753,7 @@ class D
             var unmanagedData = m1.GetUnmanagedCallersOnlyAttributeData(forceComplete: true);
             Assert.NotSame(unmanagedData, UnmanagedCallersOnlyAttributeData.Uninitialized);
             Assert.NotSame(unmanagedData, UnmanagedCallersOnlyAttributeData.AttributePresentDataNotBound);
-            Assert.False(unmanagedData!.IsValid);
-            Assert.Empty(unmanagedData.CallingConventionTypes);
+            Assert.Empty(unmanagedData!.CallingConventionTypes);
         }
 
         [Fact]
@@ -10144,6 +10153,252 @@ namespace System.Runtime.InteropServices
                 //     [UnmanagedCallersOnly(CallConvs = new[] { 1, 2 })]
                 Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyRequiresStatic, "UnmanagedCallersOnly").WithLocation(8, 6)
             );
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnly_CallConvsAsProperty()
+        {
+            string source1 = @"
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+namespace System.Runtime.InteropServices
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class UnmanagedCallersOnlyAttribute : Attribute
+    {
+        public UnmanagedCallersOnlyAttribute()
+        {
+        }
+
+        public Type[] CallConvs { get; set; }
+        public string EntryPoint;
+    }
+}
+
+public class C
+{
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static void M() {}
+}";
+            string source2 = @"
+class D
+{
+    unsafe void M2()
+    {
+        delegate* unmanaged<void> ptr1 = &C.M;
+        delegate* unmanaged[Cdecl]<void> ptr2 = &C.M;
+    }
+}";
+            var sameComp = CreateCompilationWithFunctionPointers(source1 + source2);
+            sameComp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
+            sameComp.VerifyDiagnostics(
+                // (28,50): error CS8786: Calling convention of 'C.M()' is not compatible with 'CDecl'.
+                //         delegate* unmanaged[Cdecl]<void> ptr2 = &C.M;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "CDecl").WithLocation(28, 50)
+            );
+
+            verifyUnmanagedData(sameComp);
+
+            var refComp = CreateCompilation(source1);
+
+            var differentComp = CreateCompilationWithFunctionPointers(source2, new[] { refComp.EmitToImageReference() });
+            differentComp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
+            differentComp.VerifyDiagnostics(
+                // (7,50): error CS8786: Calling convention of 'C.M()' is not compatible with 'CDecl'.
+                //         delegate* unmanaged[Cdecl]<void> ptr2 = &C.M;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "CDecl").WithLocation(7, 50)
+            );
+
+            verifyUnmanagedData(differentComp);
+
+            static void verifyUnmanagedData(CSharpCompilation compilation)
+            {
+                var c = compilation.GetTypeByMetadataName("C");
+                var m = c.GetMethod("M");
+                Assert.Empty(m.GetUnmanagedCallersOnlyAttributeData(forceComplete: true)!.CallingConventionTypes);
+            }
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnly_UnrecognizedSignature()
+        {
+            string source1 = @"
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+namespace System.Runtime.InteropServices
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class UnmanagedCallersOnlyAttribute : Attribute
+    {
+        public UnmanagedCallersOnlyAttribute(Type[] CallConvs)
+        {
+        }
+
+        public string EntryPoint;
+    }
+}
+
+public class C
+{
+    [UnmanagedCallersOnly(CallConvs: new[] { typeof(CallConvCdecl) })]
+    public static void M() {}
+}";
+            string source2 = @"
+class D
+{
+    unsafe void M2()
+    {
+        delegate* unmanaged<void> ptr1 = &C.M;
+        delegate* unmanaged[Cdecl]<void> ptr2 = &C.M;
+        delegate*<void> ptr3 = &C.M;
+    }
+}";
+            var sameComp = CreateCompilationWithFunctionPointers(source1 + source2);
+            sameComp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
+            sameComp.VerifyDiagnostics(
+                // (26,43): error CS8786: Calling convention of 'C.M()' is not compatible with 'Unmanaged'.
+                //         delegate* unmanaged<void> ptr1 = &C.M;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "Unmanaged").WithLocation(26, 43),
+                // (27,50): error CS8786: Calling convention of 'C.M()' is not compatible with 'CDecl'.
+                //         delegate* unmanaged[Cdecl]<void> ptr2 = &C.M;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "CDecl").WithLocation(27, 50)
+            );
+
+            verifyUnmanagedData(sameComp);
+
+            var refComp = CreateCompilation(source1);
+
+            var differentComp = CreateCompilationWithFunctionPointers(source2, new[] { refComp.EmitToImageReference() });
+            differentComp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
+            differentComp.VerifyDiagnostics(
+                // (6,43): error CS8786: Calling convention of 'C.M()' is not compatible with 'Unmanaged'.
+                //         delegate* unmanaged<void> ptr1 = &C.M;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "Unmanaged").WithLocation(6, 43),
+                // (7,50): error CS8786: Calling convention of 'C.M()' is not compatible with 'CDecl'.
+                //         delegate* unmanaged[Cdecl]<void> ptr2 = &C.M;
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "CDecl").WithLocation(7, 50)
+            );
+
+            verifyUnmanagedData(differentComp);
+
+            static void verifyUnmanagedData(CSharpCompilation compilation)
+            {
+                var c = compilation.GetTypeByMetadataName("C");
+                var m = c.GetMethod("M");
+                Assert.Null(m.GetUnmanagedCallersOnlyAttributeData(forceComplete: true));
+            }
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnly_PropertyAndFieldNamedCallConvs()
+        {
+            var il = @"
+.class public auto ansi sealed beforefieldinit System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute
+    extends [mscorlib]System.Attribute
+{
+    .custom instance void [mscorlib]System.AttributeUsageAttribute::.ctor(valuetype [mscorlib]System.AttributeTargets) = (
+        01 00 40 00 00 00 01 00 54 02 09 49 6e 68 65 72
+        69 74 65 64 00
+    )
+    // Fields
+    .field public class [mscorlib]System.Type[] CallConvs
+    .field public string EntryPoint
+
+    // Methods
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed 
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Attribute::.ctor()
+        ret
+    } // end of method UnmanagedCallersOnlyAttribute::.ctor
+
+    .method public hidebysig specialname instance class [mscorlib]System.Type[] get_CallConvs () cil managed
+    {
+        ldnull
+        ret
+    } // end of method UnmanagedCallersOnlyAttribute::get_CallConvs
+
+    .method public hidebysig specialname instance void set_CallConvs (
+            class [mscorlib]System.Type[] 'value'
+        ) cil managed 
+    {
+        ret
+    } // end of method UnmanagedCallersOnlyAttribute::set_CallConvs
+
+    // Properties
+    .property instance class [mscorlib]System.Type[] CallConvs()
+    {
+        .get instance class [mscorlib]System.Type[] System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::get_CallConvs()
+        .set instance void System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::set_CallConvs(class [mscorlib]System.Type[])
+    }
+
+}
+.class public auto ansi beforefieldinit C
+    extends [mscorlib]System.Object
+{
+    // Methods
+    .method public hidebysig static void M () cil managed
+    {
+        // As separate field/property assignments. Property is first.
+        // [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) }, CallConvs = new[] { typeof(CallConvCdecl) })]
+        .custom instance void System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::.ctor() = (
+            01 00 02 00 54 1d 50 09 43 61 6c 6c 43 6f 6e 76
+            73 01 00 00 00 7c 53 79 73 74 65 6d 2e 52 75 6e
+            74 69 6d 65 2e 43 6f 6d 70 69 6c 65 72 53 65 72
+            76 69 63 65 73 2e 43 61 6c 6c 43 6f 6e 76 53 74
+            64 63 61 6c 6c 2c 20 6d 73 63 6f 72 6c 69 62 2c
+            20 56 65 72 73 69 6f 6e 3d 34 2e 30 2e 30 2e 30
+            2c 20 43 75 6c 74 75 72 65 3d 6e 65 75 74 72 61
+            6c 2c 20 50 75 62 6c 69 63 4b 65 79 54 6f 6b 65
+            6e 3d 62 37 37 61 35 63 35 36 31 39 33 34 65 30
+            38 39 53 1d 50 09 43 61 6c 6c 43 6f 6e 76 73 01
+            00 00 00 7a 53 79 73 74 65 6d 2e 52 75 6e 74 69
+            6d 65 2e 43 6f 6d 70 69 6c 65 72 53 65 72 76 69
+            63 65 73 2e 43 61 6c 6c 43 6f 6e 76 43 64 65 63
+            6c 2c 20 6d 73 63 6f 72 6c 69 62 2c 20 56 65 72
+            73 69 6f 6e 3d 34 2e 30 2e 30 2e 30 2c 20 43 75
+            6c 74 75 72 65 3d 6e 65 75 74 72 61 6c 2c 20 50
+            75 62 6c 69 63 4b 65 79 54 6f 6b 65 6e 3d 62 37
+            37 61 35 63 35 36 31 39 33 34 65 30 38 39
+        )
+
+        ret
+    } // end of method C::M
+}
+";
+
+            var comp = CreateCompilationWithFunctionPointersAndIl(@"
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+unsafe class D
+{
+    static void M1()
+    {
+        delegate* unmanaged[Cdecl]<void> ptr1 = &C.M;
+        delegate* unmanaged[Stdcall]<void> ptr2 = &C.M; // Error
+        M2();
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    static void M2() {}
+}
+", il);
+
+            comp.Assembly.SetOverrideRuntimeSupportsUnmanagedSignatureCallingConvention();
+            comp.VerifyDiagnostics(
+                // (9,52): error CS8786: Calling convention of 'C.M()' is not compatible with 'Standard'.
+                //         delegate* unmanaged[Stdcall]<void> ptr2 = &C.M; // Error
+                Diagnostic(ErrorCode.ERR_WrongFuncPtrCallingConvention, "C.M").WithArguments("C.M()", "Standard").WithLocation(9, 52),
+                // (13,27): error CS0229: Ambiguity between 'UnmanagedCallersOnlyAttribute.CallConvs' and 'UnmanagedCallersOnlyAttribute.CallConvs'
+                //     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+                Diagnostic(ErrorCode.ERR_AmbigMember, "CallConvs").WithArguments("System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.CallConvs", "System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.CallConvs").WithLocation(13, 27)
+            );
+
+            var c = comp.GetTypeByMetadataName("C");
+            var m = c.GetMethod("M");
+            var callConvCdecl = comp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvCdecl");
+
+            Assert.True(callConvCdecl!.Equals((NamedTypeSymbol)m.GetUnmanagedCallersOnlyAttributeData(forceComplete: true)!.CallingConventionTypes.Single(), TypeCompareKind.ConsiderEverything));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis
 #nullable enable
     internal interface IAttributeNamedArgumentDecoder
     {
-        (KeyValuePair<string, TypedConstant> nameValuePair, bool isProperty, SerializationTypeCode typeCode) DecodeCustomAttributeNamedArgumentOrThrow(ref BlobReader argReader);
+        (KeyValuePair<string, TypedConstant> nameValuePair, bool isProperty, SerializationTypeCode typeCode, SerializationTypeCode elementTypeCode) DecodeCustomAttributeNamedArgumentOrThrow(ref BlobReader argReader);
     }
 
     internal abstract class MetadataDecoder<ModuleSymbol, TypeSymbol, MethodSymbol, FieldSymbol, Symbol> :
@@ -1589,7 +1589,7 @@ tryAgain:
 
         /// <exception cref="UnsupportedSignatureContent">If the encoded named argument is invalid.</exception>
         /// <exception cref="BadImageFormatException">An exception from metadata reader.</exception>
-        public (KeyValuePair<string, TypedConstant> nameValuePair, bool isProperty, SerializationTypeCode typeCode) DecodeCustomAttributeNamedArgumentOrThrow(ref BlobReader argReader)
+        public (KeyValuePair<string, TypedConstant> nameValuePair, bool isProperty, SerializationTypeCode typeCode, SerializationTypeCode elementTypeCode) DecodeCustomAttributeNamedArgumentOrThrow(ref BlobReader argReader)
         {
             // Ecma-335 23.3 - A NamedArg is simply a FixedArg preceded by information to identify which field or
             // property it represents. [Note: Recall that the CLI allows fields and properties to have the same name; so
@@ -1616,7 +1616,7 @@ tryAgain:
                 ? DecodeCustomAttributeElementArrayOrThrow(ref argReader, elementTypeCode, elementType, type)
                 : DecodeCustomAttributeElementOrThrow(ref argReader, typeCode, type);
 
-            return (new KeyValuePair<string, TypedConstant>(name, value), kind == CustomAttributeNamedArgumentKind.Property, typeCode);
+            return (new KeyValuePair<string, TypedConstant>(name, value), kind == CustomAttributeNamedArgumentKind.Property, typeCode, elementTypeCode);
         }
 
         internal bool IsTargetAttribute(
@@ -1717,7 +1717,7 @@ tryAgain:
 
                         for (int i = 0; i < namedArgs.Length; i++)
                         {
-                            (namedArgs[i], _, _) = DecodeCustomAttributeNamedArgumentOrThrow(ref argsReader);
+                            (namedArgs[i], _, _, _) = DecodeCustomAttributeNamedArgumentOrThrow(ref argsReader);
                         }
                     }
 

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1155,7 +1155,6 @@ namespace Microsoft.CodeAnalysis
                     var numNamed = sigReader.ReadUInt16();
                     for (int i = 0; i < numNamed; i++)
                     {
-                        // typeCode of the value is checked by the decoder itself
                         var ((name, value), isProperty, typeCode, elementTypeCode) = attributeArgumentDecoder.DecodeCustomAttributeNamedArgumentOrThrow(ref sigReader);
                         if (typeCode != SerializationTypeCode.SZArray || elementTypeCode != SerializationTypeCode.Type)
                         {

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1156,7 +1156,12 @@ namespace Microsoft.CodeAnalysis
                     for (int i = 0; i < numNamed; i++)
                     {
                         // typeCode of the value is checked by the decoder itself
-                        var ((name, value), isProperty, /* typeCode */ _) = attributeArgumentDecoder.DecodeCustomAttributeNamedArgumentOrThrow(ref sigReader);
+                        var ((name, value), isProperty, typeCode, elementTypeCode) = attributeArgumentDecoder.DecodeCustomAttributeNamedArgumentOrThrow(ref sigReader);
+                        if (typeCode != SerializationTypeCode.SZArray || elementTypeCode != SerializationTypeCode.Type)
+                        {
+                            continue;
+                        }
+
                         var namedArgumentDecoded = unmanagedCallersOnlyDecoder(name, value, !isProperty);
                         if (namedArgumentDecoded.IsCallConvs)
                         {
@@ -1764,7 +1769,7 @@ namespace Microsoft.CodeAnalysis
                 var numNamed = sig.ReadUInt16();
                 for (int i = 0; i < numNamed && (diagnosticId is null || urlFormat is null); i++)
                 {
-                    var ((name, value), isProperty, typeCode) = decoder.DecodeCustomAttributeNamedArgumentOrThrow(ref sig);
+                    var ((name, value), isProperty, typeCode, /* elementTypeCode */ _) = decoder.DecodeCustomAttributeNamedArgumentOrThrow(ref sig);
                     if (typeCode == SerializationTypeCode.String && isProperty && value.ValueInternal is string stringValue)
                     {
                         if (diagnosticId is null && name == ObsoleteAttributeData.DiagnosticIdPropertyName)

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1140,6 +1140,9 @@ namespace Microsoft.CodeAnalysis
             IAttributeNamedArgumentDecoder attributeArgumentDecoder,
             Func<string, TypedConstant, bool, (bool IsCallConvs, ImmutableHashSet<INamedTypeSymbolInternal>? CallConvs)> unmanagedCallersOnlyDecoder)
         {
+            // We don't want to load all attributes and their public data just to answer whether a PEMethodSymbol has an UnmanagedCallersOnly
+            // attached. It would create unnecessary memory pressure that isn't going to be needed 99% of the time, so we just crack this 1
+            // attribute.
             AttributeInfo info = FindTargetAttribute(token, AttributeDescription.UnmanagedCallersOnlyAttribute);
             if (!info.HasValue || info.SignatureIndex != 0 || !TryGetAttributeReader(info.Handle, out BlobReader sigReader))
             {

--- a/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
@@ -13,31 +13,30 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class UnmanagedCallersOnlyAttributeData
     {
-        internal static readonly UnmanagedCallersOnlyAttributeData Uninitialized = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
-        internal static readonly UnmanagedCallersOnlyAttributeData AttributePresentDataNotBound = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
-        private static readonly UnmanagedCallersOnlyAttributeData PlatformDefault = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: true);
+        internal static readonly UnmanagedCallersOnlyAttributeData Uninitialized = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty);
+        internal static readonly UnmanagedCallersOnlyAttributeData AttributePresentDataNotBound = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty);
+        private static readonly UnmanagedCallersOnlyAttributeData PlatformDefault = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty);
 
         public const string CallConvsPropertyName = "CallConvs";
 
-        internal static UnmanagedCallersOnlyAttributeData Create(ImmutableHashSet<INamedTypeSymbolInternal>? callingConventionTypes, bool isValid)
-            => (callingConventionTypes, isValid) switch
+        internal static UnmanagedCallersOnlyAttributeData Create(ImmutableHashSet<INamedTypeSymbolInternal>? callingConventionTypes)
+            => callingConventionTypes switch
             {
-                (null, true) or ({ IsEmpty: true }, true) => PlatformDefault,
-                _ => new UnmanagedCallersOnlyAttributeData(callingConventionTypes ?? ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid)
+                null or { IsEmpty: true } => PlatformDefault,
+                _ => new UnmanagedCallersOnlyAttributeData(callingConventionTypes ?? ImmutableHashSet<INamedTypeSymbolInternal>.Empty)
             };
 
         public readonly ImmutableHashSet<INamedTypeSymbolInternal> CallingConventionTypes;
-        public readonly bool IsValid;
 
-        private UnmanagedCallersOnlyAttributeData(ImmutableHashSet<INamedTypeSymbolInternal> callingConventionTypes, bool isValid)
+        private UnmanagedCallersOnlyAttributeData(ImmutableHashSet<INamedTypeSymbolInternal> callingConventionTypes)
         {
             CallingConventionTypes = callingConventionTypes;
-            IsValid = isValid;
         }
 
-        internal static bool IsCallConvsTypedConstant(string key, in TypedConstant value)
+        internal static bool IsCallConvsTypedConstant(string key, bool isField, in TypedConstant value)
         {
-            return key == CallConvsPropertyName
+            return isField
+                   && key == CallConvsPropertyName
                    && value.Kind == TypedConstantKind.Array
                    && (value.Values.IsDefaultOrEmpty || value.Values.All(v => v.Kind == TypedConstantKind.Type));
         }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis
         internal static readonly UnmanagedCallersOnlyAttributeData AttributePresentDataNotBound = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: false);
         private static readonly UnmanagedCallersOnlyAttributeData PlatformDefault = new UnmanagedCallersOnlyAttributeData(callingConventionTypes: ImmutableHashSet<INamedTypeSymbolInternal>.Empty, isValid: true);
 
+        public const string CallConvsPropertyName = "CallConvs";
+
         internal static UnmanagedCallersOnlyAttributeData Create(ImmutableHashSet<INamedTypeSymbolInternal>? callingConventionTypes, bool isValid)
             => (callingConventionTypes, isValid) switch
             {
@@ -35,7 +37,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static bool IsCallConvsTypedConstant(string key, in TypedConstant value)
         {
-            return key == "CallConvs"
+            return key == CallConvsPropertyName
                    && value.Kind == TypedConstantKind.Array
                    && (value.Values.IsDefaultOrEmpty || value.Values.All(v => v.Kind == TypedConstantKind.Type));
         }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/UnmanagedCallersOnlyAttributeData.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             => callingConventionTypes switch
             {
                 null or { IsEmpty: true } => PlatformDefault,
-                _ => new UnmanagedCallersOnlyAttributeData(callingConventionTypes ?? ImmutableHashSet<INamedTypeSymbolInternal>.Empty)
+                _ => new UnmanagedCallersOnlyAttributeData(callingConventionTypes)
             };
 
         public readonly ImmutableHashSet<INamedTypeSymbolInternal> CallingConventionTypes;


### PR DESCRIPTION
My simple implementation of GetUnmanagedCallersOnlyAttributeData in PEMethodSymbol would cause all PEMethodSymbols to load all attributes when the data is requested, unnecessarily increasing memory pressure. This refactors the implementation to only load the one attribute we need for it, and to not load the public-facing information that is unneeded for this. In the process, I refactored the method checks to share between regular SourceMethodSymbolWithAttributes and PEMethodSymbols, so the criteria for should be more consistent.
