### PR TITLE
Update help service to account for all `TypeDeclarationSyntax` (namespace+record+struct) as partial type

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -284,7 +284,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                             text = "partialmethod_CSharpKeyword";
                             return true;
                         }
-                        else if (token.Parent.GetAncestorOrThis<ClassDeclarationSyntax>() != null)
+                        else if (token.Parent.GetAncestorOrThis<ClassDeclarationSyntax>() != null ||
+                            token.Parent.GetAncestorOrThis<RecordDeclarationSyntax>() != null)
                         {
                             text = "partialtype_CSharpKeyword";
                             return true;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -284,8 +284,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                             text = "partialmethod_CSharpKeyword";
                             return true;
                         }
-                        else if (token.Parent.GetAncestorOrThis<ClassDeclarationSyntax>() != null ||
-                            token.Parent.GetAncestorOrThis<RecordDeclarationSyntax>() != null)
+                        else if (token.Parent.GetAncestorOrThis<TypeDeclarationSyntax>() != null)
                         {
                             text = "partialtype_CSharpKeyword";
                             return true;

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestPartialType()
+        public async Task TestClassPartialType()
         {
             await Test_KeywordAsync(
 @"part[||]ial class C
@@ -174,10 +174,30 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestPartialMethod()
+        public async Task TestRecordPartialType()
+        {
+            await Test_KeywordAsync(
+@"part[||]ial record C
+{
+    partial void goo();
+}", "partialtype");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestPartialMethodInClass()
         {
             await Test_KeywordAsync(
 @"partial class C
+{
+    par[||]tial void goo();
+}", "partialmethod");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestPartialMethodInRecord()
+        {
+            await Test_KeywordAsync(
+@"partial record C
 {
     par[||]tial void goo();
 }", "partialmethod");

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -183,7 +183,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
 }", "partialtype");
         }
 
-
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestRecordWithPrimaryConstructorPartialType()
         {

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -183,6 +183,17 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
 }", "partialtype");
         }
 
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestRecordWithPrimaryConstructorPartialType()
+        {
+            await Test_KeywordAsync(
+@"part[||]ial record C(string S)
+{
+    partial void goo();
+}", "partialtype");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestPartialMethodInClass()
         {


### PR DESCRIPTION
Parallel to https://github.com/dotnet/docs/pull/20798