### PR TITLE
Cleanup code for 'inline parameter hints' and expose cleaner options

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsFormatDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsFormatDefinition.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
     internal sealed class ClassificationTypeDefinitions
     {

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTag.cs
@@ -23,7 +23,7 @@ using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
 
-namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
     /// <summary>
     /// This is the tag which implements the IntraTextAdornmentTag and is meant to create the UIElements that get shown
@@ -39,8 +39,12 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
         private readonly IThreadingContext _threadingContext;
         private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
 
-        private InlineParameterNameHintsTag(FrameworkElement adornment, ITextView textView, SnapshotSpan span,
-                                            SymbolKey key, InlineParameterNameHintsTaggerProvider taggerProvider)
+        private InlineParameterNameHintsTag(
+            FrameworkElement adornment,
+            ITextView textView,
+            SnapshotSpan span,
+            SymbolKey key,
+            InlineParameterNameHintsTaggerProvider taggerProvider)
             : base(adornment, removalCallback: null, PositionAffinity.Predecessor)
         {
             _textView = textView;

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTagger.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Editor.InlineHints;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
@@ -11,7 +12,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Tagging;
 
-namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
     /// <summary>
     /// The purpose of this tagger is to convert the <see cref="InlineParameterNameHintDataTag"/> to

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTagger.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Editor.InlineHints;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTaggerProvider.cs
@@ -7,6 +7,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.InlineHints;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Text;
@@ -16,7 +17,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
     /// <summary>
     /// The provider that is used as a middleman to create the tagger so that the data tag

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineParameterNameHintsTaggerProvider.cs
@@ -7,7 +7,6 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Host;
-using Microsoft.CodeAnalysis.Editor.InlineHints;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Text;

--- a/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintDataTag.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintDataTag.cs
@@ -5,7 +5,7 @@
 using System;
 using Microsoft.VisualStudio.Text.Tagging;
 
-namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
     /// <summary>
     /// The simple tag that only holds information regarding the associated parameter name

--- a/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintsDataTaggerProvider.cs
@@ -7,12 +7,11 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.InlineParameterNameHints;
+using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -22,7 +21,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
     /// <summary>
     /// The TaggerProvider that calls upon the service in order to locate the spans and names
@@ -35,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
     {
         private readonly IAsynchronousOperationListener _listener;
 
-        protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(InlineParameterNameHintsOptions.EnabledForParameters);
+        protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(InlineHintsOptions.EnabledForParameters);
         protected override SpanTrackingMode SpanTrackingMode => SpanTrackingMode.EdgeInclusive;
 
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintsDataTaggerProvider.cs
@@ -48,18 +48,19 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             _listener = listenerProvider.GetListener(FeatureAttribute.InlineParameterNameHints);
         }
 
+        // This option controls whether or not we run at all.
         protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions
-            => ImmutableArray.Create(
-                InlineHintsOptions.EnabledForParameters,
-                InlineHintsOptions.ForLiteralParameters,
-                InlineHintsOptions.ForObjectCreationParameters,
-                InlineHintsOptions.ForOtherParameters);
+            => ImmutableArray.Create(InlineHintsOptions.EnabledForParameters);
 
         protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
+            // The options we check here just affect the set of results we return if we run.
             return TaggerEventSources.Compose(
                 TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt, textChangeDelay: TaggerDelay.Short, scrollChangeDelay: TaggerDelay.NearImmediate),
-                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.NearImmediate, _listener));
+                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.NearImmediate, _listener),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters, TaggerDelay.NearImmediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters, TaggerDelay.NearImmediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForOtherParameters, TaggerDelay.NearImmediate));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineParameterNameHintsDataTaggerProvider.cs
@@ -53,7 +53,10 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             // TaggerDelay is NearImmediate because we want the renaming and tag creation to be instantaneous
             return TaggerEventSources.Compose(
                 TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt, textChangeDelay: TaggerDelay.Short, scrollChangeDelay: TaggerDelay.NearImmediate),
