### PR TITLE
Handle indexers in nested object initializers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4728,7 +4728,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt,
                 resultKind,
                 implicitReceiver.Type,
-                binderOpt: this,
+                binder: this,
                 type: boundMember.Type,
                 hasErrors: hasErrors);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1744,9 +1744,9 @@
     <!-- Used by IOperation to reconstruct the receiver for this expression. -->
     <Field Name="ReceiverType" Type="TypeSymbol" Null="disallow"/>
     
-    <!-- BinderOpt is a temporary solution for IOperation implementation and should probably be removed in the future -->
+    <!-- Binder is a temporary solution for IOperation implementation and should probably be removed in the future -->
     <!-- Tracked by https://github.com/dotnet/roslyn/issues/20787 -->
-    <Field Name="BinderOpt" Type="Binder?"/>
+    <Field Name="Binder" Type="Binder"/>
   </Node>
 
   <Node Name="BoundDynamicObjectInitializerMember" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -336,6 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Step three: Now fill in the optional arguments. (Dev11 uses the getter for optional arguments in
             // compound assignments, but for deconstructions we use the setter if the getter is missing.)
             var accessor = indexer.GetOwnOrInheritedGetMethod() ?? indexer.GetOwnOrInheritedSetMethod();
+            Debug.Assert(accessor is not null);
             InsertMissingOptionalArguments(syntax, accessor.Parameters, actualArguments, refKinds);
 
             // For a call, step four would be to optimize away some of the temps.  However, we need them all to prevent

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitIndexerAccess(BoundIndexerAccess node)
         {
             Debug.Assert(node.Indexer.IsIndexer || node.Indexer.IsIndexedProperty);
-            Debug.Assert(node.Indexer.GetOwnOrInheritedGetMethod() is not null);
+            Debug.Assert((object?)node.Indexer.GetOwnOrInheritedGetMethod() != null);
 
             return VisitIndexerAccess(node, isLeftOfAssignment: false);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitIndexerAccess(BoundIndexerAccess node)
         {
             Debug.Assert(node.Indexer.IsIndexer || node.Indexer.IsIndexedProperty);
-            Debug.Assert((object)node.Indexer.GetOwnOrInheritedGetMethod() != null);
+            Debug.Assert(node.Indexer.GetOwnOrInheritedGetMethod() is not null);
 
             return VisitIndexerAccess(node, isLeftOfAssignment: false);
         }
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 var getMethod = indexer.GetOwnOrInheritedGetMethod();
-                Debug.Assert((object)getMethod != null);
+                Debug.Assert(getMethod is not null);
 
                 // We have already lowered each argument, but we may need some additional rewriting for the arguments,
                 // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, inserting arguments for optional parameters, etc.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 memberInit.ArgsToParamsOpt,
                                 memberInit.ResultKind,
                                 memberInit.ReceiverType,
-                                memberInit.BinderOpt,
+                                memberInit.Binder,
                                 memberInit.Type);
                         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -617,7 +617,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
             }
 
-            return node.Update(member, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, receiverType, node.BinderOpt, type);
+            return node.Update(member, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, receiverType, node.Binder, type);
         }
 
         public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.Operations
                         }
                     }
 
-                    return new CSharpLazyPropertyReferenceOperation(this, boundObjectInitializerMember, isObjectOrCollectionInitializer: true, property.GetPublicSymbol(), _semanticModel, syntax, type, constantValue, isImplicit);
+                    return new CSharpLazyPropertyReferenceOperation(this, boundObjectInitializerMember, isObjectOrCollectionInitializer, property.GetPublicSymbol(), _semanticModel, syntax, type, constantValue, isImplicit);
                 default:
                     throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -208,6 +208,7 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
