### PR TITLE
IntroduceVariable on target-typed new

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -7775,5 +7775,41 @@ public class P
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [WorkItem(44656, "https://github.com/dotnet/roslyn/issues/44656")]
+        public async Task ImplicitObjectCreation()
+        {
+            await TestInRegularAndScriptAsync( @"
+class A
+{
+    public void Create(A a, B b)
+    {
+    }
+}
+
+class B
+{
+    void M()
+    {
+        new A().Create(new A(), [|new(1)|]);
+    }
+}", @"
+class A
+{
+    public void Create(A a, B b)
+    {
+    }
+}
+
+class B
+{
+    void M()
+    {
+        B {|Rename:b|} = new(1);
+        new A().Create(new A(), b);
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -7780,7 +7780,7 @@ public class P
         [WorkItem(44656, "https://github.com/dotnet/roslyn/issues/44656")]
         public async Task ImplicitObjectCreation()
         {
-            await TestInRegularAndScriptAsync( @"
+            await TestInRegularAndScriptAsync(@"
 class A
 {
     public void Create(A a, B b)


### PR DESCRIPTION
Looks like this was fixed already. Just adding a test.
Closes https://github.com/dotnet/roslyn/issues/44656