### PR TITLE
Fix failure to dispose RemoteWorkspace in tests

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.EditorConfig;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -375,6 +376,14 @@ namespace Microsoft.CodeAnalysis
 
             (_optionService as IWorkspaceOptionService)?.OnWorkspaceDisposed(this);
             _optionService.UnregisterWorkspace(this);
+
+            // Directly dispose IRemoteHostClientProvider if necessary. This is a test hook to ensure RemoteWorkspace
+            // gets disposed in unit tests as soon as TestWorkspace gets disposed. This would be superseded by direct
+            // support for IDisposable in https://github.com/dotnet/roslyn/pull/47951.
+            if (Services.GetService<IRemoteHostClientProvider>() is IDisposable disposableService)
+            {
+                disposableService.Dispose();
+            }
         }
 
         #region Host API

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
@@ -15,7 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote.Testing
 {
-    internal sealed class InProcRemoteHostClientProvider : IRemoteHostClientProvider
+    internal sealed class InProcRemoteHostClientProvider : IRemoteHostClientProvider, IDisposable
     {
         [ExportWorkspaceServiceFactory(typeof(IRemoteHostClientProvider), ServiceLayer.Test), Shared, PartNotDiscoverable]
         internal sealed class Factory : IWorkspaceServiceFactory
@@ -32,20 +32,21 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
         private sealed class WorkspaceManager : RemoteWorkspaceManager
         {
-            private readonly Lazy<RemoteWorkspace> _lazyWorkspace;
-
             public WorkspaceManager(SolutionAssetCache assetStorage, Type[]? additionalRemoteParts)
                 : base(assetStorage)
             {
-                _lazyWorkspace = new Lazy<RemoteWorkspace>(
+                LazyWorkspace = new Lazy<RemoteWorkspace>(
                     () => new RemoteWorkspace(FeaturesTestCompositions.RemoteHost.AddParts(additionalRemoteParts).GetHostServices(), WorkspaceKind.RemoteWorkspace));
             }
 
+            public Lazy<RemoteWorkspace> LazyWorkspace { get; }
+
             public override RemoteWorkspace GetWorkspace()
-                => _lazyWorkspace.Value;
+                => LazyWorkspace.Value;
         }
 
         private readonly HostWorkspaceServices _services;
+        private readonly Lazy<WorkspaceManager> _lazyManager;
         private readonly AsyncLazy<RemoteHostClient> _lazyClient;
 
         public SolutionAssetCache? RemoteAssetStorage { get; }
@@ -55,13 +56,25 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         {
             _services = services;
 
+            _lazyManager = new Lazy<WorkspaceManager>(() => new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts));
             _lazyClient = new AsyncLazy<RemoteHostClient>(
                 cancellationToken => InProcRemoteHostClient.CreateAsync(
                     _services,
-                    new RemoteHostTestData(
-                        new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts),
-                        isInProc: true)),
+                    new RemoteHostTestData(_lazyManager.Value, isInProc: true)),
                 cacheResult: true);
+        }
+
+        public void Dispose()
+        {
+            // Dispose the remote workspace when the owning host workspace is disposed
+            if (_lazyManager.IsValueCreated)
+            {
+                var manager = _lazyManager.Value;
+                if (manager.LazyWorkspace.IsValueCreated)
+                {
+                    manager.LazyWorkspace.Value.Dispose();
+                }
+            }
         }
 
         public Task<RemoteHostClient?> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
This pull request implements the target functionality from #48069 using a workaround for a case where #47951 is not yet merged. If the latter change is approved, this pull request is no longer necessary.

Disposing of the `RemoteWorkspace` instance provides a tremendous performance advantage during test cleanup.