### PR TITLE
Use lightweight type constraint binding for IsValueType

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -251,10 +251,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool AreNullableAnnotationsEnabled(SyntaxToken token)
         {
             RoslynDebug.Assert(token.SyntaxTree is object);
-            if ((Flags & BinderFlags.IgnoreNullableContext) != 0)
-            {
-                return false;
-            }
             return AreNullableAnnotationsEnabled(token.SyntaxTree, token.SpanStart);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -113,9 +113,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         InEEMethodBinder = 1 << 30,
 
         /// <summary>
-        /// Assume '#nullable disable' context.
+        /// Skip binding type arguments in type constraints
         /// </summary>
-        IgnoreNullableContext = 1u << 31,
+        LightweightTypeConstraintBinding = 1u << 31,
 
         // Groups
 

--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -113,9 +114,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         InEEMethodBinder = 1 << 30,
 
         /// <summary>
-        /// Skip binding type arguments in type constraints
+        /// Skip binding type arguments (we use <see cref="PlaceholderTypeArgumentSymbol"/> instead).
+        /// For example, currently used when type constraints are bound in some scenarios.
         /// </summary>
-        LightweightTypeConstraintBinding = 1u << 31,
+        SuppressTypeArgumentBinding = 1u << 31,
 
         // Groups
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> clauses,
-            bool canUseLightweightTypeConstraintBinding,
             ref IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride,
             DiagnosticBag diagnostics,
             bool isForOverride = false)
@@ -67,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(ordinal < n);
 
                     (TypeParameterConstraintClause constraintClause, ArrayBuilder<TypeConstraintSyntax>? typeConstraintNodes) =
-                        this.BindTypeParameterConstraints(typeParameterList.Parameters[ordinal], clause, isForOverride, canUseLightweightTypeConstraintBinding, diagnostics);
+                        this.BindTypeParameterConstraints(typeParameterList.Parameters[ordinal], clause, isForOverride, diagnostics);
                     if (results[ordinal] == null)
                     {
                         results[ordinal] = constraintClause;
@@ -119,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bind and return a single type parameter constraint clause along with syntax nodes corresponding to type constraints.
         /// </summary>
         private (TypeParameterConstraintClause, ArrayBuilder<TypeConstraintSyntax>?) BindTypeParameterConstraints(
-            TypeParameterSyntax typeParameterSyntax, TypeParameterConstraintClauseSyntax constraintClauseSyntax, bool isForOverride, bool canUseLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
+            TypeParameterSyntax typeParameterSyntax, TypeParameterConstraintClauseSyntax constraintClauseSyntax, bool isForOverride, DiagnosticBag diagnostics)
         {
             var constraints = TypeParameterConstraintKind.None;
             ArrayBuilder<TypeWithAnnotations>? constraintTypes = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> clauses,
-            bool useLightweightTypeConstraintBinding,
+            bool canUseLightweightTypeConstraintBinding,
             ref IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride,
             DiagnosticBag diagnostics,
             bool isForOverride = false)
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(ordinal < n);
 
                     (TypeParameterConstraintClause constraintClause, ArrayBuilder<TypeConstraintSyntax>? typeConstraintNodes) =
-                        this.BindTypeParameterConstraints(typeParameterList.Parameters[ordinal], clause, isForOverride, useLightweightTypeConstraintBinding: useLightweightTypeConstraintBinding, diagnostics);
+                        this.BindTypeParameterConstraints(typeParameterList.Parameters[ordinal], clause, isForOverride, canUseLightweightTypeConstraintBinding, diagnostics);
                     if (results[ordinal] == null)
                     {
                         results[ordinal] = constraintClause;
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bind and return a single type parameter constraint clause along with syntax nodes corresponding to type constraints.
         /// </summary>
         private (TypeParameterConstraintClause, ArrayBuilder<TypeConstraintSyntax>?) BindTypeParameterConstraints(
-            TypeParameterSyntax typeParameterSyntax, TypeParameterConstraintClauseSyntax constraintClauseSyntax, bool isForOverride, bool useLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
+            TypeParameterSyntax typeParameterSyntax, TypeParameterConstraintClauseSyntax constraintClauseSyntax, bool isForOverride, bool canUseLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
         {
             var constraints = TypeParameterConstraintKind.None;
             ArrayBuilder<TypeWithAnnotations>? constraintTypes = null;
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!isForOverride ||
                          (constraints & (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType)) != (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType));
 
-            return (TypeParameterConstraintClause.Create(constraints, constraintTypes?.ToImmutableAndFree() ?? ImmutableArray<TypeWithAnnotations>.Empty, useLightweightTypeConstraintBinding), syntaxBuilder);
+            return (TypeParameterConstraintClause.Create(constraints, constraintTypes?.ToImmutableAndFree() ?? ImmutableArray<TypeWithAnnotations>.Empty, canUseLightweightTypeConstraintBinding), syntaxBuilder);
 
             static void reportOverrideWithConstraints(ref bool reportedOverrideWithConstraints, TypeParameterConstraintSyntax syntax, DiagnosticBag diagnostics)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> clauses,
-            bool canIgnoreNullableContext,
+            bool useLightweightTypeConstraintBinding,
             ref IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride,
             DiagnosticBag diagnostics,
             bool isForOverride = false)
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(ordinal < n);
 
                     (TypeParameterConstraintClause constraintClause, ArrayBuilder<TypeConstraintSyntax>? typeConstraintNodes) =
-                        this.BindTypeParameterConstraints(typeParameterList.Parameters[ordinal], clause, isForOverride, canIgnoreNullableContext: canIgnoreNullableContext, diagnostics);
+                        this.BindTypeParameterConstraints(typeParameterList.Parameters[ordinal], clause, isForOverride, useLightweightTypeConstraintBinding: useLightweightTypeConstraintBinding, diagnostics);
                     if (results[ordinal] == null)
                     {
                         results[ordinal] = constraintClause;
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bind and return a single type parameter constraint clause along with syntax nodes corresponding to type constraints.
         /// </summary>
         private (TypeParameterConstraintClause, ArrayBuilder<TypeConstraintSyntax>?) BindTypeParameterConstraints(
-            TypeParameterSyntax typeParameterSyntax, TypeParameterConstraintClauseSyntax constraintClauseSyntax, bool isForOverride, bool canIgnoreNullableContext, DiagnosticBag diagnostics)
+            TypeParameterSyntax typeParameterSyntax, TypeParameterConstraintClauseSyntax constraintClauseSyntax, bool isForOverride, bool useLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
         {
             var constraints = TypeParameterConstraintKind.None;
             ArrayBuilder<TypeWithAnnotations>? constraintTypes = null;
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!isForOverride ||
                          (constraints & (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType)) != (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType));
 
-            return (TypeParameterConstraintClause.Create(constraints, constraintTypes?.ToImmutableAndFree() ?? ImmutableArray<TypeWithAnnotations>.Empty, canIgnoreNullableContext), syntaxBuilder);
+            return (TypeParameterConstraintClause.Create(constraints, constraintTypes?.ToImmutableAndFree() ?? ImmutableArray<TypeWithAnnotations>.Empty, useLightweightTypeConstraintBinding), syntaxBuilder);
 
             static void reportOverrideWithConstraints(ref bool reportedOverrideWithConstraints, TypeParameterConstraintSyntax syntax, DiagnosticBag diagnostics)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -392,7 +392,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (constraintTypeBuilder.Count < n)
                 {
-                    return TypeParameterConstraintClause.Create(constraintClause.Constraints, constraintTypeBuilder.ToImmutableAndFree(), constraintClause.IgnoresNullableContext);
+                    return TypeParameterConstraintClause.Create(constraintClause.Constraints, constraintTypeBuilder.ToImmutableAndFree(), constraintClause.UsedLightweightTypeConstraintBinding);
                 }
 
                 constraintTypeBuilder.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!isForOverride ||
                          (constraints & (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType)) != (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType));
 
-            return (TypeParameterConstraintClause.Create(constraints, constraintTypes?.ToImmutableAndFree() ?? ImmutableArray<TypeWithAnnotations>.Empty, canUseLightweightTypeConstraintBinding), syntaxBuilder);
+            return (TypeParameterConstraintClause.Create(constraints, constraintTypes?.ToImmutableAndFree() ?? ImmutableArray<TypeWithAnnotations>.Empty), syntaxBuilder);
 
             static void reportOverrideWithConstraints(ref bool reportedOverrideWithConstraints, TypeParameterConstraintSyntax syntax, DiagnosticBag diagnostics)
             {
@@ -392,7 +392,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (constraintTypeBuilder.Count < n)
                 {
-                    return TypeParameterConstraintClause.Create(constraintClause.Constraints, constraintTypeBuilder.ToImmutableAndFree(), constraintClause.UsedLightweightTypeConstraintBinding);
+                    return TypeParameterConstraintClause.Create(constraintClause.Constraints, constraintTypeBuilder.ToImmutableAndFree());
                 }
 
                 constraintTypeBuilder.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1126,11 +1126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics, basesBeingResolved, qualifierOpt, node, plainName, node.Arity, options);
             NamedTypeSymbol resultType;
 
-            if ((Flags & BinderFlags.LightweightTypeConstraintBinding) != 0)
-            {
-                resultType = unconstructedType.Construct(PlaceholderTypeArgumentSymbol.CreateTypeArguments(unconstructedType.TypeParameters), unbound: false);
-            }
-            else if (isUnboundTypeExpr)
+            if (isUnboundTypeExpr)
             {
                 if (!IsUnboundTypeAllowed(node))
                 {
@@ -1152,6 +1148,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     resultType = unconstructedType.AsUnboundGenericType();
                 }
+            }
+            else if ((Flags & BinderFlags.LightweightTypeConstraintBinding) != 0)
+            {
+                resultType = unconstructedType.Construct(PlaceholderTypeArgumentSymbol.CreateTypeArguments(unconstructedType.TypeParameters), unbound: false);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1149,7 +1149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultType = unconstructedType.AsUnboundGenericType();
                 }
             }
-            else if ((Flags & BinderFlags.LightweightTypeConstraintBinding) != 0)
+            else if ((Flags & BinderFlags.SuppressTypeArgumentBinding) != 0)
             {
                 resultType = unconstructedType.Construct(PlaceholderTypeArgumentSymbol.CreateTypeArguments(unconstructedType.TypeParameters), unbound: false);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1126,7 +1126,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics, basesBeingResolved, qualifierOpt, node, plainName, node.Arity, options);
             NamedTypeSymbol resultType;
 
-            if (isUnboundTypeExpr)
+            if ((Flags & BinderFlags.LightweightTypeConstraintBinding) != 0)
+            {
+                resultType = unconstructedType.Construct(PlaceholderTypeArgumentSymbol.CreateTypeArguments(unconstructedType.TypeParameters), unbound: false);
+            }
+            else if (isUnboundTypeExpr)
             {
                 if (!IsUnboundTypeAllowed(node))
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _typeParameters; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal override int ParameterCount

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _typeParameters; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal override int ParameterCount

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -101,11 +101,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return VarianceKind.None; }
             }
 
