### PR TITLE
Implement low-hanging performance improvements from feedback investigation

### DIFF
--- a/src/CodeStyle/Core/CodeFixes/LanguageServices/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/CodeStyle/Core/CodeFixes/LanguageServices/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
             {
             }
 
-            public Task<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+            public ValueTask<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
             {
                 // TODO: port the GetSemanticModelForNodeAsync implementation from Workspaces layer,
                 // which currently relies on a bunch of internal APIs.

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/ConcurrentDictionaryExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/ConcurrentDictionaryExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
+{
+    public class ConcurrentDictionaryExtensionsTests
+    {
+        [Fact]
+        public void TestAdd()
+        {
+            var dictionary = new ConcurrentDictionary<int, int>();
+            dictionary.Add(0, 0);
+            Assert.Equal(0, dictionary[0]);
+
+            Assert.Throws<ArgumentException>(() => dictionary.Add(0, 0));
+        }
+
+        [Fact]
+        public void TestGetOrAdd()
+        {
+            var first = new object();
+            var second = new object();
+
+            var dictionary = new ConcurrentDictionary<int, object>();
+            Assert.Same(first, dictionary.GetOrAdd(0, static (key, arg) => arg, first));
+            Assert.Same(first, dictionary[0]);
+            Assert.Single(dictionary);
+            Assert.Same(first, dictionary.GetOrAdd(0, static (key, arg) => arg, second));
+            Assert.Same(first, dictionary[0]);
+            Assert.Single(dictionary);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {
@@ -19,8 +21,22 @@ namespace Roslyn.Utilities
         {
             if (!dict.TryAdd(key, value))
             {
-                throw new System.ArgumentException("adding a duplicate");
+                throw new ArgumentException("adding a duplicate", nameof(key));
             }
+        }
+
+        public static TValue GetOrAdd<TKey, TArg, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+            where TKey : notnull
+        {
+#if NETCOREAPP
+            return dictionary.GetOrAdd(key, valueFactory, factoryArgument);
+#else
+            if (dictionary.TryGetValue(key, out var value))
+                return value;
+
+            using var _ = PooledDelegates.GetPooledFunction(valueFactory, factoryArgument, out var boundFunction);
+            return dictionary.GetOrAdd(key, boundFunction);
+#endif
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/ChangeSignature/AddedParameterOrExistingIndex.cs
+++ b/src/EditorFeatures/TestUtilities/ChangeSignature/AddedParameterOrExistingIndex.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.ChangeSignature
 
         internal AddedParameter GetAddedParameter(Document document)
         {
-            var semanticModel = document.GetRequiredSemanticModelAsync(CancellationToken.None).Result;
+            var semanticModel = document.GetRequiredSemanticModelAsync(CancellationToken.None).AsTask().Result;
 
             var type = document.Project.Language switch
             {

--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             return Task.FromResult(project.Documents.ToImmutableArray());
         }
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.ExtensionMethodSymbolComputer.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.ExtensionMethodSymbolComputer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 foreach (var peReference in GetAllRelevantPeReferences())
                 {
                     tasks.Add(Task.Run(()
-                        => SymbolTreeInfo.GetInfoForMetadataReferenceAsync(Solution, peReference, loadOnly: false, cancellationToken), cancellationToken));
+                        => SymbolTreeInfo.GetInfoForMetadataReferenceAsync(Solution, peReference, loadOnly: false, cancellationToken).AsTask(), cancellationToken));
                 }
 
                 return Task.WhenAll(tasks.ToImmutable());
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     tasks.Add(Task.Run(() => GetExtensionMethodSymbolsFromPeReferenceAsync(
                         peReference,
                         forceIndexCreation,
-                        cancellationToken), cancellationToken));
+                        cancellationToken).AsTask(), cancellationToken));
                 }
 
                 foreach (var project in GetAllRelevantProjects())
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     : GetExtensionMethodsForSymbolsFromDifferentCompilation(matchingMethodSymbols, cancellationToken);
             }
 
