### PR TITLE
Update MoveToNamespaceTests.cs

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveToNamespace
         {
             new[] { "class" },
             new[] { "enum" },
-            new[] { "interface"}
+            new[] { "interface" },
+            new[] { "record" },
         };
 
         [Fact, Trait(Traits.Feature, Traits.Features.MoveToNamespace)]


### PR DESCRIPTION
Updating as I noticed a bug (or lack of support to records)

## Current behavior

```
namespace ConsoleApp20
{
    public class A { }
    public record B { }
}
```

1. Invoke move to namespace and enter a new namespace name on the class => works correctly.
2. Do the same for the record => the record is completely deleted instead of being moved to new namespace.

Opening as a draft for now. I'll debug it soon.