### PR TITLE
Fixed documentation comment ID handling for dynamic and tuples

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeCompilerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeCompilerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 return CSharpCompilation.Create(
                     projectName,
                     syntaxTrees: new[] { syntaxTree },
-                    references: new[] { TestBase.MscorlibRef });
+                    references: new[] { TestBase.MscorlibRef, TestBase.ValueTupleRef });
             }
             else
             {

--- a/src/Compilers/Core/CodeAnalysisTest/Symbols/DocumentationCommentIdTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Symbols/DocumentationCommentIdTests.cs
@@ -93,6 +93,30 @@ class C
             Assert.Equal(new[] { symbol }, foundSymbols);
         }
 
+        [Fact]
+        public void NintParameterMethod()
+        {
+            string code = @"
+class C
+{
+    void DoStuff(nint nint) {}
+}";
+
+            var comp = CreateCSharpCompilation(code);
+
+            var symbol = comp.GetSymbolsWithName("DoStuff").Single();
+
+            var actualDocId = DocumentationCommentId.CreateDeclarationId(symbol);
+
+            var expectedDocId = "M:C.DoStuff(System.IntPtr)";
+
+            Assert.Equal(expectedDocId, actualDocId);
+
+            var foundSymbols = DocumentationCommentId.GetSymbolsForDeclarationId(expectedDocId, comp);
+
+            Assert.Equal(new[] { symbol }, foundSymbols);
+        }
+
         internal override string VisualizeRealIL(
             IModuleSymbol peModule, CompilationTestData.MethodData methodData, IReadOnlyDictionary<int, string> markers, bool areLocalsZeroed)
             => throw new NotImplementedException();

--- a/src/Compilers/Core/CodeAnalysisTest/Symbols/DocumentationCommentIdTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Symbols/DocumentationCommentIdTests.cs
@@ -45,6 +45,31 @@ class C
         }
 
         [Fact]
