### PR TITLE
Remove unnecessary workaround for WithMultiplexingStream

### DIFF
--- a/src/Workspaces/Remote/Core/ServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptor.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO.Pipelines;
-using System.Reflection;
 using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.ServiceHub.Framework;
@@ -75,27 +74,6 @@ namespace Microsoft.CodeAnalysis.Remote
             var connection = base.CreateConnection(jsonRpc);
             connection.LocalRpcTargetOptions = s_jsonRpcTargetOptions;
             return connection;
-        }
-
-        [Obsolete]
-        public override ServiceRpcDescriptor WithMultiplexingStream(MultiplexingStream? multiplexingStream)
-        {
-            var baseResult = base.WithMultiplexingStream(multiplexingStream);
-            if (baseResult is ServiceDescriptor)
-                return baseResult;
-
-            // work around incorrect implementation in 16.8 Preview 2
-            if (MultiplexingStream == multiplexingStream)
-                return this;
-
-            var result = (ServiceDescriptor)Clone();
-            typeof(ServiceRpcDescriptor).GetProperty(nameof(MultiplexingStream))!.SetValue(result, multiplexingStream);
-            if (result.MultiplexingStreamOptions is null)
-                return result;
-
-            result = (ServiceDescriptor)result.Clone();
-            typeof(ServiceJsonRpcDescriptor).GetProperty(nameof(MultiplexingStreamOptions))!.SetValue(result, value: null);
-            return result;
         }
 
         internal static class TestAccessor


### PR DESCRIPTION
This pull request reverts 8c3c5aed79f39beff4d189b9f35e1b756848b1c6 now that the workaround is no longer necessary.
