### PR TITLE
Make assertion more informative

### DIFF
--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -260,7 +260,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             using (var workspace = CreateWorkspaceFromOptions(initialMarkup, parameters))
             {
                 var (actions, _) = await GetCodeActionsAsync(workspace, parameters);
-                Assert.True(actions.Length == 0, "An action was offered when none was expected");
+                var offeredActions = Environment.NewLine + string.Join(Environment.NewLine, actions.Select(action => action.Title));
+                Assert.True(actions.Length == 0, "An action was offered when none was expected. Offered actions:" + offeredActions);
             }
         }
 


### PR DESCRIPTION
- This is useful when a specific code fix or code refactoring can offer multiple actions and for a specific test you expect none. With this change, it's easier to see which code action(s) has/have the bug.

- Not very useful when the code fix/refactoring under test can only offers one action, but doesn't harm.