### PR TITLE
Test records in extract interface

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -528,6 +528,28 @@ interface IMyClass
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task ExtractInterface_CodeGen_MethodsInRecord()
+        {
+            var markup = @"
+abstract record R$$
+{
+    public void M() { }
+}";
+
+            var expectedInterfaceCode = @"
+interface IR
+{
+    bool Equals(object obj);
+    bool Equals(R other);
+    int GetHashCode();
+    void M();
+    string ToString();
+}";
+
+            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true, expectedInterfaceCode: expectedInterfaceCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
         public async Task ExtractInterface_CodeGen_Events()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -536,8 +536,7 @@ abstract record R$$
     public void M() { }
 }";
 
-            var expectedInterfaceCode = @"
-interface IR
+            var expectedInterfaceCode = @"interface IR
 {
     bool Equals(object obj);
     bool Equals(R other);

--- a/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
@@ -421,7 +421,8 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
         internal virtual bool IsExtractableMember(ISymbol m)
         {
             if (m.IsStatic ||
-                m.DeclaredAccessibility != Accessibility.Public)
+                m.DeclaredAccessibility != Accessibility.Public ||
+                m.Name == "<Clone>$") // TODO: Use WellKnownMemberNames.CloneMethodName when it's public.
             {
                 return false;
             }


### PR DESCRIPTION
Test is expected to fail due to Clone method being added.
May need to special-case it in:


https://github.com/dotnet/roslyn/blob/cf55f3a58e47298426fa971d3bd9d8857c746c65/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs#L421-L443