### PR TITLE
Fix refactorings for target-typed conditionals

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.cs
@@ -866,7 +866,7 @@ class C
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44036"), Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
         public async Task TestConversionWithUseVarForAll_CastInsertedToKeepTypeSame_Throw1()
         {
             await TestInRegularAndScript1Async(
@@ -891,12 +891,12 @@ class C
 {
     void M()
     {
-        object o = true ? throw new System.Exception() : ""b"";
+        var o = true ? throw new System.Exception() : (object)""b"";
     }
 }", new TestParameters(options: PreferImplicitTypeAlways));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44036"), Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
         public async Task TestConversionWithUseVarForAll_CastInsertedToKeepTypeSame_Throw2()
         {
             await TestInRegularAndScript1Async(
@@ -921,7 +921,7 @@ class C
 {
     void M()
     {
-        object o = true ? ""a"" : throw new System.Exception();
+        var o = true ? (object)""a"" : throw new System.Exception();
     }
 }", new TestParameters(options: PreferImplicitTypeAlways));
         }
@@ -982,7 +982,7 @@ class C
 {
     void M()
     {
-        string s = true ? throw new System.Exception() : (string)null;
+        var s = true ? throw new System.Exception() : (string)null;
     }
 }", new TestParameters(options: PreferImplicitTypeAlways));
         }
@@ -1013,7 +1013,7 @@ class C
 {
     void M()
     {
-        string s = true ? ""a"" : throw new System.Exception();
+        var s = true ? ""a"" : throw new System.Exception();
     }
 }", new TestParameters(options: PreferImplicitTypeAlways));
         }

