### PR TITLE
Add ValueTaskFactory helpers

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
@@ -11,10 +11,9 @@ namespace Roslyn.Utilities
     /// </summary>
     internal static class ValueTaskFactory
     {
-#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
+        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "This is a ValueTask wrapper, not an asynchronous method.")]
         public static ValueTask<T> FromResult<T>(T result)
             => new(result);
-#pragma warning restore
 
         public static ValueTask CompletedTask
             => new();

--- a/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// Implements <see cref="ValueTask{TResult}"/> members that are only available in .NET 5.
+    /// </summary>
+    internal static class ValueTaskFactory
+    {
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
+        public static ValueTask<T> FromResult<T>(T result)
+            => new(result);
+#pragma warning restore
+
+        public static ValueTask CompletedTask
+            => new();
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Roslyn.Utilities
 {
     /// <summary>
-    /// Implements <see cref="ValueTask{TResult}"/> members that are only available in .NET 5.
+    /// Implements <see cref="ValueTask"/> and <see cref="ValueTask{TResult}"/> static members that are only available in .NET 5.
     /// </summary>
     internal static class ValueTaskFactory
     {

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingNuGetTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
                 NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
@@ -95,7 +95,7 @@ class C
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
                 NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
@@ -124,7 +124,7 @@ class C
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
                 NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
@@ -150,7 +150,7 @@ class C
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
                 NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
@@ -194,7 +194,7 @@ parameters: new TestParameters(index: 2, fixProviderData: data));
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
                 NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
@@ -228,7 +228,7 @@ class C
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
@@ -262,7 +262,7 @@ class C
 
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-                .Returns(new ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>>(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
+                .Returns(ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingNuGetTests.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Moq;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing

--- a/src/EditorFeatures/Core/GoToBase/FindBaseHelpers.cs
+++ b/src/EditorFeatures/Core/GoToBase/FindBaseHelpers.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols.FindReferences;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.GoToBase
 {
@@ -21,18 +22,17 @@ namespace Microsoft.CodeAnalysis.Editor.GoToBase
                 namedTypeSymbol.TypeKind == TypeKind.Interface ||
                 namedTypeSymbol.TypeKind == TypeKind.Struct))
             {
-                return new ValueTask<ImmutableArray<ISymbol>>(BaseTypeFinder.FindBaseTypesAndInterfaces(namedTypeSymbol));
+                return ValueTaskFactory.FromResult(BaseTypeFinder.FindBaseTypesAndInterfaces(namedTypeSymbol));
             }
-            else if (symbol.Kind == SymbolKind.Property ||
+            
+            if (symbol.Kind == SymbolKind.Property ||
                 symbol.Kind == SymbolKind.Method ||
                 symbol.Kind == SymbolKind.Event)
             {
                 return BaseTypeFinder.FindOverriddenAndImplementedMembersAsync(symbol, solution, cancellationToken);
             }
-            else
-            {
-                return new ValueTask<ImmutableArray<ISymbol>>(ImmutableArray<ISymbol>.Empty);
-            }
+
+            return ValueTaskFactory.FromResult(ImmutableArray<ISymbol>.Empty);
         }
     }
 }

--- a/src/EditorFeatures/Core/GoToBase/FindBaseHelpers.cs
+++ b/src/EditorFeatures/Core/GoToBase/FindBaseHelpers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToBase
             {
                 return ValueTaskFactory.FromResult(BaseTypeFinder.FindBaseTypesAndInterfaces(namedTypeSymbol));
             }
-            
+
             if (symbol.Kind == SymbolKind.Property ||
                 symbol.Kind == SymbolKind.Method ||
                 symbol.Kind == SymbolKind.Event)

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -74,14 +74,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))
             {
                 // Don't have a database to search.  
-                return new(ImmutableArray<PackageWithTypeResult>.Empty);
+                return ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
             }
 
             var database = databaseWrapper.Database;
             if (name == "var")
             {
                 // never find anything named 'var'.
-                return new(ImmutableArray<PackageWithTypeResult>.Empty);
+                return ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
             }
 
             var query = new MemberQuery(name, isFullSuffix: true, isFullNamespace: false);
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 }
             }
 