-            internal override void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext)
+            internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
             {
             }
 
-            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
             {
                 return ImmutableArray<TypeWithAnnotations>.Empty;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -101,11 +101,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return VarianceKind.None; }
             }
 
-            internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
+            internal override void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding)
             {
             }
 
-            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
             {
                 return ImmutableArray<TypeWithAnnotations>.Empty;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -316,7 +316,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
-            bool canUseLightweightTypeConstraintBinding,
             DiagnosticBag diagnostics)
         {
             if (typeParameters.Length == 0)
@@ -338,7 +337,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
             return binder.BindTypeParameterConstraintClauses(containingSymbol, typeParameters, typeParameterList, constraintClauses,
-                                                             canUseLightweightTypeConstraintBinding,
                                                              ref isValueTypeOverride,
                                                              diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var bounds = typeParameter.ResolveBounds(corLibrary, inProgress, constraintTypes, inherited, canUseLightweightTypeConstraintBinding: canUseLightweightTypeConstraintBinding, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
+            var bounds = typeParameter.ResolveBounds(corLibrary, inProgress, constraintTypes, inherited, canUseLightweightTypeConstraintBinding, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Wrap binder from factory in a generic constraints specific binder
             // to avoid checking constraints when binding type names.
             Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
-            binder = binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
+            binder = binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.SuppressTypeArgumentBinding : 0));
 
             IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
             return TypeParameterConstraintClauses.Create(

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
-            bool useLightweightTypeConstraintBinding,
+            bool canUseLightweightTypeConstraintBinding,
             DiagnosticBag diagnostics)
         {
             if (typeParameters.Length == 0)
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
             return binder.BindTypeParameterConstraintClauses(containingSymbol, typeParameters, typeParameterList, constraintClauses,
-                                                             useLightweightTypeConstraintBinding,
+                                                             canUseLightweightTypeConstraintBinding,
                                                              ref isValueTypeOverride,
                                                              diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
-            bool canIgnoreNullableContext,
+            bool useLightweightTypeConstraintBinding,
             DiagnosticBag diagnostics)
         {
             if (typeParameters.Length == 0)
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
             return binder.BindTypeParameterConstraintClauses(containingSymbol, typeParameters, typeParameterList, constraintClauses,
-                                                             canIgnoreNullableContext,
+                                                             useLightweightTypeConstraintBinding,
                                                              ref isValueTypeOverride,
                                                              diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -71,13 +71,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ConsList<TypeParameterSymbol> inProgress,
             ImmutableArray<TypeWithAnnotations> constraintTypes,
             bool inherited,
-            bool ignoresNullableContext,
+            bool usedLightweightTypeConstraintBinding,
             CSharpCompilation currentCompilation,
             DiagnosticBag diagnostics)
         {
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var bounds = typeParameter.ResolveBounds(corLibrary, inProgress, constraintTypes, inherited, ignoresNullableContext: ignoresNullableContext, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
+            var bounds = typeParameter.ResolveBounds(corLibrary, inProgress, constraintTypes, inherited, usedLightweightTypeConstraintBinding: usedLightweightTypeConstraintBinding, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ConsList<TypeParameterSymbol> inProgress,
             ImmutableArray<TypeWithAnnotations> constraintTypes,
             bool inherited,
-            bool ignoresNullableContext,
+            bool usedLightweightTypeConstraintBinding,
             CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder)
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            var bounds = new TypeParameterBounds(constraintTypes, interfaces, effectiveBaseClass, deducedBaseType, ignoresNullableContext);
+            var bounds = new TypeParameterBounds(constraintTypes, interfaces, effectiveBaseClass, deducedBaseType, usedLightweightTypeConstraintBinding);
 
             // Additional constraint checks for overrides.
             if (inherited)

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -324,6 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<TypeParameterSymbol> typeParameters,
             TypeParameterListSyntax typeParameterList,
             SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
+            bool canUseLightweightTypeConstraintBinding,
             DiagnosticBag diagnostics)
         {
             if (typeParameters.Length == 0)
@@ -341,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Wrap binder from factory in a generic constraints specific binder
             // to avoid checking constraints when binding type names.
             Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
-            binder = binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks);
+            binder = binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
 
             IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
             return binder.BindTypeParameterConstraintClauses(containingSymbol, typeParameters, typeParameterList, constraintClauses,

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -134,11 +134,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            internal override void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext)
+            internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
             {
             }
 
-            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
             {
                 return ImmutableArray<TypeWithAnnotations>.Empty;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -134,11 +134,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
+            internal override void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding)
             {
             }
 
-            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
             {
                 return ImmutableArray<TypeWithAnnotations>.Empty;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -570,19 +570,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext)
+        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
         {
-            canIgnoreNullableContext = false; // Resolve bounds eagerly.
-            if (!_lazyBounds.HasValue(canIgnoreNullableContext))
+            useLightweightTypeConstraintBinding = false; // Resolve bounds eagerly.
+            if (!_lazyBounds.HasValue(useLightweightTypeConstraintBinding))
             {
                 var typeParameters = (_containingSymbol.Kind == SymbolKind.Method) ?
                     ((PEMethodSymbol)_containingSymbol).TypeParameters :
                     ((PENamedTypeSymbol)_containingSymbol).TypeParameters;
-                EnsureAllConstraintsAreResolved(typeParameters, canIgnoreNullableContext);
+                EnsureAllConstraintsAreResolved(typeParameters, useLightweightTypeConstraintBinding);
             }
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
         {
             var bounds = this.GetBounds(inProgress);
             return (bounds != null) ? bounds.ConstraintTypes : ImmutableArray<TypeWithAnnotations>.Empty;
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         internal override DiagnosticInfo GetConstraintsUseSiteErrorInfo()
         {
-            EnsureAllConstraintsAreResolved(canIgnoreNullableContext: false);
+            EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
             Debug.Assert(!ReferenceEquals(_lazyConstraintsUseSiteErrorInfo, CSDiagnosticInfo.EmptyErrorInfo));
             return _lazyConstraintsUseSiteErrorInfo;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var diagnostics = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
                 ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
                 bool inherited = (_containingSymbol.Kind == SymbolKind.Method) && ((MethodSymbol)_containingSymbol).IsOverride;
-                var bounds = this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited, usedLightweightTypeConstraintBinding: false, currentCompilation: null,
+                var bounds = this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited, canUseLightweightTypeConstraintBinding: false, currentCompilation: null,
                                                 diagnosticsBuilder: diagnostics, useSiteDiagnosticsBuilder: ref useSiteDiagnosticsBuilder);
                 DiagnosticInfo errorInfo = null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var diagnostics = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
                 ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
                 bool inherited = (_containingSymbol.Kind == SymbolKind.Method) && ((MethodSymbol)_containingSymbol).IsOverride;
-                var bounds = this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited, ignoresNullableContext: false, currentCompilation: null,
+                var bounds = this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited, usedLightweightTypeConstraintBinding: false, currentCompilation: null,
                                                 diagnosticsBuilder: diagnostics, useSiteDiagnosticsBuilder: ref useSiteDiagnosticsBuilder);
                 DiagnosticInfo errorInfo = null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -570,19 +570,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
+        internal override void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding)
         {
-            useLightweightTypeConstraintBinding = false; // Resolve bounds eagerly.
-            if (!_lazyBounds.HasValue(useLightweightTypeConstraintBinding))
+            canUseLightweightTypeConstraintBinding = false; // Resolve bounds eagerly.
+            if (!_lazyBounds.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var typeParameters = (_containingSymbol.Kind == SymbolKind.Method) ?
                     ((PEMethodSymbol)_containingSymbol).TypeParameters :
                     ((PENamedTypeSymbol)_containingSymbol).TypeParameters;
-                EnsureAllConstraintsAreResolved(typeParameters, useLightweightTypeConstraintBinding);
+                EnsureAllConstraintsAreResolved(typeParameters, canUseLightweightTypeConstraintBinding);
             }
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
         {
             var bounds = this.GetBounds(inProgress);
             return (bounds != null) ? bounds.ConstraintTypes : ImmutableArray<TypeWithAnnotations>.Empty;
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         internal override DiagnosticInfo GetConstraintsUseSiteErrorInfo()
         {
-            EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
+            EnsureAllConstraintsAreResolved(canUseLightweightTypeConstraintBinding: false);
             Debug.Assert(!ReferenceEquals(_lazyConstraintsUseSiteErrorInfo, CSDiagnosticInfo.EmptyErrorInfo));
             return _lazyConstraintsUseSiteErrorInfo;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
@@ -81,9 +81,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
         {
-            return this.RetargetingTranslator.Retarget(_underlyingTypeParameter.GetConstraintTypes(inProgress, canIgnoreNullableContext));
+            return this.RetargetingTranslator.Retarget(_underlyingTypeParameter.GetConstraintTypes(inProgress, useLightweightTypeConstraintBinding));
         }
 
         internal override bool? IsNotNullable

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
@@ -81,9 +81,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
         {
-            return this.RetargetingTranslator.Retarget(_underlyingTypeParameter.GetConstraintTypes(inProgress, useLightweightTypeConstraintBinding));
+            return this.RetargetingTranslator.Retarget(_underlyingTypeParameter.GetConstraintTypes(inProgress, canUseLightweightTypeConstraintBinding));
         }
 
         internal override bool? IsNotNullable

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -177,11 +177,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
+        internal override void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding)
         {
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
         {
             return ImmutableArray<TypeWithAnnotations>.Empty;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -177,11 +177,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext)
+        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
         {
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
         {
             return ImmutableArray<TypeWithAnnotations>.Empty;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -173,11 +173,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext)
+        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
         {
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
         {
             return ImmutableArray<TypeWithAnnotations>.Empty;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -173,11 +173,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
+        internal override void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding)
         {
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
         {
             return ImmutableArray<TypeWithAnnotations>.Empty;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsInitOnly => false;
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding) => ImmutableArray<TypeParameterConstraintClause>.Empty;
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding) => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsInitOnly => false;
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext) => ImmutableArray<TypeParameterConstraintClause>.Empty;
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding) => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (!_lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
                     {
                         _declarationDiagnostics.AddRange(diagnostics);
-                        _lazyTypeParameterConstraints = TypeParameterConstraintClauses.Create(constraints, usedLightweightTypeConstraintBinding: false);
+                        _lazyTypeParameterConstraints = constraints;
                     }
                 }
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -475,7 +475,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 lock (_declarationDiagnostics)
                 {
-                    //canUseLightweightTypeConstraintBinding = constraints.UsedLightweightTypeConstraintBinding(); // TODO2 why do we have this here and only here?
                     if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
                     {
                         if (!canUseLightweightTypeConstraintBinding)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -474,7 +474,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics);
                 lock (_declarationDiagnostics)
                 {
-                    useLightweightTypeConstraintBinding = constraints.IgnoresNullableContext();
+                    useLightweightTypeConstraintBinding = constraints.UsedLightweightTypeConstraintBinding();
                     if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
                     {
                         if (!useLightweightTypeConstraintBinding)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             _declarationDiagnostics.AddRange(diagnostics);
                         }
-                        _lazyTypeParameterConstraints = new TypeParameterConstraintClauses(constraints, canUseLightweightTypeConstraintBinding);
+                        _lazyTypeParameterConstraints = TypeParameterConstraintClauses.Create(constraints, canUseLightweightTypeConstraintBinding);
                     }
                 }
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -461,7 +461,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
         {
-            if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
+            // We're not using lightweight type constraint binding for local function because the risk of cycles is minimal (no overrides)
+            if (!_lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
             {
                 var syntax = Syntax;
                 var diagnostics = DiagnosticBag.GetInstance();
@@ -470,17 +471,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeParameters,
                     syntax.TypeParameterList,
                     syntax.ConstraintClauses,
+                    canUseLightweightTypeConstraintBinding: false,
                     diagnostics);
 
                 lock (_declarationDiagnostics)
                 {
-                    if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
+                    if (!_lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
                     {
-                        if (!canUseLightweightTypeConstraintBinding)
-                        {
-                            _declarationDiagnostics.AddRange(diagnostics);
-                        }
-                        _lazyTypeParameterConstraints = TypeParameterConstraintClauses.Create(constraints, canUseLightweightTypeConstraintBinding);
+                        _declarationDiagnostics.AddRange(diagnostics);
+                        _lazyTypeParameterConstraints = TypeParameterConstraintClauses.Create(constraints, usedLightweightTypeConstraintBinding: false);
                     }
                 }
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -459,9 +459,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result.ToImmutableAndFree();
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
         {
-            if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
+            if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var syntax = Syntax;
                 var diagnostics = DiagnosticBag.GetInstance();
@@ -470,19 +470,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeParameters,
                     syntax.TypeParameterList,
                     syntax.ConstraintClauses,
-                    useLightweightTypeConstraintBinding,
+                    canUseLightweightTypeConstraintBinding,
                     diagnostics);
 
                 lock (_declarationDiagnostics)
                 {
-                    //useLightweightTypeConstraintBinding = constraints.UsedLightweightTypeConstraintBinding(); // TODO2 why do we have this here and only here?
-                    if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
+                    //canUseLightweightTypeConstraintBinding = constraints.UsedLightweightTypeConstraintBinding(); // TODO2 why do we have this here and only here?
+                    if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
                     {
-                        if (!useLightweightTypeConstraintBinding)
+                        if (!canUseLightweightTypeConstraintBinding)
                         {
                             _declarationDiagnostics.AddRange(diagnostics);
                         }
-                        _lazyTypeParameterConstraints = new TypeParameterConstraintClauses(constraints, useLightweightTypeConstraintBinding);
+                        _lazyTypeParameterConstraints = new TypeParameterConstraintClauses(constraints, canUseLightweightTypeConstraintBinding);
                     }
                 }
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private ImmutableArray<ParameterSymbol> _lazyParameters;
         private bool _lazyIsVarArg;
         // Initialized in two steps. Hold a copy if accessing during initialization.
-        private ImmutableArray<TypeParameterConstraintClause> _lazyTypeParameterConstraints;
+        private TypeParameterConstraintClauses? _lazyTypeParameterConstraints;
         private TypeWithAnnotations.Boxed? _lazyReturnType;
         private TypeWithAnnotations.Boxed? _lazyIteratorElementType;
 
@@ -472,22 +472,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     syntax.ConstraintClauses,
                     useLightweightTypeConstraintBinding,
                     diagnostics);
+
                 lock (_declarationDiagnostics)
                 {
-                    useLightweightTypeConstraintBinding = constraints.UsedLightweightTypeConstraintBinding();
+                    //useLightweightTypeConstraintBinding = constraints.UsedLightweightTypeConstraintBinding(); // TODO2 why do we have this here and only here?
                     if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
                     {
                         if (!useLightweightTypeConstraintBinding)
                         {
                             _declarationDiagnostics.AddRange(diagnostics);
                         }
-                        _lazyTypeParameterConstraints = constraints;
+                        _lazyTypeParameterConstraints = new TypeParameterConstraintClauses(constraints, useLightweightTypeConstraintBinding);
                     }
                 }
                 diagnostics.Free();
             }
 
-            return _lazyTypeParameterConstraints;
+            Debug.Assert(_lazyTypeParameterConstraints is not null);
+            return _lazyTypeParameterConstraints.TypeParameterConstraints;
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -459,9 +459,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result.ToImmutableAndFree();
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
         {
-            if (!_lazyTypeParameterConstraints.HasValue(canIgnoreNullableContext))
+            if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
             {
                 var syntax = Syntax;
                 var diagnostics = DiagnosticBag.GetInstance();
@@ -470,14 +470,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeParameters,
                     syntax.TypeParameterList,
                     syntax.ConstraintClauses,
-                    canIgnoreNullableContext,
+                    useLightweightTypeConstraintBinding,
                     diagnostics);
                 lock (_declarationDiagnostics)
                 {
-                    canIgnoreNullableContext = constraints.IgnoresNullableContext();
-                    if (!_lazyTypeParameterConstraints.HasValue(canIgnoreNullableContext))
+                    useLightweightTypeConstraintBinding = constraints.IgnoresNullableContext();
+                    if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
                     {
-                        if (!canIgnoreNullableContext)
+                        if (!useLightweightTypeConstraintBinding)
                         {
                             _declarationDiagnostics.AddRange(diagnostics);
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -470,7 +470,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeParameters,
                     syntax.TypeParameterList,
                     syntax.ConstraintClauses,
-                    canUseLightweightTypeConstraintBinding,
                     diagnostics);
 
                 lock (_declarationDiagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -461,8 +461,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
         {
-            // We're not using lightweight type constraint binding for local function because the risk of cycles is minimal (no overrides)
-            if (!_lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
+            if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var syntax = Syntax;
                 var diagnostics = DiagnosticBag.GetInstance();
@@ -471,14 +470,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeParameters,
                     syntax.TypeParameterList,
                     syntax.ConstraintClauses,
-                    canUseLightweightTypeConstraintBinding: false,
+                    canUseLightweightTypeConstraintBinding,
                     diagnostics);
 
                 lock (_declarationDiagnostics)
                 {
-                    if (!_lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
+                    if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
                     {
-                        _declarationDiagnostics.AddRange(diagnostics);
+                        if (!canUseLightweightTypeConstraintBinding)
+                        {
+                            _declarationDiagnostics.AddRange(diagnostics);
+                        }
                         _lazyTypeParameterConstraints = constraints;
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public sealed override TypeWithAnnotations ReturnTypeWithAnnotations

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public sealed override TypeWithAnnotations ReturnTypeWithAnnotations

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal Location Location

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal Location Location

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -319,6 +319,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             MethodChecks(diagnostics);
                             AddDeclarationDiagnostics(diagnostics);
                         }
+
                         finally
                         {
                             state.NotePartComplete(CompletionPart.FinishMethodChecks);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -319,7 +319,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             MethodChecks(diagnostics);
                             AddDeclarationDiagnostics(diagnostics);
                         }
-
                         finally
                         {
                             state.NotePartComplete(CompletionPart.FinishMethodChecks);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// array of clauses, indexed by the constrained type parameter in <see cref="MethodSymbol.TypeParameters"/>.
         /// If a type parameter does not have constraints, the corresponding entry in the array is null.
         /// </summary>
-        public abstract ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext);
+        public abstract ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding);
 
         protected static void ReportBadRefToken(TypeSyntax returnTypeSyntax, DiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// array of clauses, indexed by the constrained type parameter in <see cref="MethodSymbol.TypeParameters"/>.
         /// If a type parameter does not have constraints, the corresponding entry in the array is null.
         /// </summary>
-        public abstract ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding);
+        public abstract ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding);
 
         protected static void ReportBadRefToken(TypeSyntax returnTypeSyntax, DiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -446,7 +446,7 @@ next:;
                     }
 
                     builder[i] = TypeParameterConstraintClause.Create(mergedKind,
-                                                                      mergedConstraintTypes?.ToImmutableAndFree() ?? originalConstraintTypes, usedLightweightTypeConstraintBinding: constraint.UsedLightweightTypeConstraintBinding);
+                                                                      mergedConstraintTypes?.ToImmutableAndFree() ?? originalConstraintTypes);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -327,7 +327,7 @@ next:;
                         binder = binder.WithContainingMemberOrLambda(this).WithAdditionalFlags(
                             BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
 
-                        constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, canUseLightweightTypeConstraintBinding, ref isValueTypeOverride, diagnostics);
+                        constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, ref isValueTypeOverride, diagnostics);
                     }
 
                     Debug.Assert(constraints.Length == arity);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -321,7 +321,7 @@ next:;
                         // to avoid checking constraints when binding type names.
                         Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
                         binder = binder.WithContainingMemberOrLambda(this).WithAdditionalFlags(
-                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canIgnoreNullableContext ? BinderFlags.IgnoreNullableContext : 0));
+                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canIgnoreNullableContext ? BinderFlags.LightweightTypeConstraintBinding : 0));
 
                         constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, canIgnoreNullableContext, ref isValueTypeOverride, diagnostics);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -253,14 +253,14 @@ next:;
         /// <summary>
         /// Returns the constraint clause for the given type parameter.
         /// </summary>
-        internal TypeParameterConstraintClause GetTypeParameterConstraintClause(bool canIgnoreNullableContext, int ordinal)
+        internal TypeParameterConstraintClause GetTypeParameterConstraintClause(bool useLightweightTypeConstraintBinding, int ordinal)
         {
             var clauses = _lazyTypeParameterConstraints;
-            if (!clauses.HasValue(canIgnoreNullableContext))
+            if (!clauses.HasValue(useLightweightTypeConstraintBinding))
             {
                 var diagnostics = DiagnosticBag.GetInstance();
-                if (TypeParameterConstraintClauseExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, MakeTypeParameterConstraints(canIgnoreNullableContext, diagnostics)) &&
-                    _lazyTypeParameterConstraints.HasValue(canIgnoreNullableContext: false))
+                if (TypeParameterConstraintClauseExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, MakeTypeParameterConstraints(useLightweightTypeConstraintBinding, diagnostics)) &&
+                    _lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding: false))
                 {
                     this.AddDeclarationDiagnostics(diagnostics);
                 }
@@ -271,7 +271,7 @@ next:;
             return (clauses.Length > 0) ? clauses[ordinal] : TypeParameterConstraintClause.Empty;
         }
 
-        private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(bool canIgnoreNullableContext, DiagnosticBag diagnostics)
+        private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(bool useLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
         {
             var typeParameters = this.TypeParameters;
             var results = ImmutableArray<TypeParameterConstraintClause>.Empty;
@@ -321,9 +321,9 @@ next:;
                         // to avoid checking constraints when binding type names.
                         Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
                         binder = binder.WithContainingMemberOrLambda(this).WithAdditionalFlags(
-                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canIgnoreNullableContext ? BinderFlags.LightweightTypeConstraintBinding : 0));
+                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (useLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
 
-                        constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, canIgnoreNullableContext, ref isValueTypeOverride, diagnostics);
+                        constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, useLightweightTypeConstraintBinding, ref isValueTypeOverride, diagnostics);
                     }
 
                     Debug.Assert(constraints.Length == arity);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -260,7 +260,7 @@ next:;
             {
                 var diagnostics = DiagnosticBag.GetInstance();
                 if (TypeParameterConstraintClauseExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, MakeTypeParameterConstraints(useLightweightTypeConstraintBinding, diagnostics)) &&
-                    _lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding: false))
+                    _lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
                 {
                     this.AddDeclarationDiagnostics(diagnostics);
                 }
@@ -442,7 +442,7 @@ next:;
                     }
 
                     builder[i] = TypeParameterConstraintClause.Create(mergedKind,
-                                                                      mergedConstraintTypes?.ToImmutableAndFree() ?? originalConstraintTypes, ignoresNullableContext: constraint.IgnoresNullableContext);
+                                                                      mergedConstraintTypes?.ToImmutableAndFree() ?? originalConstraintTypes, usedLightweightTypeConstraintBinding: constraint.UsedLightweightTypeConstraintBinding);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -255,13 +255,13 @@ next:;
         /// <summary>
         /// Returns the constraint clause for the given type parameter.
         /// </summary>
-        internal TypeParameterConstraintClause GetTypeParameterConstraintClause(bool useLightweightTypeConstraintBinding, int ordinal)
+        internal TypeParameterConstraintClause GetTypeParameterConstraintClause(bool canUseLightweightTypeConstraintBinding, int ordinal)
         {
             var clauses = _lazyTypeParameterConstraints;
-            if (!clauses.HasValue(useLightweightTypeConstraintBinding))
+            if (!clauses.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var diagnostics = DiagnosticBag.GetInstance();
-                var typeParameterConstraints = new TypeParameterConstraintClauses(MakeTypeParameterConstraints(useLightweightTypeConstraintBinding, diagnostics), useLightweightTypeConstraintBinding);
+                var typeParameterConstraints = new TypeParameterConstraintClauses(MakeTypeParameterConstraints(canUseLightweightTypeConstraintBinding, diagnostics), canUseLightweightTypeConstraintBinding);
 
                 if (TypeParameterConstraintClausesExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, typeParameterConstraints) &&
                    _lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
@@ -275,7 +275,7 @@ next:;
             return (clauses.TypeParameterConstraints.Length > 0) ? clauses.TypeParameterConstraints[ordinal] : TypeParameterConstraintClause.Empty;
         }
 
-        private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(bool useLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
+        private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(bool canUseLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
         {
             var typeParameters = this.TypeParameters;
             var results = ImmutableArray<TypeParameterConstraintClause>.Empty;
@@ -325,9 +325,9 @@ next:;
                         // to avoid checking constraints when binding type names.
                         Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
                         binder = binder.WithContainingMemberOrLambda(this).WithAdditionalFlags(
-                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (useLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
+                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
 
-                        constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, useLightweightTypeConstraintBinding, ref isValueTypeOverride, diagnostics);
+                        constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, canUseLightweightTypeConstraintBinding, ref isValueTypeOverride, diagnostics);
                     }
 
                     Debug.Assert(constraints.Length == arity);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -261,7 +261,7 @@ next:;
             if (!clauses.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var diagnostics = DiagnosticBag.GetInstance();
-                var typeParameterConstraints = new TypeParameterConstraintClauses(MakeTypeParameterConstraints(canUseLightweightTypeConstraintBinding, diagnostics), canUseLightweightTypeConstraintBinding);
+                var typeParameterConstraints = TypeParameterConstraintClauses.Create(MakeTypeParameterConstraints(canUseLightweightTypeConstraintBinding, diagnostics), canUseLightweightTypeConstraintBinding);
 
                 if (TypeParameterConstraintClausesExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, typeParameterConstraints) &&
                    _lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -252,6 +252,7 @@ next:;
             return parameters.AsImmutable();
         }
 
+#nullable enable
         /// <summary>
         /// Returns the constraint clause for the given type parameter.
         /// </summary>
@@ -272,8 +273,10 @@ next:;
                 clauses = _lazyTypeParameterConstraints;
             }
 
+            Debug.Assert(clauses is not null);
             return (clauses.TypeParameterConstraints.Length > 0) ? clauses.TypeParameterConstraints[ordinal] : TypeParameterConstraintClause.Empty;
         }
+#nullable restore
 
         private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(bool canUseLightweightTypeConstraintBinding, DiagnosticBag diagnostics)
         {
@@ -325,7 +328,7 @@ next:;
                         // to avoid checking constraints when binding type names.
                         Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
                         binder = binder.WithContainingMemberOrLambda(this).WithAdditionalFlags(
-                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.LightweightTypeConstraintBinding : 0));
+                            BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks | (canUseLightweightTypeConstraintBinding ? BinderFlags.SuppressTypeArgumentBinding : 0));
 
                         constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, typeParameterList, constraintClauses, ref isValueTypeOverride, diagnostics);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -300,6 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         TypeParameters,
                         syntax.TypeParameterList,
                         syntax.ConstraintClauses,
