### PR TITLE
Throw an exception if we can't parse language version

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -501,7 +501,7 @@ class C
     </Project>
     <Project Language=""C#"" LanguageVersion=""7"">
     </Project>
-    <Project Language=""C#"" LanguageVersion=""800"">
+    <Project Language=""C#"" LanguageVersion=""8"">
     </Project>
 </Workspace>",
                 new[]
@@ -607,7 +607,7 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""800"">
+    <Project Language=""C#"" LanguageVersion=""8"">
     </Project>
     <Project Language=""Visual Basic"">
     </Project>
@@ -878,7 +878,7 @@ class Test<T> where T : [|notnull|]
         {
             await TestExactActionSetOfferedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""703"">
+    <Project Language=""C#"" LanguageVersion=""7.3"">
         <Document>
 interface notnull { }
 class Test&lt;T&gt; where T : [|notnull|]
@@ -908,7 +908,7 @@ class Test
         {
             await TestExactActionSetOfferedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""703"">
+    <Project Language=""C#"" LanguageVersion=""7.3"">
         <Document>
 interface notnull { }
 class Test
@@ -935,7 +935,7 @@ class Test
         {
             await TestExactActionSetOfferedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""703"">
+    <Project Language=""C#"" LanguageVersion=""7.3"">
         <Document>
 interface notnull { }
 delegate void D&lt;T&gt;() where T : [| notnull |];
@@ -966,7 +966,7 @@ class Test
         {
             await TestExactActionSetOfferedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""703"">
+    <Project Language=""C#"" LanguageVersion=""7.3"">
         <Document>
 interface notnull { }
 class Test

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6039,8 +6039,8 @@ namespace Nested
         {
             var xmlString = @"
 <Workspace>
-    <Project Language=""C#"" LanguageVersion=""702"" CommonReferences=""true"">
-        <MetadataReferenceFromSource Language=""C#"" LanguageVersion=""702"" CommonReferences=""true"">
+    <Project Language=""C#"" LanguageVersion=""7.2"" CommonReferences=""true"">
+        <MetadataReferenceFromSource Language=""C#"" LanguageVersion=""7.2"" CommonReferences=""true"">
             <Document FilePath=""ReferencedDocument"">
 public ref struct TestRef
 {

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -1389,7 +1389,7 @@ public class [|C|]
     public C();
 
     public void M(CancellationToken cancellationToken = default);
-}}", languageVersion: "CSharp7_1");
+}}", languageVersion: "7.1");
         }
 
         [WorkItem(446567, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=446567")]
@@ -1483,7 +1483,7 @@ public class [|TestType|]<T> where T : unmanaged
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp7_3",
+                languageVersion: "7.3",
                 sourceWithSymbolReference: sourceWithSymbolReference);
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -1523,7 +1523,7 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp7_3",
+                languageVersion: "7.3",
                 sourceWithSymbolReference: sourceWithSymbolReference);
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -1552,7 +1552,7 @@ public delegate void [|D|]<T>() where T : unmanaged;";
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp7_3",
+                languageVersion: "7.3",
                 sourceWithSymbolReference: sourceWithSymbolReference);
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2267,9 +2267,9 @@ public class [|TestType|]<T> where T : notnull
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2309,9 +2309,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2340,9 +2340,9 @@ public delegate void [|D|]<T>() where T : notnull;";
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2398,9 +2398,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2453,9 +2453,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2516,9 +2516,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2566,9 +2566,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2617,9 +2617,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2665,9 +2665,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2713,9 +2713,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2759,9 +2759,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2805,9 +2805,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2851,9 +2851,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2895,9 +2895,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -2959,9 +2959,9 @@ namespace N
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -3033,9 +3033,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
@@ -3077,9 +3077,9 @@ public class TestType
                 LanguageNames.CSharp,
                 SpecializedCollections.SingletonEnumerable(metadata),
                 includeXmlDocComments: false,
-                languageVersion: "CSharp8",
+                languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
-                metadataLanguageVersion: "CSharp8");
+                metadataLanguageVersion: "8");
 
             var navigationSymbol = await context.GetNavigationSymbolAsync();
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2576,7 +2576,7 @@ End Class
         Public Async Function TestNonTrailingNamedArgumentInVB15_5() As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(
                  <Workspace>
-                     <Project Language="Visual Basic" LanguageVersion="VisualBasic15_5" CommonReferences="true" AssemblyName="VBProj">
+                     <Project Language="Visual Basic" LanguageVersion="15.5" CommonReferences="true" AssemblyName="VBProj">
                          <Document FilePath="C.vb">
 Class C
     Sub M()

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -447,17 +447,21 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             if (language == LanguageNames.CSharp)
             {
-                _ = CodeAnalysis.CSharp.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, out var languageVersion);
-                parseOptions = ((CSharpParseOptions)parseOptions).WithLanguageVersion(languageVersion);
+                if (CodeAnalysis.CSharp.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, out var languageVersion))
+                {
+                    return ((CSharpParseOptions)parseOptions).WithLanguageVersion(languageVersion);
+                }
             }
             else if (language == LanguageNames.VisualBasic)
             {
                 var languageVersion = CodeAnalysis.VisualBasic.LanguageVersion.Default;
-                _ = CodeAnalysis.VisualBasic.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, ref languageVersion);
-                parseOptions = ((VisualBasicParseOptions)parseOptions).WithLanguageVersion(languageVersion);
+                if (CodeAnalysis.VisualBasic.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, ref languageVersion))
+                {
+                    return ((VisualBasicParseOptions)parseOptions).WithLanguageVersion(languageVersion);
+                }
             }
 
-            return parseOptions;
+            throw new Exception($"LanguageVersion attribute on {languageVersionAttribute.Parent} was not recognized.");
         }
 
         private static DocumentationMode? GetDocumentationMode(XElement projectElement)

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Completion
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
@@ -10,11 +11,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                                      Optional excludedTypes As List(Of Type) = Nothing,
                                                      Optional extraExportedTypes As List(Of Type) = Nothing,
                                                      Optional includeFormatCommandHandler As Boolean = False,
-                                                     Optional languageVersion As CodeAnalysis.CSharp.LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Default,
+                                                     Optional languageVersion As LanguageVersion = LanguageVersion.Default,
                                                      Optional showCompletionInArgumentLists As Boolean = True) As TestState
 
             Dim testState = New TestState(<Workspace>
-                                              <Project Language="C#" CommonReferences="true" LanguageVersion=<%= DirectCast(languageVersion, Integer) %>>
+                                              <Project Language="C#" CommonReferences="true" LanguageVersion=<%= languageVersion.ToDisplayString() %>>
                                                   <Document>
                                                       <%= documentElement.Value %>
                                                   </Document>


### PR DESCRIPTION
Silently failing is not helpful when your test isn't behaving right.