-            return new(result.ToImmutableAndFree());
+            return ValueTaskFactory.FromResult(result.ToImmutableAndFree());
         }
 
         public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))
             {
                 // Don't have a database to search.  
-                return new(ImmutableArray<PackageWithAssemblyResult>.Empty);
+                return ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
             }
 
             var result = ArrayBuilder<PackageWithAssemblyResult>.GetInstance();
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 }
             }
 
-            return new(result.ToImmutableAndFree());
+            return ValueTaskFactory.FromResult(result.ToImmutableAndFree());
         }
 
         public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
@@ -155,14 +155,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             if (!_sourceToDatabase.TryGetValue(NugetOrgSource, out var databaseWrapper))
             {
                 // Don't have a database to search.  
-                return new(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+                return ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
             }
 
             var database = databaseWrapper.Database;
             if (name == "var")
             {
                 // never find anything named 'var'.
-                return new(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+                return ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
             }
 
             var query = new MemberQuery(name, isFullSuffix: true, isFullNamespace: false);
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 }
             }
 
-            return new(results.ToImmutableAndFree());
+            return ValueTaskFactory.FromResult(results.ToImmutableAndFree());
         }
 
         private static List<Symbol> FilterToViableTypes(PartialArray<Symbol> symbols)

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
@@ -49,13 +50,13 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         private sealed class NoOpUpdateEngine : ISymbolSearchUpdateEngine
         {
             public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
-                => new(ImmutableArray<PackageWithAssemblyResult>.Empty);
+                => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
             public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
-                => new(ImmutableArray<PackageWithTypeResult>.Empty);
+                => ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
 
             public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
-                => new(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+                => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
 
             public ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken)
                 => default;

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
@@ -86,7 +86,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
@@ -115,7 +115,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
@@ -140,7 +140,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
@@ -165,7 +165,7 @@ New TestParameters(fixProviderData:=New ProviderData(installerServiceMock.Object
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
@@ -207,7 +207,7 @@ parameters:=New TestParameters(index:=2, fixProviderData:=data))
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
@@ -239,7 +239,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
             packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(New ValueTask(Of ImmutableArray(Of ReferenceAssemblyWithTypeResult))(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
+                Returns(ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
             packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
                 Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
@@ -267,7 +267,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
         End Function
 
         Private Shared Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As ValueTask(Of ImmutableArray(Of PackageWithTypeResult))
-            Return New ValueTask(Of ImmutableArray(Of PackageWithTypeResult))(ImmutableArray.Create(results))
+            Return ValueTaskFactory.FromResult(ImmutableArray.Create(results))
         End Function
 
         Private Shared Function CreateNameParts(ParamArray parts As String()) As ImmutableArray(Of String)

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (!(analyzerOptions is WorkspaceAnalyzerOptions workspaceAnalyzerOptions))
             {
-                return new ValueTask<OptionSet?>((OptionSet?)null);
+                return ValueTaskFactory.FromResult((OptionSet?)null);
             }
 
             return workspaceAnalyzerOptions.GetDocumentOptionSetAsync(syntaxTree, cancellationToken);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -416,7 +416,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 if (InMemoryStorage.TryGetValue(_owner.Analyzer, (key, stateKey), out var entry) && serializer.Version == entry.Version)
                 {
-                    return new ValueTask<ImmutableArray<DiagnosticData>>(entry.Diagnostics);
+                    return ValueTaskFactory.FromResult(entry.Diagnostics);
                 }
 
                 return serializer.DeserializeAsync(persistentService, project, document, stateKey, cancellationToken);

--- a/src/Features/VisualBasic/Portable/SignatureHelp/AddRemoveHandlerSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/AddRemoveHandlerSignatureHelpProvider.vb
@@ -22,12 +22,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
         Protected Overrides Function GetIntrinsicOperatorDocumentationAsync(node As AddRemoveHandlerStatementSyntax, document As Document, cancellationToken As CancellationToken) As ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))
             Select Case node.Kind
                 Case SyntaxKind.AddHandlerStatement
-                    Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))(SpecializedCollections.SingletonEnumerable(New AddHandlerStatementDocumentation()))
+                    Return ValueTaskFactory.FromResult(SpecializedCollections.SingletonEnumerable(Of AbstractIntrinsicOperatorDocumentation)(New AddHandlerStatementDocumentation()))
                 Case SyntaxKind.RemoveHandlerStatement
-                    Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))(SpecializedCollections.SingletonEnumerable(New RemoveHandlerStatementDocumentation()))
+                    Return ValueTaskFactory.FromResult(SpecializedCollections.SingletonEnumerable(Of AbstractIntrinsicOperatorDocumentation)(New RemoveHandlerStatementDocumentation()))
             End Select
 
