### PR TITLE
Fix crash in CompletionSource.GetDescriptionAsync

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -140,7 +140,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             => c == '\t' || c == '\n' || c == '\0';
 
         internal static bool TryGetInitialTriggerLocation(EditorAsyncCompletion.IAsyncCompletionSession session, out SnapshotPoint initialTriggerLocation)
-            => session.Properties.TryGetProperty(CompletionSource.TriggerLocation, out initialTriggerLocation);
+        {
+            if (session != null)
+            {
+                return session.Properties.TryGetProperty(CompletionSource.TriggerLocation, out initialTriggerLocation);
+            }
+
+            initialTriggerLocation = default;
+            return false;
+        }
 
         // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will introduce this support and we will get rid of relying on the "★" then.


### PR DESCRIPTION
I made the change [here](https://github.com/dotnet/roslyn/pull/47647/files#diff-c9be69df61cf8863759a3622c8bb699bR142) with the assumption that session will not be null, which turns out isn't the case (see [here](http://index/?leftProject=Microsoft.VisualStudio.Language.Intellisense.Implementation&leftSymbol=iz7q7itpna4k&file=CompletionUI%5CDefaultCompletionControl.xaml.cs&line=230), `GetDescriptionAsync` is called by[ `OnShowTooltipTimerTick`](http://index/?leftProject=Microsoft.VisualStudio.Language.Intellisense.Implementation&leftSymbol=iz7q7itpna4k), after session is set to null)

@AmadeusW is fixing it on editor side too, to unsubscribe before releasing session.