+                        canUseLightweightTypeConstraintBinding,
                         diagnostics),
                     canUseLightweightTypeConstraintBinding);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -166,9 +166,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
                     declaredConstraints = signatureBinder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks).
                                               BindTypeParameterConstraintClauses(this, TypeParameters, syntax.TypeParameterList, syntax.ConstraintClauses,
-                                                                                 canUseLightweightTypeConstraintBinding: false,
                                                                                  ref isValueTypeOverride,
-                                                                                 diagnostics, isForOverride: true);
+                                                                                 diagnostics,
+                                                                                 isForOverride: true);
                 }
 
                 // Force resolution of nullable type parameter used in the signature of an override or explicit interface implementation
@@ -301,7 +301,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         TypeParameters,
                         syntax.TypeParameterList,
                         syntax.ConstraintClauses,
-                        canUseLightweightTypeConstraintBinding,
                         diagnostics),
                     canUseLightweightTypeConstraintBinding);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     useLightweightTypeConstraintBinding,
                     diagnostics);
                 if (TypeParameterConstraintClauseExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, constraints) &&
-                    _lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding: false))
+                    _lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))
                 {
                     this.AddDeclarationDiagnostics(diagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -294,15 +294,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     .GetBinderFactory(syntax.SyntaxTree)
                     .GetBinder(syntax.ReturnType, syntax, this);
 
-                var constraints = TypeParameterConstraintClauses.Create(
-                    this.MakeTypeParameterConstraints(
-                        withTypeParametersBinder,
-                        TypeParameters,
-                        syntax.TypeParameterList,
-                        syntax.ConstraintClauses,
-                        canUseLightweightTypeConstraintBinding,
-                        diagnostics),
-                    canUseLightweightTypeConstraintBinding);
+                var constraints = this.MakeTypeParameterConstraints(
+                    withTypeParametersBinder,
+                    TypeParameters,
+                    syntax.TypeParameterList,
+                    syntax.ConstraintClauses,
+                    canUseLightweightTypeConstraintBinding,
+                    diagnostics);
 
                 if (TypeParameterConstraintClausesExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, constraints) &&
                     _lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
                     declaredConstraints = signatureBinder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks).
                                               BindTypeParameterConstraintClauses(this, TypeParameters, syntax.TypeParameterList, syntax.ConstraintClauses,
-                                                                                 useLightweightTypeConstraintBinding: false,
+                                                                                 canUseLightweightTypeConstraintBinding: false,
                                                                                  ref isValueTypeOverride,
                                                                                  diagnostics, isForOverride: true);
                 }
