### PR TITLE
Expose MaxLangVersion publicly

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -16,7 +16,8 @@
     <!-- .NETCoreApp == 5.0 -->
     <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' == '5.0' AND
                                          '$(_MaxSupportedLangVersion)' == ''">9.0</_MaxSupportedLangVersion>
-    
+
+    <MaxSupportedLangVersion>$(_MaxSupportedLangVersion)</MaxSupportedLangVersion>
     <LangVersion Condition="'$(LangVersion)' == '' AND '$(_MaxSupportedLangVersion)' != ''">$(_MaxSupportedLangVersion)</LangVersion>
   </PropertyGroup>
 

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -461,6 +461,60 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("55.0", langVersion);
             Assert.Equal("7.3", maxLangVersion);
         }
+
+        [Fact]
+        public void MaxSupportedLangVersionIsReadable()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <PropertyGroup>
+        <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+        <_TargetFrameworkVersionWithoutV>2.0</_TargetFrameworkVersionWithoutV>
+        <LangVersion>9.0</LangVersion>
+    </PropertyGroup>
+    <Import Project=""Microsoft.CSharp.Core.targets"" />
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+            instance.Build(GetTestLoggers());
+
+            var langVersion = instance.GetPropertyValue("LangVersion");
+            var maxLangVersion = instance.GetPropertyValue("_MaxSupportedLangVersion");
+            var publicMaxLangVersion = instance.GetPropertyValue("MaxSupportedLangVersion");
+
+            Assert.Equal("9.0", langVersion);
+            Assert.Equal("7.3", maxLangVersion);
+            Assert.Equal("7.3", publicMaxLangVersion);
+        }
+
+        [Fact]
+        public void MaxSupportedLangVersionIsnotWriteable()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <PropertyGroup>
+        <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+        <_TargetFrameworkVersionWithoutV>2.0</_TargetFrameworkVersionWithoutV>
+        <LangVersion>9.0</LangVersion> 
+        <MaxSupportedLangVersion>9.0</MaxSupportedLangVersion>
+    </PropertyGroup>
+    <Import Project=""Microsoft.CSharp.Core.targets"" />
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+            instance.Build(GetTestLoggers());
+
+            var langVersion = instance.GetPropertyValue("LangVersion");
+            var maxLangVersion = instance.GetPropertyValue("_MaxSupportedLangVersion");
+            var publicMaxLangVersion = instance.GetPropertyValue("MaxSupportedLangVersion");
+
+            Assert.Equal("9.0", langVersion);
+            Assert.Equal("7.3", maxLangVersion);
+            Assert.Equal("7.3", publicMaxLangVersion);
+        }
+
         [Fact]
         public void GenerateEditorConfigIsPassedToTheCompiler()
         {


### PR DESCRIPTION
Adds a 'readonly' (in the MSbuild sense) version of MaxLangVersion that downstream clients can read.

Fixes https://github.com/dotnet/roslyn/issues/47983