-                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.NearImmediate, _listener));
+                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.NearImmediate, _listener),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters, TaggerDelay.NearImmediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters, TaggerDelay.NearImmediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForOtherParameters, TaggerDelay.NearImmediate));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/InlineParameterNameHints/InlineParameterNameHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineParameterNameHints/InlineParameterNameHintsDataTaggerProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
     {
         private readonly IAsynchronousOperationListener _listener;
 
-        protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(FeatureOnOffOptions.InlineParameterNameHints);
+        protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(InlineParameterNameHintsOptions.Enabled);
         protected override SpanTrackingMode SpanTrackingMode => SpanTrackingMode.EdgeInclusive;
 
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/EditorFeatures/Core/InlineParameterNameHints/InlineParameterNameHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineParameterNameHints/InlineParameterNameHintsDataTaggerProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
     {
         private readonly IAsynchronousOperationListener _listener;
 
-        protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(InlineParameterNameHintsOptions.Enabled);
+        protected override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(InlineParameterNameHintsOptions.EnabledForParameters);
         protected override SpanTrackingMode SpanTrackingMode => SpanTrackingMode.EdgeInclusive;
 
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
@@ -44,9 +44,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
         public static readonly PerLanguageOption2<bool> PrettyListing = new(nameof(FeatureOnOffOptions), nameof(PrettyListing), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PrettyListing"));
 
-        public static readonly PerLanguageOption2<bool> InlineParameterNameHints = new(nameof(FeatureOnOffOptions), nameof(InlineParameterNameHints), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints"));
-
         public static readonly PerLanguageOption2<bool> AutoFormattingOnTyping = new(
             nameof(FeatureOnOffOptions), nameof(AutoFormattingOnTyping), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Typing"));
@@ -111,7 +108,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
             FeatureOnOffOptions.AutoXmlDocCommentGeneration,
             FeatureOnOffOptions.AutoInsertBlockCommentStartString,
             FeatureOnOffOptions.PrettyListing,
-            FeatureOnOffOptions.InlineParameterNameHints,
             FeatureOnOffOptions.AutoFormattingOnTyping,
             FeatureOnOffOptions.AutoFormattingOnCloseBrace,
             FeatureOnOffOptions.AutoFormattingOnSemicolon,

--- a/src/EditorFeatures/Test2/InlineHints/AbstractInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/AbstractInlineParameterNameHintsTests.vb
@@ -3,18 +3,10 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
-Imports Microsoft.CodeAnalysis.Editor.InlineParameterNameHints
-Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
-Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
-Imports Microsoft.CodeAnalysis.Editor.Tagging
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.InlineParameterNameHints
-Imports Microsoft.CodeAnalysis.Shared.TestHooks
-Imports Microsoft.VisualStudio.Text
-Imports Microsoft.VisualStudio.Text.Tagging
+Imports Microsoft.CodeAnalysis.InlineHints
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineParameterNameHints
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
     <[UseExportProvider]>
     Public MustInherit Class AbstractInlineParameterNameHintsTests
 

--- a/src/EditorFeatures/Test2/InlineHints/AbstractInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/AbstractInlineParameterNameHintsTests.vb
@@ -14,6 +14,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
             Using workspace = TestWorkspace.Create(test)
                 WpfTestRunner.RequireWpfFact($"{NameOf(AbstractInlineParameterNameHintsTests)}.{NameOf(Me.VerifyParamHints)} creates asynchronous taggers")
 
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
+                    InlineHintsOptions.EnabledForParameters,
+                    workspace.CurrentSolution.Projects().First().Language,
+                    optionIsEnabled)))
+
                 Dim hostDocument = workspace.Documents.Single()
                 Dim snapshot = hostDocument.GetTextBuffer().CurrentSnapshot
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
@@ -27,17 +32,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
 
                 Dim nameAndSpansList = hostDocument.AnnotatedSpans.SelectMany(
                     Function(name) name.Value,
-                    Function(name, span) _
-                    New With {.Name = name.Key,
-                              .Span = span
-                    })
+                    Function(name, span) New With {.Name = name.Key, span})
 
                 For Each nameAndSpan In nameAndSpansList.OrderBy(Function(x) x.Span.Start)
                     expectedTags.Add(nameAndSpan.Name + ":" + nameAndSpan.Span.Start.ToString())
                 Next
 
                 AssertEx.Equal(expectedTags, producedTags)
-
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
@@ -2,7 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineParameterNameHints
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
     Public Class CSharpInlineParameterNameHintsTests
         Inherits AbstractInlineParameterNameHintsTests
 

--- a/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -2,7 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineParameterNameHints
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
     Public Class VisualBasicInlineParameterNameHintsTests
         Inherits AbstractInlineParameterNameHintsTests
 

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
@@ -4,20 +4,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.InlineParameterNameHints;
+using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.CSharp.InlineHints
 {
     /// <summary>
     /// The service to locate the positions in which the adornments should appear

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineHints
 
         protected override void AddAllParameterNameHintLocations(
              SemanticModel semanticModel, IEnumerable<SyntaxNode> nodes,
-             ArrayBuilder<InlineParameterHint> result, CancellationToken cancellationToken)
+             Action<InlineParameterHint> addHint, CancellationToken cancellationToken)
         {
             foreach (var node in nodes)
             {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineHints
                     {
                         var param = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
                         if (!string.IsNullOrEmpty(param?.Name))
-                            result.Add(new InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, argument.Span.Start, GetKind(argument.Expression)));
+                            addHint(new InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, argument.Span.Start, GetKind(argument.Expression)));
                     }
                 }
                 else if (node is AttributeArgumentSyntax attribute)
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineHints
                     {
                         var param = attribute.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
                         if (!string.IsNullOrEmpty(param?.Name))
-                            result.Add(new InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, attribute.SpanStart, GetKind(attribute.Expression)));
+                            addHint(new InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, attribute.SpanStart, GetKind(attribute.Expression)));
                     }
                 }
             }

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineHints
                     {
                         var param = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
                         if (!string.IsNullOrEmpty(param?.Name))
-                            addHint(new InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, argument.Span.Start, GetKind(argument.Expression)));
+                            addHint(new InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, argument.SpanStart, GetKind(argument.Expression)));
                     }
                 }
                 else if (node is AttributeArgumentSyntax attribute)

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.InlineHints
 {
     internal abstract class AbstractInlineParameterNameHintsService : IInlineParameterNameHintsService
     {

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -36,16 +37,14 @@ namespace Microsoft.CodeAnalysis.InlineHints
 
             var nodes = root.DescendantNodes(textSpan);
 
-            using var _1 = ArrayBuilder<InlineParameterHint>.GetInstance(out var buffer);
-            AddAllParameterNameHintLocations(semanticModel, nodes, buffer, cancellationToken);
-
-            using var _2 = ArrayBuilder<InlineParameterHint>.GetInstance(out var result);
-
-            foreach (var hint in buffer)
-            {
-                if (HintMatches(hint, literalParameters, objectCreationParameters, otherParameters))
-                    result.Add(hint);
-            }
+            using var _1 = ArrayBuilder<InlineParameterHint>.GetInstance(out var result);
+            AddAllParameterNameHintLocations(
+                semanticModel, nodes,
+                hint =>
+                {
+                    if (HintMatches(hint, literalParameters, objectCreationParameters, otherParameters))
+                        result.Add(hint);
+                }, cancellationToken);
 
             return result.ToImmutable();
         }
@@ -60,6 +59,6 @@ namespace Microsoft.CodeAnalysis.InlineHints
             };
 
         protected abstract void AddAllParameterNameHintLocations(
-            SemanticModel semanticModel, IEnumerable<SyntaxNode> nodes, ArrayBuilder<InlineParameterHint> result, CancellationToken cancellationToken);
+            SemanticModel semanticModel, IEnumerable<SyntaxNode> nodes, Action<InlineParameterHint> addHint, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/InlineHints/IInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/IInlineParameterNameHintsService.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.InlineHints
 {
     internal readonly struct InlineParameterHint
     {

--- a/src/Features/Core/Portable/InlineHints/IInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/IInlineParameterNameHintsService.cs
@@ -14,19 +14,6 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.InlineHints
 {
-    internal readonly struct InlineParameterHint
-    {
-        public readonly SymbolKey ParameterSymbolKey;
-        public readonly string Name;
-        public readonly int Position;
-
-        public InlineParameterHint(SymbolKey parameterSymbolKey, string name, int position)
-        {
-            ParameterSymbolKey = parameterSymbolKey;
-            Name = name;
-            Position = position;
-        }
-    }
 
     internal interface IInlineParameterNameHintsService : ILanguageService
     {

--- a/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
@@ -11,27 +11,27 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
 
-namespace Microsoft.CodeAnalysis.InlineParameterNameHints
+namespace Microsoft.CodeAnalysis.InlineHints
 {
-    internal static class InlineParameterNameHintsOptions
+    internal static class InlineHintsOptions
     {
         public static readonly PerLanguageOption2<bool> EnabledForParameters =
-            new(nameof(InlineParameterNameHintsOptions),
+            new(nameof(InlineHintsOptions),
                 nameof(EnabledForParameters),
                 defaultValue: false,
                 storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.EnabledForParameters"));
     }
 
     [ExportOptionProvider, Shared]
-    internal sealed class InlineParameterNameHintsOptionsProvider : IOptionProvider
+    internal sealed class InlineHintsOptionsProvider : IOptionProvider
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public InlineParameterNameHintsOptionsProvider()
+        public InlineHintsOptionsProvider()
         {
         }
 
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            InlineParameterNameHintsOptions.EnabledForParameters);
+            InlineHintsOptions.EnabledForParameters);
     }
 }

--- a/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
@@ -20,6 +20,24 @@ namespace Microsoft.CodeAnalysis.InlineHints
                 nameof(EnabledForParameters),
                 defaultValue: false,
                 storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.EnabledForParameters"));
+
+        public static readonly PerLanguageOption2<bool> ForLiteralParameters =
+            new(nameof(InlineHintsOptions),
+                nameof(ForLiteralParameters),
+                defaultValue: true,
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForLiteralParameters"));
+
+        public static readonly PerLanguageOption2<bool> ForObjectCreationParameters =
+            new(nameof(InlineHintsOptions),
+                nameof(ForObjectCreationParameters),
+                defaultValue: true,
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForObjectCreationParameters"));
+
+        public static readonly PerLanguageOption2<bool> ForOtherParameters =
+            new(nameof(InlineHintsOptions),
+                nameof(ForOtherParameters),
+                defaultValue: false,
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForOtherParameters"));
     }
 
     [ExportOptionProvider, Shared]
@@ -32,6 +50,9 @@ namespace Microsoft.CodeAnalysis.InlineHints
         }
 
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            InlineHintsOptions.EnabledForParameters);
+            InlineHintsOptions.EnabledForParameters,
+            InlineHintsOptions.ForLiteralParameters,
+            InlineHintsOptions.ForObjectCreationParameters,
+            InlineHintsOptions.ForOtherParameters);
     }
 }

