### PR TITLE
API review feedback

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AddSpace();
                     AddKeyword(SyntaxKind.UnmanagedKeyword);
 
-                    var conventionTypes = symbol.CallingConventionTypes;
+                    var conventionTypes = symbol.UnmanagedCallingConventionTypes;
 
                     if (symbol.CallingConvention != SignatureCallingConvention.Unmanaged || !conventionTypes.IsEmpty)
                     {
@@ -601,11 +601,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         AddPunctuation(SyntaxKind.CloseBracketToken);
                     }
-                }
-                else if (format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseExplicitManagedCallingConventionSpecifier))
-                {
-                    AddSpace();
-                    AddKeyword(SyntaxKind.ManagedKeyword);
                 }
 
                 AddPunctuation(SyntaxKind.LessThanToken);

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -628,7 +628,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override ImmutableArray<NamedTypeSymbol> CallingConventionTypes
+        internal override ImmutableArray<NamedTypeSymbol> UnmanagedCallingConventionTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -898,7 +898,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get;
         }
 
-        internal virtual ImmutableArray<NamedTypeSymbol> CallingConventionTypes => ImmutableArray<NamedTypeSymbol>.Empty;
+        internal virtual ImmutableArray<NamedTypeSymbol> UnmanagedCallingConventionTypes => ImmutableArray<NamedTypeSymbol>.Empty;
 
         /// <summary>
         /// Returns the map from type parameters to type arguments.

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         SignatureCallingConvention IMethodSymbol.CallingConvention => _underlying.CallingConvention.ToSignatureConvention();
 
-        ImmutableArray<INamedTypeSymbol> IMethodSymbol.CallingConventionTypes => _underlying.CallingConventionTypes.SelectAsArray(t => t.GetPublicSymbol());
+        ImmutableArray<INamedTypeSymbol> IMethodSymbol.UnmanagedCallingConventionTypes => _underlying.UnmanagedCallingConventionTypes.SelectAsArray(t => t.GetPublicSymbol());
 
         IMethodSymbol IMethodSymbol.Construct(params ITypeSymbol[] typeArguments)
         {

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -725,7 +725,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return provider?.IsGenerated(this, cancellationToken) switch
             {
                 null or GeneratedKind.Unknown => isGeneratedHeuristic(),
-                GeneratedKind kind => kind == GeneratedKind.Generated
+                GeneratedKind kind => kind == GeneratedKind.MarkedGenerated
             };
 
             bool isGeneratedHeuristic()
@@ -737,10 +737,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             this,
                             isComment: trivia => trivia.Kind() == SyntaxKind.SingleLineCommentTrivia || trivia.Kind() == SyntaxKind.MultiLineCommentTrivia,
                             cancellationToken: default);
-                    _lazyIsGeneratedCode = isGenerated ? GeneratedKind.Generated : GeneratedKind.NotGenerated;
+                    _lazyIsGeneratedCode = isGenerated ? GeneratedKind.MarkedGenerated : GeneratedKind.NotGenerated;
                 }
 
-                return _lazyIsGeneratedCode == GeneratedKind.Generated;
+                return _lazyIsGeneratedCode == GeneratedKind.MarkedGenerated;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -722,21 +722,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal bool IsGeneratedCode(SyntaxTreeOptionsProvider? provider, CancellationToken cancellationToken)
         {
-            return provider?.IsGenerated(this, cancellationToken) ?? isGeneratedHeuristic();
+            return provider?.IsGenerated(this, cancellationToken) switch
+            {
+                null or GeneratedKind.Unknown => isGeneratedHeuristic(),
+                GeneratedKind kind => kind == GeneratedKind.Generated
+            };
 
             bool isGeneratedHeuristic()
             {
-                if (_lazyIsGeneratedCode == ThreeState.Unknown)
+                if (_lazyIsGeneratedCode == GeneratedKind.Unknown)
                 {
                     // Create the generated code status on demand
                     bool isGenerated = GeneratedCodeUtilities.IsGeneratedCode(
                             this,
                             isComment: trivia => trivia.Kind() == SyntaxKind.SingleLineCommentTrivia || trivia.Kind() == SyntaxKind.MultiLineCommentTrivia,
                             cancellationToken: default);
-                    _lazyIsGeneratedCode = isGenerated.ToThreeState();
+                    _lazyIsGeneratedCode = isGenerated ? GeneratedKind.Generated : GeneratedKind.NotGenerated;
                 }
 
-                return _lazyIsGeneratedCode == ThreeState.True;
+                return _lazyIsGeneratedCode == GeneratedKind.Generated;
             }
         }
 