-            Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))(SpecializedCollections.EmptyEnumerable(Of AbstractIntrinsicOperatorDocumentation)())
+            Return ValueTaskFactory.FromResult(SpecializedCollections.EmptyEnumerable(Of AbstractIntrinsicOperatorDocumentation)())
         End Function
 
         Protected Overrides Function IsTriggerToken(token As SyntaxToken) As Boolean

--- a/src/Features/VisualBasic/Portable/SignatureHelp/CastExpressionSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/CastExpressionSignatureHelpProvider.vb
@@ -22,11 +22,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
         Protected Overrides Function GetIntrinsicOperatorDocumentationAsync(node As CastExpressionSyntax, document As Document, cancellationToken As CancellationToken) As ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))
             Select Case node.Kind
                 Case SyntaxKind.CTypeExpression
-                    Return ValueTaskFactory.FromResult({New CTypeCastExpressionDocumentation()})
+                    Return ValueTaskFactory.FromResult(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New CTypeCastExpressionDocumentation()})
                 Case SyntaxKind.DirectCastExpression
-                    Return ValueTaskFactory.FromResult({New DirectCastExpressionDocumentation()})
+                    Return ValueTaskFactory.FromResult(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New DirectCastExpressionDocumentation()})
                 Case SyntaxKind.TryCastExpression
-                    Return ValueTaskFactory.FromResult({New TryCastExpressionDocumentation()})
+                    Return ValueTaskFactory.FromResult(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New TryCastExpressionDocumentation()})
             End Select
 
             Return ValueTaskFactory.FromResult(SpecializedCollections.EmptyEnumerable(Of AbstractIntrinsicOperatorDocumentation)())

--- a/src/Features/VisualBasic/Portable/SignatureHelp/CastExpressionSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/CastExpressionSignatureHelpProvider.vb
@@ -22,14 +22,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
         Protected Overrides Function GetIntrinsicOperatorDocumentationAsync(node As CastExpressionSyntax, document As Document, cancellationToken As CancellationToken) As ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))
             Select Case node.Kind
                 Case SyntaxKind.CTypeExpression
-                    Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New CTypeCastExpressionDocumentation()})
+                    Return ValueTaskFactory.FromResult({New CTypeCastExpressionDocumentation()})
                 Case SyntaxKind.DirectCastExpression
-                    Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New DirectCastExpressionDocumentation()})
+                    Return ValueTaskFactory.FromResult({New DirectCastExpressionDocumentation()})
                 Case SyntaxKind.TryCastExpression
-                    Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New TryCastExpressionDocumentation()})
+                    Return ValueTaskFactory.FromResult({New TryCastExpressionDocumentation()})
             End Select
 
-            Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))(SpecializedCollections.EmptyEnumerable(Of AbstractIntrinsicOperatorDocumentation)())
+            Return ValueTaskFactory.FromResult(SpecializedCollections.EmptyEnumerable(Of AbstractIntrinsicOperatorDocumentation)())
         End Function
 
         Protected Overrides Function IsTriggerToken(token As SyntaxToken) As Boolean

--- a/src/Features/VisualBasic/Portable/SignatureHelp/ConditionalExpressionSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/ConditionalExpressionSignatureHelpProvider.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
         Protected MustOverride ReadOnly Property Kind As SyntaxKind
 
         Protected Overrides Function GetIntrinsicOperatorDocumentationAsync(node As T, document As Document, cancellationToken As CancellationToken) As ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))
-            Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New BinaryConditionalExpressionDocumentation(), New TernaryConditionalExpressionDocumentation()})
+            Return ValueTaskFactory.FromResult(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New BinaryConditionalExpressionDocumentation(), New TernaryConditionalExpressionDocumentation()})
         End Function
 
         Protected Overrides Function IsTriggerToken(token As SyntaxToken) As Boolean

--- a/src/Features/VisualBasic/Portable/SignatureHelp/MidAssignmentSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/MidAssignmentSignatureHelpProvider.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
         End Sub
 
         Protected Overrides Function GetIntrinsicOperatorDocumentationAsync(node As AssignmentStatementSyntax, document As Document, cancellationToken As CancellationToken) As ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))