--- a/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
             new(nameof(InlineHintsOptions),
                 nameof(EnabledForParameters),
                 defaultValue: false,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.EnabledForParameters"));
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints"));
 
         public static readonly PerLanguageOption2<bool> ForLiteralParameters =
             new(nameof(InlineHintsOptions),

--- a/src/Features/Core/Portable/InlineHints/InlineParameterHint.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineParameterHint.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+namespace Microsoft.CodeAnalysis.InlineHints
+{
+    internal readonly struct InlineParameterHint
+    {
+        public readonly SymbolKey ParameterSymbolKey;
+        public readonly string Name;
+        public readonly int Position;
+        public readonly InlineParameterHintKind Kind;
+
+        public InlineParameterHint(SymbolKey parameterSymbolKey, string name, int position, InlineParameterHintKind kind)
+        {
+            ParameterSymbolKey = parameterSymbolKey;
+            Name = name;
+            Position = position;
+            Kind = kind;
+        }
+    }
+}

--- a/src/Features/Core/Portable/InlineHints/InlineParameterHintKind.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineParameterHintKind.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-
 namespace Microsoft.CodeAnalysis.InlineHints
 {
     internal enum InlineParameterHintKind

--- a/src/Features/Core/Portable/InlineHints/InlineParameterHintKind.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineParameterHintKind.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+
+namespace Microsoft.CodeAnalysis.InlineHints
+{
+    internal enum InlineParameterHintKind
+    {
+        Literal,
+        ObjectCreation,
+        Other
+    }
+}

--- a/src/Features/Core/Portable/InlineParameterNameHints/IInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineParameterNameHints/IInlineParameterNameHintsService.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.InlineParameterNameHints

--- a/src/Features/Core/Portable/InlineParameterNameHints/InlineParameterNameHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineParameterNameHints/InlineParameterNameHintsOptions.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.InlineParameterNameHints
 {
     internal static class InlineParameterNameHintsOptions
     {
-        public static readonly PerLanguageOption2<bool> Enabled =
+        public static readonly PerLanguageOption2<bool> EnabledForParameters =
             new(nameof(InlineParameterNameHintsOptions),
-                nameof(Enabled),
+                nameof(EnabledForParameters),
                 defaultValue: false,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.Enabled"));
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.EnabledForParameters"));
     }
 
     [ExportOptionProvider, Shared]
@@ -32,6 +32,6 @@ namespace Microsoft.CodeAnalysis.InlineParameterNameHints
         }
 
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            InlineParameterNameHintsOptions.Enabled);
+            InlineParameterNameHintsOptions.EnabledForParameters);
     }
 }

--- a/src/Features/Core/Portable/InlineParameterNameHints/InlineParameterNameHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineParameterNameHints/InlineParameterNameHintsOptions.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.Providers;
+
+namespace Microsoft.CodeAnalysis.InlineParameterNameHints
+{
+    internal static class InlineParameterNameHintsOptions
+    {
+        public static readonly PerLanguageOption2<bool> Enabled =
+            new(nameof(InlineParameterNameHintsOptions),
+                nameof(Enabled),
+                defaultValue: false,
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.Enabled"));
+    }
+
+    [ExportOptionProvider, Shared]
+    internal sealed class InlineParameterNameHintsOptionsProvider : IOptionProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public InlineParameterNameHintsOptionsProvider()
+        {
+        }
+
+        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
+            InlineParameterNameHintsOptions.Enabled);
+    }
+}

--- a/src/Features/VisualBasic/Portable/InlineParameterNameHints/VisualBasicInlineParameterNameHintsService.vb
+++ b/src/Features/VisualBasic/Portable/InlineParameterNameHints/VisualBasicInlineParameterNameHintsService.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineParameterNameHints
         Protected Overrides Sub AddAllParameterNameHintLocations(
                 semanticModel As SemanticModel,
                 nodes As IEnumerable(Of SyntaxNode),
-                result As ArrayBuilder(Of InlineParameterHint),
+                addHint As Action(Of InlineParameterHint),
                 cancellationToken As CancellationToken)
 
             For Each node In nodes
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineParameterNameHints
                     If Not simpleArgument.IsNamed AndAlso simpleArgument.NameColonEquals Is Nothing Then
                         Dim param = simpleArgument.DetermineParameter(semanticModel, allowParamArray:=False, cancellationToken)
                         If Not String.IsNullOrEmpty(param?.Name) Then
-                            result.Add(New InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, simpleArgument.Span.Start, GetKind(simpleArgument.Expression)))
+                            addHint(New InlineParameterHint(param.GetSymbolKey(cancellationToken), param.Name, simpleArgument.Span.Start, GetKind(simpleArgument.Expression)))
                         End If
                     End If
                 End If

--- a/src/Features/VisualBasic/Portable/InlineParameterNameHints/VisualBasicInlineParameterNameHintsService.vb
+++ b/src/Features/VisualBasic/Portable/InlineParameterNameHints/VisualBasicInlineParameterNameHintsService.vb
@@ -5,7 +5,7 @@
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.InlineParameterNameHints
+Imports Microsoft.CodeAnalysis.InlineHints
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -626,4 +626,7 @@
   <data name="Insert_slash_slash_at_the_start_of_new_lines_when_writing_slash_slash_comments" xml:space="preserve">
     <value>Insert // at the start of new lines when writing // comments</value>
   </data>
