### PR TITLE
Do not show unspeakable names in override completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -3044,6 +3045,7 @@ namespace NS3
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(47941, "https://github.com/dotnet/roslyn/issues/47941")]
         public async Task OverrideInRecordWithoutExplicitOverriddenMember()
         {
             await VerifyItemExistsAsync(@"record Program
@@ -3053,6 +3055,7 @@ namespace NS3
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(47941, "https://github.com/dotnet/roslyn/issues/47941")]
         public async Task OverrideInRecordWithExplicitOverriddenMember()
         {
             await VerifyItemIsAbsentAsync(@"record Program
@@ -3061,6 +3064,21 @@ namespace NS3
 
     override $$
 }", "ToString()");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(47973, "https://github.com/dotnet/roslyn/issues/47973")]
+        public async Task NoCloneInOverriddenRecord()
+        {
+            var cloneMemberName = (string)typeof(WellKnownMemberNames).GetField("CloneMethodName", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+            Assert.Equal("<Clone>$", cloneMemberName);
+            await VerifyItemIsAbsentAsync(@"
+record Base();
+
+record Program : Base
+{
+    override $$
+}", cloneMemberName);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -3042,5 +3042,25 @@ namespace NS3
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Bar(NS2.Baz baz)", expectedCodeAfterCommit);
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task OverrideInRecordWithoutExplicitOverriddenMember()
+        {
+            await VerifyItemExistsAsync(@"record Program
+{
+    override $$
+}", "ToString()");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task OverrideInRecordWithExplicitOverriddenMember()
+        {
+            await VerifyItemIsAbsentAsync(@"record Program
+{
+    public override string ToString() => "";
+
+    override $$
+}", "ToString()");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -3070,8 +3070,13 @@ namespace NS3
         [WorkItem(47973, "https://github.com/dotnet/roslyn/issues/47973")]
         public async Task NoCloneInOverriddenRecord()
         {
+            // Currently WellKnownMemberNames.CloneMethodName is not public, so we can't reference it directly.  We
+            // could hardcode in the value "<Clone>$", however if the compiler ever changed the name and we somehow
+            // started showing it in completion, this test would continue to pass.  So this allows us to at least go
+            // back and explicitly validate this scenario even in that event.
             var cloneMemberName = (string)typeof(WellKnownMemberNames).GetField("CloneMethodName", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
             Assert.Equal("<Clone>$", cloneMemberName);
+
             await VerifyItemIsAbsentAsync(@"
 record Base();
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -584,10 +584,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var overriddenMember = member.OverriddenMember();
-                if (overriddenMember != null)
+                if (!member.IsImplicitlyDeclared)
                 {
-                    result.Remove(overriddenMember);
+                    var overriddenMember = member.OverriddenMember();
+                    if (overriddenMember != null)
+                        result.Remove(overriddenMember);
                 }
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -557,16 +557,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (member.IsSealed)
                 return false;
 
-            if (!member.CanBeReferencedByName)
-                return false;
-
             if (!member.IsAccessibleWithin(containingType))
                 return false;
 
             return member switch
             {
                 IEventSymbol => true,
-                IMethodSymbol { MethodKind: MethodKind.Ordinary } => true,
+                IMethodSymbol { MethodKind: MethodKind.Ordinary, CanBeReferencedByName: true } => true,
                 IPropertySymbol { IsWithEvents: false } => true,
                 _ => false,
             };


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47973