-            private async Task<ImmutableArray<IMethodSymbol>?> GetExtensionMethodSymbolsFromPeReferenceAsync(
+            private async ValueTask<ImmutableArray<IMethodSymbol>?> GetExtensionMethodSymbolsFromPeReferenceAsync(
                 PortableExecutableReference peReference,
                 bool forceIndexCreation,
                 CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoCacheService.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoCacheService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 _metadataIdToInfo = metadataIdToInfo;
             }
 
-            public async Task<SymbolTreeInfo> TryGetMetadataSymbolTreeInfoAsync(
+            public async ValueTask<SymbolTreeInfo> TryGetMetadataSymbolTreeInfoAsync(
                 Solution solution,
                 PortableExecutableReference reference,
                 CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -321,7 +321,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             // Organize using directives
             addedDocument = ThreadHelper.JoinableTaskFactory.Run(() => OrganizeUsingsCreatedFromTemplateAsync(addedDocument, cancellationToken));
-            rootToFormat = ThreadHelper.JoinableTaskFactory.Run(() => addedDocument.GetRequiredSyntaxRootAsync(cancellationToken));
+            rootToFormat = ThreadHelper.JoinableTaskFactory.Run(() => addedDocument.GetRequiredSyntaxRootAsync(cancellationToken).AsTask());
 
             // Format document
             var unformattedText = addedDocument.GetTextSynchronously(cancellationToken);

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/AddParameterDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/AddParameterDialogViewModel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         public AddParameterDialogViewModel(Document document, int positionForTypeBinding)
         {
             _notificationService = document.Project.Solution.Workspace.Services.GetService<INotificationService>();
-            _semanticModel = document.GetRequiredSemanticModelAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+            _semanticModel = document.GetRequiredSemanticModelAsync(CancellationToken.None).AsTask().WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
 
             TypeIsEmptyImage = Visibility.Visible;
             TypeBindsImage = Visibility.Collapsed;

--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaDocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaDocumentExtensions.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
     internal static class PythiaDocumentExtensions
     {
         public static Task<SemanticModel> GetSemanticModelForNodeAsync(this Document document, SyntaxNode? node, CancellationToken cancellationToken)
-            => DocumentExtensions.ReuseExistingSpeculativeModelAsync(document, node, cancellationToken);
+            => DocumentExtensions.ReuseExistingSpeculativeModelAsync(document, node, cancellationToken).AsTask();
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -84,25 +85,34 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     syntaxFacts, root, sourceText, key, cancellationToken));
         }
 
+        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", AllowCaptures = false)]
         private static ImmutableArray<SyntaxToken> GetIdentifierOrGlobalNamespaceTokensWithText(
             ISyntaxFactsService syntaxFacts, SyntaxNode root, SourceText sourceText,
             string text, CancellationToken cancellationToken)
         {
-            // identifier is not escaped
             if (sourceText != null)
             {
-                return GetTokensFromText(syntaxFacts, root, sourceText, text, IsCandidate, cancellationToken);
+                // identifier is not escaped
+                Func<SyntaxToken, ISyntaxFactsService, string, bool> isCandidate = static (t, syntaxFacts, text) => IsCandidate(t, syntaxFacts, text);
+                return GetTokensFromText(syntaxFacts, root, sourceText, text, isCandidate, cancellationToken);
+            }
+            else
+            {
+                // identifier is escaped
+                using var _ = PooledDelegates.GetPooledFunction<SyntaxToken, (ISyntaxFactsService syntaxFacts, string text), bool>(
+                    static (t, arg) => IsCandidate(t, arg.syntaxFacts, arg.text),
+                    (syntaxFacts, text),
+                    out var isCandidate);
+
+                return root.DescendantTokens(descendIntoTrivia: true).Where(isCandidate).ToImmutableArray();
             }
 
-            // identifier is escaped
-            return root.DescendantTokens(descendIntoTrivia: true).Where(IsCandidate).ToImmutableArray();
-
-            bool IsCandidate(SyntaxToken t)
+            static bool IsCandidate(SyntaxToken t, ISyntaxFactsService syntaxFacts, string text)
                 => syntaxFacts.IsGlobalNamespaceKeyword(t) || (syntaxFacts.IsIdentifier(t) && syntaxFacts.TextMatch(t.ValueText, text));
         }
 
         private static ImmutableArray<SyntaxToken> GetTokensFromText(
-            ISyntaxFactsService syntaxFacts, SyntaxNode root, SourceText content, string text, Func<SyntaxToken, bool> candidate, CancellationToken cancellationToken)
+            ISyntaxFactsService syntaxFacts, SyntaxNode root, SourceText content, string text, Func<SyntaxToken, ISyntaxFactsService, string, bool> candidate, CancellationToken cancellationToken)
         {
             if (text.Length == 0)
             {
@@ -120,7 +130,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 var token = root.FindToken(index, findInsideTrivia: true);
                 var span = token.Span;
-                if (!token.IsMissing && span.Start == index && span.Length == text.Length && candidate(token))
+                if (!token.IsMissing && span.Start == index && span.Length == text.Length && candidate(token, syntaxFacts, text))
                 {
                     result.Add(token);
                 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return model.GetSymbolInfo(node, cancellationToken);
             }
 
-            return nodeCache.GetOrAdd(node, n => model.GetSymbolInfo(n, cancellationToken));
+            return nodeCache.GetOrAdd(node, static (n, arg) => arg.model.GetSymbolInfo(n, arg.cancellationToken), (model, cancellationToken));
         }
 
         public static IAliasSymbol GetAliasInfo(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return Task.FromResult(ImmutableArray.Create(document));
         }
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             TSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         public abstract Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             ISymbol symbol, Project project, IImmutableSet<Document> documents, FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
-        public abstract Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        public abstract ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ISymbol symbol, Document document, SemanticModel semanticModel, FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
         protected static bool TryGetNameWithoutAttributeSuffix(
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected static bool IdentifiersMatch(ISyntaxFactsService syntaxFacts, string name, SyntaxToken token)
             => syntaxFacts.IsIdentifier(token) && syntaxFacts.TextMatch(token.ValueText, name);
 
-        protected static Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
+        protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
             ISymbol symbol,
             string identifier,
             Document document,
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 cancellationToken: cancellationToken);
         }
 
-        protected static Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
+        protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
             ISymbol symbol,
             string identifier,
             Document document,
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 symbol, identifier, document, semanticModel, symbolsMatch, cancellationToken);
         }
 
