### PR TITLE
Fix cancellation handling in Parallel.For

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -11,13 +11,12 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -60,9 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (Arguments.CompilationOptions.ConcurrentBuild)
             {
-                Parallel.For(0, sourceFiles.Length, UICultureUtilities.WithCurrentUICulture<int>(i =>
-                {
-                    try
+                RoslynParallel.For(
+                    0,
+                    sourceFiles.Length,
+                    UICultureUtilities.WithCurrentUICulture<int>(i =>
                     {
                         //NOTE: order of trees is important!!
                         trees[i] = ParseFile(
@@ -72,12 +72,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             sourceFiles[i],
                             diagnosticBag,
                             out normalizedFilePaths[i]);
-                    }
-                    catch (Exception e) when (FatalError.Report(e))
-                    {
-                        throw ExceptionUtilities.Unreachable;
-                    }
-                }));
+                    }),
+                    CancellationToken.None);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2489,6 +2489,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 throw ExceptionUtilities.Unreachable;
                             }
+                            catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested && e.CancellationToken != cancellationToken)
+                            {
+                                // Parallel.For checks for a specific cancellation token, so make sure we throw with the
+                                // correct one.
+                                cancellationToken.ThrowIfCancellationRequested();
+                                throw ExceptionUtilities.Unreachable;
+                            }
                         }));
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
@@ -64,6 +64,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     {
                                         throw ExceptionUtilities.Unreachable;
                                     }
+                                    catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested && e.CancellationToken != cancellationToken)
+                                    {
+                                        // Parallel.For checks for a specific cancellation token, so make sure we throw with the
+                                        // correct one.
+                                        cancellationToken.ThrowIfCancellationRequested();
+                                        throw ExceptionUtilities.Unreachable;
+                                    }
                                 }));
 
                                 foreach (var member in members)

--- a/src/Compilers/Core/Portable/InternalUtilities/RoslynParallel.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RoslynParallel.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Utilities
+{
+    internal static class RoslynParallel
+    {
+        internal static readonly ParallelOptions DefaultParallelOptions = new ParallelOptions();
+
+        /// <inheritdoc cref="Parallel.For(int, int, ParallelOptions, Action{int})"/>
+        public static ParallelLoopResult For(int fromInclusive, int toExclusive, Action<int> body, CancellationToken cancellationToken)
+        {
+            var parallelOptions = cancellationToken.CanBeCanceled
+                ? new ParallelOptions { CancellationToken = cancellationToken }
+                : DefaultParallelOptions;
+
+            return Parallel.For(fromInclusive, toExclusive, parallelOptions, errorHandlingBody);
+
+            // Local function
+            void errorHandlingBody(int i)
+            {
+                try
+                {
+                    body(i);
+                }
+                catch (Exception e) when (FatalError.ReportUnlessCanceled(e, cancellationToken))
+                {
+                    throw ExceptionUtilities.Unreachable;
+                }
+                catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested && e.CancellationToken != cancellationToken)
+                {
+                    // Parallel.For checks for a specific cancellation token, so make sure we throw with the
+                    // correct one.
+                    cancellationToken.ThrowIfCancellationRequested();
+                    throw ExceptionUtilities.Unreachable;
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2094,6 +2094,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 builder.AddRange(SyntaxTrees(i).GetDiagnostics(cancellationToken))
                             Catch e As Exception When FatalError.ReportUnlessCanceled(e)
                                 Throw ExceptionUtilities.Unreachable
+                            Catch e As OperationCanceledException When cancellationToken.IsCancellationRequested AndAlso e.CancellationToken <> cancellationToken
+                                ' Parallel.For checks for a specific cancellation token, so make sure we throw with the
+                                ' correct one.
+                                cancellationToken.ThrowIfCancellationRequested()
+                                Throw ExceptionUtilities.Unreachable
                             End Try
                         End Sub))
                 Else

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2087,20 +2087,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Embedded trees shouldn't have any errors, let's avoid making decision if they should be added too early.
                 ' Otherwise IDE performance might be affect.
                 If Options.ConcurrentBuild Then
-                    Dim options = New ParallelOptions() With {.CancellationToken = cancellationToken}
-                    Parallel.For(0, SyntaxTrees.Length, options, UICultureUtilities.WithCurrentUICulture(
-                        Sub(i As Integer)
-                            Try
+                    RoslynParallel.For(
+                        0,
+                        SyntaxTrees.Length,
+                        UICultureUtilities.WithCurrentUICulture(
+                            Sub(i As Integer)
                                 builder.AddRange(SyntaxTrees(i).GetDiagnostics(cancellationToken))
-                            Catch e As Exception When FatalError.ReportUnlessCanceled(e)
-                                Throw ExceptionUtilities.Unreachable
-                            Catch e As OperationCanceledException When cancellationToken.IsCancellationRequested AndAlso e.CancellationToken <> cancellationToken
-                                ' Parallel.For checks for a specific cancellation token, so make sure we throw with the
-                                ' correct one.
-                                cancellationToken.ThrowIfCancellationRequested()
-                                Throw ExceptionUtilities.Unreachable
-                            End Try
-                        End Sub))
+                            End Sub),
+                        cancellationToken)
                 Else
                     For Each tree In SyntaxTrees
                         cancellationToken.ThrowIfCancellationRequested()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -625,6 +625,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 TryGetSourceFile(trees(i)).GenerateAllDeclarationErrors()
                             Catch e As Exception When FatalError.ReportUnlessCanceled(e)
                                 Throw ExceptionUtilities.Unreachable
+                            Catch e As OperationCanceledException When cancellationToken.IsCancellationRequested AndAlso e.CancellationToken <> cancellationToken
+                                ' Parallel.For checks for a specific cancellation token, so make sure we throw with the
+                                ' correct one.
+                                cancellationToken.ThrowIfCancellationRequested()
+                                Throw ExceptionUtilities.Unreachable
                             End Try
                         End Sub))
                 trees.Free()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -616,22 +616,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim trees = ArrayBuilder(Of SyntaxTree).GetInstance()
                 trees.AddRange(SyntaxTrees)
 
-                Dim options = New ParallelOptions() With {.CancellationToken = cancellationToken}
-                Parallel.For(0, trees.Count, options,
+                RoslynParallel.For(
+                    0,
+                    trees.Count,
                     UICultureUtilities.WithCurrentUICulture(
                         Sub(i As Integer)
-                            Try
-                                cancellationToken.ThrowIfCancellationRequested()
-                                TryGetSourceFile(trees(i)).GenerateAllDeclarationErrors()
-                            Catch e As Exception When FatalError.ReportUnlessCanceled(e)
-                                Throw ExceptionUtilities.Unreachable
-                            Catch e As OperationCanceledException When cancellationToken.IsCancellationRequested AndAlso e.CancellationToken <> cancellationToken
-                                ' Parallel.For checks for a specific cancellation token, so make sure we throw with the
-                                ' correct one.
-                                cancellationToken.ThrowIfCancellationRequested()
-                                Throw ExceptionUtilities.Unreachable
-                            End Try
-                        End Sub))
+                            TryGetSourceFile(trees(i)).GenerateAllDeclarationErrors()
+                        End Sub),
+                    cancellationToken)
                 trees.Free()
             Else
                 For Each tree In SyntaxTrees


### PR DESCRIPTION
This change ensures that cancellation exceptions that get wrapped in an `AggregateException` are treated as cancellation instead of failure.

This fixes the error that resulted in a failure of `NotNullIfNotNull_Return_DuplicateParameters` in [Pipelines - Run 20200925.9 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=831032&view=results).