### PR TITLE
Correct IsImplicitlyDeclared for SimpleProgramNamedTypeSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                               instanceInitializersSyntaxLength: 0);
         }
 
-        public override bool IsImplicitlyDeclared => false;
+        public override bool IsImplicitlyDeclared => true;
 
         internal override bool IsDefinedInSourceTree(SyntaxTree tree, TextSpan? definedWithinSpan, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
The class documentation clearly states:

```csharp
    /// <summary>
    /// Represents implicitly declared type for a Simple Program feature.
    /// </summary>
```

Fixes #48171