-            Return New ValueTask(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New MidAssignmentDocumentation()})
+            Return ValueTaskFactory.FromResult(Of IEnumerable(Of AbstractIntrinsicOperatorDocumentation))({New MidAssignmentDocumentation()})
         End Function
 
         Protected Overrides Function IsTriggerToken(token As SyntaxToken) As Boolean

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -336,13 +336,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         {
             Contract.ThrowIfNull(_workQueue);
             _workQueue.AddWork(data);
-            return new ValueTask();
+            return ValueTaskFactory.CompletedTask;
         }
 
         public ValueTask OnProjectRemovedAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
             _cpsProjects.TryRemove(projectId, out _);
-            return new ValueTask();
+            return ValueTaskFactory.CompletedTask;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectTelemetry/VisualStudioProjectTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectTelemetry/VisualStudioProjectTelemetryService.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectTelemetr
         {
             Contract.ThrowIfNull(_workQueue);
             _workQueue.AddWork(info);
-            return new ValueTask();
+            return ValueTaskFactory.CompletedTask;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var client = await ServiceHubRemoteHostClient.CreateAsync(_services, _listenerProvider, serviceBroker, cancellationToken).ConfigureAwait(false);
 
                 // proffer in-proc brokered services:
-                _ = brokeredServiceContainer.Proffer(SolutionAssetProvider.ServiceDescriptor, (_, _, _, _) => new ValueTask<object?>(new SolutionAssetProvider(_services)));
+                _ = brokeredServiceContainer.Proffer(SolutionAssetProvider.ServiceDescriptor, (_, _, _, _) => ValueTaskFactory.FromResult<object?>(new SolutionAssetProvider(_services)));
 
                 return client;
             }

--- a/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
@@ -40,10 +40,10 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
                 }
             }
 
-            return new ValueTask<ImmutableArray<(Checksum, object)>>(results.ToImmutableArray());
+            return ValueTaskFactory.FromResult(results.ToImmutableArray());
         }
 
         public ValueTask<bool> IsExperimentEnabledAsync(string experimentName, CancellationToken cancellationToken)
-            => new ValueTask<bool>(false);
+            => ValueTaskFactory.FromResult(false);
     }
 }

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -169,14 +169,14 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
         private class TodoCommentsListener : ITodoCommentsListener
         {
-            private readonly TaskCompletionSource<(DocumentId, ImmutableArray<TodoCommentData>)> _dataSource
-                = new TaskCompletionSource<(DocumentId, ImmutableArray<TodoCommentData>)>();
+            private readonly TaskCompletionSource<(DocumentId, ImmutableArray<TodoCommentData>)> _dataSource = new();
+
             public Task<(DocumentId, ImmutableArray<TodoCommentData>)> Data => _dataSource.Task;
 
             public ValueTask ReportTodoCommentDataAsync(DocumentId documentId, ImmutableArray<TodoCommentData> data, CancellationToken cancellationToken)
             {
                 _dataSource.SetResult((documentId, data));
-                return new ValueTask();
+                return ValueTaskFactory.CompletedTask;
             }
         }
 
@@ -236,17 +236,17 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
         private class DesignerAttributeListener : IDesignerAttributeListener
         {
-            private readonly TaskCompletionSource<ImmutableArray<DesignerAttributeData>> _infosSource
-                = new TaskCompletionSource<ImmutableArray<DesignerAttributeData>>();
+            private readonly TaskCompletionSource<ImmutableArray<DesignerAttributeData>> _infosSource = new();
+
             public Task<ImmutableArray<DesignerAttributeData>> Infos => _infosSource.Task;
 
             public ValueTask OnProjectRemovedAsync(ProjectId projectId, CancellationToken cancellationToken)
-                => new ValueTask();
+                => ValueTaskFactory.CompletedTask;
 
             public ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> infos, CancellationToken cancellationToken)
             {
                 _infosSource.SetResult(infos);
-                return new ValueTask();
+                return ValueTaskFactory.CompletedTask;
             }
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             return FindReferencesInDocumentAsync(document, semanticModel, t =>
                 IsPotentialReference(predefinedType, syntaxFacts, t),
-                (t, m) => new ValueTask<(bool matched, CandidateReason reason)>((matched: true, reason: CandidateReason.None)),
+                (t, m) => ValueTaskFactory.FromResult((matched: true, reason: CandidateReason.None)),
                 docCommentId: null,
                 findInGlobalSuppressions: false,
                 cancellationToken);

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -164,12 +164,12 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         }
 
         public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