+  <data name="Show_hints_for_new_expressions" xml:space="preserve">
+    <value>Show hints for 'new' expressions</value>
+  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -111,7 +111,20 @@
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints_experimental}">
                 <StackPanel>
                     <CheckBox x:Name="DisplayInlineParameterNameHints"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}" />
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}"
+                              Checked="DisplayInlineParameterNameHints_Checked"
+                              Unchecked="DisplayInlineParameterNameHints_Unchecked"/>
+                    <StackPanel Margin="15, 0, 0, 0">
+                        <CheckBox x:Uid="ShowHintsForLiterals"
+                                  x:Name="ShowHintsForLiterals"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_hints_for_literals}" />
+                        <CheckBox x:Uid="ShowHintsForNewExpressions"
+                                  x:Name="ShowHintsForNewExpressions"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_hints_for_new_expressions}" />
+                        <CheckBox x:Uid="ShowHintsForEverythingElse"
+                                  x:Name="ShowHintsForEverythingElse"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_hints_for_everything_else}" />
+                    </StackPanel>
                 </StackPanel>
             </GroupBox>
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -121,19 +121,19 @@
                 </StackPanel>
             </GroupBox>
 
-          <GroupBox x:Uid="RegularExpressionsGroupBox"
-                    Header="{x:Static local:AdvancedOptionPageStrings.Option_Regular_Expressions}">
-            <StackPanel>
-              <CheckBox x:Name="Colorize_regular_expressions"
-                        Content="{x:Static local:AdvancedOptionPageStrings.Option_Colorize_regular_expressions}" />
-              <CheckBox x:Name="Report_invalid_regular_expressions"
-                        Content="{x:Static local:AdvancedOptionPageStrings.Option_Report_invalid_regular_expressions}" />
-              <CheckBox x:Name="Highlight_related_components_under_cursor"
-                        Content="{x:Static local:AdvancedOptionPageStrings.Option_Highlight_related_components_under_cursor}" />
-              <CheckBox x:Name="Show_completion_list"
-                        Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_completion_list}" />
-            </StackPanel>
-          </GroupBox>
+            <GroupBox x:Uid="RegularExpressionsGroupBox"
+                        Header="{x:Static local:AdvancedOptionPageStrings.Option_Regular_Expressions}">
+                <StackPanel>
+                    <CheckBox x:Name="Colorize_regular_expressions"
+                            Content="{x:Static local:AdvancedOptionPageStrings.Option_Colorize_regular_expressions}" />
+                    <CheckBox x:Name="Report_invalid_regular_expressions"
+                            Content="{x:Static local:AdvancedOptionPageStrings.Option_Report_invalid_regular_expressions}" />
+                    <CheckBox x:Name="Highlight_related_components_under_cursor"
+                            Content="{x:Static local:AdvancedOptionPageStrings.Option_Highlight_related_components_under_cursor}" />
+                    <CheckBox x:Name="Show_completion_list"
+                            Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_completion_list}" />
+                </StackPanel>
+            </GroupBox>
 
             <GroupBox x:Uid="ClassificationsGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Editor_Color_Scheme}">

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -94,6 +94,7 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_guides_for_code_level_constructs}" />
                 </StackPanel>
             </GroupBox>
+            
             <GroupBox x:Uid="CommentsGuidesGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Comments}">
                 <StackPanel>
@@ -105,11 +106,18 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments}"/>
                 </StackPanel>
             </GroupBox>
-            <GroupBox x:Uid="EditorHelpGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_EditorHelp}">
+
+            <GroupBox x:Uid="InlineHintsGroupBox"
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints_experimental}">
                 <StackPanel>
                     <CheckBox x:Name="DisplayInlineParameterNameHints"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}" />
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox x:Uid="EditorHelpGroupBox"
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_EditorHelp}">
+                <StackPanel>
                     <CheckBox x:Name="ShowRemarksInQuickInfo"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_ShowRemarksInQuickInfo}" />
                     <CheckBox x:Name="RenameTrackingPreview"

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Fading;
 using Microsoft.CodeAnalysis.ImplementType;
+using Microsoft.CodeAnalysis.InlineParameterNameHints;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -64,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(InsertSlashSlashAtTheStartOfNewLinesWhenWritingSingleLineComments, SplitStringLiteralOptions.Enabled, LanguageNames.CSharp);
             BindToOption(InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments, FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp);
 
-            BindToOption(DisplayInlineParameterNameHints, FeatureOnOffOptions.InlineParameterNameHints, LanguageNames.CSharp);
+            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.CSharp);
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.CSharp);
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.CSharp);
             BindToOption(EnableHighlightReferences, FeatureOnOffOptions.ReferenceHighlighting, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -69,7 +69,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(ShowHintsForLiterals, InlineHintsOptions.ForLiteralParameters, LanguageNames.CSharp);
             BindToOption(ShowHintsForNewExpressions, InlineHintsOptions.ForObjectCreationParameters, LanguageNames.CSharp);
             BindToOption(ShowHintsForEverythingElse, InlineHintsOptions.ForOtherParameters, LanguageNames.CSharp);
-            UpdateInlineHintsOptions();
 
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.CSharp);
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.CSharp);
@@ -105,6 +104,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             Editor_color_scheme.Visibility = isSupportedTheme ? Visibility.Visible : Visibility.Collapsed;
             Customized_Theme_Warning.Visibility = isSupportedTheme && isThemeCustomized ? Visibility.Visible : Visibility.Collapsed;
             Custom_VS_Theme_Warning.Visibility = isSupportedTheme ? Visibility.Collapsed : Visibility.Visible;
+
+            UpdateInlineHintsOptions();
 
             base.OnLoad();
         }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Fading;
 using Microsoft.CodeAnalysis.ImplementType;
-using Microsoft.CodeAnalysis.InlineParameterNameHints;
+using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(InsertSlashSlashAtTheStartOfNewLinesWhenWritingSingleLineComments, SplitStringLiteralOptions.Enabled, LanguageNames.CSharp);
             BindToOption(InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments, FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp);
 
-            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.EnabledForParameters, LanguageNames.CSharp);
+            BindToOption(DisplayInlineParameterNameHints, InlineHintsOptions.EnabledForParameters, LanguageNames.CSharp);
 
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.CSharp);
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(InsertSlashSlashAtTheStartOfNewLinesWhenWritingSingleLineComments, SplitStringLiteralOptions.Enabled, LanguageNames.CSharp);
             BindToOption(InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments, FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp);
 
-            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.CSharp);
+            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.EnabledForParameters, LanguageNames.CSharp);
 
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.CSharp);
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -66,6 +66,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments, FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp);
 
             BindToOption(DisplayInlineParameterNameHints, InlineHintsOptions.EnabledForParameters, LanguageNames.CSharp);
