### PR TITLE
Begin using the GitHub service connection with the Rich Nav build

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -26,6 +26,7 @@ jobs:
       inputs:
         languages: 'csharp'
         environment: production
+        githubServiceConnection: dotnet
         richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
       continueOnError: true
       env:


### PR DESCRIPTION
A recent update to our service requires a Git token with all indexing requests. With this change, the Rich Nav task will have access to the aforementioned token to make requests to our service. 