-            => new(ImmutableArray<PackageWithTypeResult>.Empty);
+            => ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
 
         public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
-            => new(ImmutableArray<PackageWithAssemblyResult>.Empty);
+            => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
         public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
-            => new(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+            => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
     }
 }

--- a/src/Workspaces/CoreTest/UtilityTest/SpecializedTasksTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SpecializedTasksTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void WhenAll_AllCompletedSuccessfully()
         {
-            var whenAll = SpecializedTasks.WhenAll(new[] { new ValueTask<int>(0), new ValueTask<int>(1) });
+            var whenAll = SpecializedTasks.WhenAll(new[] { ValueTaskFactory.FromResult(0), ValueTaskFactory.FromResult(1) });
             Debug.Assert(whenAll.IsCompleted);
             Assert.True(whenAll.IsCompletedSuccessfully);
             Assert.Equal(new[] { 0, 1 }, whenAll.Result);

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
                 clientConnection.StartListening();
 
-                return ValueTaskFactory.FromResult(clientConnection.ConstructRpcClient<T>());
+                return ValueTaskFactory.FromResult((T?)clientConnection.ConstructRpcClient<T>());
             }
         }
 

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
                 clientConnection.StartListening();
 
-                return new ValueTask<T?>(clientConnection.ConstructRpcClient<T>());
+                return ValueTaskFactory.FromResult(clientConnection.ConstructRpcClient<T>());
             }
         }
 

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -104,6 +104,6 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         public ValueTask<bool> IsExperimentEnabledAsync(string experimentName, CancellationToken cancellationToken)
-            => new ValueTask<bool>(_services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(experimentName));
+            => ValueTaskFactory.FromResult(_services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(experimentName));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -36,6 +36,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Singleton.Collection`1.cs" Link="InternalUtilities\SpecializedCollections.Singleton.Collection`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Singleton.Enumerator`1.cs" Link="InternalUtilities\SpecializedCollections.Singleton.Enumerator`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\StringExtensions.cs" Link="InternalUtilities\StringExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ValueTaskFactory.cs" Link="InternalUtilities\ValueTaskFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Syntax\SyntaxTreeExtensions.cs" Link="Syntax\SyntaxTreeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Collections\ImmutableArrayExtensions.cs" Link="Collections\ImmutableArrayExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Collections\BitVector.cs" Link="Collections\BitVector.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SpecializedTasks.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SpecializedTasks.cs
@@ -58,7 +58,7 @@ namespace Roslyn.Utilities
         {
             var taskArray = tasks.AsArray();
             if (taskArray.Length == 0)
-                return new ValueTask<T[]>(Array.Empty<T>());
+                return ValueTaskFactory.FromResult(Array.Empty<T>());
 
             var allCompletedSuccessfully = true;
             for (var i = 0; i < taskArray.Length; i++)
@@ -78,7 +78,7 @@ namespace Roslyn.Utilities
                     result[i] = taskArray[i].Result;
                 }
 
-                return new ValueTask<T[]>(result);
+                return ValueTaskFactory.FromResult(result);
             }
             else
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/AsyncSymbolVisitor`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/AsyncSymbolVisitor`1.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -12,10 +11,10 @@ namespace Microsoft.CodeAnalysis
     {
         protected abstract TResult DefaultResult { get; }
 
-        public override ValueTask<TResult> Visit(ISymbol symbol)
-            => symbol?.Accept(this) ?? new ValueTask<TResult>(DefaultResult);
+        public override ValueTask<TResult> Visit(ISymbol? symbol)
+            => symbol?.Accept(this) ?? ValueTaskFactory.FromResult(DefaultResult);
 
         public override ValueTask<TResult> DefaultVisit(ISymbol symbol)
-            => new(DefaultResult);
+            => ValueTaskFactory.FromResult(DefaultResult);
     }
 }


### PR DESCRIPTION
`ValueTask.FromResult` and `ValueTask.CompletedTask` are only available in net5.0. Adds a helper class that fills in the gap.