### PR TITLE
Replace function with property change to Retain in line comment

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2361,7 +2361,7 @@ class C
         }
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
         [WorkItem(42698, "https://github.com/dotnet/roslyn/issues/42698")]
-        public async Task TestRefactorRetainsComments()
+        public async Task TestMethodWithTrivia_3()
         {
             await TestInRegularAndScript1Async(
 @"class C
@@ -2376,6 +2376,37 @@ class C
     //Vital Comment
     int FooBar => 1;
 }");
+        }
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [WorkItem(42698, "https://github.com/dotnet/roslyn/issues/42698")]
+        public async Task TestMethodWithTrivia_4()
+        {
+            await TestWithAllCodeStyleOff(
+@"class C
+{
+    int [||]GetGoo()    // Goo
+    {
+    }
+    void SetGoo(int i)    // SetGoo
+    {
+    }
+}",
+@"class C
+{
+    // Goo
+    // SetGoo
+    int Goo
+    {
+        get
+        {
+        }
+
+        set
+        {
+        }
+    }
+}",
+index: 1);
         }
         private async Task TestWithAllCodeStyleOff(
             string initialMarkup, string expectedMarkup,

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2359,6 +2359,7 @@ class C
     }
 }");
         }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
         [WorkItem(42698, "https://github.com/dotnet/roslyn/issues/42698")]
         public async Task TestMethodWithTrivia_3()

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2359,7 +2359,24 @@ class C
     }
 }");
         }
-
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [WorkItem(42698, "https://github.com/dotnet/roslyn/issues/42698")]
+        public async Task TestRefactorRetainsComments()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    [||]int FooBar() //Vital Comment
+    {
+      return 1;
+    }
+}",
+@"class C
+{
+    //Vital Comment
+    int FooBar => 1;
+}");
+        }
         private async Task TestWithAllCodeStyleOff(
             string initialMarkup, string expectedMarkup,
             ParseOptions parseOptions = null, int index = 0)

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2410,6 +2410,7 @@ class C
 }",
 index: 1);
         }
+
         private async Task TestWithAllCodeStyleOff(
             string initialMarkup, string expectedMarkup,
             ParseOptions parseOptions = null, int index = 0)

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2367,7 +2367,7 @@ class C
             await TestInRegularAndScript1Async(
 @"class C
 {
-    [||]int FooBar() //Vital Comment
+    [||]int Goo() //Vital Comment
     {
       return 1;
     }
@@ -2375,7 +2375,7 @@ class C
 @"class C
 {
     //Vital Comment
-    int FooBar => 1;
+    int Goo => 1;
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2378,6 +2378,7 @@ class C
     int FooBar => 1;
 }");
         }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
         [WorkItem(42698, "https://github.com/dotnet/roslyn/issues/42698")]
         public async Task TestMethodWithTrivia_4()

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -74,16 +74,15 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 
         //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
         //If it's there we need to add it to the final comments
-        private static List<SyntaxTrivia> AddParamListTriviaIfNeeded(ISyntaxFacts syntaxFacts, SyntaxNode methodDeclaration, List<SyntaxTrivia> finalLeadingTrivia)
+        private static void AddParamListTriviaIfNeeded(ISyntaxFacts syntaxFacts, SyntaxNode methodDeclaration, List<SyntaxTrivia> finalLeadingTrivia)
         {
             var paramList = syntaxFacts.GetParameterList(methodDeclaration);
-            if (paramList.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t)))
+            var trailingTrivia = paramList.GetTrailingTrivia();
+            if (trailingTrivia .Any(t => syntaxFacts.IsRegularComment(t)))
             {
-                //we have a meaningful comment on the parameter list so add it to the trivia list
-                finalLeadingTrivia.AddRange(paramList.GetTrailingTrivia());
+                // we have a meaningful comment on the parameter list so add it to the trivia list
+                finalLeadingTrivia.AddRange(trailingTrivia);
             }
