### PR TITLE
Fix failure to dispose RemoteWorkspace in tests

### DIFF
--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+virtual Microsoft.CodeAnalysis.Host.HostLanguageServices.Dispose() -> void
 virtual Microsoft.CodeAnalysis.Host.HostWorkspaceServices.Dispose() -> void

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Microsoft.CodeAnalysis.Host.HostWorkspaceServices.Dispose() -> void

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostLanguageServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostLanguageServices.cs
@@ -6,12 +6,21 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Host
 {
     /// <summary>
-    /// Per language services provided by the host environment.
+    /// Per-language services provided by the host environment.
     /// </summary>
+    /// <remarks>
+    /// <para>Language services which implement <see cref="IDisposable"/> are considered ownable, in which case the
+    /// owner is responsible for disposing of owned instances when they are no longer in use. The ownership rules are
+    /// described in detail for <see cref="HostWorkspaceServices"/>. Instances of <see cref="ILanguageService"/> have
+    /// the same ownership rules as <see cref="IWorkspaceService"/>, and instances of
+    /// <see cref="ILanguageServiceFactory"/> have the same ownership rules as
+    /// <see cref="IWorkspaceServiceFactory"/>.</para>
+    /// </remarks>
     public abstract class HostLanguageServices : IDisposable
     {
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostLanguageServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostLanguageServices.cs
@@ -5,13 +5,14 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.Host
 {
     /// <summary>
     /// Per language services provided by the host environment.
     /// </summary>
-    public abstract class HostLanguageServices
+    public abstract class HostLanguageServices : IDisposable
     {
         /// <summary>
         /// The <see cref="HostWorkspaceServices"/> that originated this language service.
@@ -28,6 +29,11 @@ namespace Microsoft.CodeAnalysis.Host
         /// If the host does not provide the service, this method returns null.
         /// </summary>
         public abstract TLanguageService? GetService<TLanguageService>() where TLanguageService : ILanguageService;
+
+        [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Derived types are not allowed to include a finalizer for this pattern.")]
+        public virtual void Dispose()
+        {
+        }
 
         /// <summary>
         /// Gets a language specific service provided by the host identified by the service type. 

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// Per workspace services provided by the host environment.
     /// </summary>
-    public abstract class HostWorkspaceServices
+    public abstract class HostWorkspaceServices : IDisposable
     {
         /// <summary>
         /// The host services this workspace services originated from.
@@ -32,6 +33,11 @@ namespace Microsoft.CodeAnalysis.Host
         /// If the host does not provide the service, this method returns null.
         /// </summary>
         public abstract TWorkspaceService? GetService<TWorkspaceService>() where TWorkspaceService : IWorkspaceService;
+
+        [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Derived types are not allowed to include a finalizer for this pattern.")]
+        public virtual void Dispose()
+        {
+        }
 
         /// <summary>
         /// Gets a workspace specific service provided by the host identified by the service type. 

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -15,6 +16,34 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// Per workspace services provided by the host environment.
     /// </summary>
+    /// <remarks>
+    /// <para>Workspace services which implement <see cref="IDisposable"/> are considered ownable, in which case the
+    /// owner is responsible for disposing of owned instances when they are no longer in use. When
+    /// <see cref="IWorkspaceService"/> or <see cref="IWorkspaceServiceFactory"/> instances are provided directly to the
+    /// <see cref="HostWorkspaceServices"/>, the owner of the instances is the type or container (e.g. a MEF export
+    /// provider) which created the instances. For the specific case of ownable workspace services created by a factory
+    /// (i.e. instances returned by <see cref="IWorkspaceServiceFactory.CreateService"/>), the <see cref="Workspace"/>
+    /// is considered the owner of the resulting instance and is expected to be disposed during the call to
+    /// <see cref="Dispose"/>.</para>
+    ///
+    /// <para><strong>Summary of lifetime rules</strong></para>
+    ///
+    /// <list type="bullet">
+    /// <item><description>
+    ///   <strong><see cref="IWorkspaceService"/> instance constructed externally (e.g. MEF):</strong> Owned by the
+    ///   external source, and will not be automatically disposed when <see cref="Workspace"/> is disposed.
+    /// </description></item>
+    /// <item><description>
+    ///   <strong><see cref="IWorkspaceServiceFactory"/> instance constructed externally (e.g. MEF):</strong> Owned by
+    ///   the external source, and will not be automatically disposed when <see cref="Workspace"/> is disposed.
+    /// </description></item>
+    /// <item><description>
+    ///   <strong><see cref="IWorkspaceService"/> instance constructed by <see cref="IWorkspaceServiceFactory"/> within
+    ///   the context of <see cref="HostWorkspaceServices"/>:</strong> Owned by <see cref="Workspace"/>, and
+    ///   <strong>will</strong> be automatically disposed when <see cref="Workspace"/> is disposed.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
     public abstract class HostWorkspaceServices : IDisposable
     {
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -375,6 +375,10 @@ namespace Microsoft.CodeAnalysis
 
             (_optionService as IWorkspaceOptionService)?.OnWorkspaceDisposed(this);
             _optionService.UnregisterWorkspace(this);
+
+            // Dispose per-instance services created for this workspace (direct MEF exports, including factories, will
+            // be disposed when the MEF catalog is disposed).
+            Services.Dispose();
         }
 
         #region Host API

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
@@ -15,7 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote.Testing
 {
-    internal sealed class InProcRemoteHostClientProvider : IRemoteHostClientProvider
+    internal sealed class InProcRemoteHostClientProvider : IRemoteHostClientProvider, IDisposable
     {
         [ExportWorkspaceServiceFactory(typeof(IRemoteHostClientProvider), ServiceLayer.Test), Shared, PartNotDiscoverable]
         internal sealed class Factory : IWorkspaceServiceFactory
@@ -32,20 +32,21 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
         private sealed class WorkspaceManager : RemoteWorkspaceManager
         {
-            private readonly Lazy<RemoteWorkspace> _lazyWorkspace;
-
             public WorkspaceManager(SolutionAssetCache assetStorage, Type[]? additionalRemoteParts)
                 : base(assetStorage)
             {
-                _lazyWorkspace = new Lazy<RemoteWorkspace>(
+                LazyWorkspace = new Lazy<RemoteWorkspace>(
                     () => new RemoteWorkspace(FeaturesTestCompositions.RemoteHost.AddParts(additionalRemoteParts).GetHostServices(), WorkspaceKind.RemoteWorkspace));
             }
 
+            public Lazy<RemoteWorkspace> LazyWorkspace { get; }
+
             public override RemoteWorkspace GetWorkspace()
-                => _lazyWorkspace.Value;
+                => LazyWorkspace.Value;
         }
 
         private readonly HostWorkspaceServices _services;
+        private readonly Lazy<WorkspaceManager> _lazyManager;
         private readonly AsyncLazy<RemoteHostClient> _lazyClient;
 
         public SolutionAssetCache? RemoteAssetStorage { get; }
@@ -55,13 +56,25 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         {
             _services = services;
 
+            _lazyManager = new Lazy<WorkspaceManager>(() => new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts));
             _lazyClient = new AsyncLazy<RemoteHostClient>(
                 cancellationToken => InProcRemoteHostClient.CreateAsync(
                     _services,
-                    new RemoteHostTestData(
-                        new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts),
-                        isInProc: true)),
+                    new RemoteHostTestData(_lazyManager.Value, isInProc: true)),
                 cacheResult: true);
+        }
+
+        public void Dispose()
+        {
+            // Dispose the remote workspace when the owning host workspace is disposed
+            if (_lazyManager.IsValueCreated)
+            {
+                var manager = _lazyManager.Value;
+                if (manager.LazyWorkspace.IsValueCreated)
+                {
+                    manager.LazyWorkspace.Value.Dispose();
+                }
+            }
         }
 
         public Task<RemoteHostClient?> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensionsResources.resx
@@ -282,4 +282,7 @@
   <data name="NotSupported_FixedSizeCollection" xml:space="preserve">
     <value>Collection was of a fixed size.</value>
   </data>
+  <data name="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose" xml:space="preserve">
+    <value>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</value>
+  </data>
 </root>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Předvolby polí</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Einstellungen für Felder</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferencias de campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Préférences de champ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferenze per campi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">フィールド設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">필드 기본 설정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferencje pól</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Preferências de campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Предпочтения для полей</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Alan tercihleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">字段首选项</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/xlf/CompilerExtensionsResources.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">欄位喜好設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Instantiated_parts_threw_exceptions_from_IDisposable_Dispose">
+        <source>Instantiated part(s) threw exception(s) from IDisposable.Dispose().</source>
+        <target state="new">Instantiated part(s) threw exception(s) from IDisposable.Dispose().</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Interface">
         <source>Interface</source>
         <target state="new">Interface</target>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefUtilities.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Host.Mef
+{
+    internal static class MefUtilities
+    {
+        public static void DisposeWithExceptionTracking<T>(T instance, [NotNullIfNotNull("exceptions")] ref List<Exception>? exceptions)
+            where T : IDisposable
+        {
+            try
+            {
+                instance.Dispose();
+            }
+            catch (Exception ex) when (FatalError.ReportWithoutCrashAndPropagate(ex))
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+            catch (Exception ex)
+            {
+                exceptions ??= new List<Exception>();
+                exceptions.Add(ex);
+            }
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
@@ -78,6 +78,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\LanguageServiceMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefConstruction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefLanguageServices.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefWorkspaceServices.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\OrderableLanguageMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\OrderableMetadata.cs" />


### PR DESCRIPTION
This change leverages the new `IDisposable` support from #47951 to ensure `RemoteWorkspace` instances created by tests are disposed when the owning `Workspace` is disposed.