### PR TITLE
Record langversion diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -830,6 +830,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Keep processing it as a non-const local.
                     isConst = false;
                 }
+
+                declType.Type.CheckRecordLangVersion(diagnostics, typeSyntax, typeSyntax.Location);
             }
 
             return declType;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -267,6 +267,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_MethodReturnCantBeRefAny, returnTypeSyntax.Location, returnType.Type);
             }
 
+            returnType.Type.CheckRecordLangVersion(diagnostics, returnTypeSyntax, returnTypeSyntax.Location);
+
             Debug.Assert(_refKind == RefKind.None
                 || !returnType.IsVoidType()
                 || returnTypeSyntax.HasErrors);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -82,6 +82,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_VolatileStruct, this.ErrorLocation, this, type);
             }
 
+            type.CheckRecordLangVersion(diagnostics, TypeSyntax, TypeSyntax?.Location);
+
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             if (!this.IsNoMoreVisibleThan(type, ref useSiteDiagnostics))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -145,6 +145,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            returnType.Type.CheckRecordLangVersion(diagnostics, returnTypeSyntax, returnTypeSyntax.Location);
+
             Debug.Assert(this.RefKind == RefKind.None || !returnType.IsVoidType() || returnTypeSyntax.HasErrors);
 
             ImmutableArray<TypeParameterConstraintClause> declaredConstraints = default;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -145,8 +145,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            returnType.Type.CheckRecordLangVersion(diagnostics, returnTypeSyntax, returnTypeSyntax.Location);
-
             Debug.Assert(this.RefKind == RefKind.None || !returnType.IsVoidType() || returnTypeSyntax.HasErrors);
 
             ImmutableArray<TypeParameterConstraintClause> declaredConstraints = default;
@@ -179,6 +177,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 forceMethodTypeParameters(returnType, this, declaredConstraints);
             }
+
+            returnType.Type.CheckRecordLangVersion(diagnostics, returnTypeSyntax, returnTypeSyntax.Location);
 
             return (returnType, parameters, _lazyIsVararg, declaredConstraints);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -391,6 +391,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(errorCode, Location, this);
             }
 
+            type.Type.CheckRecordLangVersion(diagnostics, typeSyntax, typeSyntax.Location);
+
             return type;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1964,5 +1964,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 default: return -1;
             }
         }
+
+        internal static void CheckRecordLangVersion(this TypeSymbol type, DiagnosticBag diagnostics, SyntaxNode syntax, Location location)
+        {
+            if (type.IsErrorType() && type.Name == SyntaxFacts.GetText(SyntaxKind.RecordKeyword))
+            {
+                MessageID.IDS_FeatureRecords.CheckFeatureAvailability(diagnostics, syntax, location);
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -1965,9 +1966,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static void CheckRecordLangVersion(this TypeSymbol type, DiagnosticBag diagnostics, SyntaxNode syntax, Location location)
+        internal static void CheckRecordLangVersion(this TypeSymbol type, DiagnosticBag diagnostics, TypeSyntax syntax, Location location)
         {
-            if (type.IsErrorType() && type.Name == SyntaxFacts.GetText(SyntaxKind.RecordKeyword))
+            if (type.IsErrorType() && syntax is IdentifierNameSyntax name && name.Identifier.Text == SyntaxFacts.GetText(SyntaxKind.RecordKeyword))
             {
                 MessageID.IDS_FeatureRecords.CheckFeatureAvailability(diagnostics, syntax, location);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -409,6 +409,58 @@ class E
                 Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithArguments("record").WithLocation(1, 14));
         }
 
+        [Fact, WorkItem(45900, "https://github.com/dotnet/roslyn/issues/45900")]
+        public void RecordLanguageVersion_Qualified_01()
+        {
+            var src4 = @"
+class E
+{
+    X.record Point;
+}
+";
+            var comp = CreateCompilation(src4, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (4,5): error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)
+                //     X.record Point;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("X").WithLocation(4, 5),
+                // (4,14): warning CS0169: The field 'E.Point' is never used
+                //     X.record Point;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "Point").WithArguments("E.Point").WithLocation(4, 14)
+                );
+
+            comp = CreateCompilation(src4);
+            comp.VerifyDiagnostics(
+                // (4,5): error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)
+                //     X.record Point;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("X").WithLocation(4, 5),
+                // (4,14): warning CS0169: The field 'E.Point' is never used
+                //     X.record Point;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "Point").WithArguments("E.Point").WithLocation(4, 14)
+                );
+
+            comp = CreateCompilation(new[] { src4, "public class record { }" }, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (4,5): error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)
+                //     X.record Point;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("X").WithLocation(4, 5),
+                // (4,14): warning CS0169: The field 'E.Point' is never used
+                //     X.record Point;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "Point").WithArguments("E.Point").WithLocation(4, 14)
+                );
+
+            comp = CreateCompilation(new[] { src4, "public class record { }" });
+            comp.VerifyDiagnostics(
+                // (1,14): warning CS8860: Types and aliases should not be named 'record'.
+                // public class record { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithArguments("record").WithLocation(1, 14),
+                // (4,5): error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)
+                //     X.record Point;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("X").WithLocation(4, 5),
+                // (4,14): warning CS0169: The field 'E.Point' is never used
+                //     X.record Point;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "Point").WithArguments("E.Point").WithLocation(4, 14));
+        }
+
         [Fact, WorkItem(46123, "https://github.com/dotnet/roslyn/issues/46123")]
         public void IncompletePositionalRecord()
         {


### PR DESCRIPTION
Related to #45900

Fixes https://github.com/dotnet/roslyn/projects/57#card-39518530 (this was already marked Done, but seems like it was only working when we incidentally were getting a diagnostic for top-level-statements which resemble record declarations.)

The idea here is that if 'record' fails to bind to a type in C# 8 or less, in a position where we would have parsed the declaration as a record in C# 9, such as a field, property, or ordinary method, local variable, or local function (for top level statement scenarios) we will give a LangVersion error in order to help you upgrade your project in the IDE.