### PR TITLE
Fix deadlocks in the use of OOP services

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -81,15 +81,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             });
         }
 
-        public void WaitForLightBulbSession()
+        public void WaitForLightBulbSession(TimeSpan timeout)
         {
+            using var cancellationTokenSource = new CancellationTokenSource(timeout);
+
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationTokenSource.Token);
 
                 var view = GetActiveTextView();
                 var broker = GetComponentModel().GetService<ILightBulbBroker>();
-                await LightBulbHelper.WaitForLightBulbSessionAsync(broker, view);
+                await LightBulbHelper.WaitForLightBulbSessionAsync(broker, view).ConfigureAwait(false);
             });
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.Verifier.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 bool blockUntilComplete = true)
             {
                 _textViewWindow.ShowLightBulb();
-                _textViewWindow.WaitForLightBulbSession();
+                _textViewWindow.WaitForLightBulbSession(Helper.HangMitigatingTimeout);
 
                 if (verifyNotShowing)
                 {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
@@ -70,8 +71,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void ShowLightBulb()
             => _textViewWindowInProc.ShowLightBulb();
 
-        public void WaitForLightBulbSession()
-            => _textViewWindowInProc.WaitForLightBulbSession();
+        public void WaitForLightBulbSession(TimeSpan timeout)
+            => _textViewWindowInProc.WaitForLightBulbSession(timeout);
 
         public bool IsLightBulbSessionExpanded()
             => _textViewWindowInProc.IsLightBulbSessionExpanded();
@@ -103,7 +104,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.DiagnosticService);
 
             ShowLightBulb();
-            WaitForLightBulbSession();
+            WaitForLightBulbSession(Helper.HangMitigatingTimeout);
             _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.LightBulb);
         }
 
@@ -114,7 +115,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void InvokeCodeActionListWithoutWaiting()
         {
             ShowLightBulb();
-            WaitForLightBulbSession();
+            WaitForLightBulbSession(Helper.HangMitigatingTimeout);
         }
 
         public void InvokeQuickInfo()


### PR DESCRIPTION
IServiceBroker may depend on the UI thread to provide proxies, so synchronous operations on the UI thread must use JTF-aware waits for asynchronous operations that may directly or indirectly use brokered services. This change fixes a specific deadlock observed in roslyn-integration-CI.