### PR TITLE
Specify culture used for Sort-Object

### DIFF
--- a/scripts/PublicApi/mark-shipped.ps1
+++ b/scripts/PublicApi/mark-shipped.ps1
@@ -29,7 +29,7 @@ function MarkShipped([string]$dir) {
         }
     }
 
-    $shipped | Sort-Object | ?{ -not $removed.Contains($_) } | Out-File $shippedFilePath -Encoding Ascii
+    $shipped | Sort-Object -Culture en-US | ?{ -not $removed.Contains($_) } | Out-File $shippedFilePath -Encoding Ascii
     "" | Out-File $unshippedFilePath -Encoding Ascii
 }
 


### PR DESCRIPTION
Hope this fixes part of #48067 (The second part of the issue isn't addressed).

@RikkiGibson This is a quick change made through GitHub UI. To confirm if this fixes the issue, the script needs to be run from the same different machines (I think it's not related to OSes, but the default culture for the machine) and confirm if they produce the same output with this change or not.

cc: @333fred