+            BindToOption(ShowHintsForLiterals, InlineHintsOptions.ForLiteralParameters, LanguageNames.CSharp);
+            BindToOption(ShowHintsForNewExpressions, InlineHintsOptions.ForObjectCreationParameters, LanguageNames.CSharp);
+            BindToOption(ShowHintsForEverythingElse, InlineHintsOptions.ForOtherParameters, LanguageNames.CSharp);
+            UpdateInlineHintsOptions();
 
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.CSharp);
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.CSharp);
@@ -103,6 +107,26 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             Custom_VS_Theme_Warning.Visibility = isSupportedTheme ? Visibility.Collapsed : Visibility.Visible;
 
             base.OnLoad();
+        }
+
+        private void UpdateInlineHintsOptions()
+        {
+            var enabledForParameters = this.OptionStore.GetOption(InlineHintsOptions.EnabledForParameters, LanguageNames.CSharp);
+            ShowHintsForLiterals.IsEnabled = enabledForParameters;
+            ShowHintsForNewExpressions.IsEnabled = enabledForParameters;
+            ShowHintsForEverythingElse.IsEnabled = enabledForParameters;
+        }
+
+        private void DisplayInlineParameterNameHints_Checked(object sender, RoutedEventArgs e)
+        {
+            this.OptionStore.SetOption(InlineHintsOptions.EnabledForParameters, LanguageNames.CSharp, true);
+            UpdateInlineHintsOptions();
+        }
+
+        private void DisplayInlineParameterNameHints_Unchecked(object sender, RoutedEventArgs e)
+        {
+            this.OptionStore.SetOption(InlineHintsOptions.EnabledForParameters, LanguageNames.CSharp, false);
+            UpdateInlineHintsOptions();
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -66,6 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments, FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp);
 
             BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.CSharp);
