### PR TITLE
Do not close pipe writer on exceptions originating from JSON-RPC.

### DIFF
--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -165,8 +165,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 catch (Exception e) when (e is not (OperationCanceledException or RemoteRpcException))
                 {
                     // Ensure that the writer is complete if an exception is thrown
-                    // that is not handled by the RPC proxy. The proxy completes the writer
-                    // if a remote exception occurs on the server or when the call succeeds.
+                    // that is not thrown by the RPC proxy. The proxy completes the writer
+                    // if a remote exception occurs on the server or the request is canceled.
+                    // The remote service completes the writer when the call succeeds.
                     await pipe.Writer.CompleteAsync(e).ConfigureAwait(false);
 
                     throw;

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -161,11 +162,11 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     await invocation(service, pipe.Writer, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch (Exception e) when (e is not (OperationCanceledException or RemoteRpcException))
                 {
                     // Ensure that the writer is complete if an exception is thrown
-                    // before the writer is passed to the RPC proxy. Once it's passed to the proxy 
-                    // the proxy should complete it as soon as the remote side completes it.
+                    // that is not handled by the RPC proxy. The proxy completes the writer
+                    // if a remote exception occurs on the server or when the call succeeds.
                     await pipe.Writer.CompleteAsync(e).ConfigureAwait(false);
 
                     throw;


### PR DESCRIPTION
JSON-RPC closes the writer itself when handling these exceptions.