### PR TITLE
Fix inference with ref parameter with maybe-null value

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5746,9 +5746,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var visitArgumentResult = argumentResults[i];
                 var lambdaState = visitArgumentResult.StateForLambda;
-                var argumentResult = visitArgumentResult.LValueType;
-                if (!argumentResult.HasType)
-                    argumentResult = visitArgumentResult.RValueType.ToTypeWithAnnotations(compilation);
+                // Note: for `out` arguments, the argument result contains the declaration type (see `VisitArgumentEvaluate`)
+                var argumentResult = visitArgumentResult.RValueType.ToTypeWithAnnotations(compilation);
                 builder.Add(getArgumentForMethodTypeInference(arguments[i], argumentResult, lambdaState));
             }
             return builder.ToImmutableAndFree();


### PR DESCRIPTION
Previously, the L-value of a `ref` argument would contribute its type+nullability. Now we're using the R-value.

Fixes https://github.com/dotnet/roslyn/issues/47663
Fixes https://github.com/dotnet/roslyn/issues/35534

Note that the inference in some scenario becomes a bit worse (for example with `CompareExchange`) when there is a `ref` argument and `null`. There is a [known issue](https://github.com/dotnet/roslyn/issues/43536) with `null` not contributing nullability to method type inference.

We could discuss whether to hold off this change until the issue with `null` is fixed. 
I think the current change can be taken as-is, because (1) they involve having a nullable but not-null `ref`, which is uncommon for `CompareExchange`, and (2) they can be mitigated with explicit type parameters.