### PR TITLE
Fix EnC unexpected error: 'Sequence contains no elements'

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTrackingService.cs
@@ -290,10 +290,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 
                 lock (_trackingSpans)
                 {
-                    if (_trackingSpans.TryGetValue(document.Id, out var documentSpans) && documentSpans != null)
+                    if (_trackingSpans.TryGetValue(document.Id, out var documentSpans) && !documentSpans.IsDefaultOrEmpty)
                     {
-                        Debug.Assert(!documentSpans.IsEmpty);
-
                         var snapshot = sourceText.FindCorrespondingEditorTextSnapshot();
                         if (snapshot != null && snapshot.TextBuffer == documentSpans.First().Span.TextBuffer)
                         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47711.

Will follow up with adding a test.