### PR TITLE
Ensure initial binding always binds to natural type

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3167,7 +3167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    size = BindToNaturalType(size, diagnostics);
+                    size = BindToTypeForErrorRecovery(size);
                 }
 
                 return size;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3165,6 +3165,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hasErrors = true;
                     }
                 }
+                else
+                {
+                    size = BindToNaturalType(size, diagnostics);
+                }
 
                 return size;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2354,7 +2354,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // The expression could not be bound. Insert a fake conversion
                 // around it to bool and keep on going.
                 // NOTE: no user-defined conversion candidates.
-                return BoundConversion.Synthesized(node, expr, Conversion.NoConversion, false, explicitCastInCode: false, conversionGroupOpt: null, ConstantValue.NotAvailable, boolean, hasErrors: true);
+                return BoundConversion.Synthesized(node, BindToTypeForErrorRecovery(expr), Conversion.NoConversion, false, explicitCastInCode: false, conversionGroupOpt: null, ConstantValue.NotAvailable, boolean, hasErrors: true);
             }
 
             // Oddly enough, "if(dyn)" is bound not as a dynamic conversion to bool, but as a dynamic

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.cs
@@ -814,6 +814,28 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact, WorkItem(1198816, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/")]
+        public void ImplicitObjectCreationUnconverted_IfCondition()
+        {
+            var comp = CreateCompilation(@"
+if (/*<bind>*/new(bad)/*</bind>*/) {}
+", options: TestOptions.UnsafeReleaseExe);
+
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // (2,19): error CS0103: The name 'bad' does not exist in the current context
+                // if (/*<bind>*/new(bad)/*</bind>*/) {}
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(2, 19)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ImplicitObjectCreationExpressionSyntax>(comp, @"
+IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)')
+  Children(1):
+      IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'bad')
+        Children(0)
+            ", expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
         [Fact]
         public void ImplicitObjectCreationWithDynamicMemberInitializer_01()
         {

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.cs
@@ -837,7 +837,7 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)
 
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact, WorkItem(1198816, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/")]
-        public void DefiniteAssignment_UnconvertedConditionalOperator()
+        public void ImplicitObjectCreationUnconverted_ConditionalOperator()
         {
             var source =
 @"class Program
@@ -853,6 +853,62 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)
                 // (5,27): error CS0103: The name 'bad' does not exist in the current context
                 //         _ = /*<bind>*/new(bad)/*</bind>*/ ? null : new object();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(5, 27)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ImplicitObjectCreationExpressionSyntax>(comp, @"
+IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)')
+  Children(1):
+      IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'bad')
+        Children(0)
+            ", expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact, WorkItem(1198816, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/")]
+        public void ImplicitObjectCreationUnconverted_ConditionalOperator_Nested1()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        _ = (/*<bind>*/new(bad)/*</bind>*/, null) ? null : new object();
+    }
+}";
+            var comp = CreateCompilation(source);
+
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // (5,28): error CS0103: The name 'bad' does not exist in the current context
+                //         _ = (/*<bind>*/new(bad)/*</bind>*/, null) ? null : new object();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(5, 28)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ImplicitObjectCreationExpressionSyntax>(comp, @"
+IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)')
+  Children(1):
+      IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'bad')
+        Children(0)
+            ", expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact, WorkItem(1198816, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/")]
+        public void ImplicitObjectCreationUnconverted_ConditionalOperator_Nested2()
+        {
+            var source =
+@"class Program
+{
+    static void Main(int i)
+    {
+        _ = i switch { 1 => /*<bind>*/new(bad)/*</bind>*/, _ => null } ? null : new object();
+    }
+}";
+            var comp = CreateCompilation(source);
+
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // (5,43): error CS0103: The name 'bad' does not exist in the current context
+                //         _ = i switch { 1 => /*<bind>*/new(bad)/*</bind>*/, _ => null } ? null : new object();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(5, 43)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<ImplicitObjectCreationExpressionSyntax>(comp, @"

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.cs
@@ -794,6 +794,26 @@ IObjectCreationOperation (Constructor: C..ctor()) (OperationKind.ObjectCreation,
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact, WorkItem(1198816, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/")]
+        public void ImplicitObjectCreationUnconverted_ArrayIndex()
+        {
+            var comp = CreateCompilation("_ = new int[/*<bind>*/new(bad)/*</bind>*/];", options: TestOptions.ReleaseExe);
+
+            var expectedDiagnostics = new DiagnosticDescription[] { 
+                // (1,27): error CS0103: The name 'bad' does not exist in the current context
+                // _ = new int[/*<bind>*/new(bad)/*</bind>*/];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(1, 27)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ImplicitObjectCreationExpressionSyntax>(comp, @"
+IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'new(bad)')
+  Children(1):
+      IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'bad')
+        Children(0)
+            ", expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
         [Fact]
         public void ImplicitObjectCreationWithDynamicMemberInitializer_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
@@ -1499,5 +1499,24 @@ Test
 
             CompileAndVerify(compilation, expectedOutput: "---");
         }
+
+        [Fact, WorkItem(1198816, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/")]
+        public void DefiniteAssignment_UnconvertedConditionalOperator()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        _ = new(bad) ? null : new object();
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (5,17): error CS0103: The name 'bad' does not exist in the current context
+                //         _ = new(bad) ? null : new object();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(5, 17)
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198816/, which is about `CSharpOperationFactory.CreateInternal` being passed a node it does not expect. I looked through all the places in the binder where we use `BindValue` and ensured the results were being correctly bound to a natural type, even if there was some error. I found 2 such cases:

- Array rank specifiers were not being bound to their natural type if they had some error.
- `if` conditions were not being bound to their natural type if they had some error. This is the case that results in the specific stack pattern from the watson, where a `BoundConversion` sat on top of a `BoundUnconvertedObjectCreationExpression`.

In both of these cases, unconverted results were passed to the factory, which cannot handle nodes of these types and threw.