+
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.CSharp);
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.CSharp);
             BindToOption(EnableHighlightReferences, FeatureOnOffOptions.ReferenceHighlighting, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -31,6 +31,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_use_64bit_analysis_process
             => ServicesVSResources.Use_64_bit_process_for_code_analysis_requires_restart;
 
+        public static string Option_Inline_Hints_experimental
+            => ServicesVSResources.Inline_Hints_experimental;
+
         public static string Option_Display_inline_parameter_name_hints
             => ServicesVSResources.Display_inline_parameter_name_hints;
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -37,6 +37,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Display_inline_parameter_name_hints
             => ServicesVSResources.Display_inline_parameter_name_hints;
 
+        public static string Option_Show_hints_for_literals
+            => ServicesVSResources.Show_hints_for_literals;
+
+        public static string Option_Show_hints_for_new_expressions
+            => CSharpVSResources.Show_hints_for_new_expressions;
+
+        public static string Option_Show_hints_for_everything_else
+            => ServicesVSResources.Show_hints_for_everything_else;
+
         public static string Option_RenameTrackingPreview => CSharpVSResources.Show_preview_for_rename_tracking;
         public static string Option_Split_string_literals_on_enter => CSharpVSResources.Split_string_literals_on_enter;
 
@@ -170,9 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             => ServicesVSResources.Fade_out_unreachable_code;
 
         public static string Option_Performance
-        {
-            get { return CSharpVSResources.Performance; }
-        }
+            => CSharpVSResources.Performance;
 
         public static string Option_PlaceSystemNamespaceFirst
             => CSharpVSResources.Place_System_directives_first_when_sorting_usings;

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Odebrat nepotřebné direktivy using</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Zobrazit položky z neimportovaných oborů názvů (experimentální)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Nicht benötigte Using-Direktiven entfernen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Elemente aus nicht importierten Namespaces anzeigen (experimentell)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Eliminar instrucciones Using innecesarias</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Mostrar elementos de espacios de nombres no importados (experimental)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Supprimer les Usings inutiles</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Afficher les éléments des espaces de noms qui ne sont pas importés (expérimental)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Rimuovi istruzioni using non necessarie</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Mostra elementi da spazi dei nomi non importati (sperimentale)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -122,6 +122,11 @@
         <target state="translated">不要な using の削除</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">インポートされていない名前空間の項目を表示する (試験段階)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -122,6 +122,11 @@
         <target state="translated">불필요한 Using 제거</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">가져오지 않은 네임스페이스의 항목 표시(실험적)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Usuń niepotrzebne użycia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Pokaż elementy z nieimportowanych przestrzeni nazw (eksperymentalne)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Remover Usos Desnecessários</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Mostrar itens de namespaces não importados (experimental)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Удалить ненужные директивы using</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Показать элементы из неимпортированных пространств имен (экспериментальная функция)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Gereksiz Kullanımları Kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">İçeri aktarılmayan ad alanlarındaki öğeleri göster (deneysel)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -122,6 +122,11 @@
         <target state="translated">删除不必要的 Using</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">显示 unimported 命名空间中的项(实验)</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -122,6 +122,11 @@
         <target state="translated">移除不必要的 Using</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_new_expressions">
+        <source>Show hints for 'new' expressions</source>
+        <target state="new">Show hints for 'new' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">顯示來自未匯入命名空間的項目 (實驗性)</target>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1560,4 +1560,10 @@ I agree to all of the foregoing:</value>
   <data name="Inline_Hints_experimental" xml:space="preserve">
     <value>Inline Hints (experimental)</value>
   </data>
+  <data name="Show_hints_for_everything_else" xml:space="preserve">
+    <value>Show hints for everything else</value>
+  </data>
+  <data name="Show_hints_for_literals" xml:space="preserve">
+    <value>Show hints for literals</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1521,7 +1521,7 @@ I agree to all of the foregoing:</value>
     <value>Warning: type does not bind</value>
   </data>
   <data name="Display_inline_parameter_name_hints" xml:space="preserve">
-    <value>Disp_lay inline parameter name hints (experimental)</value>
+    <value>Disp_lay inline parameter name hints</value>
   </data>
   <data name="Current_parameter" xml:space="preserve">
     <value>Current parameter</value>
@@ -1556,5 +1556,8 @@ I agree to all of the foregoing:</value>
   </data>
   <data name="Comments" xml:space="preserve">
     <value>Comments</value>
+  </data>
+  <data name="Inline_Hints_experimental" xml:space="preserve">
+    <value>Inline Hints (experimental)</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="translated">Zobrazovat nápovědy k názvům v_ložených parametrů (experimentální)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="needs-review-translation">Zobrazovat nápovědy k názvům v_ložených parametrů (experimentální)</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Indexováno v úložišti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Zobrazit seznam pro doplňování</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Některé barvy barevného schématu se přepsaly změnami na stránce možností Prostředí &gt; Písma a barvy. Pokud chcete zrušit všechna přizpůsobení, vyberte na stránce Písma a barvy možnost Použít výchozí.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Vervollständigungsliste anzeigen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Einige Farbschemafarben werden durch Änderungen überschrieben, die auf der Optionsseite "Umgebung" &gt; "Schriftarten und Farben" vorgenommen wurden. Wählen Sie auf der Seite "Schriftarten und Farben" die Option "Standardwerte verwenden" aus, um alle Anpassungen rückgängig zu machen.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">In Repository indiziert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Mostrar lista de finalización</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Algunos de los colores de la combinación se reemplazan por los cambios realizados en la página de opciones de Entorno &gt; Fuentes y colores. Elija "Usar valores predeterminados" en la página Fuentes y colores para revertir todas las personalizaciones.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Indexado en el repositorio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Indexé dans le dépôt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Afficher la liste de saisie semi-automatique</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Certaines couleurs du modèle de couleurs sont substituées à la suite des changements apportés dans la page d'options Environnement &gt; Polices et couleurs. Choisissez Utiliser les valeurs par défaut dans la page Polices et couleurs pour restaurer toutes les personnalisations.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Indicizzata nel repository</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Mostra l'elenco di completamento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Alcuni colori della combinazione colori sono sostituiti dalle modifiche apportate nella pagina di opzioni Ambiente &gt; Tipi di carattere e colori. Scegliere `Usa impostazioni predefinite` nella pagina Tipi di carattere e colori per ripristinare tutte le personalizzazioni.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -777,6 +777,16 @@
         <target state="translated">入力候補一覧の表示</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">一部の配色パターンの色は、[環境] &gt; [フォントおよび色] オプション ページで行われた変更によって上書きされます。[フォントおよび色] オプション ページで [既定値を使用] を選択すると、すべてのカスタマイズが元に戻ります。</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">リポジトリ内でインデックス付け</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -777,6 +777,16 @@
         <target state="translated">완성 목록 표시</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">색 구성표의 일부 색이 [환경] &gt; [글꼴 및 색] 옵션 페이지에서 변경한 내용에 따라 재정의됩니다. 모든 사용자 지정을 되돌리려면 [글꼴 및 색] 페이지에서 '기본값 사용'을 선택하세요.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">리포지토리에서 인덱싱됨</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Indeksowane w repozytorium</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Pokaż listę uzupełniania</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Niektóre kolory w schemacie kolorów są przesłaniane przez zmiany wprowadzone na stronie opcji Środowisko &gt; Czcionki i kolory. Wybierz pozycję „Użyj ustawień domyślnych” na stronie Czcionki i kolory, aby wycofać wszystkie dostosowania.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Mostrar a lista de conclusão</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Algumas cores do esquema de cores estão sendo substituídas pelas alterações feitas na página de Ambiente &gt; Opções de Fontes e Cores. Escolha 'Usar Padrões' na página Fontes e Cores para reverter todas as personalizações.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Indexado no repositório</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Индексированный в репозитории</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Показать список завершения</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Некоторые цвета цветовой схемы переопределяются изменениями, сделанными на странице "Среда" &gt; "Шрифты и цвета". Выберите "Использовать значения по умолчанию" на странице "Шрифты и цвета", чтобы отменить все настройки.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -777,6 +777,16 @@
         <target state="translated">Tamamlama listesini göster</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Bazı renk düzeni renkleri, Ortam &gt; Yazı Tipleri ve Renkler seçenek sayfasında yapılan değişiklikler tarafından geçersiz kılınıyor. Tüm özelleştirmeleri geri döndürmek için Yazı Tipleri ve Renkler sayfasında `Varsayılanları Kullan` seçeneğini belirleyin.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">Depo içinde dizini oluşturulmuş</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="translated">显示内联参数名称提示(实验)(_L)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="needs-review-translation">显示内联参数名称提示(实验)(_L)</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">已在存储库中编入索引</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -777,6 +777,16 @@
         <target state="translated">显示完成列表</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">在“环境”&gt;“字体和颜色”选项页中所做的更改将替代某些配色方案颜色。在“字体和颜色”页中选择“使用默认值”，还原所有自定义项。</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -777,6 +777,16 @@
         <target state="translated">顯示自動完成清單</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_everything_else">
+        <source>Show hints for everything else</source>
+        <target state="new">Show hints for everything else</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Show_hints_for_literals">
+        <source>Show hints for literals</source>
+        <target state="new">Show hints for literals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">[環境] &gt; [字型和色彩選項] 頁面中所做的變更覆寫了某些色彩配置的色彩。請選擇 [字型和色彩] 頁面中的 [使用預設] 來還原所有自訂。</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -178,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints (experimental)</source>
-        <target state="new">Disp_lay inline parameter name hints (experimental)</target>
+        <source>Disp_lay inline parameter name hints</source>
+        <target state="new">Disp_lay inline parameter name hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Edit">
@@ -270,6 +270,11 @@
       <trans-unit id="Indexed_in_repo">
         <source>Indexed in repo</source>
         <target state="translated">已在存放庫中編制索引</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inline_Hints_experimental">
+        <source>Inline Hints (experimental)</source>
+        <target state="new">Inline Hints (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
@@ -307,4 +307,7 @@
   <data name="Insert_apostrophe_at_the_start_of_new_lines_when_writing_apostrophe_comments" xml:space="preserve">
     <value>Insert ' at the start of new lines when writing ' comments</value>
   </data>
+  <data name="Show_hints_for_New_expressions" xml:space="preserve">
+    <value>Show hints for 'New' expressions</value>
+  </data>
 </root>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -105,7 +105,20 @@
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints_experimental}">
                 <StackPanel>
                     <CheckBox x:Name="DisplayInlineParameterNameHints"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}" />
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}"
+                              Checked="DisplayInlineParameterNameHints_Checked"
+                              Unchecked="DisplayInlineParameterNameHints_Unchecked"/>
+                    <StackPanel Margin="15, 0, 0, 0">
+                        <CheckBox x:Uid="ShowHintsForLiterals"
+                                  x:Name="ShowHintsForLiterals"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_hints_for_literals}" />
+                        <CheckBox x:Uid="ShowHintsForNewExpressions"
+                                  x:Name="ShowHintsForNewExpressions"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_hints_for_New_expressions}" />
+                        <CheckBox x:Uid="ShowHintsForEverythingElse"
+                                  x:Name="ShowHintsForEverythingElse"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_hints_for_everything_else}" />
+                    </StackPanel>
                 </StackPanel>
             </GroupBox>
             

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -100,11 +100,18 @@
                                   Content="{x:Static local:AdvancedOptionPageStrings.Option_InsertApostropheAtTheStartOfNewLinesWhenWritingApostropheComments}" />
                 </StackPanel>
             </GroupBox>