--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
@@ -482,7 +482,7 @@ class C
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44036"), Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
         public async Task TestConversion1_Throw1()
         {
             await TestInRegularAndScript1Async(
@@ -512,7 +512,7 @@ class C
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/44036"), Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
         public async Task TestConversion1_Throw2()
         {
             await TestInRegularAndScript1Async(
@@ -571,8 +571,10 @@ class C
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
-        public async Task TestConversion2_Throw1()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [InlineData(LanguageVersion.CSharp8, "(string)null")]
+        [InlineData(LanguageVersion.CSharp9, "null")]
+        public async Task TestConversion2_Throw1(LanguageVersion languageVersion, string expectedFalseExpression)
         {
             await TestInRegularAndScript1Async(
 @"
@@ -595,9 +597,9 @@ class C
 {
     string M()
     {
-        return true ? throw new System.Exception() : (string)null;
+        return true ? throw new System.Exception() : " + expectedFalseExpression + @";
     }
-}");
+}", parameters: new(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(languageVersion)));
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
@@ -630,8 +632,10 @@ class C
 }");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
-        public async Task TestConversion3()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [InlineData(LanguageVersion.CSharp8, "(string)null")]
+        [InlineData(LanguageVersion.CSharp9, "null")]
+        public async Task TestConversion3(LanguageVersion languageVersion, string expectedFalseExpression)
         {
             await TestInRegularAndScript1Async(
 @"
@@ -654,14 +658,16 @@ class C
 {
     string M()
     {
-        return true ? null : (string)null;
+        return true ? null : " + expectedFalseExpression + @";
     }
-}");
+}", parameters: new(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(languageVersion)));
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
-        public async Task TestConversion3_Throw1()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [InlineData(LanguageVersion.CSharp8, "(string)null")]
+        [InlineData(LanguageVersion.CSharp9, "null")]
+        public async Task TestConversion3_Throw1(LanguageVersion languageVersion, string expectedFalseExpression)
         {
             await TestInRegularAndScript1Async(
 @"
@@ -684,14 +690,16 @@ class C
 {
     string M()
     {
-        return true ? throw new System.Exception() : (string)null;
+        return true ? throw new System.Exception() : " + expectedFalseExpression + @";
     }
-}");
+}", parameters: new(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(languageVersion)));
         }
 
         [WorkItem(43291, "https://github.com/dotnet/roslyn/issues/43291")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
-        public async Task TestConversion3_Throw2()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        [InlineData(LanguageVersion.CSharp8, "(string)null")]
+        [InlineData(LanguageVersion.CSharp9, "null")]
+        public async Task TestConversion3_Throw2(LanguageVersion languageVersion, string expectedTrue)
         {
             await TestInRegularAndScript1Async(
 @"
@@ -714,9 +722,9 @@ class C
 {
     string M()
     {
-        return true ? (string)null : throw new System.Exception();
+        return true ? " + expectedTrue + @" : throw new System.Exception();
     }
-}");
+}", parameters: new(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(languageVersion)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -339,6 +339,62 @@ class C
 ");
         }
 
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [InlineData(LanguageVersion.CSharp8)]
+        [InlineData(LanguageVersion.CSharp9)]
+        public async Task Conversion_NonTargetTypedConditionalExpression(LanguageVersion languageVersion)
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void F()
+    {
+        int? [||]x = 42;
+        var y = true ? x : null;
+    }
+}
+",
+
+@"
+class C
+{
+    void F()
+    {
+        var y = true ? (int?)42 : null;
+    }
+}
+", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(languageVersion));
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [InlineData(LanguageVersion.CSharp8, "(int?)42")]
+        [InlineData(LanguageVersion.CSharp9, "42")] // In C# 9, target-typed conditionals makes this work
+        public async Task Conversion_TargetTypedConditionalExpression(LanguageVersion languageVersion, string expectedSubstitution)
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void F()
+    {
+        int? [||]x = 42;
+        int? y = true ? x : null;
+    }
+}
+",
+
+@"
+class C
+{
+    void F()
+    {
+        int? y = true ? " + expectedSubstitution + @" : null;
+    }
+}
+", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(languageVersion));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task NoCastOnVar()
         {

--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.CSharp
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
     Public Class CastSimplificationTests
@@ -1237,12 +1238,14 @@ class Program
             Await TestAsync(input, expected)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <Theory, Trait(Traits.Feature, Traits.Features.Simplification)>
         <WorkItem(530248, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530248")>
-        Public Async Function TestCSharp_DoNotRemove_NecessaryCastInTernaryExpression() As Task
+        <InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp8, "(Base)d2")>
+        <InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp9, "d2")>
+        Public Async Function TestCSharp_CastInTernaryExpression(languageVersion As LanguageVersion, expectedFalseExpression As String) As Task
             Dim input =
 <Workspace>
-    <Project Language="C#" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true" LanguageVersion=<%= languageVersion.ToDisplayString() %>>
         <Document><![CDATA[
 class Base { }
 class Derived1 : Base { }
@@ -1261,7 +1264,7 @@ class Test
 </Workspace>
 
             Dim expected =
-<code><![CDATA[
+<code>
 class Base { }
 class Derived1 : Base { }
 class Derived2 : Base { }
@@ -1270,21 +1273,22 @@ class Test
 {
     public Base F(bool flag, Derived1 d1, Derived2 d2)
     {
-        return flag ? d1 : (Base)d2;
+        return flag ? d1 : <%= expectedFalseExpression %>;
     }
 }
-]]>
 </code>
 
             Await TestAsync(input, expected)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <Theory, Trait(Traits.Feature, Traits.Features.Simplification)>
         <WorkItem(530248, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530248")>
-        Public Async Function TestCSharp_DoNotRemove_NecessaryCastInTernaryExpression2() As Task
+        <InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp8, "(Base)d1")>
+        <InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp9, "d1")>
+        Public Async Function TestCSharp_CastInTernaryExpression2(languageVersion As LanguageVersion, expectedTrueExpression As String) As Task
             Dim input =
 <Workspace>
-    <Project Language="C#" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true" LanguageVersion=<%= languageVersion.ToDisplayString() %>>
         <Document><![CDATA[
 class Base { }
 class Derived1 : Base { }
@@ -1303,7 +1307,7 @@ class Test
 </Workspace>
 
             Dim expected =
-<code><![CDATA[
+<code>
 class Base { }
 class Derived1 : Base { }
 class Derived2 : Base { }
@@ -1312,21 +1316,22 @@ class Test
 {
     public Base F(bool flag, Derived1 d1, Derived2 d2)
     {
-        return flag ? (Base)d1 : d2;
+        return flag ? <%= expectedTrueExpression %> : d2;
     }
 }
-]]>
 </code>
 
             Await TestAsync(input, expected)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <Theory, Trait(Traits.Feature, Traits.Features.Simplification)>
         <WorkItem(530085, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530085")>
-        Public Async Function TestCSharp_DoNotRemove_NecessaryCastInTernaryExpression3() As Task
+        <InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp8, "(long?)value")>
+        <InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp9, "value")>
+        Public Async Function TestCSharp_CastInTernaryExpression3(languageVersion As LanguageVersion, expectedTrueExpression As String) As Task
             Dim input =
 <Workspace>
-    <Project Language="C#" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true" LanguageVersion=<%= languageVersion.ToDisplayString() %>>
         <Document><![CDATA[
 class Program
 {
@@ -1343,17 +1348,16 @@ class Program
 </Workspace>
 
             Dim expected =
-<code><![CDATA[
+<code>
 class Program
 {
     static void Main(string[] args)
     {
         bool b = true;
         long value = 0;
-        long? a = b ? (long?)value : null;
+        long? a = b ? <%= expectedTrueExpression %> : null;
     }
 }
-]]>
 </code>
 
             Await TestAsync(input, expected)
@@ -4207,10 +4211,10 @@ class B
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestCSharp_DoNotRemove_NecessaryCastInConditionalExpression() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryCastInConditionalExpression_CSharp8() As Task
             Dim input =
 <Workspace>
-    <Project Language="C#" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true" LanguageVersion="8">
         <Document><![CDATA[
 public struct Subject<T>
 {
@@ -4254,6 +4258,91 @@ public struct Subject<T>
     }
 }
 ]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_Remove_CastInConditionalExpression_CSharp9() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="9">
+        <Document><![CDATA[
+public struct Subject<T>
+{
+    private readonly T _value;
+    public Subject(T value)
+    : this()
+    {
+        _value = value;
+    }
+    public T Value
+    {
+        get { return _value; }
+    }
+    public Subject<TResult>? Is<TResult>() where TResult : T
+    {
+        return _value is TResult ? {|Simplify:(Subject<TResult>?)|}new Subject<TResult>((TResult)_value) : null;
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+public struct Subject<T>
+{
+    private readonly T _value;
+    public Subject(T value)
+    : this()
+    {
+        _value = value;
+    }
+    public T Value
+    {
+        get { return _value; }
+    }
+    public Subject<TResult>? Is<TResult>() where TResult : T
+    {
+        return _value is TResult ? new Subject<TResult>((TResult)_value) : null;
+    }
+}
+]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_DoNotRemove_CastInConditionalExpressionWithDefault() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="9">
+        <Document><![CDATA[
+public struct S
+{
+    void M()
+    {
+        int? x = DateTime.Now.DayOfWeek == DayOfWeek.Tuesday ? {|Simplify:(int?)|}42 : default;
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+public struct S
+{
+    void M()
+    {
+        int? x = DateTime.Now.DayOfWeek == DayOfWeek.Tuesday ? (int?)42 : default;
+    }
+}
 </code>
 
             Await TestAsync(input, expected)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -74,6 +74,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             if (expressionToCastType.IsIdentity)
                 return true;
 
+            // Is this a cast inside a conditional expression? Because of target typing we already sorted that out
+            // in ReplacementChangesSemantics()
+            if (IsBranchOfConditionalExpression(castNode))
+            {
+                return true;
+            }
+
             // We already bailed out of we had an explicit/none conversions back in CastMustBePreserved 
             // (except for implicit user defined conversions).
             Debug.Assert(!expressionToCastType.IsExplicit || expressionToCastType.IsUserDefined);
@@ -353,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                 return true;
 
             // Almost all explicit conversions can cause an exception or data loss, hence can never be removed.
-            if (IsExplicitCastThatMustBePreserved(conversion))
+            if (IsExplicitCastThatMustBePreserved(castNode, conversion))
                 return true;
 
             // If this conversion doesn't even exist, then this code is in error, and we don't want to touch it.
@@ -497,10 +504,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             return false;
         }
 
-        private static bool IsExplicitCastThatMustBePreserved(Conversion conversion)
+        private static bool IsExplicitCastThatMustBePreserved(ExpressionSyntax castNode, Conversion conversion)
         {
             if (conversion.IsExplicit)
             {
+                // Consider the explicit cast in a line like:
+                //
+                // string? s = conditional ? (string?)"hello" : null;
+                //
+                // That string? cast is an explicit conversion that not IsUserDefined, but it may be removable if we support
+                // target-typed conditionals; in that case we'll return false here and force the full algorithm to be ran rather
+                // than this fast-path.
+                if (IsBranchOfConditionalExpression(castNode) &&
+                    !CastMustBePreservedInConditionalBranch(castNode, conversion))
+                {
+                    return false;
+                }
+
                 // if it's not a user defined conversion, we must preserve it as it has runtime impact that we don't want to change.
                 if (!conversion.IsUserDefined)
                     return true;
@@ -556,6 +576,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                    castedExpressionNode.WalkDownParentheses().IsKind(SyntaxKind.NullLiteralExpression, SyntaxKind.DefaultLiteralExpression);
         }
 
+        private static bool IsBranchOfConditionalExpression(ExpressionSyntax expression)
+        {
+            return expression.Parent is ConditionalExpressionSyntax conditionalExpression &&
+                   expression != conditionalExpression.Condition;
+        }
+
         private static bool CastMustBePreservedInConditionalBranch(
             ExpressionSyntax castNode, Conversion conversion)
         {
@@ -577,7 +603,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                             : conditionalExpression.WhenTrue;
 
                         otherSide = otherSide.WalkDownParentheses();
-                        return otherSide.IsKind(SyntaxKind.NullLiteralExpression) ||
+
+                        // In C# 9 we can potentially remove the cast if the other side is null, since the cast was previously required to
+                        // resolve a situation like:
+                        //
+                        //     var x = condition ? (int?)i : null
+                        //
+                        // but it isn't with target-typed conditionals. We do have to keep the cast if it's default, as:
+                        //
+                        //     var x = condition ? (int?)i : default
+                        //
+                        // is inferred by the compiler to mean 'default(int?)', whereas removing the cast would mean default(int).
+                        var languageVersion = ((CSharpParseOptions)castNode.SyntaxTree.Options).LanguageVersion;
+
+                        return (otherSide.IsKind(SyntaxKind.NullLiteralExpression) && languageVersion < LanguageVersion.CSharp9) ||
                                otherSide.IsKind(SyntaxKind.DefaultLiteralExpression);
                     }
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -557,7 +557,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
         }
 
         private static bool CastMustBePreservedInConditionalBranch(
-            ExpressionSyntax expression, Conversion conversion)
+            ExpressionSyntax castNode, Conversion conversion)
         {
             // `... ? (int?)i : default`.  This cast is necessary as the 'null/default' on the other side of the
             // conditional can change meaning since based on the type on the other side.
@@ -566,13 +566,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             // `... ? (int)1 : default`.
             if (!conversion.IsIdentity)
             {
-                expression = expression.WalkUpParentheses();
-                if (expression.Parent is ConditionalExpressionSyntax conditionalExpression)
+                castNode = castNode.WalkUpParentheses();
+                if (castNode.Parent is ConditionalExpressionSyntax conditionalExpression)
                 {
-                    if (conditionalExpression.WhenTrue == expression ||
-                        conditionalExpression.WhenFalse == expression)
+                    if (conditionalExpression.WhenTrue == castNode ||
+                        conditionalExpression.WhenFalse == castNode)
                     {
-                        var otherSide = conditionalExpression.WhenTrue == expression
+                        var otherSide = conditionalExpression.WhenTrue == castNode
                             ? conditionalExpression.WhenFalse
                             : conditionalExpression.WhenTrue;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
@@ -363,6 +363,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                     var originalExpressionType = originalExpressionTypeInfo.Type;
                     var newExpressionType = newExpressionTypeInfo.Type;
 
+                    // A conditional expression may have no type of it's own, but can be converted to a type if there's target-typed
+                    // conditional expressions in play. For example:
+                    //
+                    //     int? x = conditional ? (int?)trueValue : null;
+                    //
+                    // Once you remove the cast, the conditional has no type itself, but is being converted to int? by a conditional
+                    // expression conversion.
+                    if (newExpressionType == null &&
+                        this.SpeculativeSemanticModel.GetConversion(newExpression, this.CancellationToken).IsConditionalExpression)
+                    {
+                        newExpressionType = newExpressionTypeInfo.ConvertedType;
+                    }
+
                     if (originalExpressionType == null || newExpressionType == null)
                     {
                         // With the current implementation of the C# binder, this is impossible, but it's probably not wise to
@@ -701,8 +714,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 !SymbolInfosAreCompatible(originalClauseInfo.OperationInfo, newClauseInfo.OperationInfo);
         }
 
+        private static bool IsPotentiallyTargetTypedConditionalExpression(ExpressionSyntax expressionSyntax)
+        {
+            return expressionSyntax is ConditionalExpressionSyntax &&
+                   ((CSharpParseOptions)expressionSyntax.SyntaxTree.Options).LanguageVersion >= LanguageVersion.CSharp9;
+        }
+
+        protected override bool ReplacementIntroducesErrorType(ExpressionSyntax originalExpression, ExpressionSyntax newExpression)
+        {
+            // The base implementation will see that the type of the new expression may potentially change to null,
+            // because the expression has no type but can be converted to a conditional expression type. In that case,
+            // we don't want to consider the null type to be an error type.
+            if (IsPotentiallyTargetTypedConditionalExpression(newExpression) &&
+                this.SpeculativeSemanticModel.GetConversion(newExpression).IsConditionalExpression)
+            {
+                return false;
+            }
+
+            return base.ReplacementIntroducesErrorType(originalExpression, newExpression);
+        }
+
         protected override bool ConversionsAreCompatible(SemanticModel originalModel, ExpressionSyntax originalExpression, SemanticModel newModel, ExpressionSyntax newExpression)
-            => ConversionsAreCompatible(originalModel.GetConversion(originalExpression), newModel.GetConversion(newExpression));
+        {
+            var originalConversion = originalModel.GetConversion(originalExpression);
+            var newConversion = newModel.GetConversion(newExpression);
+
+            if (IsPotentiallyTargetTypedConditionalExpression(originalExpression) &&
+                IsPotentiallyTargetTypedConditionalExpression(newExpression))
+            {
+                // If the only change to the conversion here is the introduction of a conditional expression conversion,
+                // that means types didn't really change in a meaningful way.
+                if (originalConversion.IsIdentity && newConversion.IsConditionalExpression)
+                {
+                    return true;
+                }
+            }
+
+            return ConversionsAreCompatible(originalConversion, newConversion);
+        }
 
         protected override bool ConversionsAreCompatible(ExpressionSyntax originalExpression, ITypeSymbol originalTargetType, ExpressionSyntax newExpression, ITypeSymbol newTargetType)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
         #region Semantic comparison helpers
 
-        private bool ReplacementIntroducesErrorType(TExpressionSyntax originalExpression, TExpressionSyntax newExpression)
+        protected virtual bool ReplacementIntroducesErrorType(TExpressionSyntax originalExpression, TExpressionSyntax newExpression)
         {
             Debug.Assert(originalExpression != null);
             Debug.Assert(this.SemanticRootOfOriginalExpression.DescendantNodesAndSelf().Contains(originalExpression));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -30,6 +30,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return expression;
             }
 
+            // Throw expressions are not permitted to be parenthesized:
+            //
+            //     "a" ?? throw new ArgumentNullException()
+            //
+            // is legal whereas
+            //
+            //     "a" ?? (throw new ArgumentNullException())
+            //
+            // is not.
+            if (expression.IsKind(SyntaxKind.ThrowExpression))
+            {
+                return expression;
+            }
+
             var result = ParenthesizeWorker(expression, includeElasticTrivia);
             return addSimplifierAnnotation
                 ? result.WithAdditionalAnnotations(Simplifier.Annotation)


### PR DESCRIPTION
This updates our unnecessary cast removal logic to recognize some cases when we can now remove casts because of the target-typed-conditional feature. Do note the explanation in the commit message for the one commit changing test baselines; my conclusion was the test was testing the wrong baseline (it didn't match the test name), and the baseline was happening due to broken behavior in the first place.

Closes https://github.com/dotnet/roslyn/issues/44036