-        protected static Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
+        protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
             ISymbol symbol,
             string identifier,
             Document document,
@@ -188,7 +188,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 docCommentId, findInGlobalSuppressions, cancellationToken);
         }
 
-        protected static async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
+        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
+        protected static async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingIdentifierAsync(
             string identifier,
             Document document,
             SemanticModel semanticModel,
@@ -900,7 +901,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             TSymbol symbol, Project project, IImmutableSet<Document> documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
-        protected abstract Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected abstract ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             TSymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
@@ -920,13 +921,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 : SpecializedTasks.EmptyImmutableArray<Document>();
         }
 
-        public override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        public override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ISymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             return symbol is TSymbol typedSymbol && CanFind(typedSymbol)
                 ? FindReferencesInDocumentAsync(typedSymbol, document, semanticModel, options, cancellationToken)
-                : SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+                : new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
 
         public override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
@@ -959,7 +960,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return SpecializedTasks.EmptyImmutableArray<ISymbol>();
         }
 
-        protected static Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingSymbolNameAsync(
+        protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingSymbolNameAsync(
             TSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -1002,7 +1003,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 cancellationToken);
         }
 
-        protected static Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             TSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -1014,7 +1015,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 findParentNode: null, cancellationToken: cancellationToken);
         }
 
-        protected static Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             TSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -1028,7 +1029,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 symbolsMatchAsync, docCommentId, findInGlobalSuppressions, cancellationToken);
         }
 