-
-            return finalLeadingTrivia;
         }
     }
 }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -4,9 +4,9 @@
 
 #nullable enable
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.LanguageServices;
 

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -48,14 +48,15 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
             var getMethodDeclaration = getAndSetMethods.GetMethodDeclaration;
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration;
             var finalLeadingTrivia = getAndSetMethods.GetMethodDeclaration.GetLeadingTrivia().ToList();
+            var paramList = syntaxFacts.GetParameterList(getMethodDeclaration);
 
             //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
             //If it's there we need to add it to the final comments
             //this is to fix issue 42699, https://github.com/dotnet/roslyn/issues/42699
-            if (getMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
+            if (paramList.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t)))
             {
                 //we have a meaningful comment on the parameter list so add it to the trivia list
-                finalLeadingTrivia.AddRange(getMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
+                finalLeadingTrivia.AddRange(paramList.GetTrailingTrivia());
             }
 
             if (setMethodDeclaration == null)
@@ -70,10 +71,11 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 
             //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
             //If it's there we need to add it to the final comments
-            if (setMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
+            paramList = syntaxFacts.GetParameterList(setMethodDeclaration);
+            if (paramList.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t)))
             {
                 //we have a meaningful comment on the parameter list so add it to the trivia list
-                finalLeadingTrivia.AddRange(setMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
+                finalLeadingTrivia.AddRange(paramList.GetTrailingTrivia());
             }
 
             return property.WithLeadingTrivia(finalLeadingTrivia);

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -49,8 +49,12 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration;
             var finalLeadingTrivia = getAndSetMethods.GetMethodDeclaration.GetLeadingTrivia().ToList();
 
+            //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
+            //If it's there we need to add it to the final comments
+            //this is to fix issue 42699, https://github.com/dotnet/roslyn/issues/42699
             if (getMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
             {
+                //we have a meaningful comment on the parameter list so add it to the trivia list
                 finalLeadingTrivia.AddRange(getMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
             }
 
@@ -63,8 +67,12 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
                 setMethodDeclaration.GetLeadingTrivia()
                                     .SkipWhile(t => syntaxFacts.IsEndOfLineTrivia(t))
                                     .Where(t => !t.IsDirective));
+
+            //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
+            //If it's there we need to add it to the final comments
             if (setMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
             {
+                //we have a meaningful comment on the parameter list so add it to the trivia list
                 finalLeadingTrivia.AddRange(setMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
             }
 

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -77,11 +77,14 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         private static void AddParamListTriviaIfNeeded(ISyntaxFacts syntaxFacts, SyntaxNode methodDeclaration, List<SyntaxTrivia> finalLeadingTrivia)
         {
             var paramList = syntaxFacts.GetParameterList(methodDeclaration);
-            var trailingTrivia = paramList.GetTrailingTrivia();
-            if (trailingTrivia .Any(t => syntaxFacts.IsRegularComment(t)))
+            if (paramList != null)
             {
-                // we have a meaningful comment on the parameter list so add it to the trivia list
-                finalLeadingTrivia.AddRange(trailingTrivia);
+                var trailingTrivia = paramList.GetTrailingTrivia();
+                if (trailingTrivia.Any(t => syntaxFacts.IsRegularComment(t)))
+                {
+                    // we have a meaningful comment on the parameter list so add it to the trivia list
+                    finalLeadingTrivia.AddRange(trailingTrivia);
+                }
             }
         }
     }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -49,12 +49,13 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration;
             var finalLeadingTrivia = getAndSetMethods.GetMethodDeclaration.GetLeadingTrivia().ToList();
 
+            if (getMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
+            {
+                finalLeadingTrivia.AddRange(getMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
+            }
+
             if (setMethodDeclaration == null)
             {
-                if (getMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
-                {
-                    finalLeadingTrivia.AddRange(getMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
-                }
                 return property.WithLeadingTrivia(finalLeadingTrivia);
             }
 
@@ -62,6 +63,10 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
                 setMethodDeclaration.GetLeadingTrivia()
                                     .SkipWhile(t => syntaxFacts.IsEndOfLineTrivia(t))
                                     .Where(t => !t.IsDirective));
+            if (setMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
+            {
+                finalLeadingTrivia.AddRange(setMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
+            }
 
             return property.WithLeadingTrivia(finalLeadingTrivia);
         }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 
             //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
             //If it's there we need to add it to the final comments
-            finalLeadingTrivia = AddParamListTriviaIfNeeded(syntaxFacts, setMethodDeclaration, finalLeadingTrivia);
+            AddParamListTriviaIfNeeded(syntaxFacts, setMethodDeclaration, finalLeadingTrivia);
 
             return property.WithLeadingTrivia(finalLeadingTrivia);
         }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -47,12 +47,16 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         {
             var getMethodDeclaration = getAndSetMethods.GetMethodDeclaration;
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration;
+            var finalLeadingTrivia = getAndSetMethods.GetMethodDeclaration.GetLeadingTrivia().ToList();
+
             if (setMethodDeclaration == null)
             {
-                return property.WithLeadingTrivia(getMethodDeclaration.GetLeadingTrivia());
+                if (getMethodDeclaration.ChildNodes().Any(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList && n.GetTrailingTrivia().Any(t => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t))))
+                {
+                    finalLeadingTrivia.AddRange(getMethodDeclaration.ChildNodes().Where(n => n.RawKind == syntaxFacts.SyntaxKinds.ParameterList).First().GetTrailingTrivia());
+                }
+                return property.WithLeadingTrivia(finalLeadingTrivia);
             }
-
-            var finalLeadingTrivia = getAndSetMethods.GetMethodDeclaration.GetLeadingTrivia().ToList();
 
             finalLeadingTrivia.AddRange(
                 setMethodDeclaration.GetLeadingTrivia()

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
             //If there is a comment on the same line as the method it is contained in trailing trivia for the parameter list
             //If it's there we need to add it to the final comments
             //this is to fix issue 42699, https://github.com/dotnet/roslyn/issues/42699
-            finalLeadingTrivia = AddParamListTriviaIfNeeded(syntaxFacts, getMethodDeclaration, finalLeadingTrivia);
+            AddParamListTriviaIfNeeded(syntaxFacts, getMethodDeclaration, finalLeadingTrivia);
 
             if (setMethodDeclaration == null)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public int Parameter => (int)SyntaxKind.Parameter;
         public int TypeConstraint => (int)SyntaxKind.TypeConstraint;
         public int VariableDeclarator => (int)SyntaxKind.VariableDeclarator;
-
+        public int ParameterList => (int)SyntaxKind.ParameterList;
         public int TypeArgumentList => (int)SyntaxKind.TypeArgumentList;
         public int? GlobalStatement => (int)SyntaxKind.GlobalStatement;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         int IncompleteMember { get; }
         int TypeArgumentList { get; }
-
+        int ParameterList { get; }
         #endregion
 
         #region other

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
@@ -87,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
         Public ReadOnly Property Parameter As Integer = SyntaxKind.Parameter Implements ISyntaxKinds.Parameter
         Public ReadOnly Property TypeConstraint As Integer = SyntaxKind.TypeConstraint Implements ISyntaxKinds.TypeConstraint
         Public ReadOnly Property VariableDeclarator As Integer = SyntaxKind.VariableDeclarator Implements ISyntaxKinds.VariableDeclarator
-
+        Public ReadOnly Property ParameterList As Integer = SyntaxKind.ParameterList Implements ISyntaxKinds.ParameterList
         Public ReadOnly Property TypeArgumentList As Integer = SyntaxKind.TypeArgumentList Implements ISyntaxKinds.TypeArgumentList
         Public ReadOnly Property GlobalStatement As Integer? = Nothing Implements ISyntaxKinds.GlobalStatement
 


### PR DESCRIPTION
This pull request closes issue #42698. 
## The issue 
The comment (trivia) was attached to the "parameter child node of the primary syntax node. Thus the "GetLeading/TrailingTrivia" didn't return that trivia. 
## Solution
Added a call to test the parameter child node for the presence of non-whitespace/end of line trivia and add that to the leading trivia. Added this for the "get" and "set" routines.
Needed the RawKind "ParameterList" to test for the proper node. Added the property to the SyntaxKind interface and CSharp/VisualBasic SyntaxKind.