@@ -283,10 +283,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
         {
             var clauses = _lazyTypeParameterConstraints;
-            if (!clauses.HasValue(useLightweightTypeConstraintBinding))
+            if (!clauses.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var diagnostics = DiagnosticBag.GetInstance();
                 var syntax = GetSyntax();
@@ -301,9 +301,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         TypeParameters,
                         syntax.TypeParameterList,
                         syntax.ConstraintClauses,
-                        useLightweightTypeConstraintBinding,
+                        canUseLightweightTypeConstraintBinding,
                         diagnostics),
-                    useLightweightTypeConstraintBinding);
+                    canUseLightweightTypeConstraintBinding);
 
                 if (TypeParameterConstraintClausesExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, constraints) &&
                     _lazyTypeParameterConstraints.HasValue(usedLightweightTypeConstraintBinding: false))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -285,8 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
         {
-            var clauses = _lazyTypeParameterConstraints;
-            if (!clauses.HasValue(canUseLightweightTypeConstraintBinding))
+            if (!_lazyTypeParameterConstraints.HasValue(canUseLightweightTypeConstraintBinding))
             {
                 var diagnostics = DiagnosticBag.GetInstance();
                 var syntax = GetSyntax();
@@ -295,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     .GetBinderFactory(syntax.SyntaxTree)
                     .GetBinder(syntax.ReturnType, syntax, this);
 
-                var constraints = new TypeParameterConstraintClauses(
+                var constraints = TypeParameterConstraintClauses.Create(
                     this.MakeTypeParameterConstraints(
                         withTypeParametersBinder,
                         TypeParameters,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverride = null;
                     declaredConstraints = signatureBinder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks).
                                               BindTypeParameterConstraintClauses(this, TypeParameters, syntax.TypeParameterList, syntax.ConstraintClauses,
-                                                                                 canIgnoreNullableContext: false,
+                                                                                 useLightweightTypeConstraintBinding: false,
                                                                                  ref isValueTypeOverride,
                                                                                  diagnostics, isForOverride: true);
                 }
@@ -283,9 +283,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
         {
-            if (!_lazyTypeParameterConstraints.HasValue(canIgnoreNullableContext))
+            if (!_lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding))
             {
                 var diagnostics = DiagnosticBag.GetInstance();
                 var syntax = GetSyntax();
@@ -298,10 +298,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeParameters,
                     syntax.TypeParameterList,
                     syntax.ConstraintClauses,
-                    canIgnoreNullableContext,
+                    useLightweightTypeConstraintBinding,
                     diagnostics);
                 if (TypeParameterConstraintClauseExtensions.InterlockedUpdate(ref _lazyTypeParameterConstraints, constraints) &&
-                    _lazyTypeParameterConstraints.HasValue(canIgnoreNullableContext: false))
+                    _lazyTypeParameterConstraints.HasValue(useLightweightTypeConstraintBinding: false))
                 {
                     this.AddDeclarationDiagnostics(diagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public sealed override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public sealed override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -237,14 +237,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var diagnostics = DiagnosticBag.GetInstance();
                 var bounds = this.ResolveBounds(inProgress, canUseLightweightTypeConstraintBinding, diagnostics);
-
-                if (bounds is null && canUseLightweightTypeConstraintBinding)
-                {
-                    // We have no bounds, but need to record that we've only done
-                    // lightweight binding of type constraints so far.
-                    bounds = TypeParameterBounds.NullFromLightweightBinding;
-                }
-
                 if (TypeParameterBoundsExtensions.InterlockedUpdate(ref _lazyBounds, bounds) &&
                     _lazyBounds.HasValue(canUseLightweightTypeConstraintBinding: false))
                 {
@@ -943,7 +935,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(map != null);
 
             var constraintTypes = map.SubstituteTypes(typeParameter.ConstraintTypesNoUseSiteDiagnostics);
-            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited: true, usedLightweightTypeConstraintBinding: false, this.DeclaringCompilation, diagnostics);
+            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited: true, canUseLightweightTypeConstraintBinding: false, this.DeclaringCompilation, diagnostics);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -590,7 +590,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var constraintTypes = constraintClause.ConstraintTypes;
-            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited: false, usedLightweightTypeConstraintBinding: constraintClause.UsedLightweightTypeConstraintBinding, this.DeclaringCompilation, diagnostics);
+            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited: false, canUseLightweightTypeConstraintBinding, this.DeclaringCompilation, diagnostics);
         }
 
         private TypeParameterConstraintKind GetDeclaredConstraints(bool canUseLightweightTypeConstraintBinding)
