### PR TITLE
Optimize OrderPreservingMultiDictionary<TKey, TValue>.TryGetValue

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -683,14 +683,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private MetadataNode GetOrCreateChildNode(
                MetadataNode currentNode, string simpleName)
             {
-                foreach (var childNode in _parentToChildren[currentNode])
+                if (_parentToChildren.TryGetValue(currentNode, static (childNode, simpleName) => childNode.Name == simpleName, simpleName, out var childNode))
                 {
-                    if (childNode.Name == simpleName)
-                    {
-                        // Found an existing child node.  Just return that and all 
-                        // future parts off of it.
-                        return childNode;
-                    }
+                    // Found an existing child node.  Just return that and all 
+                    // future parts off of it.
+                    return childNode;
                 }
 
                 // Couldn't find a child node with this name.  Make a new node for


### PR DESCRIPTION
The indexer for `OrderPreservingMultiDictionary<K, V>` creates a new array for each usage. This change implements a `TryGetValue` for the collection with a predicate to avoid the need to use the indexer on a `SymbolTreeInfo` hot path.

This change is a 10% allocation reduction for the OOP test scenario I was profiling (`TotalClassifierTests` for `TestHost.OutOfProcess`).