+        public void TupleParameterMethod()
+        {
+            string code = @"
+class C
+{
+    void DoStuff((int i, int) tuple) {}
+}";
+
+            var comp = CreateCompilation(code);
+            comp.VerifyDiagnostics();
+
+            var symbol = comp.GetSymbolsWithName("DoStuff").Single();
+
+            var actualDocId = DocumentationCommentId.CreateDeclarationId(symbol);
+
+            string expectedDocId = "M:C.DoStuff(System.ValueTuple{System.Int32,System.Int32})";
+
+            Assert.Equal(expectedDocId, actualDocId);
+
+            var foundSymbols = DocumentationCommentId.GetSymbolsForDeclarationId(expectedDocId, comp);
+
+            Assert.Equal(new[] { symbol }, foundSymbols);
+        }
+
+        [Fact]
         public void DynamicParameterMethod()
         {
             string code = @"

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -656,9 +656,6 @@ namespace Microsoft.CodeAnalysis
 
         private static class Parser
         {
-            private static readonly SymbolEqualityComparer s_symbolEqualityComparer =
-                new(TypeCompareKind.CLRSignatureCompareOptions);
-
             public static bool ParseDeclaredSymbolId(string id, Compilation compilation, List<ISymbol> results)
             {
                 if (id == null)
@@ -1222,7 +1219,7 @@ namespace Microsoft.CodeAnalysis
                                     ITypeSymbol? returnType = ParseTypeSymbol(id, ref index, compilation, methodSymbol);
 
                                     // if return type is specified, then it must match
-                                    if (returnType != null && methodSymbol.ReturnType.Equals(returnType, s_symbolEqualityComparer))
+                                    if (returnType != null && methodSymbol.ReturnType.Equals(returnType, SymbolEqualityComparer.CLRSignature))
                                     {
                                         // return type matches
                                         results.Add(methodSymbol);
@@ -1365,7 +1362,7 @@ namespace Microsoft.CodeAnalysis
 
                 var parameterType = parameterInfo.Type;
 
-                return parameterType != null && symbol.Type.Equals(parameterType, s_symbolEqualityComparer);
+                return parameterType != null && symbol.Type.Equals(parameterType, SymbolEqualityComparer.CLRSignature);
             }
 
             private static ITypeParameterSymbol GetNthTypeParameter(INamedTypeSymbol typeSymbol, int n)

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -575,6 +575,13 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
+            public override bool VisitDynamicType(IDynamicTypeSymbol symbol)
+            {
+                _builder.Append("System.Object");
+
+                return true;
+            }
+
             public override bool VisitArrayType(IArrayTypeSymbol symbol)
             {
                 this.Visit(symbol.ElementType);
@@ -649,6 +656,9 @@ namespace Microsoft.CodeAnalysis
 
         private static class Parser
         {
+            private static readonly SymbolEqualityComparer s_symbolEqualityComparer =
+                new(TypeCompareKind.CLRSignatureCompareOptions);
+
             public static bool ParseDeclaredSymbolId(string id, Compilation compilation, List<ISymbol> results)
             {
                 if (id == null)
@@ -1212,7 +1222,7 @@ namespace Microsoft.CodeAnalysis
                                     ITypeSymbol? returnType = ParseTypeSymbol(id, ref index, compilation, methodSymbol);
 
                                     // if return type is specified, then it must match
-                                    if (returnType != null && methodSymbol.ReturnType.Equals(returnType))
+                                    if (returnType != null && methodSymbol.ReturnType.Equals(returnType, s_symbolEqualityComparer))
                                     {
                                         // return type matches
                                         results.Add(methodSymbol);
@@ -1355,7 +1365,7 @@ namespace Microsoft.CodeAnalysis
 
                 var parameterType = parameterInfo.Type;
 
-                return parameterType != null && symbol.Type.Equals(parameterType);
+                return parameterType != null && symbol.Type.Equals(parameterType, s_symbolEqualityComparer);
             }
 
             private static ITypeParameterSymbol GetNthTypeParameter(INamedTypeSymbol typeSymbol, int n)

--- a/src/Compilers/Core/Portable/Symbols/SymbolEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/Symbols/SymbolEqualityComparer.cs
@@ -16,16 +16,17 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Compares two <see cref="ISymbol"/> instances based on the default comparison rules, equivalent to calling <see cref="IEquatable{ISymbol}.Equals(ISymbol)"/>
         /// </summary>
-        public static readonly SymbolEqualityComparer Default = new SymbolEqualityComparer(TypeCompareKind.AllNullableIgnoreOptions);
+        public static readonly SymbolEqualityComparer Default = new(TypeCompareKind.AllNullableIgnoreOptions);
 
         /// <summary>
         /// Compares  two <see cref="ISymbol"/> instances, considering their nullability
         /// </summary>
-        public static readonly SymbolEqualityComparer IncludeNullability = new SymbolEqualityComparer(TypeCompareKind.ConsiderEverything2); //TODO: should this be explicitly *not* compare everything
+        public static readonly SymbolEqualityComparer IncludeNullability = new(TypeCompareKind.ConsiderEverything2); //TODO: should this be explicitly *not* compare everything
 
         // Internal only comparisons:
-        internal static readonly SymbolEqualityComparer ConsiderEverything = new SymbolEqualityComparer(TypeCompareKind.ConsiderEverything);
-        internal static readonly SymbolEqualityComparer IgnoreAll = new SymbolEqualityComparer(TypeCompareKind.AllIgnoreOptions);
+        internal static readonly SymbolEqualityComparer ConsiderEverything = new(TypeCompareKind.ConsiderEverything);
+        internal static readonly SymbolEqualityComparer IgnoreAll = new(TypeCompareKind.AllIgnoreOptions);
+        internal static readonly SymbolEqualityComparer CLRSignature = new(TypeCompareKind.CLRSignatureCompareOptions);
 
         internal TypeCompareKind CompareKind { get; }
 

--- a/src/Compilers/Core/Portable/Symbols/SymbolEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/Symbols/SymbolEqualityComparer.cs
@@ -16,17 +16,17 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Compares two <see cref="ISymbol"/> instances based on the default comparison rules, equivalent to calling <see cref="IEquatable{ISymbol}.Equals(ISymbol)"/>
         /// </summary>
-        public static readonly SymbolEqualityComparer Default = new(TypeCompareKind.AllNullableIgnoreOptions);
+        public static readonly SymbolEqualityComparer Default = new SymbolEqualityComparer(TypeCompareKind.AllNullableIgnoreOptions);
 
         /// <summary>
         /// Compares  two <see cref="ISymbol"/> instances, considering their nullability
         /// </summary>
-        public static readonly SymbolEqualityComparer IncludeNullability = new(TypeCompareKind.ConsiderEverything2); //TODO: should this be explicitly *not* compare everything
+        public static readonly SymbolEqualityComparer IncludeNullability = new SymbolEqualityComparer(TypeCompareKind.ConsiderEverything2); //TODO: should this be explicitly *not* compare everything
 
         // Internal only comparisons:
-        internal static readonly SymbolEqualityComparer ConsiderEverything = new(TypeCompareKind.ConsiderEverything);
-        internal static readonly SymbolEqualityComparer IgnoreAll = new(TypeCompareKind.AllIgnoreOptions);
-        internal static readonly SymbolEqualityComparer CLRSignature = new(TypeCompareKind.CLRSignatureCompareOptions);
+        internal static readonly SymbolEqualityComparer ConsiderEverything = new SymbolEqualityComparer(TypeCompareKind.ConsiderEverything);
+        internal static readonly SymbolEqualityComparer IgnoreAll = new SymbolEqualityComparer(TypeCompareKind.AllIgnoreOptions);
+        internal static readonly SymbolEqualityComparer CLRSignature = new SymbolEqualityComparer(TypeCompareKind.CLRSignatureCompareOptions);
 
         internal TypeCompareKind CompareKind { get; }
 

--- a/src/Test/Utilities/Portable/Diagnostics/SuppressMessageAttributeTests.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/SuppressMessageAttributeTests.cs
@@ -300,6 +300,25 @@ public class C
         }
 
         [Fact]
+        public async Task GlobalSuppressionOnValueTupleMemberWithDocId()
+        {
+            await VerifyCSharpAsync(@"
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+[assembly: SuppressMessage(""Test"", ""Declaration"", Scope=""Member"", Target=""~M:C.M~System.Threading.Tasks.Task{System.ValueTuple{System.Boolean,ErrorCode}}"")]
+
+enum ErrorCode {}
+
+class C
+{
+    Task<(bool status, ErrorCode errorCode)> M() => null;
+}
+",
+                new[] { new WarningOnNamePrefixDeclarationAnalyzer("M") });
+        }
+
+        [Fact]
         public async Task MultipleGlobalSuppressionsOnSingleSymbol()
         {
             await VerifyCSharpAsync(@"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/34839.
Fixes https://github.com/dotnet/roslyn/issues/48495.

Previously, `DocumentationCommentId.CreateDeclarationId` behaved correctly for named and unnamed tuples, but not for `dynamic`. And `DocumentationCommentId.GetSymbolsForDeclarationId` only behaved correctly for unnamed tuples, but not for named tuples or `dynamic`.

This PR fixes all the cases that didn't behave correctly so that the documentation comment ID represents CLR signature of the member (i.e. `System.Object` for `dynamic` and `System.ValueTuple` for tuples).