@@ -712,7 +712,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var constraintTypes = constraintClause.ConstraintTypes;
-            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited: false, constraintClause.UsedLightweightTypeConstraintBinding, this.DeclaringCompilation, diagnostics);
+            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited: false, canUseLightweightTypeConstraintBinding, this.DeclaringCompilation, diagnostics);
         }
 
         internal TypeParameterConstraintKind GetDeclaredConstraints(bool canUseLightweightTypeConstraintBinding)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -247,7 +247,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (TypeParameterBoundsExtensions.InterlockedUpdate(ref _lazyBounds, bounds) &&
                     _lazyBounds.HasValue(useLightweightTypeConstraintBinding: false))
-                //!useLightweightTypeConstraintBinding) // TODO2
                 {
                     this.CheckConstraintTypeConstraints(diagnostics);
                     this.CheckUnmanagedConstraint(diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public sealed override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<TypeParameterSymbol>.Empty; }
         }
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         public sealed override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -76,21 +76,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal static readonly TypeParameterConstraintClause Empty = new TypeParameterConstraintClause(
             TypeParameterConstraintKind.None,
-            ImmutableArray<TypeWithAnnotations>.Empty,
-            usedLightweightTypeConstraintBinding: false);
+            ImmutableArray<TypeWithAnnotations>.Empty);
 
         internal static readonly TypeParameterConstraintClause ObliviousNullabilityIfReferenceType = new TypeParameterConstraintClause(
             TypeParameterConstraintKind.ObliviousNullabilityIfReferenceType,
-            ImmutableArray<TypeWithAnnotations>.Empty,
-            usedLightweightTypeConstraintBinding: false);
+            ImmutableArray<TypeWithAnnotations>.Empty);
 
         internal static TypeParameterConstraintClause Create(
             TypeParameterConstraintKind constraints,
-            ImmutableArray<TypeWithAnnotations> constraintTypes,
-            bool usedLightweightTypeConstraintBinding)
+            ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
             Debug.Assert(!constraintTypes.IsDefault);
-            if (!usedLightweightTypeConstraintBinding && constraintTypes.IsEmpty)
+            if (constraintTypes.IsEmpty)
             {
                 switch (constraints)
                 {
@@ -102,13 +99,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            return new TypeParameterConstraintClause(constraints, constraintTypes, usedLightweightTypeConstraintBinding);
+            return new TypeParameterConstraintClause(constraints, constraintTypes);
         }
 
         private TypeParameterConstraintClause(
             TypeParameterConstraintKind constraints,
-            ImmutableArray<TypeWithAnnotations> constraintTypes,
-            bool usedLightweightTypeConstraintBinding)
+            ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
 #if DEBUG
             switch (constraints & TypeParameterConstraintKind.AllReferenceTypeKinds)
@@ -128,12 +124,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #endif 
             this.Constraints = constraints;
             this.ConstraintTypes = constraintTypes;
-            this.UsedLightweightTypeConstraintBinding = usedLightweightTypeConstraintBinding;
         }
 
         public readonly TypeParameterConstraintKind Constraints;
         public readonly ImmutableArray<TypeWithAnnotations> ConstraintTypes;
-        public readonly bool UsedLightweightTypeConstraintBinding; // TODO2 remove?
 
         internal bool IsEmpty => Constraints == TypeParameterConstraintKind.None && ConstraintTypes.IsEmpty;
 
@@ -243,12 +237,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return usedLightweightTypeConstraintBinding || !constraintClauses.UsedLightweightTypeConstraintBinding;
         }
 #nullable restore
-
-        // TODO2
-        //internal static bool UsedLightweightTypeConstraintBinding(this ImmutableArray<TypeParameterConstraintClause> constraintClauses)
-        //{
-        //    return constraintClauses.Any(clause => clause.UsedLightweightTypeConstraintBinding);
-        //}
 
         internal static bool ContainsOnlyEmptyConstraintClauses(this ImmutableArray<TypeParameterConstraintClause> constraintClauses)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -61,17 +61,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public readonly ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraints;
         public readonly bool UsedLightweightTypeConstraintBinding;
 
-        private static readonly TypeParameterConstraintClauses EmptyFromLightweightBinding =
+        private static readonly TypeParameterConstraintClauses s_emptyFromLightweightBinding =
             new TypeParameterConstraintClauses(ImmutableArray<TypeParameterConstraintClause>.Empty, usedLightweightTypeConstraintBinding: true);
-        private static readonly TypeParameterConstraintClauses Empty =
+        private static readonly TypeParameterConstraintClauses s_empty =
             new TypeParameterConstraintClauses(ImmutableArray<TypeParameterConstraintClause>.Empty, usedLightweightTypeConstraintBinding: false);
 
         public static TypeParameterConstraintClauses Create(ImmutableArray<TypeParameterConstraintClause> typeParameterConstraints, bool usedLightweightTypeConstraintBinding)
         {
             return (typeParameterConstraints.IsEmpty, usedLightweightTypeConstraintBinding) switch
             {
-                (true, true) => EmptyFromLightweightBinding,
-                (true, false) => Empty,
+                (true, true) => s_emptyFromLightweightBinding,
+                (true, false) => s_empty,
                 _ => new TypeParameterConstraintClauses(typeParameterConstraints, usedLightweightTypeConstraintBinding)
             };
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         AllNonNullableKinds = ReferenceType | ValueType | Constructor | Unmanaged,
     }
 
+#nullable enable
     internal sealed class TypeParameterConstraintClauses
     {
         public readonly ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraints;
@@ -82,6 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             UsedLightweightTypeConstraintBinding = usedLightweightTypeConstraintBinding;
         }
     }
+#nullable restore
 
     /// <summary>
     /// A simple representation of a type parameter constraint clause
@@ -251,7 +253,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             return usedLightweightTypeConstraintBinding || !constraintClauses.UsedLightweightTypeConstraintBinding;
         }