-            <GroupBox x:Uid="EditorHelpGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_EditorHelp}">
+
+            <GroupBox x:Uid="InlineHintsGroupBox"
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints_experimental}">
                 <StackPanel>
                     <CheckBox x:Name="DisplayInlineParameterNameHints"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}" />
+                </StackPanel>
+            </GroupBox>
+            
+            <GroupBox x:Uid="EditorHelpGroupBox"
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_EditorHelp}">
+                <StackPanel>
                     <CheckBox x:Name="EnableLineCommit"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_EnableLineCommit}" />
                     <CheckBox x:Name="EnableEndConstruct"
@@ -119,6 +126,7 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Report_invalid_placeholders_in_string_dot_format_calls}" />
                 </StackPanel>
             </GroupBox>
+            
             <GroupBox x:Uid="GoToDefinitionGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_GoToDefinition}">
                 <StackPanel>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -13,7 +13,6 @@ Imports Microsoft.CodeAnalysis.ExtractMethod
 Imports Microsoft.CodeAnalysis.Fading
 Imports Microsoft.CodeAnalysis.ImplementType
 Imports Microsoft.CodeAnalysis.InlineHints
-Imports Microsoft.CodeAnalysis.InlineParameterNameHints
 Imports Microsoft.CodeAnalysis.QuickInfo
 Imports Microsoft.CodeAnalysis.Remote
 Imports Microsoft.CodeAnalysis.SolutionCrawler

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(GenerateXmlDocCommentsForTripleApostrophes, FeatureOnOffOptions.AutoXmlDocCommentGeneration, LanguageNames.VisualBasic)
             BindToOption(InsertApostropheAtTheStartOfNewLinesWhenWritingApostropheComments, SplitCommentOptions.Enabled, LanguageNames.VisualBasic)
 
-            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.VisualBasic)
+            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.EnabledForParameters, LanguageNames.VisualBasic)
 
             BindToOption(EnableEndConstruct, FeatureOnOffOptions.EndConstruct, LanguageNames.VisualBasic)
             BindToOption(EnableLineCommit, FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -60,6 +60,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(InsertApostropheAtTheStartOfNewLinesWhenWritingApostropheComments, SplitCommentOptions.Enabled, LanguageNames.VisualBasic)
 
             BindToOption(DisplayInlineParameterNameHints, InlineHintsOptions.EnabledForParameters, LanguageNames.VisualBasic)
+            BindToOption(ShowHintsForLiterals, InlineHintsOptions.ForLiteralParameters, LanguageNames.VisualBasic)
+            BindToOption(ShowHintsForNewExpressions, InlineHintsOptions.ForObjectCreationParameters, LanguageNames.VisualBasic)
+            BindToOption(ShowHintsForEverythingElse, InlineHintsOptions.ForOtherParameters, LanguageNames.VisualBasic)
+            UpdateInlineHintsOptions()
 
             BindToOption(EnableEndConstruct, FeatureOnOffOptions.EndConstruct, LanguageNames.VisualBasic)
             BindToOption(EnableLineCommit, FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)
@@ -100,6 +104,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             Custom_VS_Theme_Warning.Visibility = If(isSupportedTheme, Visibility.Collapsed, Visibility.Visible)
 
             MyBase.OnLoad()
+        End Sub
+
+        Private Sub UpdateInlineHintsOptions()
+            Dim enabledForParameters = Me.OptionStore.GetOption(InlineHintsOptions.EnabledForParameters, LanguageNames.VisualBasic) <> False
+            ShowHintsForLiterals.IsEnabled = enabledForParameters
+            ShowHintsForNewExpressions.IsEnabled = enabledForParameters
+            ShowHintsForEverythingElse.IsEnabled = enabledForParameters
+        End Sub
+
+        Private Sub DisplayInlineParameterNameHints_Checked()
+            Me.OptionStore.SetOption(InlineHintsOptions.EnabledForParameters, LanguageNames.VisualBasic, True)
+            UpdateInlineHintsOptions()
+        End Sub
+
+        Private Sub DisplayInlineParameterNameHints_Unchecked()
+            Me.OptionStore.SetOption(InlineHintsOptions.EnabledForParameters, LanguageNames.VisualBasic, False)
+            UpdateInlineHintsOptions()
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
 Imports Microsoft.CodeAnalysis.ExtractMethod
 Imports Microsoft.CodeAnalysis.Fading
 Imports Microsoft.CodeAnalysis.ImplementType
+Imports Microsoft.CodeAnalysis.InlineParameterNameHints
 Imports Microsoft.CodeAnalysis.QuickInfo
 Imports Microsoft.CodeAnalysis.Remote
 Imports Microsoft.CodeAnalysis.SolutionCrawler
@@ -62,7 +63,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(EnableLineCommit, FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)
             BindToOption(AutomaticInsertionOfInterfaceAndMustOverrideMembers, FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic)
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.VisualBasic)
-            BindToOption(DisplayInlineParameterNameHints, FeatureOnOffOptions.InlineParameterNameHints, LanguageNames.VisualBasic)
+            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.VisualBasic)
             BindToOption(EnableHighlightReferences, FeatureOnOffOptions.ReferenceHighlighting, LanguageNames.VisualBasic)
             BindToOption(EnableHighlightKeywords, FeatureOnOffOptions.KeywordHighlighting, LanguageNames.VisualBasic)
             BindToOption(RenameTrackingPreview, FeatureOnOffOptions.RenameTrackingPreview, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
 Imports Microsoft.CodeAnalysis.ExtractMethod
 Imports Microsoft.CodeAnalysis.Fading
 Imports Microsoft.CodeAnalysis.ImplementType
+Imports Microsoft.CodeAnalysis.InlineHints
 Imports Microsoft.CodeAnalysis.InlineParameterNameHints
 Imports Microsoft.CodeAnalysis.QuickInfo
 Imports Microsoft.CodeAnalysis.Remote
@@ -59,7 +60,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(GenerateXmlDocCommentsForTripleApostrophes, FeatureOnOffOptions.AutoXmlDocCommentGeneration, LanguageNames.VisualBasic)
             BindToOption(InsertApostropheAtTheStartOfNewLinesWhenWritingApostropheComments, SplitCommentOptions.Enabled, LanguageNames.VisualBasic)
 
-            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.EnabledForParameters, LanguageNames.VisualBasic)
+            BindToOption(DisplayInlineParameterNameHints, InlineHintsOptions.EnabledForParameters, LanguageNames.VisualBasic)
 
             BindToOption(EnableEndConstruct, FeatureOnOffOptions.EndConstruct, LanguageNames.VisualBasic)
             BindToOption(EnableLineCommit, FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -63,7 +63,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(ShowHintsForLiterals, InlineHintsOptions.ForLiteralParameters, LanguageNames.VisualBasic)
             BindToOption(ShowHintsForNewExpressions, InlineHintsOptions.ForObjectCreationParameters, LanguageNames.VisualBasic)
             BindToOption(ShowHintsForEverythingElse, InlineHintsOptions.ForOtherParameters, LanguageNames.VisualBasic)
-            UpdateInlineHintsOptions()
 
             BindToOption(EnableEndConstruct, FeatureOnOffOptions.EndConstruct, LanguageNames.VisualBasic)
             BindToOption(EnableLineCommit, FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)
@@ -102,6 +101,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             Editor_color_scheme.Visibility = If(isSupportedTheme, Visibility.Visible, Visibility.Collapsed)
             Customized_Theme_Warning.Visibility = If(isSupportedTheme AndAlso isCustomized, Visibility.Visible, Visibility.Collapsed)
             Custom_VS_Theme_Warning.Visibility = If(isSupportedTheme, Visibility.Collapsed, Visibility.Visible)
+
+            UpdateInlineHintsOptions()
 
             MyBase.OnLoad()
         End Sub

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -59,11 +59,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(GenerateXmlDocCommentsForTripleApostrophes, FeatureOnOffOptions.AutoXmlDocCommentGeneration, LanguageNames.VisualBasic)
             BindToOption(InsertApostropheAtTheStartOfNewLinesWhenWritingApostropheComments, SplitCommentOptions.Enabled, LanguageNames.VisualBasic)
 
+            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.VisualBasic)
+
             BindToOption(EnableEndConstruct, FeatureOnOffOptions.EndConstruct, LanguageNames.VisualBasic)
             BindToOption(EnableLineCommit, FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)
             BindToOption(AutomaticInsertionOfInterfaceAndMustOverrideMembers, FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic)
             BindToOption(DisplayLineSeparators, FeatureOnOffOptions.LineSeparator, LanguageNames.VisualBasic)
