### PR TITLE
Pass along option to diagnostic analyzer.

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -265,7 +265,7 @@ dotnet_diagnostic.IDE0036.severity = %value%
 dotnet_diagnostic.IDE0037.severity = %value%
 
 # IDE0038
-dotnet_diagnostic.IDE0038.severity = %value%
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 
 # IDE0039
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
@@ -806,8 +806,8 @@ dotnet_style_prefer_inferred_tuple_names = true:suggestion
 # IDE0037, PreferInferredAnonymousTypeMemberNames
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 
-# IDE0038
-No editorconfig based code style option
+# IDE0038, PreferPatternMatchingOverIsWithCastCheck
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 
 # IDE0039, PreferLocalOverAnonymousFunction
 csharp_style_pattern_local_over_anonymous_function = true:suggestion

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
         public CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.InlineIsTypeWithoutNameCheckDiagnosticsId,
-                   option: null,    // Analyzer is currently disabled
+                   option: CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck,
+                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Use_pattern_matching), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/48327

THe `option: null` code was added in https://github.com/dotnet/roslyn/commit/5b6cee9c53a2a8dbf4bed8d473e77fd740dff114.  I can't really understand why though.  Absent a good reason for this, this analyzer should behave the same as the rest of our analyzers.  @mavasani do you know why you did things this way in that PR?