-        protected static async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected static async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             Document document,
             SemanticModel semanticModel,
             Func<SyntaxToken, bool> tokensMatch,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// A reference to this field inside a global suppression would be as following:
         ///     [assembly: SuppressMessage("RuleCategory", "RuleId', Scope = "member", Target = "~F:C.Field")]
         /// </summary>
-        protected static async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentInsideGlobalSuppressionsAsync(
+        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
+        protected static async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentInsideGlobalSuppressionsAsync(
             Document document,
             SemanticModel semanticModel,
             ISyntaxFacts syntaxFacts,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
@@ -2,37 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
     internal abstract partial class AbstractReferenceFinder : IReferenceFinder
     {
-        /// <summary>
-        /// Regex for symbol documentation comment ID.
-        /// For example, "~M:C.X(System.String)" represents the documentation comment ID of a method named 'X'
-        /// that takes a single string typed parameter and is contained in a type named 'C'.
-        /// 
-        /// We divide the regex it into 3 groups:
-        /// 1. Prefix:
-        ///     - Starts with an optional '~'
-        ///     - Followed by a single capital letter indicating the symbol kind (for example, 'M' indicates method symbol)
-        ///     - Followed by ':'
-        /// 2. Core symbol ID, which is its fully qualified name before the optional parameter list and return type (i.e. before the '(' or '[' tokens)
-        /// 3. Optional parameter list and/or return type that begins with a '(' or '[' tokens.
-        /// 
-        /// For the above example, "~M:" is the prefix, "C.X" is the core symbol ID and "(System.String)" is the parameter list.
-        /// </summary>
-        private static readonly Regex s_docCommentIdPattern = new(@"(~?[A-Z]:)([^([]*)(.*)");
-
         protected static bool ShouldFindReferencesInGlobalSuppressions(ISymbol symbol, [NotNullWhen(returnValue: true)] out string? documentationCommentId)
         {
             if (!SupportsGlobalSuppression(symbol))
@@ -100,7 +84,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             using var _ = ArrayBuilder<FinderLocation>.GetInstance(out var locations);
             foreach (var token in root.DescendantTokens())
             {
-                if (IsCandidate(token, expectedDocCommentId, semanticModel, syntaxFacts, suppressMessageAttribute, cancellationToken, out var offsetOfReferenceInToken))
+                if (IsCandidate(token, expectedDocCommentId.Span, semanticModel, syntaxFacts, suppressMessageAttribute, cancellationToken, out var offsetOfReferenceInToken))
                 {
                     var referenceLocation = CreateReferenceLocation(offsetOfReferenceInToken, token, root, document, syntaxFacts);
                     locations.Add(new FinderLocation(token.GetRequiredParent(), referenceLocation));
@@ -111,7 +95,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 
             // Local functions
             static bool IsCandidate(
-                SyntaxToken token, string expectedDocCommentId, SemanticModel semanticModel, ISyntaxFacts syntaxFacts,
+                SyntaxToken token, ReadOnlySpan<char> expectedDocCommentId, SemanticModel semanticModel, ISyntaxFacts syntaxFacts,
                 INamedTypeSymbol suppressMessageAttribute, CancellationToken cancellationToken, out int offsetOfReferenceInToken)
             {
                 offsetOfReferenceInToken = -1;
@@ -123,7 +107,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 }
 
                 // Target string must contain a valid symbol DocumentationCommentId.
-                if (!ValidateAndSplitDocumentationCommentId(token.ValueText, out var prefix, out var idPartBeforeArguments, out var arguments))
+                if (!ValidateAndSplitDocumentationCommentId(token.ValueText, out var prefix, out var docCommentId))
                 {
                     return false;
                 }
@@ -139,8 +123,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 // When doing a FAR query on 'Field', we would return true from case 1.
                 // When doing a FAR query on 'C', we would return true from case 2.
 
-                var docCommentId = idPartBeforeArguments + arguments;
-                if (!docCommentId.StartsWith(expectedDocCommentId))
+                if (!docCommentId.Span.StartsWith(expectedDocCommentId))
                 {
                     return false;
                 }
@@ -152,7 +135,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 {
                     // Expected doc comment ID belongs to a containing symbol of the symbol referenced in suppression's target doc comment ID.
                     // Verify the next character in suppression doc comment ID is the '.' separator for its member.
-                    if (docCommentId[expectedDocCommentId.Length] != '.')
+                    if (docCommentId.Span[expectedDocCommentId.Length] != '.')
                         return false;
 
                     offsetOfReferenceInToken += expectedDocCommentId.LastIndexOf('.') + 1;
@@ -160,7 +143,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 else
                 {
                     // Expected doc comment ID matches the suppression's target doc comment ID.
-                    offsetOfReferenceInToken += idPartBeforeArguments.LastIndexOf('.') + 1;
+                    SplitIdAndArguments(docCommentId, out var idPartBeforeArguments, out var _);
+                    offsetOfReferenceInToken += idPartBeforeArguments.Span.LastIndexOf('.') + 1;
                 }
 
                 return true;
@@ -254,42 +238,114 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 
         private static bool TryGetExpectedDocumentationCommentId(
             string id,
-            [NotNullWhen(true)] out string? docCommentId)
+            out ReadOnlyMemory<char> docCommentId)
         {
-            if (!ValidateAndSplitDocumentationCommentId(id, out _, out var idPartBeforeArguments, out var arguments))
+            return ValidateAndSplitDocumentationCommentId(id, out _, out docCommentId);
+        }
+
+        /// <summary>
+        /// Validate and split a documentation comment ID into a prefix and complete symbol ID. For the
+        /// <paramref name="docCommentId"/> <c>~M:C.X(System.String)</c>, the <paramref name="prefix"/> would be
+        /// <c>~M:</c> and <paramref name="id"/> would be <c>C.X(System.String)</c>.
+        /// </summary>
+        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", Constraint = "Avoid Regex splitting due to high allocation costs.")]
+        private static bool ValidateAndSplitDocumentationCommentId(
+            [NotNullWhen(true)] string? docCommentId,
+            out ReadOnlyMemory<char> prefix,
+            out ReadOnlyMemory<char> id)
+        {
+            prefix = ReadOnlyMemory<char>.Empty;
+            id = ReadOnlyMemory<char>.Empty;
+            if (docCommentId is null)
             {
-                docCommentId = null;
                 return false;
             }
 
-            docCommentId = idPartBeforeArguments + arguments;
+            // Parse the prefix
+            if (docCommentId.StartsWith("~"))
+            {
+                if (docCommentId.Length < 3)
+                    return false;
+
+                prefix = docCommentId.AsMemory()[0..3];
+            }
+            else
+            {
+                if (docCommentId.Length < 2)
+                    return false;
+
+                prefix = docCommentId.AsMemory()[0..2];
+            }
+
+            if (prefix.Span[^2] is < 'A' or > 'Z')
+            {
+                return false;
+            }
+
+            if (prefix.Span[^1] is not ':')
+            {
+                return false;
+            }
+
+            // The rest of the ID is returned without splitting
+            id = docCommentId.AsMemory()[prefix.Length..];
             return true;
         }
 
-        private static bool ValidateAndSplitDocumentationCommentId(
-            string docCommentId,
-            [NotNullWhen(true)] out string? prefix,
-            [NotNullWhen(true)] out string? idPartBeforeArguments,
-            [NotNullWhen(true)] out string? arguments)
+        /// <summary>
+        /// Split a full documentation symbol ID into the core symbol ID and optional parameter list. For the
+        /// <paramref name="id"/> <c>C.X(System.String)</c>, the <paramref name="idPartBeforeArguments"/> would be
+        /// <c>C.X</c> and <paramref name="arguments"/> would be <c>(System.String)</c>.
+        /// </summary>
+        private static void SplitIdAndArguments(
+            ReadOnlyMemory<char> id,
+            out ReadOnlyMemory<char> idPartBeforeArguments,
+            out ReadOnlyMemory<char> arguments)
         {
-            prefix = null;
-            idPartBeforeArguments = null;
-            arguments = null;
-            if (docCommentId == null)
+            ReadOnlySpan<char> argumentSeparators = stackalloc[] { '(', '[' };
+            var indexOfArguments = id.Span.IndexOfAny(argumentSeparators);
+            if (indexOfArguments < 0)
+            {
+                idPartBeforeArguments = id;
+                arguments = ReadOnlyMemory<char>.Empty;
+            }
+            else
+            {
+                idPartBeforeArguments = id[0..indexOfArguments];
+                arguments = id[indexOfArguments..];
+            }
+        }
+
+        /// <summary>
+        /// Validate and split symbol documentation comment ID.
+        /// For example, "~M:C.X(System.String)" represents the documentation comment ID of a method named 'X'
+        /// that takes a single string-typed parameter and is contained in a type named 'C'.
+        ///
+        /// We divide the ID into 3 groups:
+        /// 1. Prefix:
+        ///     - Starts with an optional '~'
+        ///     - Followed by a single capital letter indicating the symbol kind (for example, 'M' indicates method symbol)
+        ///     - Followed by ':'
+        /// 2. Core symbol ID, which is its fully qualified name before the optional parameter list and return type (i.e. before the '(' or '[' tokens)
+        /// 3. Optional parameter list and/or return type that begins with a '(' or '[' tokens.
+        ///
+        /// For the above example, "~M:" is the prefix, "C.X" is the core symbol ID and "(System.String)" is the parameter list.
+        /// </summary>
+        private static bool ValidateAndSplitDocumentationCommentId(
+            [NotNullWhen(true)] string? docCommentId,
+            out ReadOnlyMemory<char> prefix,
+            out ReadOnlyMemory<char> idPartBeforeArguments,
+            out ReadOnlyMemory<char> arguments)
+        {
+            idPartBeforeArguments = ReadOnlyMemory<char>.Empty;
+            arguments = ReadOnlyMemory<char>.Empty;
+            if (!ValidateAndSplitDocumentationCommentId(docCommentId, out prefix, out var id))
             {
                 return false;
             }
 
-            // Match the documentation comment ID with the regex
-            var match = s_docCommentIdPattern.Match(docCommentId);
-            if (!match.Success)
-            {
-                return false;
-            }
-
-            prefix = match.Groups[1].Value;
-            idPartBeforeArguments = match.Groups[2].Value;
-            arguments = match.Groups[3].Value;
+            // Parse the id part and arguments
+            SplitIdAndArguments(id, out idPartBeforeArguments, out arguments);
             return true;
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             }, cancellationToken);
         }
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 predefinedType == actualType;
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindAllReferencesInDocumentAsync(methodSymbol, document, semanticModel, cancellationToken);
         }
 
-        internal async Task<ImmutableArray<FinderLocation>> FindAllReferencesInDocumentAsync(
+        internal async ValueTask<ImmutableArray<FinderLocation>> FindAllReferencesInDocumentAsync(
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return ordinaryRefs.Concat(attributeRefs, predefinedTypeRefs, implicitObjectCreationMatches);
         }
 
-        private static Task<ImmutableArray<FinderLocation>> FindOrdinaryReferencesAsync(
+        private static ValueTask<ImmutableArray<FinderLocation>> FindOrdinaryReferencesAsync(
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 symbol, name, document, semanticModel, findParentNode, cancellationToken);
         }
 
-        private static Task<ImmutableArray<FinderLocation>> FindPredefinedTypeReferencesAsync(
+        private static ValueTask<ImmutableArray<FinderLocation>> FindPredefinedTypeReferencesAsync(
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             var predefinedType = symbol.ContainingType.SpecialType.ToPredefinedType();
             if (predefinedType == PredefinedType.None)
             {
-                return SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+                return new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
             }
 
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 cancellationToken);
         }
 
-        private static Task<ImmutableArray<FinderLocation>> FindAttributeReferencesAsync(
+        private static ValueTask<ImmutableArray<FinderLocation>> FindAttributeReferencesAsync(
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             return TryGetNameWithoutAttributeSuffix(symbol.ContainingType.Name, syntaxFacts, out var simpleName)
                 ? FindReferencesInDocumentUsingIdentifierAsync(symbol, simpleName, document, semanticModel, cancellationToken)
-                : SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+                : new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -34,14 +34,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return SpecializedTasks.EmptyImmutableArray<Document>();
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+            return new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindDocumentsAsync(project, documents, findInGlobalSuppressions: true, cancellationToken, symbol.Name);
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IEventSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return SpecializedTasks.EmptyImmutableArray<Document>();
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             CancellationToken cancellationToken)
         {
             // An explicit method can't be referenced anywhere.
-            return SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+            return new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindDocumentsAsync(project, documents, findInGlobalSuppressions: true, cancellationToken, symbol.Name);
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IFieldSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// 
         /// Implementations of this method must be thread-safe.
         /// </summary>
-        Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ISymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
@@ -28,11 +28,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         public Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(ISymbol symbol, Solution solution, IImmutableSet<Project>? projects = null, CancellationToken cancellationToken = default)
             => SpecializedTasks.EmptyImmutableArray<Project>();
 
-        public Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        public ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ISymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+            return new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 : fullName;
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ITypeParameterSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 predefinedType == actualType;
         }
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             INamedTypeSymbol namedType,
             Document document,
             SemanticModel semanticModel,
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return nonAliasReferences.Concat(aliasReferences);
         }
 
-        internal static async Task<ImmutableArray<FinderLocation>> FindNonAliasReferencesAsync(
+        internal static async ValueTask<ImmutableArray<FinderLocation>> FindNonAliasReferencesAsync(
             INamedTypeSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return ordinaryRefs.Concat(attributeRefs).Concat(predefinedTypeRefs);
         }
 
-        private static Task<ImmutableArray<FinderLocation>> FindOrdinaryReferencesAsync(
+        private static ValueTask<ImmutableArray<FinderLocation>> FindOrdinaryReferencesAsync(
             INamedTypeSymbol namedType,
             Document document,
             SemanticModel semanticModel,
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 namedType, namedType.Name, document, semanticModel, symbolsMatch, cancellationToken);
         }
 
-        private static Task<ImmutableArray<FinderLocation>> FindPredefinedTypeReferencesAsync(
+        private static ValueTask<ImmutableArray<FinderLocation>> FindPredefinedTypeReferencesAsync(
             INamedTypeSymbol symbol,
             Document document,
             SemanticModel semanticModel,
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             var predefinedType = symbol.SpecialType.ToPredefinedType();
             if (predefinedType == PredefinedType.None)
             {
-                return SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+                return new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
             }
 
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 cancellationToken);
         }
 
-        private static Task<ImmutableArray<FinderLocation>> FindAttributeReferencesAsync(
+        private static ValueTask<ImmutableArray<FinderLocation>> FindAttributeReferencesAsync(
             INamedTypeSymbol namedType,
             Document document,
             SemanticModel semanticModel,
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return TryGetNameWithoutAttributeSuffix(namedType.Name, syntaxFacts, out var simpleName)
                 ? FindReferencesInDocumentUsingIdentifierAsync(simpleName, document, semanticModel,
                     symbolsMatch, docCommentId: null, findInGlobalSuppressions: false, cancellationToken)
-                : SpecializedTasks.EmptyImmutableArray<FinderLocation>();
+                : new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 : symbol.Name;
         }
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             INamespaceSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindDocumentsAsync(project, documents, op, cancellationToken);
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         private static bool IsGetAwaiterMethod(IMethodSymbol methodSymbol)
             => methodSymbol.Name == WellKnownMemberNames.GetAwaiter;
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindDocumentsAsync(project, documents, findInGlobalSuppressions: false, cancellationToken, symbol.Name);
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IParameterSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return result;
         }
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IMethodSymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         private static bool IsForEachProperty(IPropertySymbol symbol)
             => symbol.Name == WellKnownMemberNames.CurrentPropertyName;
 
-        protected override async Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             IPropertySymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindDocumentsAsync(project, documents, findInGlobalSuppressions: false, cancellationToken, symbol.Name, symbol.ContainingType.Name);
         }
 
-        protected override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ITypeParameterSymbol symbol,
             Document document,
             SemanticModel semanticModel,

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/ISymbolTreeInfoCacheService.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/ISymbolTreeInfoCacheService.cs
@@ -20,6 +20,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols.SymbolTree
         /// <summary>
         /// Returns null if the info cannot be retrieved from the cache.
         /// </summary>
-        Task<SymbolTreeInfo> TryGetMetadataSymbolTreeInfoAsync(Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken);
+        ValueTask<SymbolTreeInfo> TryGetMetadataSymbolTreeInfoAsync(Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        public static Task<SymbolTreeInfo> GetInfoForMetadataReferenceAsync(
+        public static ValueTask<SymbolTreeInfo> GetInfoForMetadataReferenceAsync(
             Solution solution, PortableExecutableReference reference,
             bool loadOnly, CancellationToken cancellationToken)
         {
@@ -79,7 +79,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Produces a <see cref="SymbolTreeInfo"/> for a given <see cref="PortableExecutableReference"/>.
         /// Note:  will never return null;
         /// </summary>
-        public static async Task<SymbolTreeInfo> GetInfoForMetadataReferenceAsync(
+        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
+        public static async ValueTask<SymbolTreeInfo> GetInfoForMetadataReferenceAsync(
             Solution solution,
             PortableExecutableReference reference,
             Checksum checksum,

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -64,10 +64,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        public static Task<SyntaxTreeIndex> GetIndexAsync(Document document, CancellationToken cancellationToken)
+        public static ValueTask<SyntaxTreeIndex> GetIndexAsync(Document document, CancellationToken cancellationToken)
             => GetIndexAsync(document, loadOnly: false, cancellationToken);
 
-        public static async Task<SyntaxTreeIndex> GetIndexAsync(
+        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
+        public static async ValueTask<SyntaxTreeIndex> GetIndexAsync(
             Document document,
             bool loadOnly,
             CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
                 };
             }
 
-            public async Task<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+            public async ValueTask<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
             {
                 var reuseService = document.GetRequiredLanguageService<ISemanticModelReuseLanguageService>();
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -43,10 +43,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
         }
 
-        public static Task<SyntaxTreeIndex> GetSyntaxTreeIndexAsync(this Document document, CancellationToken cancellationToken)
+        public static ValueTask<SyntaxTreeIndex> GetSyntaxTreeIndexAsync(this Document document, CancellationToken cancellationToken)
             => SyntaxTreeIndex.GetIndexAsync(document, loadOnly: false, cancellationToken);
 
-        public static Task<SyntaxTreeIndex> GetSyntaxTreeIndexAsync(this Document document, bool loadOnly, CancellationToken cancellationToken)
+        public static ValueTask<SyntaxTreeIndex> GetSyntaxTreeIndexAsync(this Document document, bool loadOnly, CancellationToken cancellationToken)
             => SyntaxTreeIndex.GetIndexAsync(document, loadOnly, cancellationToken);
 
         /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Microsoft.CodeAnalysis.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ConcurrentDictionaryExtensions.cs" Link="InternalUtilities\ConcurrentDictionaryExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\Debug.cs" Link="InternalUtilities\Debug.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\EnumerableExtensions.cs" Link="InternalUtilities\EnumerableExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs" Link="InternalUtilities\ExceptionUtilities.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceServices/SemanticModelReuse/ISemanticModelReuseWorkspaceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceServices/SemanticModelReuse/ISemanticModelReuseWorkspaceService.cs
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
         /// <summary>
         /// Don't call this directly. use <see cref="DocumentExtensions.ReuseExistingSpeculativeModelAsync(Document, SyntaxNode, CancellationToken)"/> (or an overload).
         /// </summary>
-        Task<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken);
+        ValueTask<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Total allocations in the trace were 16GB.

Each of the first four commits saves allocations of >600MB.

Each of the last three commits saves allocations of >200MB.

Total improvement >20%.

Closes [AB#1224834](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1224834)