-#nullable restore
 
         internal static bool ContainsOnlyEmptyConstraintClauses(this ImmutableArray<TypeParameterConstraintClause> constraintClauses)
         {
@@ -261,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Returns true if constraintClauses was updated with value.
         // Returns false if constraintClauses already had a value with sufficient 'canUseLightweightTypeConstraintBinding'
         // or was updated to a value with sufficient 'canUseLightweightTypeConstraintBinding' on another thread.
-        internal static bool InterlockedUpdate(ref TypeParameterConstraintClauses constraintClauses, TypeParameterConstraintClauses value)
+        internal static bool InterlockedUpdate(ref TypeParameterConstraintClauses? constraintClauses, TypeParameterConstraintClauses value)
         {
             bool canUseLightweightTypeConstraintBinding = value.UsedLightweightTypeConstraintBinding;
             while (true)
@@ -277,5 +278,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
         }
+#nullable restore
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -220,13 +220,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal static class TypeParameterConstraintClauseExtensions
     {
-        internal static bool HasValue(this ImmutableArray<TypeParameterConstraintClause> constraintClauses, bool canIgnoreNullableContext)
+        internal static bool HasValue(this ImmutableArray<TypeParameterConstraintClause> constraintClauses, bool useLightweightTypeConstraintBinding)
         {
             if (constraintClauses.IsDefault)
             {
                 return false;
             }
-            return canIgnoreNullableContext || !constraintClauses.IgnoresNullableContext();
+            return useLightweightTypeConstraintBinding || !constraintClauses.IgnoresNullableContext();
         }
 
         internal static bool IgnoresNullableContext(this ImmutableArray<TypeParameterConstraintClause> constraintClauses)
@@ -244,11 +244,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // or was updated to a value with sufficient 'IgnoresNullableContext' on another thread.
         internal static bool InterlockedUpdate(ref ImmutableArray<TypeParameterConstraintClause> constraintClauses, ImmutableArray<TypeParameterConstraintClause> value)
         {
-            bool canIgnoreNullableContext = value.IgnoresNullableContext();
+            bool useLightweightTypeConstraintBinding = value.IgnoresNullableContext();
             while (true)
             {
                 var comparand = constraintClauses;
-                if (comparand.HasValue(canIgnoreNullableContext))
+                if (comparand.HasValue(useLightweightTypeConstraintBinding))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -256,15 +256,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         // Returns true if constraintClauses was updated with value.
-        // Returns false if constraintClauses already had a value with sufficient 'UseLightweightTypeConstraintBinding'
-        // or was updated to a value with sufficient 'UseLightweightTypeConstraintBinding' on another thread.
+        // Returns false if constraintClauses already had a value with sufficient 'canUseLightweightTypeConstraintBinding'
+        // or was updated to a value with sufficient 'canUseLightweightTypeConstraintBinding' on another thread.
         internal static bool InterlockedUpdate(ref TypeParameterConstraintClauses constraintClauses, TypeParameterConstraintClauses value)
         {
-            bool useLightweightTypeConstraintBinding = value.UsedLightweightTypeConstraintBinding;
+            bool canUseLightweightTypeConstraintBinding = value.UsedLightweightTypeConstraintBinding;
             while (true)
             {
                 var comparand = constraintClauses;
-                if (comparand.HasValue(useLightweightTypeConstraintBinding))
+                if (comparand.HasValue(canUseLightweightTypeConstraintBinding))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -61,7 +61,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public readonly ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraints;
         public readonly bool UsedLightweightTypeConstraintBinding;
 
-        public TypeParameterConstraintClauses(ImmutableArray<TypeParameterConstraintClause> typeParameterConstraints, bool usedLightweightTypeConstraintBinding)
+        private static readonly TypeParameterConstraintClauses EmptyFromLightweightBinding =
+            new TypeParameterConstraintClauses(ImmutableArray<TypeParameterConstraintClause>.Empty, usedLightweightTypeConstraintBinding: true);
+        private static readonly TypeParameterConstraintClauses Empty =
+            new TypeParameterConstraintClauses(ImmutableArray<TypeParameterConstraintClause>.Empty, usedLightweightTypeConstraintBinding: false);
+
+        public static TypeParameterConstraintClauses Create(ImmutableArray<TypeParameterConstraintClause> typeParameterConstraints, bool usedLightweightTypeConstraintBinding)
+        {
+            return (typeParameterConstraints.IsEmpty, usedLightweightTypeConstraintBinding) switch
+            {
+                (true, true) => EmptyFromLightweightBinding,
+                (true, false) => Empty,
+                _ => new TypeParameterConstraintClauses(typeParameterConstraints, usedLightweightTypeConstraintBinding)
+            };
+        }
+
+        private TypeParameterConstraintClauses(ImmutableArray<TypeParameterConstraintClause> typeParameterConstraints, bool usedLightweightTypeConstraintBinding)
         {
             TypeParameterConstraints = typeParameterConstraints;
             UsedLightweightTypeConstraintBinding = usedLightweightTypeConstraintBinding;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -96,10 +96,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding)
         {
             var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();
-            _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(inProgress, useLightweightTypeConstraintBinding), constraintTypes, null);
+            _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(inProgress, canUseLightweightTypeConstraintBinding), constraintTypes, null);
 
             TypeWithAnnotations bestObjectConstraint = default;
 
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (bestObjectConstraint.HasType)
             {
                 // See if we need to put Object! or Object~ back in order to preserve nullability information for the type parameter.
-                if (!useLightweightTypeConstraintBinding && ConstraintsHelper.IsObjectConstraintSignificant(CalculateIsNotNullableFromNonTypeConstraints(), bestObjectConstraint))
+                if (!canUseLightweightTypeConstraintBinding && ConstraintsHelper.IsObjectConstraintSignificant(CalculateIsNotNullableFromNonTypeConstraints(), bestObjectConstraint))
                 {
                     Debug.Assert(!HasNotNullConstraint && !HasValueTypeConstraint);
                     if (constraintTypes.Count == 0)
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else if (!HasNotNullConstraint && !HasValueTypeConstraint && !HasReferenceTypeConstraint)
                 {
                     var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();
-                    _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, useLightweightTypeConstraintBinding: false), constraintTypes, null);
+                    _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, canUseLightweightTypeConstraintBinding: false), constraintTypes, null);
                     return IsNotNullableFromConstraintTypes(constraintTypes.ToImmutableAndFree());
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -96,10 +96,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext)
+        internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding)
         {
             var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();
-            _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(inProgress, canIgnoreNullableContext), constraintTypes, null);
+            _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(inProgress, useLightweightTypeConstraintBinding), constraintTypes, null);
 
             TypeWithAnnotations bestObjectConstraint = default;
 
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (bestObjectConstraint.HasType)
             {
                 // See if we need to put Object! or Object~ back in order to preserve nullability information for the type parameter.
-                if (!canIgnoreNullableContext && ConstraintsHelper.IsObjectConstraintSignificant(CalculateIsNotNullableFromNonTypeConstraints(), bestObjectConstraint))
+                if (!useLightweightTypeConstraintBinding && ConstraintsHelper.IsObjectConstraintSignificant(CalculateIsNotNullableFromNonTypeConstraints(), bestObjectConstraint))
                 {
                     Debug.Assert(!HasNotNullConstraint && !HasValueTypeConstraint);
                     if (constraintTypes.Count == 0)
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else if (!HasNotNullConstraint && !HasValueTypeConstraint && !HasReferenceTypeConstraint)
                 {
                     var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();
-                    _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, canIgnoreNullableContext: false), constraintTypes, null);
+                    _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, useLightweightTypeConstraintBinding: false), constraintTypes, null);
                     return IsNotNullableFromConstraintTypes(constraintTypes.ToImmutableAndFree());
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override ImmutableArray<TypeParameterSymbol> MakeTypeParameters(CSharpSyntaxNode node, DiagnosticBag diagnostics) => ImmutableArray<TypeParameterSymbol>.Empty;
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding) => ImmutableArray<TypeParameterConstraintClause>.Empty;
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding) => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         protected sealed override void PartialMethodChecks(DiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override ImmutableArray<TypeParameterSymbol> MakeTypeParameters(CSharpSyntaxNode node, DiagnosticBag diagnostics) => ImmutableArray<TypeParameterSymbol>.Empty;
 
-        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext) => ImmutableArray<TypeParameterConstraintClause>.Empty;
+        public sealed override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding) => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         protected sealed override void PartialMethodChecks(DiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsExpressionBodied => false;
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canUseLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         protected override object MethodChecksLockObject => _declaration;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsExpressionBodied => false;
 
-        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool canIgnoreNullableContext)
+        public override ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool useLightweightTypeConstraintBinding)
             => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         protected override object MethodChecksLockObject => _declaration;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterBounds.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterBounds.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal static class TypeParameterBoundsExtensions
     {
-        internal static bool HasValue(this TypeParameterBounds? boundsOpt, bool useLightweightTypeConstraintBinding)
+        internal static bool HasValue(this TypeParameterBounds? boundsOpt, bool canUseLightweightTypeConstraintBinding)
         {
             if (boundsOpt == TypeParameterBounds.Unset)
             {
@@ -102,18 +102,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return true;
             }
-            return useLightweightTypeConstraintBinding || !boundsOpt.UsedLightweightTypeConstraintBinding;
+            return canUseLightweightTypeConstraintBinding || !boundsOpt.UsedLightweightTypeConstraintBinding;
         }
 
         /// <summary>
         /// Returns true if bounds was updated with value.
-        /// Returns false if bounds already had a value with sufficient 'useLightweightTypeConstraintBinding'
-        /// or was updated to a value with sufficient 'useLightweightTypeConstraintBinding' on another thread.
+        /// Returns false if bounds already had a value with sufficient 'canUseLightweightTypeConstraintBinding'
+        /// or was updated to a value with sufficient 'canUseLightweightTypeConstraintBinding' on another thread.
         /// </summary>
         internal static bool InterlockedUpdate(ref TypeParameterBounds? bounds, TypeParameterBounds? value)
         {
             Debug.Assert(value != TypeParameterBounds.Unset);
-            bool valueUsedLightweightTypeConstraintBinding = !value.HasValue(useLightweightTypeConstraintBinding: false);
+            bool valueUsedLightweightTypeConstraintBinding = !value.HasValue(canUseLightweightTypeConstraintBinding: false);
 
             while (true)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterBounds.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterBounds.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal static class TypeParameterBoundsExtensions
     {
-        internal static bool HasValue(this TypeParameterBounds? boundsOpt, bool canIgnoreNullableContext)
+        internal static bool HasValue(this TypeParameterBounds? boundsOpt, bool useLightweightTypeConstraintBinding)
         {
             if (boundsOpt == TypeParameterBounds.Unset)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return true;
             }
-            return canIgnoreNullableContext || !boundsOpt.IgnoresNullableContext;
+            return useLightweightTypeConstraintBinding || !boundsOpt.IgnoresNullableContext;
         }
 
         // Returns true if bounds was updated with value.
@@ -100,11 +100,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // or was updated to a value with sufficient 'IgnoresNullableContext' on another thread.
         internal static bool InterlockedUpdate(ref TypeParameterBounds? bounds, TypeParameterBounds? value)
         {
-            bool canIgnoreNullableContext = (value?.IgnoresNullableContext == true);
+            bool useLightweightTypeConstraintBinding = (value?.IgnoresNullableContext == true);
             while (true)
             {
                 var comparand = bounds;
-                if (comparand != TypeParameterBounds.Unset && comparand.HasValue(canIgnoreNullableContext))
+                if (comparand != TypeParameterBounds.Unset && comparand.HasValue(useLightweightTypeConstraintBinding))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterBounds.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterBounds.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class TypeParameterBounds
     {
         public static readonly TypeParameterBounds Unset = new TypeParameterBounds();
-        public static readonly TypeParameterBounds NullFromLightweightBinding = new TypeParameterBounds(usedLightweightTypeConstraintBinding: true);
+        public static readonly TypeParameterBounds NullFromLightweightBinding = new TypeParameterBounds();
 
         public TypeParameterBounds(
             ImmutableArray<TypeWithAnnotations> constraintTypes,
@@ -43,11 +43,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private TypeParameterBounds()
         {
-        }
-
-        private TypeParameterBounds(bool usedLightweightTypeConstraintBinding)
-        {
-            Debug.Assert(usedLightweightTypeConstraintBinding);
             this.UsedLightweightTypeConstraintBinding = true;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -79,14 +79,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Duplicates and cycles are removed, although the collection may include
         /// redundant constraints where one constraint is a base type of another.
         /// </summary>
-        internal ImmutableArray<TypeWithAnnotations> GetConstraintTypesNoUseSiteDiagnostics(bool canIgnoreNullableContext)
+        internal ImmutableArray<TypeWithAnnotations> GetConstraintTypesNoUseSiteDiagnostics(bool useLightweightTypeConstraintBinding)
         {
-            this.EnsureAllConstraintsAreResolved(canIgnoreNullableContext);
-            return this.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, canIgnoreNullableContext);
+            this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding);
+            return this.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, useLightweightTypeConstraintBinding);
         }
 
         internal ImmutableArray<TypeWithAnnotations> ConstraintTypesNoUseSiteDiagnostics =>
-            GetConstraintTypesNoUseSiteDiagnostics(canIgnoreNullableContext: false);
+            GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: false);
 
         internal ImmutableArray<TypeWithAnnotations> ConstraintTypesWithDefinitionUseSiteDiagnostics(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                this.EnsureAllConstraintsAreResolved(canIgnoreNullableContext: false);
+                this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
                 return this.GetEffectiveBaseClass(ConsList<TypeParameterSymbol>.Empty);
             }
         }
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                this.EnsureAllConstraintsAreResolved(canIgnoreNullableContext: false);
+                this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
                 return this.GetInterfaces(ConsList<TypeParameterSymbol>.Empty);
             }
         }
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                this.EnsureAllConstraintsAreResolved(canIgnoreNullableContext: false);
+                this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
                 return this.GetDeducedBaseType(ConsList<TypeParameterSymbol>.Empty);
             }
         }
