### PR TITLE
Don't optimize large tuple literal switch inputs

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
@@ -426,6 +426,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 if (loweredInput.Type.IsTupleType &&
+                    !loweredInput.Type.OriginalDefinition.Equals(_factory.Compilation.GetWellKnownType(WellKnownType.System_ValueTuple_TRest)) &&
                     loweredInput.Syntax.Kind() == SyntaxKind.TupleExpression &&
                     loweredInput is BoundObjectCreationExpression expr &&
                     !decisionDag.TopologicallySortedNodes.Any(n => usesOriginalInput(n)))

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -3005,7 +3005,7 @@ public class C
     }
 }
 ";
-            CompileAndVerify(text).VerifyIL("C.Main", @"
+            CompileAndVerify(text, expectedOutput: "1").VerifyIL("C.Main", @"
 {
   // Code size      110 (0x6e)
   .maxstack  9
@@ -3068,7 +3068,7 @@ public class C
         }
 
         [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
-        public void VerifyIL_GreatherThan8ElementsTuple()
+        public void VerifyIL_GreaterThan8ElementsTuple_01()
         {
             var text = @"
 using System;
@@ -3086,7 +3086,7 @@ public class C
     }
 }
 ";
-            CompileAndVerify(text).VerifyIL("C.Main", @"
+            CompileAndVerify(text, expectedOutput: "1").VerifyIL("C.Main", @"
 {
   // Code size      204 (0xcc)
   .maxstack  14
@@ -3176,6 +3176,254 @@ public class C
   IL_00cb:  ret
 }
 ");
+        }
+
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void VerifyIL_GreaterThan8ElementsTuple_02()
+        {
+            var text = @"
+using System;
+public class C
+{
+    public static void Main()
+    {
+        int x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20) => 1,
+            _ => -1,
+        };
+
+        Console.WriteLine(x);
+    }
+}
+";
+            CompileAndVerify(text).VerifyIL("C.Main", @"
+{
+  // Code size      388 (0x184)
+  .maxstack  21
+  .locals init (int V_0,
+                System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>> V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  ldc.i4.3
+  IL_0005:  ldc.i4.4
+  IL_0006:  ldc.i4.5
+  IL_0007:  ldc.i4.6
+  IL_0008:  ldc.i4.7
+  IL_0009:  ldc.i4.8
+  IL_000a:  ldc.i4.s   9
+  IL_000c:  ldc.i4.s   10
+  IL_000e:  ldc.i4.s   11
+  IL_0010:  ldc.i4.s   12
+  IL_0012:  ldc.i4.s   13
+  IL_0014:  ldc.i4.s   14
+  IL_0016:  ldc.i4.s   15
+  IL_0018:  ldc.i4.s   16
+  IL_001a:  ldc.i4.s   17
+  IL_001c:  ldc.i4.s   18
+  IL_001e:  ldc.i4.s   19
+  IL_0020:  ldc.i4.s   20
+  IL_0022:  newobj     ""System.ValueTuple<int, int, int, int, int, int>..ctor(int, int, int, int, int, int)""
+  IL_0027:  newobj     ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>)""
+  IL_002c:  call       ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>)""
+  IL_0031:  ldloc.1
+  IL_0032:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item1""
+  IL_0037:  ldc.i4.1
+  IL_0038:  bne.un     IL_017b
+  IL_003d:  ldloc.1
+  IL_003e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item2""
+  IL_0043:  ldc.i4.2
+  IL_0044:  bne.un     IL_017b
+  IL_0049:  ldloc.1
+  IL_004a:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item3""
+  IL_004f:  ldc.i4.3
+  IL_0050:  bne.un     IL_017b
+  IL_0055:  ldloc.1
+  IL_0056:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item4""
+  IL_005b:  ldc.i4.4
+  IL_005c:  bne.un     IL_017b
+  IL_0061:  ldloc.1
+  IL_0062:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item5""
+  IL_0067:  ldc.i4.5
+  IL_0068:  bne.un     IL_017b
+  IL_006d:  ldloc.1
+  IL_006e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item6""
+  IL_0073:  ldc.i4.6
+  IL_0074:  bne.un     IL_017b
+  IL_0079:  ldloc.1
+  IL_007a:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Item7""
+  IL_007f:  ldc.i4.7
+  IL_0080:  bne.un     IL_017b
+  IL_0085:  ldloc.1
+  IL_0086:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_008b:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item1""
+  IL_0090:  ldc.i4.8
+  IL_0091:  bne.un     IL_017b
+  IL_0096:  ldloc.1
+  IL_0097:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_009c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item2""
+  IL_00a1:  ldc.i4.s   9
+  IL_00a3:  bne.un     IL_017b
+  IL_00a8:  ldloc.1
+  IL_00a9:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_00ae:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item3""
+  IL_00b3:  ldc.i4.s   10
+  IL_00b5:  bne.un     IL_017b
+  IL_00ba:  ldloc.1
+  IL_00bb:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_00c0:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item4""
+  IL_00c5:  ldc.i4.s   11
+  IL_00c7:  bne.un     IL_017b
+  IL_00cc:  ldloc.1
+  IL_00cd:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_00d2:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item5""
+  IL_00d7:  ldc.i4.s   12
+  IL_00d9:  bne.un     IL_017b
+  IL_00de:  ldloc.1
+  IL_00df:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_00e4:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item6""
+  IL_00e9:  ldc.i4.s   13
+  IL_00eb:  bne.un     IL_017b
+  IL_00f0:  ldloc.1
+  IL_00f1:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_00f6:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item7""
+  IL_00fb:  ldc.i4.s   14
+  IL_00fd:  bne.un.s   IL_017b
+  IL_00ff:  ldloc.1
+  IL_0100:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_0105:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_010a:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item1""
+  IL_010f:  ldc.i4.s   15
+  IL_0111:  bne.un.s   IL_017b
+  IL_0113:  ldloc.1
+  IL_0114:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_0119:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_011e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item2""
+  IL_0123:  ldc.i4.s   16
+  IL_0125:  bne.un.s   IL_017b
+  IL_0127:  ldloc.1
+  IL_0128:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_012d:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_0132:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item3""
+  IL_0137:  ldc.i4.s   17
+  IL_0139:  bne.un.s   IL_017b
+  IL_013b:  ldloc.1
+  IL_013c:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_0141:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_0146:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item4""
+  IL_014b:  ldc.i4.s   18
+  IL_014d:  bne.un.s   IL_017b
+  IL_014f:  ldloc.1
+  IL_0150:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_0155:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_015a:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item5""
+  IL_015f:  ldc.i4.s   19
+  IL_0161:  bne.un.s   IL_017b
+  IL_0163:  ldloc.1
+  IL_0164:  ldfld      ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>>.Rest""
+  IL_0169:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_016e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item6""
+  IL_0173:  ldc.i4.s   20
+  IL_0175:  bne.un.s   IL_017b
+  IL_0177:  ldc.i4.1
+  IL_0178:  stloc.0
+  IL_0179:  br.s       IL_017d
+  IL_017b:  ldc.i4.m1
+  IL_017c:  stloc.0
+  IL_017d:  ldloc.0
+  IL_017e:  call       ""void System.Console.WriteLine(int)""
+  IL_0183:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void VerifyIL_8ElementsTuple_SideEffects_DefaultLabel()
+        {
+            var text = @"
+using System;
+using System.Runtime.CompilerServices;
+public class C
+{
+    public static void Main()
+    {
+        try
+        {
+            int x = (M(1), M(2), M(3), M(4), M(5), M(6), M(7), M(8)) switch
+            {
+                (1, 2, 3, 4, 5, 6, 7, 7) => 1,
+            };
+
+            Console.WriteLine(x);
+        }
+        catch (SwitchExpressionException ex)
+        {
+            Console.Write(""💥"");
+        }
+    }
+
+    static int M(int x)
+    {
+        Console.Write(x);
+        return x;
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    public class SwitchExpressionException : InvalidOperationException
+    {
+        public SwitchExpressionException() {}
+        public SwitchExpressionException(object unmatchedValue) => UnmatchedValue = unmatchedValue;
+        public object UnmatchedValue { get; }
+    }
+}
+";
+            CompileAndVerify(text, expectedOutput: "12345678💥");
+        }
+
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void VerifyIL_9ElementsTuple_SideEffects_DefaultLabel()
+        {
+            var text = @"
+using System;
+using System.Runtime.CompilerServices;
+public class C
+{
+    public static void Main()
+    {
+        try
+        {
+            int x = (M(1), M(2), M(3), M(4), M(5), M(6), M(7), M(8), M(9)) switch
+            {
+                (1, 2, 3, 4, 5, 6, 7, 8, 8) => 1,
+            };
+
+            Console.WriteLine(x);
+        }
+        catch (SwitchExpressionException ex)
+        {
+            Console.Write(""💥"");
+        }
+    }
+
+    static int M(int x)
+    {
+        Console.Write(x);
+        return x;
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    public class SwitchExpressionException : InvalidOperationException
+    {
+        public SwitchExpressionException() {}
+        public SwitchExpressionException(object unmatchedValue) => UnmatchedValue = unmatchedValue;
+        public object UnmatchedValue { get; }
+    }
+}
+";
+            CompileAndVerify(text, expectedOutput: "123456789💥");
         }
         #endregion
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -2949,6 +2949,234 @@ public class TestClass
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(14, 17));
         }
 
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void Bug47878()
+        {
+            var text = @"
+using System;
+public class C
+{
+    public static void Main()
+    {
+        int x1 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) => 1,
+            _ => -1,
+        };
+        int x2 = (1, 2, 3, 4, 5, 6, 7, 8) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8) => 1,
+            _ => -1,
+        };
+        int x3 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) => 1,
+            _ => -1,
+        };
+        int x4 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19) => 1,
+            _ => -1,
+        };
+        Console.WriteLine($""{x1} {x2} {x3} {x4}"");
+    }
+}
+";
+            var comp = CompileAndVerify(text, expectedOutput: "1 1 1 1");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void VerifyIL_8ElementsTuple()
+        {
+            var text = @"
+using System;
+public class C
+{
+    public static void Main()
+    {
+        int x = (1, 2, 3, 4, 5, 6, 7, 8) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8) => 1,
+            _ => -1,
+        };
+
+        Console.WriteLine(x);
+    }
+}
+";
+            CompileAndVerify(text).VerifyIL("C.Main", @"
+{
+  // Code size      110 (0x6e)
+  .maxstack  9
+  .locals init (int V_0,
+                System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>> V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  ldc.i4.3
+  IL_0005:  ldc.i4.4
+  IL_0006:  ldc.i4.5
+  IL_0007:  ldc.i4.6
+  IL_0008:  ldc.i4.7
+  IL_0009:  ldc.i4.8
+  IL_000a:  newobj     ""System.ValueTuple<int>..ctor(int)""
+  IL_000f:  call       ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int>)""
+  IL_0014:  ldloc.1
+  IL_0015:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item1""
+  IL_001a:  ldc.i4.1
+  IL_001b:  bne.un.s   IL_0065
+  IL_001d:  ldloc.1
+  IL_001e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item2""
+  IL_0023:  ldc.i4.2
+  IL_0024:  bne.un.s   IL_0065
+  IL_0026:  ldloc.1
+  IL_0027:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item3""
+  IL_002c:  ldc.i4.3
+  IL_002d:  bne.un.s   IL_0065
+  IL_002f:  ldloc.1
+  IL_0030:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item4""
+  IL_0035:  ldc.i4.4
+  IL_0036:  bne.un.s   IL_0065
+  IL_0038:  ldloc.1
+  IL_0039:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item5""
+  IL_003e:  ldc.i4.5
+  IL_003f:  bne.un.s   IL_0065
+  IL_0041:  ldloc.1
+  IL_0042:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item6""
+  IL_0047:  ldc.i4.6
+  IL_0048:  bne.un.s   IL_0065
+  IL_004a:  ldloc.1
+  IL_004b:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item7""
+  IL_0050:  ldc.i4.7
+  IL_0051:  bne.un.s   IL_0065
+  IL_0053:  ldloc.1
+  IL_0054:  ldfld      ""System.ValueTuple<int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Rest""
+  IL_0059:  ldfld      ""int System.ValueTuple<int>.Item1""
+  IL_005e:  ldc.i4.8
+  IL_005f:  bne.un.s   IL_0065
+  IL_0061:  ldc.i4.1
+  IL_0062:  stloc.0
+  IL_0063:  br.s       IL_0067
+  IL_0065:  ldc.i4.m1
+  IL_0066:  stloc.0
+  IL_0067:  ldloc.0
+  IL_0068:  call       ""void System.Console.WriteLine(int)""
+  IL_006d:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void VerifyIL_GreatherThan8ElementsTuple()
+        {
+            var text = @"
+using System;
+public class C
+{
+    public static void Main()
+    {
+        int x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13) switch
+        {
+            (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13) => 1,
+            _ => -1,
+        };
+
+        Console.WriteLine(x);
+    }
+}
+";
+            CompileAndVerify(text).VerifyIL("C.Main", @"
+{
+  // Code size      204 (0xcc)
+  .maxstack  14
+  .locals init (int V_0,
+                System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  ldc.i4.3
+  IL_0005:  ldc.i4.4
+  IL_0006:  ldc.i4.5
+  IL_0007:  ldc.i4.6
+  IL_0008:  ldc.i4.7
+  IL_0009:  ldc.i4.8
+  IL_000a:  ldc.i4.s   9
+  IL_000c:  ldc.i4.s   10
+  IL_000e:  ldc.i4.s   11
+  IL_0010:  ldc.i4.s   12
+  IL_0012:  ldc.i4.s   13
+  IL_0014:  newobj     ""System.ValueTuple<int, int, int, int, int, int>..ctor(int, int, int, int, int, int)""
+  IL_0019:  call       ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>)""
+  IL_001e:  ldloc.1
+  IL_001f:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item1""
+  IL_0024:  ldc.i4.1
+  IL_0025:  bne.un     IL_00c3
+  IL_002a:  ldloc.1
+  IL_002b:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item2""
+  IL_0030:  ldc.i4.2
+  IL_0031:  bne.un     IL_00c3
+  IL_0036:  ldloc.1
+  IL_0037:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item3""
+  IL_003c:  ldc.i4.3
+  IL_003d:  bne.un     IL_00c3
+  IL_0042:  ldloc.1
+  IL_0043:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item4""
+  IL_0048:  ldc.i4.4
+  IL_0049:  bne.un.s   IL_00c3
+  IL_004b:  ldloc.1
+  IL_004c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item5""
+  IL_0051:  ldc.i4.5
+  IL_0052:  bne.un.s   IL_00c3
+  IL_0054:  ldloc.1
+  IL_0055:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item6""
+  IL_005a:  ldc.i4.6
+  IL_005b:  bne.un.s   IL_00c3
+  IL_005d:  ldloc.1
+  IL_005e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item7""
+  IL_0063:  ldc.i4.7
+  IL_0064:  bne.un.s   IL_00c3
+  IL_0066:  ldloc.1
+  IL_0067:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_006c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item1""
+  IL_0071:  ldc.i4.8
+  IL_0072:  bne.un.s   IL_00c3
+  IL_0074:  ldloc.1
+  IL_0075:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_007a:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item2""
+  IL_007f:  ldc.i4.s   9
+  IL_0081:  bne.un.s   IL_00c3
+  IL_0083:  ldloc.1
+  IL_0084:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_0089:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item3""
+  IL_008e:  ldc.i4.s   10
+  IL_0090:  bne.un.s   IL_00c3
+  IL_0092:  ldloc.1
+  IL_0093:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_0098:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item4""
+  IL_009d:  ldc.i4.s   11
+  IL_009f:  bne.un.s   IL_00c3
+  IL_00a1:  ldloc.1
+  IL_00a2:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_00a7:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item5""
+  IL_00ac:  ldc.i4.s   12
+  IL_00ae:  bne.un.s   IL_00c3
+  IL_00b0:  ldloc.1
+  IL_00b1:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_00b6:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item6""
+  IL_00bb:  ldc.i4.s   13
+  IL_00bd:  bne.un.s   IL_00c3
+  IL_00bf:  ldc.i4.1
+  IL_00c0:  stloc.0
+  IL_00c1:  br.s       IL_00c5
+  IL_00c3:  ldc.i4.m1
+  IL_00c4:  stloc.0
+  IL_00c5:  ldloc.0
+  IL_00c6:  call       ""void System.Console.WriteLine(int)""
+  IL_00cb:  ret
+}
+");
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -3187,6 +3187,118 @@ public class C
 {
     public static void Main()
     {
+        int x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13) switch
+        {
+            (1, 2, 3, 4, 5, 6, not 7, 8, 9, 10, 11, 12, 13) => 1,
+            _ => -1,
+        };
+
+        Console.WriteLine(x);
+    }
+}
+";
+            CompileAndVerify(text, expectedOutput: "-1").VerifyIL("C.Main", @"
+
+{
+  // Code size      204 (0xcc)
+  .maxstack  14
+  .locals init (int V_0,
+                System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>> V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  ldc.i4.3
+  IL_0005:  ldc.i4.4
+  IL_0006:  ldc.i4.5
+  IL_0007:  ldc.i4.6
+  IL_0008:  ldc.i4.7
+  IL_0009:  ldc.i4.8
+  IL_000a:  ldc.i4.s   9
+  IL_000c:  ldc.i4.s   10
+  IL_000e:  ldc.i4.s   11
+  IL_0010:  ldc.i4.s   12
+  IL_0012:  ldc.i4.s   13
+  IL_0014:  newobj     ""System.ValueTuple<int, int, int, int, int, int>..ctor(int, int, int, int, int, int)""
+  IL_0019:  call       ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>)""
+  IL_001e:  ldloc.1
+  IL_001f:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item1""
+  IL_0024:  ldc.i4.1
+  IL_0025:  bne.un     IL_00c3
+  IL_002a:  ldloc.1
+  IL_002b:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item2""
+  IL_0030:  ldc.i4.2
+  IL_0031:  bne.un     IL_00c3
+  IL_0036:  ldloc.1
+  IL_0037:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item3""
+  IL_003c:  ldc.i4.3
+  IL_003d:  bne.un     IL_00c3
+  IL_0042:  ldloc.1
+  IL_0043:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item4""
+  IL_0048:  ldc.i4.4
+  IL_0049:  bne.un.s   IL_00c3
+  IL_004b:  ldloc.1
+  IL_004c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item5""
+  IL_0051:  ldc.i4.5
+  IL_0052:  bne.un.s   IL_00c3
+  IL_0054:  ldloc.1
+  IL_0055:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item6""
+  IL_005a:  ldc.i4.6
+  IL_005b:  bne.un.s   IL_00c3
+  IL_005d:  ldloc.1
+  IL_005e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Item7""
+  IL_0063:  ldc.i4.7
+  IL_0064:  beq.s      IL_00c3
+  IL_0066:  ldloc.1
+  IL_0067:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_006c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item1""
+  IL_0071:  ldc.i4.8
+  IL_0072:  bne.un.s   IL_00c3
+  IL_0074:  ldloc.1
+  IL_0075:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_007a:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item2""
+  IL_007f:  ldc.i4.s   9
+  IL_0081:  bne.un.s   IL_00c3
+  IL_0083:  ldloc.1
+  IL_0084:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_0089:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item3""
+  IL_008e:  ldc.i4.s   10
+  IL_0090:  bne.un.s   IL_00c3
+  IL_0092:  ldloc.1
+  IL_0093:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_0098:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item4""
+  IL_009d:  ldc.i4.s   11
+  IL_009f:  bne.un.s   IL_00c3
+  IL_00a1:  ldloc.1
+  IL_00a2:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_00a7:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item5""
+  IL_00ac:  ldc.i4.s   12
+  IL_00ae:  bne.un.s   IL_00c3
+  IL_00b0:  ldloc.1
+  IL_00b1:  ldfld      ""System.ValueTuple<int, int, int, int, int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int, int, int, int, int>>.Rest""
+  IL_00b6:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int>.Item6""
+  IL_00bb:  ldc.i4.s   13
+  IL_00bd:  bne.un.s   IL_00c3
+  IL_00bf:  ldc.i4.1
+  IL_00c0:  stloc.0
+  IL_00c1:  br.s       IL_00c5
+  IL_00c3:  ldc.i4.m1
+  IL_00c4:  stloc.0
+  IL_00c5:  ldloc.0
+  IL_00c6:  call       ""void System.Console.WriteLine(int)""
+  IL_00cb:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
+        public void VerifyIL_GreaterThan8ElementsTuple_03()
+        {
+            var text = @"
+using System;
+public class C
+{
+    public static void Main()
+    {
         int x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20) switch
         {
             (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20) => 1,
@@ -3379,7 +3491,87 @@ namespace System.Runtime.CompilerServices
     }
 }
 ";
-            CompileAndVerify(text, expectedOutput: "12345678💥");
+            CompileAndVerify(text, expectedOutput: "12345678💥").VerifyIL("C.Main", @"
+{
+  // Code size      174 (0xae)
+  .maxstack  8
+  .locals init (int V_0,
+                System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>> V_1)
+  .try
+  {
+    IL_0000:  ldc.i4.1
+    IL_0001:  call       ""int C.M(int)""
+    IL_0006:  ldc.i4.2
+    IL_0007:  call       ""int C.M(int)""
+    IL_000c:  ldc.i4.3
+    IL_000d:  call       ""int C.M(int)""
+    IL_0012:  ldc.i4.4
+    IL_0013:  call       ""int C.M(int)""
+    IL_0018:  ldc.i4.5
+    IL_0019:  call       ""int C.M(int)""
+    IL_001e:  ldc.i4.6
+    IL_001f:  call       ""int C.M(int)""
+    IL_0024:  ldc.i4.7
+    IL_0025:  call       ""int C.M(int)""
+    IL_002a:  ldc.i4.8
+    IL_002b:  call       ""int C.M(int)""
+    IL_0030:  newobj     ""System.ValueTuple<int>..ctor(int)""
+    IL_0035:  newobj     ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int>)""
+    IL_003a:  stloc.1
+    IL_003b:  ldloc.1
+    IL_003c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item1""
+    IL_0041:  ldc.i4.1
+    IL_0042:  bne.un.s   IL_008c
+    IL_0044:  ldloc.1
+    IL_0045:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item2""
+    IL_004a:  ldc.i4.2
+    IL_004b:  bne.un.s   IL_008c
+    IL_004d:  ldloc.1
+    IL_004e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item3""
+    IL_0053:  ldc.i4.3
+    IL_0054:  bne.un.s   IL_008c
+    IL_0056:  ldloc.1
+    IL_0057:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item4""
+    IL_005c:  ldc.i4.4
+    IL_005d:  bne.un.s   IL_008c
+    IL_005f:  ldloc.1
+    IL_0060:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item5""
+    IL_0065:  ldc.i4.5
+    IL_0066:  bne.un.s   IL_008c
+    IL_0068:  ldloc.1
+    IL_0069:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item6""
+    IL_006e:  ldc.i4.6
+    IL_006f:  bne.un.s   IL_008c
+    IL_0071:  ldloc.1
+    IL_0072:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Item7""
+    IL_0077:  ldc.i4.7
+    IL_0078:  bne.un.s   IL_008c
+    IL_007a:  ldloc.1
+    IL_007b:  ldfld      ""System.ValueTuple<int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>.Rest""
+    IL_0080:  ldfld      ""int System.ValueTuple<int>.Item1""
+    IL_0085:  ldc.i4.7
+    IL_0086:  bne.un.s   IL_008c
+    IL_0088:  ldc.i4.1
+    IL_0089:  stloc.0
+    IL_008a:  br.s       IL_0098
+    IL_008c:  ldloc.1
+    IL_008d:  box        ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>""
+    IL_0092:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor(object)""
+    IL_0097:  throw
+    IL_0098:  ldloc.0
+    IL_0099:  call       ""void System.Console.WriteLine(int)""
+    IL_009e:  leave.s    IL_00ad
+  }
+  catch System.Runtime.CompilerServices.SwitchExpressionException
+  {
+    IL_00a0:  pop
+    IL_00a1:  ldstr      ""💥""
+    IL_00a6:  call       ""void System.Console.Write(string)""
+    IL_00ab:  leave.s    IL_00ad
+  }
+  IL_00ad:  ret
+}
+");
         }
 
         [Fact, WorkItem(47878, "https://github.com/dotnet/roslyn/issues/47878")]
@@ -3423,7 +3615,94 @@ namespace System.Runtime.CompilerServices
     }
 }
 ";
-            CompileAndVerify(text, expectedOutput: "123456789💥");
+            CompileAndVerify(text, expectedOutput: "123456789💥").VerifyIL("C.Main", @"
+{
+  // Code size      195 (0xc3)
+  .maxstack  9
+  .locals init (int V_0,
+                System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>> V_1)
+  .try
+  {
+    IL_0000:  ldc.i4.1
+    IL_0001:  call       ""int C.M(int)""
+    IL_0006:  ldc.i4.2
+    IL_0007:  call       ""int C.M(int)""
+    IL_000c:  ldc.i4.3
+    IL_000d:  call       ""int C.M(int)""
+    IL_0012:  ldc.i4.4
+    IL_0013:  call       ""int C.M(int)""
+    IL_0018:  ldc.i4.5
+    IL_0019:  call       ""int C.M(int)""
+    IL_001e:  ldc.i4.6
+    IL_001f:  call       ""int C.M(int)""
+    IL_0024:  ldc.i4.7
+    IL_0025:  call       ""int C.M(int)""
+    IL_002a:  ldc.i4.8
+    IL_002b:  call       ""int C.M(int)""
+    IL_0030:  ldc.i4.s   9
+    IL_0032:  call       ""int C.M(int)""
+    IL_0037:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+    IL_003c:  newobj     ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>..ctor(int, int, int, int, int, int, int, System.ValueTuple<int, int>)""
+    IL_0041:  stloc.1
+    IL_0042:  ldloc.1
+    IL_0043:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item1""
+    IL_0048:  ldc.i4.1
+    IL_0049:  bne.un.s   IL_00a1
+    IL_004b:  ldloc.1
+    IL_004c:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item2""
+    IL_0051:  ldc.i4.2
+    IL_0052:  bne.un.s   IL_00a1
+    IL_0054:  ldloc.1
+    IL_0055:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item3""
+    IL_005a:  ldc.i4.3
+    IL_005b:  bne.un.s   IL_00a1
+    IL_005d:  ldloc.1
+    IL_005e:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item4""
+    IL_0063:  ldc.i4.4
+    IL_0064:  bne.un.s   IL_00a1
+    IL_0066:  ldloc.1
+    IL_0067:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item5""
+    IL_006c:  ldc.i4.5
+    IL_006d:  bne.un.s   IL_00a1
+    IL_006f:  ldloc.1
+    IL_0070:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item6""
+    IL_0075:  ldc.i4.6
+    IL_0076:  bne.un.s   IL_00a1
+    IL_0078:  ldloc.1
+    IL_0079:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Item7""
+    IL_007e:  ldc.i4.7
+    IL_007f:  bne.un.s   IL_00a1
+    IL_0081:  ldloc.1
+    IL_0082:  ldfld      ""System.ValueTuple<int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Rest""
+    IL_0087:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+    IL_008c:  ldc.i4.8
+    IL_008d:  bne.un.s   IL_00a1
+    IL_008f:  ldloc.1
+    IL_0090:  ldfld      ""System.ValueTuple<int, int> System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>.Rest""
+    IL_0095:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+    IL_009a:  ldc.i4.8
+    IL_009b:  bne.un.s   IL_00a1
+    IL_009d:  ldc.i4.1
+    IL_009e:  stloc.0
+    IL_009f:  br.s       IL_00ad
+    IL_00a1:  ldloc.1
+    IL_00a2:  box        ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>""
+    IL_00a7:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor(object)""
+    IL_00ac:  throw
+    IL_00ad:  ldloc.0
+    IL_00ae:  call       ""void System.Console.WriteLine(int)""
+    IL_00b3:  leave.s    IL_00c2
+  }
+  catch System.Runtime.CompilerServices.SwitchExpressionException
+  {
+    IL_00b5:  pop
+    IL_00b6:  ldstr      ""💥""
+    IL_00bb:  call       ""void System.Console.Write(string)""
+    IL_00c0:  leave.s    IL_00c2
+  }
+  IL_00c2:  ret
+}
+");
         }
         #endregion
     }


### PR DESCRIPTION
Fixes #47878

This is a simpler, less optimal fix than #47893. We can try to figure out how to fix the optimization, but I wanted to submit this as a candidate fix for 16.8 in case the optimization is hard to get right for large tuples.