-            BindToOption(DisplayInlineParameterNameHints, InlineParameterNameHintsOptions.Enabled, LanguageNames.VisualBasic)
             BindToOption(EnableHighlightReferences, FeatureOnOffOptions.ReferenceHighlighting, LanguageNames.VisualBasic)
             BindToOption(EnableHighlightKeywords, FeatureOnOffOptions.KeywordHighlighting, LanguageNames.VisualBasic)
             BindToOption(RenameTrackingPreview, FeatureOnOffOptions.RenameTrackingPreview, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -39,6 +39,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_Display_inline_parameter_name_hints As String =
             ServicesVSResources.Display_inline_parameter_name_hints
 
+        Public ReadOnly Property Option_Show_hints_for_literals As String =
+            ServicesVSResources.Show_hints_for_literals
+
+        Public ReadOnly Property Option_Show_hints_for_New_expressions As String =
+            BasicVSResources.Show_hints_for_New_expressions
+
+        Public ReadOnly Property Option_Show_hints_for_everything_else As String =
+            ServicesVSResources.Show_hints_for_everything_else
+
         Public ReadOnly Property Option_DontPutOutOrRefOnStruct As String
             Get
                 Return BasicVSResources.Don_t_put_ByRef_on_custom_structure

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -30,17 +30,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_use_64bit_analysis_process As String =
             ServicesVSResources.Use_64_bit_process_for_code_analysis_requires_restart
 
-        Public ReadOnly Property Option_DisplayLineSeparators As String
-            Get
-                Return BasicVSResources.Show_procedure_line_separators
-            End Get
-        End Property
+        Public ReadOnly Property Option_DisplayLineSeparators As String =
+            BasicVSResources.Show_procedure_line_separators
 
-        Public ReadOnly Property Option_Display_inline_parameter_name_hints As String
-            Get
-                Return ServicesVSResources.Display_inline_parameter_name_hints
-            End Get
-        End Property
+        Public ReadOnly Property Option_Inline_Hints_experimental As String =
+            ServicesVSResources.Inline_Hints_experimental
+
+        Public ReadOnly Property Option_Display_inline_parameter_name_hints As String =
+            ServicesVSResources.Display_inline_parameter_name_hints
 
         Public ReadOnly Property Option_DontPutOutOrRefOnStruct As String
             Get

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.cs.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">U kontrol rovnosti odkazů dávat přednost možnosti Is Nothing</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Zobrazit položky z neimportovaných oborů názvů (experimentální)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">"Is Nothing" für Verweisübereinstimmungsprüfungen vorziehen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Elemente aus nicht importierten Namespaces anzeigen (experimentell)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Preferir “Is Nothing” para comprobaciones de igualdad de referencias</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Mostrar elementos de espacios de nombres no importados (experimental)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.fr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Préférer 'Is Nothing' pour les vérifications d'égalité de référence</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Afficher les éléments des espaces de noms qui ne sont pas importés (expérimental)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.it.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Preferisci 'Is Nothing' per i controlli di uguaglianza dei riferimenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Mostra elementi da spazi dei nomi non importati (sperimentale)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">参照の等値性のチェックには 'Is Nothing' を優先する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">インポートされていない名前空間の項目を表示する (試験段階)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">참조 같음 검사에 대해 'Is Nothing' 선호</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">가져오지 않은 네임스페이스의 항목 표시(실험적)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pl.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Preferuj wyrażenie „Is Nothing” w przypadku sprawdzeń odwołań pod kątem równości</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Pokaż elementy z nieimportowanych przestrzeni nazw (eksperymentalne)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pt-BR.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Prefira 'Is Nothing' para as verificações de igualdade de referência</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Mostrar itens de namespaces não importados (experimental)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Предпочитать Is Nothing для проверок равенства ссылок</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">Показать элементы из неимпортированных пространств имен (экспериментальная функция)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Başvuru eşitliği denetimleri için 'Is Nothing'i tercih et</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">İçeri aktarılmayan ad alanlarındaki öğeleri göster (deneysel)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">引用相等检查偏好 “Is Nothing”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">显示 unimported 命名空间中的项(实验)</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">參考相等檢查最好使用 'Is Nothing'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Show_hints_for_New_expressions">
+        <source>Show hints for 'New' expressions</source>
+        <target state="new">Show hints for 'New' expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Show_items_from_unimported_namespaces">
         <source>Show items from unimported namespaces (experimental)</source>
         <target state="translated">顯示來自未匯入命名空間的項目 (實驗性)</target>


### PR DESCRIPTION
This PR should be reviewed commit by commit.  This cleans up a fair portion of the impl and exposes more fine grained options for contorlling things in the UI.  This is a precursor to more work i'm doing to have more fine grained control over this feature (i.e. disabling it for certain API patterns).  

New UI looks like this:

![image](https://user-images.githubusercontent.com/4564579/95240853-d6471f80-07c1-11eb-97bb-b2443cf1c9d2.png)