@@ -744,7 +748,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private CSharpPragmaWarningStateMap? _lazyPragmaWarningStateMap;
         private StrongBox<NullableContextStateMap>? _lazyNullableContextStateMap;
 
-        private ThreeState _lazyIsGeneratedCode = ThreeState.Unknown;
+        private GeneratedKind _lazyIsGeneratedCode = GeneratedKind.Unknown;
 
         private LinePosition GetLinePosition(int position)
         {

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -725,7 +725,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return provider?.IsGenerated(this, cancellationToken) switch
             {
                 null or GeneratedKind.Unknown => isGeneratedHeuristic(),
-                GeneratedKind kind => kind == GeneratedKind.MarkedGenerated
+                GeneratedKind kind => kind != GeneratedKind.NotGenerated
             };
 
             bool isGeneratedHeuristic()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -1663,15 +1663,6 @@ unsafe class C
         }
 
         [Fact]
-        public void PublicApi_ExplicitManagedFormatOption()
-        {
-            var comp = (Compilation)CreateCompilation("");
-            var @string = comp.GetSpecialType(SpecialType.System_String);
-            var ptr = comp.CreateFunctionPointerTypeSymbol(@string, returnRefKind: RefKind.None, parameterTypes: ImmutableArray<ITypeSymbol>.Empty, parameterRefKinds: ImmutableArray<RefKind>.Empty);
-            AssertEx.Equal("delegate* managed<System.String>", ptr.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseExplicitManagedCallingConventionSpecifier)));
-        }
-
-        [Fact]
         public void PublicApi_SemanticInfo01()
         {
             var comp = CreateFunctionPointerCompilation(@"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -2342,17 +2342,17 @@ class C
             var m1 = (IMethodSymbol)c.GetMember("M1");
             Assert.NotNull(m1);
             Assert.Equal(SignatureCallingConvention.Default, m1.CallingConvention);
-            Assert.Empty(m1.CallingConventionTypes);
+            Assert.Empty(m1.UnmanagedCallingConventionTypes);
 
             var m2 = (IMethodSymbol)c.GetMember("M2");
             Assert.NotNull(m2);
             Assert.Equal(SignatureCallingConvention.Default, m2.CallingConvention);
-            Assert.Empty(m2.CallingConventionTypes);
+            Assert.Empty(m2.UnmanagedCallingConventionTypes);
 
             var m3 = (IMethodSymbol)c.GetMember("M3");
             Assert.NotNull(m3);
             Assert.Equal(SignatureCallingConvention.VarArgs, m3.CallingConvention);
-            Assert.Empty(m3.CallingConventionTypes);
+            Assert.Empty(m3.UnmanagedCallingConventionTypes);
         }
 
         [Fact]
@@ -2390,17 +2390,17 @@ class C
             var m1 = (IMethodSymbol)c.GetMember("M1");
             Assert.NotNull(m1);
             Assert.Equal(SignatureCallingConvention.Default, m1.CallingConvention);
-            Assert.Empty(m1.CallingConventionTypes);
+            Assert.Empty(m1.UnmanagedCallingConventionTypes);
 
             var m2 = (IMethodSymbol)c.GetMember("M2");
             Assert.NotNull(m2);
             Assert.Equal(SignatureCallingConvention.Default, m2.CallingConvention);
-            Assert.Empty(m2.CallingConventionTypes);
+            Assert.Empty(m2.UnmanagedCallingConventionTypes);
 
             var m3 = (IMethodSymbol)c.GetMember("M3");
             Assert.NotNull(m3);
             Assert.Equal(SignatureCallingConvention.VarArgs, m3.CallingConvention);
-            Assert.Empty(m3.CallingConventionTypes);
+            Assert.Empty(m3.UnmanagedCallingConventionTypes);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Compilation/GeneratedKind.cs
+++ b/src/Compilers/Core/Portable/Compilation/GeneratedKind.cs
@@ -6,8 +6,17 @@ namespace Microsoft.CodeAnalysis
 {
     public enum GeneratedKind
     {
+        /// <summary>
+        /// Whether the <see cref="SyntaxTree"/> is automatically generated is unknown.
+        /// </summary>
         Unknown,
+        /// <summary>
+        /// The <see cref="SyntaxTree"/> is not automatically generated.
+        /// </summary>
         NotGenerated,
-        Generated
+        /// <summary>
+        /// The <see cref="SyntaxTree"/> is marked as automatically generated.
+        /// </summary>
+        MarkedGenerated
     }
 }

--- a/src/Compilers/Core/Portable/Compilation/GeneratedKind.cs
+++ b/src/Compilers/Core/Portable/Compilation/GeneratedKind.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis
     public enum GeneratedKind
     {
         /// <summary>
-        /// Whether the <see cref="SyntaxTree"/> is automatically generated is unknown.
+        /// It is unknown if the <see cref="SyntaxTree"/> is automatically generated.
         /// </summary>
         Unknown,
         /// <summary>

--- a/src/Compilers/Core/Portable/Compilation/GeneratedKind.cs
+++ b/src/Compilers/Core/Portable/Compilation/GeneratedKind.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis
+{
+    public enum GeneratedKind
+    {
+        Unknown,
+        NotGenerated,
+        Generated
+    }
+}

--- a/src/Compilers/Core/Portable/Compilation/SyntaxTreeOptionsProvider.cs
+++ b/src/Compilers/Core/Portable/Compilation/SyntaxTreeOptionsProvider.cs
@@ -12,7 +12,10 @@ namespace Microsoft.CodeAnalysis
 {
     public abstract class SyntaxTreeOptionsProvider
     {
-        public abstract bool? IsGenerated(SyntaxTree tree, CancellationToken cancellationToken);
+        /// <summary>
+        /// Get whether the given tree is generated.
+        /// </summary>
+        public abstract GeneratedKind IsGenerated(SyntaxTree tree, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get diagnostic severity setting for a given diagnostic identifier in a given tree.
@@ -29,7 +32,7 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly struct Options
         {
-            public readonly bool? IsGenerated;
+            public readonly GeneratedKind IsGenerated;
             public readonly ImmutableDictionary<string, ReportDiagnostic> DiagnosticOptions;
 
             public Options(AnalyzerConfigOptionsResult? result)
@@ -42,7 +45,7 @@ namespace Microsoft.CodeAnalysis
                 else
                 {
                     DiagnosticOptions = SyntaxTree.EmptyDiagnosticOptions;
-                    IsGenerated = null;
+                    IsGenerated = GeneratedKind.Unknown;
                 }
             }
         }
@@ -70,8 +73,8 @@ namespace Microsoft.CodeAnalysis
             _globalOptions = globalResults;
         }
 
-        public override bool? IsGenerated(SyntaxTree tree, CancellationToken _)
-            => _options.TryGetValue(tree, out var value) ? value.IsGenerated : null;
+        public override GeneratedKind IsGenerated(SyntaxTree tree, CancellationToken _)
+            => _options.TryGetValue(tree, out var value) ? value.IsGenerated : GeneratedKind.Unknown;
 
         public override bool TryGetDiagnosticValue(SyntaxTree tree, string diagnosticId, CancellationToken _, out ReportDiagnostic severity)
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/GeneratedCodeUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/GeneratedCodeUtilities.cs
@@ -154,7 +154,7 @@ namespace Roslyn.Utilities
             if (options.TryGetValue("generated_code", out string? optionValue) &&
                 bool.TryParse(optionValue, out var boolValue))
             {
-                return boolValue ? GeneratedKind.Generated : GeneratedKind.NotGenerated;
+                return boolValue ? GeneratedKind.MarkedGenerated : GeneratedKind.NotGenerated;
             }
 
             // Either no explicit user configuration or we don't recognize the option value.

--- a/src/Compilers/Core/Portable/InternalUtilities/GeneratedCodeUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/GeneratedCodeUtilities.cs
@@ -147,18 +147,18 @@ namespace Roslyn.Utilities
             return false;
         }
 
-        internal static bool? GetIsGeneratedCodeFromOptions(ImmutableDictionary<string, string> options)
+        internal static GeneratedKind GetIsGeneratedCodeFromOptions(ImmutableDictionary<string, string> options)
         {
             // Check for explicit user configuration for generated code.
             //     generated_code = true | false
             if (options.TryGetValue("generated_code", out string? optionValue) &&
                 bool.TryParse(optionValue, out var boolValue))
             {
-                return boolValue;
+                return boolValue ? GeneratedKind.Generated : GeneratedKind.NotGenerated;
             }
 
             // Either no explicit user configuration or we don't recognize the option value.
-            return null;
+            return GeneratedKind.Unknown;
         }
 
         internal static bool? GetIsGeneratedCodeFromOptions(AnalyzerConfigOptions options)

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -31,12 +31,11 @@ Microsoft.CodeAnalysis.GeneratorInitializationContext
 Microsoft.CodeAnalysis.GeneratorInitializationContext.CancellationToken.get -> System.Threading.CancellationToken
 Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForSyntaxNotifications(Microsoft.CodeAnalysis.SyntaxReceiverCreator receiverCreator) -> void
 Microsoft.CodeAnalysis.IMethodSymbol.CallingConvention.get -> System.Reflection.Metadata.SignatureCallingConvention
-Microsoft.CodeAnalysis.IMethodSymbol.CallingConventionTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>
+Microsoft.CodeAnalysis.IMethodSymbol.UnmanagedCallingConventionTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>
 Microsoft.CodeAnalysis.ISourceGenerator.Execute(Microsoft.CodeAnalysis.GeneratorExecutionContext context) -> void
 Microsoft.CodeAnalysis.ISourceGenerator.Initialize(Microsoft.CodeAnalysis.GeneratorInitializationContext context) -> void
 Microsoft.CodeAnalysis.InitializationContext.InitializationContext() -> void
 Microsoft.CodeAnalysis.SourceGeneratorContext.SourceGeneratorContext() -> void
-Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.UseExplicitManagedCallingConventionSpecifier = 512 -> Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.Diagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.GeneratedTrees.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SyntaxTree>
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.Results.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.GeneratorRunResult>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -16,7 +16,7 @@ Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsy
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.set -> void
 Microsoft.CodeAnalysis.GeneratedKind
-Microsoft.CodeAnalysis.GeneratedKind.Generated = 2 -> Microsoft.CodeAnalysis.GeneratedKind
+Microsoft.CodeAnalysis.GeneratedKind.MarkedGenerated = 2 -> Microsoft.CodeAnalysis.GeneratedKind
 Microsoft.CodeAnalysis.GeneratedKind.NotGenerated = 1 -> Microsoft.CodeAnalysis.GeneratedKind
 Microsoft.CodeAnalysis.GeneratedKind.Unknown = 0 -> Microsoft.CodeAnalysis.GeneratedKind
 Microsoft.CodeAnalysis.GeneratorDriver.RemoveAdditionalTexts(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AdditionalText> additionalTexts) -> Microsoft.CodeAnalysis.GeneratorDriver

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -15,6 +15,10 @@ Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsy
 Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.AdditionalText file, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.set -> void
+Microsoft.CodeAnalysis.GeneratedKind
+Microsoft.CodeAnalysis.GeneratedKind.Generated = 2 -> Microsoft.CodeAnalysis.GeneratedKind
+Microsoft.CodeAnalysis.GeneratedKind.NotGenerated = 1 -> Microsoft.CodeAnalysis.GeneratedKind
+Microsoft.CodeAnalysis.GeneratedKind.Unknown = 0 -> Microsoft.CodeAnalysis.GeneratedKind
 Microsoft.CodeAnalysis.GeneratorDriver.RemoveAdditionalTexts(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AdditionalText> additionalTexts) -> Microsoft.CodeAnalysis.GeneratorDriver
 Microsoft.CodeAnalysis.GeneratorDriver.RunGeneratorsAndUpdateCompilation(Microsoft.CodeAnalysis.Compilation compilation, out Microsoft.CodeAnalysis.Compilation outputCompilation, out System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.GeneratorDriver
 Microsoft.CodeAnalysis.GeneratorExecutionContext
@@ -34,15 +38,13 @@ Microsoft.CodeAnalysis.IMethodSymbol.CallingConvention.get -> System.Reflection.
 Microsoft.CodeAnalysis.IMethodSymbol.UnmanagedCallingConventionTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol>
 Microsoft.CodeAnalysis.ISourceGenerator.Execute(Microsoft.CodeAnalysis.GeneratorExecutionContext context) -> void
 Microsoft.CodeAnalysis.ISourceGenerator.Initialize(Microsoft.CodeAnalysis.GeneratorInitializationContext context) -> void
-Microsoft.CodeAnalysis.InitializationContext.InitializationContext() -> void
-Microsoft.CodeAnalysis.SourceGeneratorContext.SourceGeneratorContext() -> void
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.Diagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.GeneratedTrees.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SyntaxTree>
 Microsoft.CodeAnalysis.GeneratorDriverRunResult.Results.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.GeneratorRunResult>
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.SyntaxTreeOptionsProvider() -> void
 abstract Microsoft.CodeAnalysis.DataFlowAnalysis.UsedLocalFunctions.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IMethodSymbol>
-abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree, System.Threading.CancellationToken cancellationToken) -> bool?
+abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.GeneratedKind
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetDiagnosticValue(Microsoft.CodeAnalysis.SyntaxTree tree, string diagnosticId, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetGlobalDiagnosticValue(string diagnosticId, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
 Microsoft.CodeAnalysis.GeneratorRunResult.GeneratedSources.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.GeneratedSourceResult>

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
@@ -74,10 +74,5 @@ namespace Microsoft.CodeAnalysis
         /// Append '!' to non-nullable reference types.
         /// </summary>
         IncludeNotNullableReferenceTypeModifier = 1 << 8,
-
-        /// <summary>
-        /// Use the `managed` keyword for managed function pointer types.
-        /// </summary>
-        UseExplicitManagedCallingConventionSpecifier = 1 << 9,
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis
         /// and the <see cref="CallingConvention"/> is <see cref="SignatureCallingConvention.Unmanaged"/>. If this is not a function pointer signature or the calling convention is
         /// not unmanaged, this is an empty array. Order and duplication of these modifiers reflect source/metadata order and duplication, whichever this symbol came from.
         /// </summary>
-        ImmutableArray<INamedTypeSymbol> CallingConventionTypes { get; }
+        ImmutableArray<INamedTypeSymbol> UnmanagedCallingConventionTypes { get; }
 
         /// <summary>
         /// Returns a symbol (e.g. property, event, etc.) associated with the method.

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -1016,7 +1016,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public ReadOnly Property CallingConventionTypes As ImmutableArray(Of INamedTypeSymbol) Implements IMethodSymbol.CallingConventionTypes
+        Private ReadOnly Property IMethodSymbol_UnmanagedCallingConventionTypes As ImmutableArray(Of INamedTypeSymbol) Implements IMethodSymbol.UnmanagedCallingConventionTypes
             Get
                 Return ImmutableArray(Of INamedTypeSymbol).Empty
             End Get

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public SignatureCallingConvention CallingConvention => _symbol.CallingConvention;
 
-            public ImmutableArray<INamedTypeSymbol> CallingConventionTypes => _symbol.CallingConventionTypes;
+            public ImmutableArray<INamedTypeSymbol> UnmanagedCallingConventionTypes => _symbol.UnmanagedCallingConventionTypes;
         }
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestSyntaxTreeOptionsProvider.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Utilities
     public sealed class TestSyntaxTreeOptionsProvider : SyntaxTreeOptionsProvider
     {
         private readonly Dictionary<SyntaxTree, Dictionary<string, ReportDiagnostic>>? _options;
-        private readonly Dictionary<SyntaxTree, bool?>? _isGenerated;
+        private readonly Dictionary<SyntaxTree, GeneratedKind>? _isGenerated;
         private readonly Dictionary<string, ReportDiagnostic>? _globalOptions;
         public TestSyntaxTreeOptionsProvider(
             IEqualityComparer<string> comparer,
@@ -53,7 +53,7 @@ namespace Roslyn.Utilities
         { }
 
         public TestSyntaxTreeOptionsProvider(
-            params (SyntaxTree, bool? isGenerated)[] isGenerated
+            params (SyntaxTree, GeneratedKind isGenerated)[] isGenerated
         )
         {
             _options = null;
@@ -63,8 +63,8 @@ namespace Roslyn.Utilities
             );
         }
 
-        public override bool? IsGenerated(SyntaxTree tree, CancellationToken cancellationToken)
-        => _isGenerated != null && _isGenerated.TryGetValue(tree, out var val) ? val : null;
+        public override GeneratedKind IsGenerated(SyntaxTree tree, CancellationToken cancellationToken)
+            => _isGenerated != null && _isGenerated.TryGetValue(tree, out var kind) ? kind : GeneratedKind.Unknown;
 
         public override bool TryGetDiagnosticValue(
             SyntaxTree tree,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public SignatureCallingConvention CallingConvention => SignatureCallingConvention.Default;
 
-        public ImmutableArray<INamedTypeSymbol> CallingConventionTypes => ImmutableArray<INamedTypeSymbol>.Empty;
+        public ImmutableArray<INamedTypeSymbol> UnmanagedCallingConventionTypes => ImmutableArray<INamedTypeSymbol>.Empty;
 
         public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
             => new CodeGenerationConstructedMethodSymbol(this, typeArguments.ToImmutableArray());

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FunctionPointerTypeSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.FunctionPointerTypeSymbolKey.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (callingConvention == SignatureCallingConvention.Unmanaged)
                 {
-                    visitor.WriteSymbolKeyArray(symbol.Signature.CallingConventionTypes);
+                    visitor.WriteSymbolKeyArray(symbol.Signature.UnmanagedCallingConventionTypes);
                 }
 
                 visitor.WriteRefKind(symbol.Signature.RefKind);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis
             public WorkspaceSyntaxTreeOptionsProvider(ValueSource<CachingAnalyzerConfigSet> lazyAnalyzerConfigSet)
                 => _lazyAnalyzerConfigSet = lazyAnalyzerConfigSet;
 
-            public override bool? IsGenerated(SyntaxTree tree, CancellationToken cancellationToken)
+            public override GeneratedKind IsGenerated(SyntaxTree tree, CancellationToken cancellationToken)
             {
                 var options = _lazyAnalyzerConfigSet
                     .GetValue(cancellationToken).GetOptionsForSourcePath(tree.FilePath);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.MinimalAccessibilityVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.MinimalAccessibilityVisitor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
                 // CallingConvention types are currently specced to always be public, but if that spec ever changes
                 // or the runtime creates special private types for it's own use, we'll be ready.
-                foreach (var callingConventionType in symbol.Signature.CallingConventionTypes)
+                foreach (var callingConventionType in symbol.Signature.UnmanagedCallingConventionTypes)
                 {
                     accessibility = AccessibilityUtilities.Minimum(accessibility, callingConventionType.Accept(this));
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -140,8 +140,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         System.Reflection.Metadata.SignatureCallingConvention.Unmanaged =>
                             // All types that come from CallingConventionTypes start with "CallConv". We don't want the prefix for the actual
                             // syntax, so strip it off
-                            symbol.Signature.CallingConventionTypes.IsEmpty
-                                ? null : symbol.Signature.CallingConventionTypes.Select(type => GetConventionForString(type.Name["CallConv".Length..])),
+                            symbol.Signature.UnmanagedCallingConventionTypes.IsEmpty
+                                ? null : symbol.Signature.UnmanagedCallingConventionTypes.Select(type => GetConventionForString(type.Name["CallConv".Length..])),
 
                         _ => throw ExceptionUtilities.UnexpectedValue(symbol.Signature.CallingConvention),
                     };


### PR DESCRIPTION
Addresses the remaining API review feedback items. Fixes https://github.com/dotnet/roslyn/issues/46979.

Commit 1: Removes SymbolDisplayMiscellaneousOptions.UseExplicitManagedCallingConventionSpecifier, rename IMethodSymbol.CallingConventionTypes.
Commit 2: Make SyntaxTreeOptionsProvider.IsGenerated use a new GeneratedKind enum, not a bool?.

@dotnet/roslyn-compiler @chsienki @jasonmalinowski for review.