+#nullable enable
         internal ImmutableArray<IArgumentOperation> DeriveArguments(BoundNode containingExpression, bool isObjectOrCollectionInitializer)
         {
             switch (containingExpression.Kind)
@@ -215,11 +216,13 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.ObjectInitializerMember:
                     {
                         var boundObjectInitializerMember = (BoundObjectInitializerMember)containingExpression;
-                        var property = (PropertySymbol)boundObjectInitializerMember.MemberSymbol;
-                        MethodSymbol accessor = isObjectOrCollectionInitializer ? property.GetOwnOrInheritedGetMethod() : property.GetOwnOrInheritedSetMethod();
+                        var property = (PropertySymbol?)boundObjectInitializerMember.MemberSymbol;
+                        MethodSymbol? accessor = isObjectOrCollectionInitializer ? property.GetOwnOrInheritedGetMethod() : property.GetOwnOrInheritedSetMethod();
+                        Debug.Assert(property is not null);
+                        Debug.Assert(accessor is not null);
                         return DeriveArguments(
                                     boundObjectInitializerMember,
-                                    boundObjectInitializerMember.BinderOpt,
+                                    boundObjectInitializerMember.Binder,
                                     property,
                                     accessor,
                                     boundObjectInitializerMember.Arguments,
@@ -235,6 +238,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     return DeriveArguments(containingExpression);
             }
         }
+#nullable disable
 
         internal ImmutableArray<IArgumentOperation> DeriveArguments(BoundNode containingExpression)
         {
@@ -309,6 +313,7 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
+#nullable enable
         private ImmutableArray<IArgumentOperation> DeriveArguments(
             BoundNode boundNode,
             Binder binder,
@@ -342,6 +347,7 @@ namespace Microsoft.CodeAnalysis.Operations
                  argsToParamsOpt: argumentsToParametersOpt,
                  invokedAsExtensionMethod: invokedAsExtensionMethod);
         }
+#nullable disable
 
         internal static ImmutableArray<BoundNode> CreateInvalidChildrenFromArgumentsExpression(BoundNode receiverOpt, ImmutableArray<BoundExpression> arguments, BoundExpression additionalNodeOpt = null)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -219,7 +219,6 @@ namespace Microsoft.CodeAnalysis.Operations
                         var property = (PropertySymbol?)boundObjectInitializerMember.MemberSymbol;
                         MethodSymbol? accessor = isObjectOrCollectionInitializer ? property.GetOwnOrInheritedGetMethod() : property.GetOwnOrInheritedSetMethod();
                         Debug.Assert(property is not null);
-                        Debug.Assert(accessor is not null);
                         return DeriveArguments(
                                     boundObjectInitializerMember,
                                     boundObjectInitializerMember.Binder,
@@ -318,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Operations
             BoundNode boundNode,
             Binder binder,
             Symbol methodOrIndexer,
-            MethodSymbol optionalParametersMethod,
+            MethodSymbol? optionalParametersMethod,
             ImmutableArray<BoundExpression> boundArguments,
             ImmutableArray<string> argumentNamesOpt,
             ImmutableArray<int> argumentsToParametersOpt,
@@ -335,6 +334,8 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 return ImmutableArray<IArgumentOperation>.Empty;
             }
+
+            Debug.Assert(optionalParametersMethod is not null);
 
             return LocalRewriter.MakeArgumentsInEvaluationOrder(
                  operationFactory: this,

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -217,8 +217,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     {
                         var boundObjectInitializerMember = (BoundObjectInitializerMember)containingExpression;
                         var property = (PropertySymbol?)boundObjectInitializerMember.MemberSymbol;
-                        MethodSymbol? accessor = isObjectOrCollectionInitializer ? property.GetOwnOrInheritedGetMethod() : property.GetOwnOrInheritedSetMethod();
                         Debug.Assert(property is not null);
+                        MethodSymbol? accessor = isObjectOrCollectionInitializer ? property.GetOwnOrInheritedGetMethod() : property.GetOwnOrInheritedSetMethod();
                         return DeriveArguments(
                                     boundObjectInitializerMember,
                                     boundObjectInitializerMember.Binder,

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbolExtensions.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
+#nullable enable
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -14,12 +12,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If the property has a GetMethod, return that.  Otherwise check the overridden
         /// property, if any.  Repeat for each overridden property.
         /// </summary>
-        public static MethodSymbol GetOwnOrInheritedGetMethod(this PropertySymbol property)
+        public static MethodSymbol? GetOwnOrInheritedGetMethod(this PropertySymbol? property)
         {
-            while ((object)property != null)
+            while (property is not null)
             {
                 MethodSymbol getMethod = property.GetMethod;
-                if ((object)getMethod != null)
+                if (getMethod is not null)
                 {
                     return getMethod;
                 }
@@ -34,12 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If the property has a SetMethod, return that.  Otherwise check the overridden
         /// property, if any.  Repeat for each overridden property.
         /// </summary>
-        public static MethodSymbol GetOwnOrInheritedSetMethod(this PropertySymbol property)
+        public static MethodSymbol? GetOwnOrInheritedSetMethod(this PropertySymbol? property)
         {
-            while ((object)property != null)
+            while (property is not null)
             {
                 MethodSymbol setMethod = property.SetMethod;
-                if ((object)setMethod != null)
+                if (setMethod is not null)
                 {
                     return setMethod;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbolExtensions.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public static MethodSymbol? GetOwnOrInheritedGetMethod(this PropertySymbol? property)
         {
-            while (property is not null)
+            while ((object?)property != null)
             {
                 MethodSymbol getMethod = property.GetMethod;
-                if (getMethod is not null)
+                if ((object?)getMethod != null)
                 {
                     return getMethod;
                 }
@@ -34,10 +34,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public static MethodSymbol? GetOwnOrInheritedSetMethod(this PropertySymbol? property)
         {
-            while (property is not null)
+            while ((object?)property != null)
             {
                 MethodSymbol setMethod = property.SetMethod;
-                if (setMethod is not null)
+                if ((object?)setMethod != null)
                 {
                     return setMethod;
                 }

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IPropertyReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IPropertyReferenceExpression.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -1002,6 +1003,95 @@ Block[B12] - Exit
             var expectedDiagnostics = DiagnosticDescription.None;
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(45692, "https://github.com/dotnet/roslyn/issues/45692")]
+        public void NestedObjectInitializerMissingGet()
+        {
+            var comp = CreateCompilation(@"
+_ = new C { Prop1 = /*<bind>*/new C { [0] = 1 }/*</bind>*/ };
+
+class C
+{
+    public object Prop1 { get; set; }
+    public object this[int i] { set { } }
+
+}
+", options: TestOptions.ReleaseExe);
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(comp, @"
+IObjectCreationOperation (Constructor: C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'new C { [0] = 1 }')
+  Arguments(0)
+  Initializer: 
+    IObjectOrCollectionInitializerOperation (OperationKind.ObjectOrCollectionInitializer, Type: C) (Syntax: '{ [0] = 1 }')
+      Initializers(1):
+          ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object) (Syntax: '[0] = 1')
+            Left: 
+              IPropertyReferenceOperation: System.Object C.this[System.Int32 i] { set; } (OperationKind.PropertyReference, Type: System.Object) (Syntax: '[0]')
+                Instance Receiver: 
+                  IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: '[0]')
+                Arguments(1):
+                    IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: i) (OperationKind.Argument, Type: null) (Syntax: '0')
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+                      InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                      OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+            Right: 
+              IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: '1')
+                Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                Operand: 
+                  ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+            ", DiagnosticDescription.None);
+        }
+
+        [Fact, WorkItem(45692, "https://github.com/dotnet/roslyn/issues/45692")]
+        public void NestedObjectInitializerMissingGet_NestedInitializer()
+        {
+            var comp = CreateCompilation(@"
+_ = new C { Prop1 = /*<bind>*/new C { [0] = new C { Prop1 = 1 } }/*</bind>*/ };
+
+class C
+{
+    public object Prop1 { get; set; }
+    public object this[int i] { set { } }
+}
+", options: TestOptions.ReleaseExe);
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(comp, @"
+IObjectCreationOperation (Constructor: C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'new C { [0] ... op1 = 1 } }')
+  Arguments(0)
+  Initializer: 
+    IObjectOrCollectionInitializerOperation (OperationKind.ObjectOrCollectionInitializer, Type: C) (Syntax: '{ [0] = new ... op1 = 1 } }')
+      Initializers(1):
+          ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object) (Syntax: '[0] = new C ... Prop1 = 1 }')
+            Left: 
+              IPropertyReferenceOperation: System.Object C.this[System.Int32 i] { set; } (OperationKind.PropertyReference, Type: System.Object) (Syntax: '[0]')
+                Instance Receiver: 
+                  IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: '[0]')
+                Arguments(1):
+                    IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: i) (OperationKind.Argument, Type: null) (Syntax: '0')
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+                      InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                      OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+            Right: 
+              IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'new C { Prop1 = 1 }')
+                Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                Operand: 
+                  IObjectCreationOperation (Constructor: C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'new C { Prop1 = 1 }')
+                    Arguments(0)
+                    Initializer: 
+                      IObjectOrCollectionInitializerOperation (OperationKind.ObjectOrCollectionInitializer, Type: C) (Syntax: '{ Prop1 = 1 }')
+                        Initializers(1):
+                            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object) (Syntax: 'Prop1 = 1')
+                              Left: 
+                                IPropertyReferenceOperation: System.Object C.Prop1 { get; set; } (OperationKind.PropertyReference, Type: System.Object) (Syntax: 'Prop1')
+                                  Instance Receiver: 
+                                    IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: 'Prop1')
+                              Right: 
+                                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: '1')
+                                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                                  Operand: 
+                                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+            ", DiagnosticDescription.None);
         }
     }
 }


### PR DESCRIPTION
When I removed the usage of `Lazy<T>` from IOperation, I mishandled setting whether a property initializer in a nested object initializer expression is a object initializer itself. This meant that during the build of the parent node, we'd correctly check the setter for the property to ensure that it was valid, but then when handling deriving the arguments for the child node we'd use the wrong method (the getter, instead of the setter). Practically, this only had observably bad results from indexers: indexers without a get method would cause the code to null ref. This is because when deriving the arguments for the getter for non-indexed properties, we'd use the getter, and then immediately bail out because the getter had no arguments. Fixes https://github.com/dotnet/roslyn/issues/45692.

Commit-by-commit review is recommended. Commit 1 nullable enables code so that I could figure out what the bug was. The second commit actually fixes the bug.