@@ -364,21 +364,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// type or method are resolved in a consistent order, regardless of the
         /// order the callers query individual type parameters.
         /// </summary>
-        internal abstract void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext);
+        internal abstract void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding);
 
         /// <summary>
         /// Helper method to force type parameter constraints to be resolved.
         /// </summary>
-        protected static void EnsureAllConstraintsAreResolved(ImmutableArray<TypeParameterSymbol> typeParameters, bool canIgnoreNullableContext)
+        protected static void EnsureAllConstraintsAreResolved(ImmutableArray<TypeParameterSymbol> typeParameters, bool useLightweightTypeConstraintBinding)
         {
             foreach (var typeParameter in typeParameters)
             {
                 // Invoke any method that forces constraints to be resolved.
-                var unused = typeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, canIgnoreNullableContext);
+                var unused = typeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, useLightweightTypeConstraintBinding);
             }
         }
 
-        internal abstract ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canIgnoreNullableContext);
+        internal abstract ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding);
 
         internal abstract ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress);
 
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (constraint.TypeKind == TypeKind.TypeParameter)
             {
-                return IsReferenceTypeFromConstraintTypes(((TypeParameterSymbol)constraint).GetConstraintTypesNoUseSiteDiagnostics(canIgnoreNullableContext: true));
+                return IsReferenceTypeFromConstraintTypes(((TypeParameterSymbol)constraint).GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: true));
             }
             else if (!constraint.IsReferenceType)
             {
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 }
 
-                return IsReferenceTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(canIgnoreNullableContext: true));
+                return IsReferenceTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: true));
             }
         }
 
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 }
 
-                return IsValueTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(canIgnoreNullableContext: true));
+                return IsValueTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: true));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -79,14 +79,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Duplicates and cycles are removed, although the collection may include
         /// redundant constraints where one constraint is a base type of another.
         /// </summary>
-        internal ImmutableArray<TypeWithAnnotations> GetConstraintTypesNoUseSiteDiagnostics(bool useLightweightTypeConstraintBinding)
+        internal ImmutableArray<TypeWithAnnotations> GetConstraintTypesNoUseSiteDiagnostics(bool canUseLightweightTypeConstraintBinding)
         {
-            this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding);
-            return this.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, useLightweightTypeConstraintBinding);
+            this.EnsureAllConstraintsAreResolved(canUseLightweightTypeConstraintBinding);
+            return this.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, canUseLightweightTypeConstraintBinding);
         }
 
         internal ImmutableArray<TypeWithAnnotations> ConstraintTypesNoUseSiteDiagnostics =>
-            GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: false);
+            GetConstraintTypesNoUseSiteDiagnostics(canUseLightweightTypeConstraintBinding: false);
 
         internal ImmutableArray<TypeWithAnnotations> ConstraintTypesWithDefinitionUseSiteDiagnostics(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
+                this.EnsureAllConstraintsAreResolved(canUseLightweightTypeConstraintBinding: false);
                 return this.GetEffectiveBaseClass(ConsList<TypeParameterSymbol>.Empty);
             }
         }
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
+                this.EnsureAllConstraintsAreResolved(canUseLightweightTypeConstraintBinding: false);
                 return this.GetInterfaces(ConsList<TypeParameterSymbol>.Empty);
             }
         }
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                this.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding: false);
+                this.EnsureAllConstraintsAreResolved(canUseLightweightTypeConstraintBinding: false);
                 return this.GetDeducedBaseType(ConsList<TypeParameterSymbol>.Empty);
             }
         }
@@ -364,21 +364,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// type or method are resolved in a consistent order, regardless of the
         /// order the callers query individual type parameters.
         /// </summary>
-        internal abstract void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding);
+        internal abstract void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding);
 
         /// <summary>
         /// Helper method to force type parameter constraints to be resolved.
         /// </summary>
-        protected static void EnsureAllConstraintsAreResolved(ImmutableArray<TypeParameterSymbol> typeParameters, bool useLightweightTypeConstraintBinding)
+        protected static void EnsureAllConstraintsAreResolved(ImmutableArray<TypeParameterSymbol> typeParameters, bool canUseLightweightTypeConstraintBinding)
         {
             foreach (var typeParameter in typeParameters)
             {
                 // Invoke any method that forces constraints to be resolved.
-                var unused = typeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, useLightweightTypeConstraintBinding);
+                var unused = typeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, canUseLightweightTypeConstraintBinding);
             }
         }
 
-        internal abstract ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool useLightweightTypeConstraintBinding);
+        internal abstract ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress, bool canUseLightweightTypeConstraintBinding);
 
         internal abstract ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress);
 
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (constraint.TypeKind == TypeKind.TypeParameter)
             {
-                return IsReferenceTypeFromConstraintTypes(((TypeParameterSymbol)constraint).GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: true));
+                return IsReferenceTypeFromConstraintTypes(((TypeParameterSymbol)constraint).GetConstraintTypesNoUseSiteDiagnostics(canUseLightweightTypeConstraintBinding: true));
             }
             else if (!constraint.IsReferenceType)
             {
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 }
 
-                return IsReferenceTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: true));
+                return IsReferenceTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(canUseLightweightTypeConstraintBinding: true));
             }
         }
 
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 }
 
-                return IsValueTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(useLightweightTypeConstraintBinding: true));
+                return IsValueTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(canUseLightweightTypeConstraintBinding: true));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -468,6 +468,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return newTypeWithModifiers;
             }
 
+            if (newTypeWithModifiers.Type is PlaceholderTypeArgumentSymbol)
+            {
+                return newTypeWithModifiers;
+            }
+
             NullableAnnotation newAnnotation;
 
             Debug.Assert(!IsIndexedTypeParameter(newTypeWithModifiers.DefaultType) || newTypeWithModifiers.NullableAnnotation.IsOblivious());
@@ -489,18 +494,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 newAnnotation = NullableAnnotation;
             }
-            else if (NullableAnnotation != NullableAnnotation.Oblivious)
+            else if (NullableAnnotation.IsNotAnnotated())
             {
-                if (!typeSymbol.IsTypeParameterDisallowingAnnotationInCSharp8())
-                {
-                    newAnnotation = NullableAnnotation;
-                }
-                else
+                if (typeSymbol.IsTypeParameterDisallowingAnnotationInCSharp8() && !newTypeWithModifiers.Type.IsTypeParameterDisallowingAnnotationInCSharp8())
                 {
                     newAnnotation = newTypeWithModifiers.NullableAnnotation;
                 }
+                else
+                {
+                    newAnnotation = NullableAnnotation;
+                }
             }
-            else if (newTypeWithModifiers.NullableAnnotation != NullableAnnotation.Oblivious)
+            else if (newTypeWithModifiers.NullableAnnotation.IsNotAnnotated())
             {
                 newAnnotation = newTypeWithModifiers.NullableAnnotation;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -127,34 +127,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class PlaceholderTypeArgumentSymbol : ErrorTypeSymbol
     {
+        private static readonly PlaceholderTypeArgumentSymbol s_instance = new PlaceholderTypeArgumentSymbol();
+
         public static ImmutableArray<TypeWithAnnotations> CreateTypeArguments(ImmutableArray<TypeParameterSymbol> typeParameters)
         {
             var result = ArrayBuilder<TypeWithAnnotations>.GetInstance();
             foreach (var typeParameter in typeParameters)
             {
-                result.Add(TypeWithAnnotations.Create(new PlaceholderTypeArgumentSymbol(typeParameter.Name)));
+                result.Add(TypeWithAnnotations.Create(s_instance));
             }
             return result.ToImmutableAndFree();
         }
 
-        private readonly string _name;
-
-        private PlaceholderTypeArgumentSymbol(string name, TupleExtraData? tupleData = null)
+        private PlaceholderTypeArgumentSymbol(TupleExtraData? tupleData = null)
             : base(tupleData)
         {
-            _name = name;
         }
 
         protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData)
         {
-            return new PlaceholderTypeArgumentSymbol(_name, newData);
+            return new PlaceholderTypeArgumentSymbol(newData);
         }
 
         public override string Name
         {
             get
             {
-                return _name;
+                return string.Empty;
             }
         }
 
@@ -167,11 +166,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override DiagnosticInfo ErrorInfo
+        internal override DiagnosticInfo? ErrorInfo
         {
             get
             {
-                return new CSDiagnosticInfo(ErrorCode.Void);
+                return null;
             }
         }
 
@@ -182,12 +181,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            return t2 is PlaceholderTypeArgumentSymbol other && string.Equals(other._name, _name, StringComparison.Ordinal);
+            return t2 is PlaceholderTypeArgumentSymbol;
         }
 
         public override int GetHashCode()
         {
-            return _name.GetHashCode();
+            return 0;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -131,12 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static ImmutableArray<TypeWithAnnotations> CreateTypeArguments(ImmutableArray<TypeParameterSymbol> typeParameters)
         {
-            var result = ArrayBuilder<TypeWithAnnotations>.GetInstance();
-            foreach (var typeParameter in typeParameters)
-            {
-                result.Add(s_instance);
-            }
-            return result.ToImmutableAndFree();
+            return typeParameters.SelectAsArray(_ => s_instance);
         }
 
         private PlaceholderTypeArgumentSymbol(TupleExtraData? tupleData = null)

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -134,8 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return typeParameters.SelectAsArray(_ => s_instance);
         }
 
-        private PlaceholderTypeArgumentSymbol(TupleExtraData? tupleData = null)
-            : base(tupleData)
+        private PlaceholderTypeArgumentSymbol()
         {
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return new CSDiagnosticInfo(ErrorCode.ERR_UnexpectedUnboundGenericName); // TODO2
+                return new CSDiagnosticInfo(ErrorCode.Void);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData)
         {
-            return new PlaceholderTypeArgumentSymbol(newData);
+            throw ExceptionUtilities.Unreachable;
         }
 
         public override string Name
