### PR TITLE
Implement a test serializer for improved performance of common metadata references

### DIFF
--- a/src/EditorFeatures/TestUtilities/EditorTestCompositions.cs
+++ b/src/EditorFeatures/TestUtilities/EditorTestCompositions.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests.Fakes;
+using Microsoft.CodeAnalysis.UnitTests.Remote;
 using Microsoft.VisualStudio.InteractiveWindow;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
@@ -53,6 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 // Microsoft.VisualStudio.Text.Internal
                 typeof(VisualStudio.Text.Utilities.IExperimentationServiceInternal).Assembly)
             .AddParts(
+                typeof(TestSerializerService.Factory),
                 typeof(TestExportJoinableTaskContext),
                 typeof(StubStreamingFindUsagesPresenter), // actual implementation is in VS layer
                 typeof(EditorNotificationServiceFactory), // TODO: use mock INotificationService instead (https://github.com/dotnet/roslyn/issues/46045)

--- a/src/Features/Core/Portable/IncrementalCaches/MetadataInfo.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/MetadataInfo.cs
@@ -21,11 +21,10 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
             /// <summary>
             /// The set of projects that are referencing this metadata-index.  When this becomes empty we can dump the
             /// index from memory.
-            /// <para/>
-            /// Note: the Incremental-Analyzer infrastructure guarantees that it will call all the
-            /// methods on <see cref="SymbolTreeInfoIncrementalAnalyzer"/> in a serial fashion.  As that is the only
-            /// type that reads/writes these <see cref="MetadataInfo"/> objects, we don't need to lock this.
             /// </summary>
+            /// <remarks>
+            /// <para>Accesses to this collection must lock the set.</para>
+            /// </remarks>
             public readonly HashSet<ProjectId> ReferencingProjects;
 
             public MetadataInfo(SymbolTreeInfo info, HashSet<ProjectId> referencingProjects)

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         private readonly ConcurrentDictionary<string, IOptionsSerializationService> _lazyLanguageSerializationService;
 
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        private SerializerService(HostWorkspaceServices workspaceServices)
+        [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
+        private protected SerializerService(HostWorkspaceServices workspaceServices)
         {
             _workspaceServices = workspaceServices;
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         public void SerializeMetadataReference(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            WriteTo(reference, writer, cancellationToken);
+            WriteMetadataReferenceTo(reference, writer, cancellationToken);
         }
 
         private MetadataReference DeserializeMetadataReference(ObjectReader reader, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             return Checksum.Create(stream);
         }
 
-        public static void WriteTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        public virtual void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
         {
             if (reference is PortableExecutableReference portable)
             {
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             throw ExceptionUtilities.UnexpectedValue(reference.GetType());
         }
 
-        public MetadataReference ReadMetadataReferenceFrom(ObjectReader reader, CancellationToken cancellationToken)
+        public virtual MetadataReference ReadMetadataReferenceFrom(ObjectReader reader, CancellationToken cancellationToken)
         {
             var type = reader.ReadString();
             if (type == nameof(PortableExecutableReference))

--- a/src/Workspaces/CoreTestUtilities/MEF/ExportProviderCache.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/ExportProviderCache.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.UnitTests.Remote;
 using Microsoft.VisualStudio.Composition;
 using Roslyn.Utilities;
 
@@ -23,7 +24,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         private static readonly PartDiscovery s_partDiscovery = CreatePartDiscovery(Resolver.DefaultInstance);
 
-        private static readonly TestComposition s_defaultHostExportProviderComposition = TestComposition.Empty.AddAssemblies(MefHostServices.DefaultAssemblies);
+        private static readonly TestComposition s_defaultHostExportProviderComposition = TestComposition.Empty
+            .AddAssemblies(MefHostServices.DefaultAssemblies)
+            .AddParts(typeof(TestSerializerService.Factory));
 
         private static bool _enabled;
 

--- a/src/Workspaces/CoreTestUtilities/MEF/FeaturesTestCompositions.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/FeaturesTestCompositions.cs
@@ -8,6 +8,7 @@ using System;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.Testing;
+using Microsoft.CodeAnalysis.UnitTests.Remote;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
@@ -16,11 +17,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public static readonly TestComposition Features = TestComposition.Empty
             .AddAssemblies(MefHostServices.DefaultAssemblies)
             .AddParts(
+                typeof(TestSerializerService.Factory),
                 typeof(MockWorkspaceEventListenerProvider),  // by default, avoid running Solution Crawler and other services that start in workspace event listeners
                 typeof(TestErrorReportingService));          // mocks the info-bar error reporting
 
         public static readonly TestComposition RemoteHost = TestComposition.Empty
-            .AddAssemblies(RemoteWorkspaceManager.RemoteHostAssemblies);
+            .AddAssemblies(RemoteWorkspaceManager.RemoteHostAssemblies)
+            .AddParts(typeof(TestSerializerService.Factory));
 
         public static TestComposition WithTestHostParts(this TestComposition composition, TestHost host)
             => (host == TestHost.InProcess) ? composition : composition.AddAssemblies(typeof(RemoteWorkspacesResources).Assembly).AddParts(typeof(InProcRemoteHostClientProvider.Factory));

--- a/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Serialization;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Remote
+{
+    internal sealed class TestSerializerService : SerializerService
+    {
+        private static readonly ImmutableDictionary<MetadataReference, string> s_wellKnownReferenceNames = ImmutableDictionary.Create<MetadataReference, string>(ReferenceEqualityComparer.Instance)
+            .Add(TestBase.MscorlibRef_v46, nameof(TestBase.MscorlibRef_v46))
+            .Add(TestBase.SystemRef_v46, nameof(TestBase.SystemRef_v46))
+            .Add(TestBase.SystemCoreRef_v46, nameof(TestBase.SystemCoreRef_v46))
+            .Add(TestBase.ValueTupleRef, nameof(TestBase.ValueTupleRef))
+            .Add(TestBase.SystemRuntimeFacadeRef, nameof(TestBase.SystemRuntimeFacadeRef));
+        private static readonly ImmutableDictionary<string, MetadataReference> s_wellKnownReferences = ImmutableDictionary.Create<string, MetadataReference>()
+            .AddRange(s_wellKnownReferenceNames.Select(pair => KeyValuePairUtil.Create(pair.Value, pair.Key)));
+
+        [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
+        public TestSerializerService(HostWorkspaceServices workspaceServices)
+            : base(workspaceServices)
+        {
+        }
+
+        public override void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        {
+            var wellKnownReferenceName = s_wellKnownReferenceNames.GetValueOrDefault(reference, null);
+            if (wellKnownReferenceName is not null)
+            {
+                writer.WriteBoolean(true);
+                writer.WriteString(wellKnownReferenceName);
+            }
+            else
+            {
+                writer.WriteBoolean(false);
+                base.WriteMetadataReferenceTo(reference, writer, cancellationToken);
+            }
+        }
+
+        public override MetadataReference ReadMetadataReferenceFrom(ObjectReader reader, CancellationToken cancellationToken)
+        {
+            if (reader.ReadBoolean())
+            {
+                // this is a well-known reference
+                return s_wellKnownReferences[reader.ReadString()];
+            }
+            else
+            {
+                return base.ReadMetadataReferenceFrom(reader, cancellationToken);
+            }
+        }
+
+        [ExportWorkspaceServiceFactory(typeof(ISerializerService), layer: ServiceLayer.Test), Shared, PartNotDiscoverable]
+        internal new sealed class Factory : IWorkspaceServiceFactory
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public Factory()
+            {
+            }
+
+            [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
+            public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+                => new TestSerializerService(workspaceServices);
+        }
+    }
+}


### PR DESCRIPTION
`MetadataImageReference` is used heavily in tests, but it does not have the same serialization performance as the `MetadataReference` instances provided by `VisualStudioMetadataReferenceManager`. This change implements a modified serialization service that allows the most common references to be serialized efficiently.

This change is a 25% allocation reduction for the OOP test scenario I was profiling (`TotalClassifierTests` for `TestHost.OutOfProcess`).