### PR TITLE
Fix identifier completion exploding.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // C# and VB share the same LSP language server, and thus share the same default trigger characters.
             // We need to ensure the trigger character is valid in the document's language. For example, the '{'
             // character, while a trigger character in VB, is not a trigger character in C#.
-            var triggerCharacter = char.Parse(request.Context.TriggerCharacter);
+            char.TryParse(request.Context.TriggerCharacter, out var triggerCharacter);
             if (request.Context.TriggerKind == LSP.CompletionTriggerKind.TriggerCharacter && !char.IsLetterOrDigit(triggerCharacter) &&
                 !IsValidTriggerCharacterForDocument(document, request.Context.TriggerCharacter))
             {


### PR DESCRIPTION
- This is an interesting issue because the VS LSP platform violates the LSP spec whereas Razor does not violate the spec and translates VS LSP platform requests into spec abiding messages; however, this in turn breaks Roslyn. So for instance, when typing an identifier to trigger completion the trigger kind should be `invoked` and the trigger character should be `null`; however, the LSP platform passes `CompletionTriggerKind.TriggerCharacter` and either a `\0` trigger character or the actual identifier. Because of this difference in behavior prior to this change you'd run `char.Parse` on `null` which would of course explode.