@@ -176,17 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null)
         {
-            if ((object)t2 == (object)this)
-            {
-                return true;
-            }
-
-            return t2 is PlaceholderTypeArgumentSymbol;
-        }
-
-        public override int GetHashCode()
-        {
-            return 0;
+            return (object)t2 == this;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static readonly ErrorTypeSymbol Instance = new UnboundArgumentErrorTypeSymbol(string.Empty, new CSDiagnosticInfo(ErrorCode.ERR_UnexpectedUnboundGenericName));
 
         private readonly string _name;
-        private readonly DiagnosticInfo? _errorInfo;
+        private readonly DiagnosticInfo _errorInfo;
 
-        private UnboundArgumentErrorTypeSymbol(string name, DiagnosticInfo? errorInfo, TupleExtraData? tupleData = null)
+        private UnboundArgumentErrorTypeSymbol(string name, DiagnosticInfo errorInfo, TupleExtraData? tupleData = null)
             : base(tupleData)
         {
             _name = name;
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override DiagnosticInfo? ErrorInfo
+        internal override DiagnosticInfo ErrorInfo
         {
             get
             {
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override DiagnosticInfo? ErrorInfo
+        internal override DiagnosticInfo ErrorInfo
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -127,14 +127,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class PlaceholderTypeArgumentSymbol : ErrorTypeSymbol
     {
-        private static readonly PlaceholderTypeArgumentSymbol s_instance = new PlaceholderTypeArgumentSymbol();
+        private static readonly TypeWithAnnotations s_instance = TypeWithAnnotations.Create(new PlaceholderTypeArgumentSymbol());
 
         public static ImmutableArray<TypeWithAnnotations> CreateTypeArguments(ImmutableArray<TypeParameterSymbol> typeParameters)
         {
             var result = ArrayBuilder<TypeWithAnnotations>.GetInstance();
             foreach (var typeParameter in typeParameters)
             {
-                result.Add(TypeWithAnnotations.Create(s_instance));
+                result.Add(s_instance);
             }
             return result.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return new CSDiagnosticInfo(ErrorCode.ERR_UnexpectedUnboundGenericName);
+                return new CSDiagnosticInfo(ErrorCode.ERR_UnexpectedUnboundGenericName); // TODO2
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return null;
+                return new CSDiagnosticInfo(ErrorCode.ERR_UnexpectedUnboundGenericName);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
@@ -146,9 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _underlyingTypeParameter.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool canIgnoreNullableContext)
+        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
         {
-            _underlyingTypeParameter.EnsureAllConstraintsAreResolved(canIgnoreNullableContext);
+            _underlyingTypeParameter.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding);
         }
 
         public override ImmutableArray<CSharpAttributeData> GetAttributes()

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
@@ -146,9 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _underlyingTypeParameter.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
         }
 
-        internal override void EnsureAllConstraintsAreResolved(bool useLightweightTypeConstraintBinding)
+        internal override void EnsureAllConstraintsAreResolved(bool canUseLightweightTypeConstraintBinding)
         {
-            _underlyingTypeParameter.EnsureAllConstraintsAreResolved(useLightweightTypeConstraintBinding);
+            _underlyingTypeParameter.EnsureAllConstraintsAreResolved(canUseLightweightTypeConstraintBinding);
         }
 
         public override ImmutableArray<CSharpAttributeData> GetAttributes()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -441,9 +441,9 @@ class Program
             CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
 
             comp.VerifyDiagnostics(
-                // (13,26): error CS0701: 'Span<T>' is not a valid constraint. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                // (13,26): error CS0701: 'Span<int>' is not a valid constraint. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
                 //     class C1<T> where T: Span<int>
-                Diagnostic(ErrorCode.ERR_BadBoundType, "Span<int>").WithArguments("System.Span<T>").WithLocation(13, 26),
+                Diagnostic(ErrorCode.ERR_BadBoundType, "Span<int>").WithArguments("System.Span<int>").WithLocation(13, 26),
                 // (10,14): error CS0306: The type 'Span<int>' may not be used as a type argument
                 //         Func<Span<int>> d = ()=>x;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "Span<int>").WithArguments("System.Span<int>").WithLocation(10, 14),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -441,9 +441,9 @@ class Program
             CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
 
             comp.VerifyDiagnostics(
-                // (13,26): error CS0701: 'Span<int>' is not a valid constraint. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                // (13,26): error CS0701: 'Span<T>' is not a valid constraint. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
                 //     class C1<T> where T: Span<int>
-                Diagnostic(ErrorCode.ERR_BadBoundType, "Span<int>").WithArguments("System.Span<int>").WithLocation(13, 26),
+                Diagnostic(ErrorCode.ERR_BadBoundType, "Span<int>").WithArguments("System.Span<T>").WithLocation(13, 26),
                 // (10,14): error CS0306: The type 'Span<int>' may not be used as a type argument
                 //         Func<Span<int>> d = ()=>x;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "Span<int>").WithArguments("System.Span<int>").WithLocation(10, 14),

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -1564,7 +1564,7 @@ class C<T, U, V>
             AssertEx.None(actualTypeParameters, p => p.HasReferenceTypeConstraint);
             AssertEx.None(actualTypeParameters, p => p.HasConstructorConstraint);
             AssertEx.All(actualTypeParameters, p => p.ContainingSymbol == null);
-            AssertEx.All(actualTypeParameters, p => p.GetConstraintTypes(null, useLightweightTypeConstraintBinding: false).Length == 0);
+            AssertEx.All(actualTypeParameters, p => p.GetConstraintTypes(null, canUseLightweightTypeConstraintBinding: false).Length == 0);
             AssertEx.All(actualTypeParameters, p => p.GetInterfaces(null).Length == 0);
 
             foreach (var p in actualTypeParameters)

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -1564,7 +1564,7 @@ class C<T, U, V>
             AssertEx.None(actualTypeParameters, p => p.HasReferenceTypeConstraint);
             AssertEx.None(actualTypeParameters, p => p.HasConstructorConstraint);
             AssertEx.All(actualTypeParameters, p => p.ContainingSymbol == null);
-            AssertEx.All(actualTypeParameters, p => p.GetConstraintTypes(null, canIgnoreNullableContext: false).Length == 0);
+            AssertEx.All(actualTypeParameters, p => p.GetConstraintTypes(null, useLightweightTypeConstraintBinding: false).Length == 0);
             AssertEx.All(actualTypeParameters, p => p.GetInterfaces(null).Length == 0);
 
             foreach (var p in actualTypeParameters)

--- a/src/Compilers/Core/Portable/Symbols/ISymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbol.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis
         ISymbol OriginalDefinition { get; }
 
         void Accept(SymbolVisitor visitor);
-        TResult Accept<TResult>(SymbolVisitor<TResult> visitor);
+        TResult? Accept<TResult>(SymbolVisitor<TResult> visitor);
 
         /// <summary>
         /// Returns the Documentation Comment ID for the symbol, or null if the symbol doesn't

--- a/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
+++ b/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         void SerializeOptionSet(SerializableOptionSet options, ObjectWriter writer, CancellationToken cancellationToken);
 
-        T Deserialize<T>(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken);
+        T? Deserialize<T>(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken);
 
         Checksum CreateChecksum(object value, CancellationToken cancellationToken);
     }

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -138,9 +138,9 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public static ImmutableArray<(Checksum, object)> ReadData(Stream stream, int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
+        public static ImmutableArray<(Checksum, object?)> ReadData(Stream stream, int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
-            using var _ = ArrayBuilder<(Checksum, object)>.GetInstance(out var results);
+            using var _ = ArrayBuilder<(Checksum, object?)>.GetInstance(out var results);
 
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
 

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public static async ValueTask<ImmutableArray<(Checksum, object)>> ReadDataAsync(PipeReader pipeReader, int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
+        public static async ValueTask<ImmutableArray<(Checksum, object?)>> ReadDataAsync(PipeReader pipeReader, int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
             // We can cancel at entry, but once the pipe operations are scheduled we rely on both operations running to
             // avoid deadlocks (the exception handler in 'copyTask' ensures progress is made in the blocking read).

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static ExpressionSyntax GenerateExpressionSyntax(
             this ITypeSymbol typeSymbol)
         {
-            return typeSymbol.Accept(ExpressionSyntaxGeneratorVisitor.Instance).WithAdditionalAnnotations(Simplifier.Annotation);
+            var expression = typeSymbol.Accept(ExpressionSyntaxGeneratorVisitor.Instance);
+            RoslynDebug.Assert(expression is not null);
+            return expression.WithAdditionalAnnotations(Simplifier.Annotation);
         }
 
         public static NameSyntax GenerateNameSyntax(
@@ -48,8 +50,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return SyntaxFactory.IdentifierName("var");
             }
 
-            var syntax = symbol.Accept(TypeSyntaxGeneratorVisitor.Create(nameSyntax))
-                               .WithAdditionalAnnotations(Simplifier.Annotation);
+            var syntax = symbol.Accept(TypeSyntaxGeneratorVisitor.Create(nameSyntax));
+            RoslynDebug.Assert(syntax is not null);
+            syntax = syntax.WithAdditionalAnnotations(Simplifier.Annotation);
 
             if (!allowVar)
             {


### PR DESCRIPTION
~~Fixes https://github.com/dotnet/roslyn/issues/41368 by building up on https://github.com/dotnet/roslyn/pull/47968~~

When binding type constraints for purpose of computing `IsValueType`, we don't need to bind the type arguments of the type constraints. We can bind the type constraints by using placeholder type arguments.
This allows making a fix to nullability rules for type substitution (also included in this PR), which we'd previously held off because of cycles.

We'll discuss whether this is better to take for 16.8 or 16.9. As the bootstrapping issue shows, the fix catches some nullability mismatches that were previously unreported, so it may be better to keep this change in early 16.9 so that VS and BCL can adjust accordingly (if needed).

Overview:
- the central change is in `BindGenericSimpleNamespaceOrTypeOrAliasSymbol` in `Binder_Symbols.cs`
- the fix for the substitution bug is in `TypeWithAnnotations.SubstituteTypeCore`
- changed how we store `_lazyTypeParameterConstraints` (in `NamedTypeSymbol` and other) and `_lazyBounds` (in `TypeParameterSymbol`) is because bad constraints get filtered out. Otherwise, we had a bug where we were reporting diagnostics in the wrong phase (based on result of lightweight binding instead of full binding).

Note: there is a bootstrapping issue. The fix reveals some wrong annotations in Roslyn, but fixing them is a bit of a rabbit hole. Still working on that.

----
Update: putting this PR on hold for a short while. We think the nullability bug probably shouldn't be fixed by changing type substitution. So I'll take that part out of this PR.
