### PR TITLE
Disable hash collision resistance for user data

### DIFF
--- a/src/Workspaces/Remote/Core/ServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptor.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Remote
             => ConfigureFormatter((MessagePackFormatter)base.CreateFormatter());
 
         private static readonly MessagePackSerializerOptions s_options = StandardResolverAllowPrivate.Options
-            .WithSecurity(MessagePackSecurity.UntrustedData)
+            .WithSecurity(MessagePackSecurity.UntrustedData.WithHashCollisionResistant(false))
             .WithResolver(CompositeResolver.Create(
                 MessagePackFormatters.GetFormatters(),
                 new IFormatterResolver[] { ImmutableCollectionMessagePackResolver.Instance, StandardResolverAllowPrivate.Instance }));


### PR DESCRIPTION
MessagePack is not able to deserialize `SuccessfulConflictResolution` with a collision resistant equality comparer due to the use of `DocumentId` as a dictionary key.

Fixes #48108
Fixes [AB#1220433](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1220433)