### PR TITLE
Do not crash on unexpected exception

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         Visit(m);
                     }
-                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                    catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         CompileNamespace(symbol);
                     }
-                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                    catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         CompileNamedType(symbol);
                     }
-                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                    catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 return assembly.LookupTopLevelMetadataType(ref emittedName, digThroughForwardedTypes: true);
             }
-            catch (Exception e) when (FatalError.Report(e)) // Trying to get more useful Watson dumps.
+            catch (Exception e) when (FatalError.ReportAndPropagate(e)) // Trying to get more useful Watson dumps.
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
             {
                 return GetOperationCore(node, cancellationToken);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // Log a Non-fatal-watson and then ignore the crash in the attempt of getting operation
                 Debug.Assert(false, "\n" + e.ToString());

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     OnCompilationEventsGenerated_NoLock(getCompilationEvents(eventQueue, additionalFiles));
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1407,7 +1407,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     await ProcessEventAsync(completedEvent, analysisScope, analysisState, cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1466,7 +1466,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 return completedEvent;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -2686,7 +2686,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     return GetOperationsToAnalyze(operationBlocksToAnalyze);
                 }
-                catch (Exception ex) when (ex is InsufficientExecutionStackException || FatalError.ReportWithoutCrashUnlessCanceled(ex))
+                catch (Exception ex) when (ex is InsufficientExecutionStackException || FatalError.ReportAndCatchUnlessCanceled(ex))
                 {
                     // the exception filter will short-circuit if `ex` is `InsufficientExecutionStackException` (from OperationWalker)
                     // and no non-fatal-watson will be logged as a result.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1665,7 +1665,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     diagnosticIds = diagnosticIds.Add(diagnostic.Id);
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 // Intentionally empty
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -593,7 +593,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEventsOpt: null, taskToken, cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -698,7 +698,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -829,7 +829,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                                 FreeEventQueue(eventQueue, _eventQueuePool);
                                             }
                                         }
-                                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                                         {
                                             throw ExceptionUtilities.Unreachable;
                                         }
@@ -868,7 +868,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     FreeDriver(driver);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -962,7 +962,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1009,7 +1009,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1137,7 +1137,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     await WaitForExecutingTaskAsync(executingTreeTask.Item1).ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1344,7 +1344,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var executionTime = GetAnalyzerExecutionTime(analyzer);
                 return new AnalyzerTelemetryInfo(actionCounts, suppressionActionCounts, executionTime);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -89,14 +89,14 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <returns>False to avoid catching the exception.</returns>
         [DebuggerHidden]
-        public static bool ReportUnlessCanceled(Exception exception)
+        public static bool ReportAndPropagateUnlessCanceled(Exception exception)
         {
             if (exception is OperationCanceledException)
             {
                 return false;
             }
 
-            return Report(exception);
+            return ReportAndPropagate(exception);
         }
 
         /// <summary>
@@ -106,14 +106,14 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <returns>False to avoid catching the exception.</returns>
         [DebuggerHidden]
-        public static bool ReportUnlessCanceled(Exception exception, CancellationToken cancellationToken)
+        public static bool ReportAndPropagateUnlessCanceled(Exception exception, CancellationToken cancellationToken)
         {
             if (IsCurrentOperationBeingCancelled(exception, cancellationToken))
             {
                 return false;
             }
 
-            return Report(exception);
+            return ReportAndPropagate(exception);
         }
 
         /// <summary>
@@ -123,14 +123,14 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <returns>True to catch the exception.</returns>
         [DebuggerHidden]
-        public static bool ReportWithoutCrashUnlessCanceled(Exception exception)
+        public static bool ReportAndCatchUnlessCanceled(Exception exception)
         {
             if (exception is OperationCanceledException)
             {
                 return false;
             }
 
-            return ReportWithoutCrash(exception);
+            return ReportAndCatch(exception);
         }
 
         /// <summary>
@@ -140,31 +140,14 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <returns>True to catch the exception.</returns>
         [DebuggerHidden]
-        public static bool ReportWithoutCrashUnlessCanceled(Exception exception, CancellationToken cancellationToken)
+        public static bool ReportAndCatchUnlessCanceled(Exception exception, CancellationToken cancellationToken)
         {
             if (IsCurrentOperationBeingCancelled(exception, cancellationToken))
             {
                 return false;
             }
 
-            return ReportWithoutCrash(exception);
-        }
-
-        /// <summary>
-        /// Use in an exception filter to report a fatal error. 
-        /// Unless the exception is <see cref="NotImplementedException"/> 
-        /// it calls <see cref="Handler"/>. The exception is passed through (the method returns false).
-        /// </summary>
-        /// <returns>False to avoid catching the exception.</returns>
-        [DebuggerHidden]
-        public static bool ReportUnlessNotImplemented(Exception exception)
-        {
-            if (exception is NotImplementedException)
-            {
-                return false;
-            }
-
-            return Report(exception);
+            return ReportAndCatch(exception);
         }
 
         /// <summary>
@@ -173,7 +156,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <returns>False to avoid catching the exception.</returns>
         [DebuggerHidden]
-        public static bool Report(Exception exception)
+        public static bool ReportAndPropagate(Exception exception)
         {
             Report(exception, s_fatalHandler);
             return false;
@@ -190,7 +173,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <returns>True to catch the exception.</returns>
         [DebuggerHidden]
-        public static bool ReportWithoutCrash(Exception exception)
+        public static bool ReportAndCatch(Exception exception)
         {
             Report(exception, s_nonFatalHandler);
             return true;

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -196,47 +196,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             return true;
         }
 
-        /// <summary>
-        /// Report a non-fatal error like <see cref="ReportWithoutCrash"/> but propagates the exception.
-        /// </summary>
-        /// <returns>False to propagate the exception.</returns>
-        [DebuggerHidden]
-        public static bool ReportWithoutCrashAndPropagate(Exception exception)
-        {
-            Report(exception, s_nonFatalHandler);
-            return false;
-        }
-
-        /// <summary>
-        /// Report a non-fatal error like <see cref="ReportWithoutCrash"/> but propagates the exception.
-        /// </summary>
-        /// <returns>False to propagate the exception.</returns>
-        [DebuggerHidden]
-        public static bool ReportWithoutCrashUnlessCanceledAndPropagate(Exception exception)
-        {
-            if (!(exception is OperationCanceledException))
-            {
-                Report(exception, s_nonFatalHandler);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Report a non-fatal error like <see cref="ReportWithoutCrash"/> but propagates the exception, unless the operation has been cancelled.
-        /// </summary>
-        /// <returns>False to propagate the exception.</returns>
-        [DebuggerHidden]
-        public static bool ReportWithoutCrashUnlessCanceledAndPropagate(Exception exception, CancellationToken cancellationToken)
-        {
-            if (!IsCurrentOperationBeingCancelled(exception, cancellationToken))
-            {
-                Report(exception, s_nonFatalHandler);
-            }
-
-            return false;
-        }
-
         private static readonly object s_reportedMarker = new();
 
         private static void Report(Exception exception, Action<Exception>? handler)

--- a/src/Compilers/Core/Portable/InternalUtilities/RoslynParallel.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RoslynParallel.cs
@@ -29,7 +29,7 @@ namespace Roslyn.Utilities
                 {
                     body(i);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e, cancellationToken))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 Debug.Assert(controlFlowGraph.OriginalOperation == operation);
                 return controlFlowGraph;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // Log a Non-fatal-watson and then ignore the crash in the attempt of getting flow graph.
                 Debug.Assert(false, "\n" + e.ToString());

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Sub()
                                 Try
                                     VisitModule(m)
-                                Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                                Catch e As Exception When FatalError.ReportAndPropagateUnlessCanceled(e)
                                     Throw ExceptionUtilities.Unreachable
                                 End Try
                             End Sub),
@@ -156,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Sub()
                                 Try
                                     Visit(m)
-                                Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                                Catch e As Exception When FatalError.ReportAndPropagateUnlessCanceled(e)
                                     Throw ExceptionUtilities.Unreachable
                                 End Try
                             End Sub),

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -472,7 +472,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Sub()
                         Try
                             CompileNamespace(symbol)
-                        Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                        Catch e As Exception When FatalError.ReportAndPropagateUnlessCanceled(e)
                             Throw ExceptionUtilities.Unreachable
                         End Try
                     End Sub),
@@ -505,7 +505,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Sub()
                         Try
                             CompileNamedType(symbol, filter)
-                        Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                        Catch e As Exception When FatalError.ReportAndPropagateUnlessCanceled(e)
                             Throw ExceptionUtilities.Unreachable
                         End Try
                     End Sub),

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -133,7 +133,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             Try
                 Return assembly.LookupTopLevelMetadataType(emittedName, digThroughForwardedTypes:=True)
-            Catch e As Exception When FatalError.Report(e) ' Trying to get more useful Watson dumps.
+            Catch e As Exception When FatalError.ReportAndPropagate(e) ' Trying to get more useful Watson dumps.
                 Throw ExceptionUtilities.Unreachable
             End Try
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -700,7 +700,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 Sub()
                                     Try
                                         visitor(symbol)
-                                    Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                                    Catch e As Exception When FatalError.ReportAndPropagateUnlessCanceled(e)
                                         Throw ExceptionUtilities.Unreachable
                                     End Try
                                 End Sub),

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
                     var fullAssemblyName = symbol.ContainingAssembly.Identity.GetDisplayName();
                     GlobalAssemblyCache.Instance.ResolvePartialName(fullAssemblyName, out assemblyLocation, preferredCulture: CultureInfo.CurrentCulture);
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                catch (Exception e) when (FatalError.ReportAndCatch(e))
                 {
                 }
             }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                         return await textDiffService.GetTextChangesAsync(oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     var textSnapshot = text.FindCorrespondingEditorTextSnapshot();
                     if (textSnapshot == null)
                     {
-                        FatalError.ReportWithoutCrash(new NullTextBufferException(document, text));
+                        FatalError.ReportAndCatch(new NullTextBufferException(document, text));
                         continue;
                     }
                     Contract.ThrowIfNull(textSnapshot.TextBuffer);

--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
 
                 return new ExecutionResult(result.Success);
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                     return new ExecutionResult(result.Success);
                 }, _shutdownCancellationSource.Token).ConfigureAwait(false);
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                 var result = await _interactiveHost.SetPathsAsync(referenceSearchPaths.ToArray(), sourceSearchPaths.ToArray(), workingDirectory).ConfigureAwait(false);
                 UpdatePathsNoLock(result);
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/EditorFeatures/Core.Wpf/Preview/DifferenceViewerPreview.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/DifferenceViewerPreview.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 return;
             }
 
-            FatalError.ReportWithoutCrash(new Exception($"Dispose is not called how? viewer state : {_viewer.IsClosed}"));
+            FatalError.ReportAndCatch(new Exception($"Dispose is not called how? viewer state : {_viewer.IsClosed}"));
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Structure/AbstractStructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Structure/AbstractStructureTaggerProvider.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
                         blockStructure.Spans);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
                         blockStructure.Spans);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
                             {
                                 throw new InvalidOutliningRegionException(service, snapshot, snapshotSpan, regionSpan);
                             }
-                            catch (InvalidOutliningRegionException e) when (FatalError.ReportWithoutCrash(e))
+                            catch (InvalidOutliningRegionException e) when (FatalError.ReportAndCatch(e))
                             {
                             }
                         }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             {
                 throw new InvalidOperationException("Invoke should not be called on a SuggestedActionWithNestedActions");
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
             }
         }

--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
             catch (OperationCanceledException)
             {
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
             }
         }

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                     context.State = version;
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     }
                 }
             }
-            catch (ArgumentOutOfRangeException ex) when (FatalError.ReportWithoutCrash(ex))
+            catch (ArgumentOutOfRangeException ex) when (FatalError.ReportAndCatch(ex))
             {
                 // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=428328&_a=edit&triage=false
                 // explicitly report NFW to find out what is causing us for out of range.

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     var result = serializer.ReadObject(stream) as IEnumerable<int>;
                     return result ?? Array.Empty<int>();
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                catch (Exception e) when (FatalError.ReportAndCatch(e))
                 {
                     return ImmutableArray<int>.Empty;
                 }

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTrackingService.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                 {
                     // nop
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                catch (Exception e) when (FatalError.ReportAndCatch(e))
                 {
                     // nop
                 }
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                 {
                     // nop
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                catch (Exception e) when (FatalError.ReportAndCatch(e))
                 {
                     // nop
                 }
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                 {
                     // nop
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                catch (Exception e) when (FatalError.ReportAndCatch(e))
                 {
                     // nop
                 }

--- a/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
+++ b/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
                     // run them in UI thread
                     await InvokeBelowInputPriorityAsync(NotifyOnForeground).ConfigureAwait(continueOnCapturedContext: false);
                 }
-                catch (Exception ex) when (FatalError.ReportWithoutCrash(ex))
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex))
                 {
                     // This is an error condition but we must continue to drain the work queue.  If we
                     // do not then IAsyncToken values will remain uncomplete and the unit test code
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
                         {
                             // eat up cancellation
                         }
-                        catch (Exception ex) when (FatalError.ReportWithoutCrash(ex))
+                        catch (Exception ex) when (FatalError.ReportAndCatch(ex))
                         {
                             // The PendingWork callbacks should never throw.  In the case they do we
                             // must ensure the IAsyncToken implementation is completed.  If it is not

--- a/src/EditorFeatures/Core/Implementation/Formatting/InferredIndentationDocumentOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/InferredIndentationDocumentOptionsProviderFactory.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                             }
                             else
                             {
-                                FatalError.ReportWithoutCrash(new System.Exception("We had an open document but it wasn't associated with a buffer. That meant we coudln't apply formatting settings."));
+                                FatalError.ReportAndCatch(new System.Exception("We had an open document but it wasn't associated with a buffer. That meant we coudln't apply formatting settings."));
                             }
                         }
                     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -187,13 +187,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (!subjectBuffer.CheckEditAccess())
             {
                 // We are on the wrong thread.
-                FatalError.ReportWithoutCrash(new InvalidOperationException("Subject buffer did not provide Edit Access"));
+                FatalError.ReportAndCatch(new InvalidOperationException("Subject buffer did not provide Edit Access"));
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
             if (subjectBuffer.EditInProgress)
             {
-                FatalError.ReportWithoutCrash(new InvalidOperationException("Subject buffer is editing by someone else."));
+                FatalError.ReportAndCatch(new InvalidOperationException("Subject buffer is editing by someone else."));
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             {
                 change = completionService.GetChangeAsync(document, roslynItem, completionListSpan, commitCharacter, disallowAddingImports, cancellationToken).WaitAndGetResult(cancellationToken);
             }
-            catch (OperationCanceledException e) when (e.CancellationToken != cancellationToken && FatalError.ReportWithoutCrash(e))
+            catch (OperationCanceledException e) when (e.CancellationToken != cancellationToken && FatalError.ReportAndCatch(e))
             {
                 return CommitResultUnhandled;
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/QuickInfoSourceProvider.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/QuickInfoSourceProvider.QuickInfoSource.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                         return null;
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_ComputeModel.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                                     .WithSelectedParameter(selection.SelectedParameter);
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
                     return (bestProvider, bestItems);
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
                 {
                     return (null, null);
                 }

--- a/src/EditorFeatures/Core/Implementation/Interactive/Completion/AbstractDirectivePathCompletionProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Interactive/Completion/AbstractDirectivePathCompletionProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.Completion.FileSystem
 
                 await ProvideCompletionsAsync(context, pathThroughLastSlash).ConfigureAwait(false);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                     return default;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                 return default;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
                         textSnapshot.GetSpan(Span.FromBounds(span.TextSpan.Start, span.TextSpan.End)), tag));
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // report NFW and continue.
                 // also, rather than return partial results, return nothing

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextBufferEditExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextBufferEditExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             {
                 return edit.Apply();
             }
-            catch (Exception e) when (ErrorReporting.FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (ErrorReporting.FatalError.ReportAndCatch(e))
             {
                 s_lastException = e;
 

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
                 return option.DefaultValue;
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/EditorFeatures/Core/Shared/Utilities/ClassificationTypeMap.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ClassificationTypeMap.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             var type = GetClassificationTypeWorker(name);
             if (type == null)
             {
-                FatalError.ReportWithoutCrash(new Exception($"classification type doesn't exist for {name}"));
+                FatalError.ReportAndCatch(new Exception($"classification type doesn't exist for {name}"));
             }
 
             return type ?? GetClassificationTypeWorker(ClassificationTypeNames.Text);

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                    new PatchService(),
                    new DatabaseFactoryService(),
                    // Report all exceptions we encounter, but don't crash on them.
-                   FatalError.ReportWithoutCrash)
+                   FatalError.ReportAndCatch)
         {
         }
 

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                 Loop
 
                 Return typesAndDeclarations.Select(Function(kvp) Tuple.Create(kvp.Key, kvp.Value)).OrderBy(Function(t) t.Item1.Name)
-            Catch ex As Exception When FatalError.ReportUnlessCanceled(ex)
+            Catch ex As Exception When FatalError.ReportAndPropagateUnlessCanceled(ex)
                 Throw ExceptionUtilities.Unreachable
             End Try
         End Function

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -34,11 +34,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private readonly IDkmLanguageInstructionDecoder _languageInstructionDecoder;
         private readonly bool _useReferencedAssembliesOnly;
 
-        static ExpressionCompiler()
-        {
-            FatalError.Handler = FailFast.OnFatalException;
-        }
-
         public ExpressionCompiler(IDkmLanguageFrameDecoder languageFrameDecoder, IDkmLanguageInstructionDecoder languageInstructionDecoder)
         {
             _languageFrameDecoder = languageFrameDecoder;

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
             }
 
-            return FatalError.Report(exception);
+            return FatalError.ReportAndPropagate(exception);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     context.AddItems(nameColonItems);
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 context.AddItems(items);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 completionContext.SuggestionModeItem = CommonCompletionItem.Create(
                     CSharpFeaturesResources.Name, displayTextSuffix: "", CompletionItemRules.Default);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     context.AddItem(item);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         rules: CompletionItemRules.Default));
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         CSharpFeaturesResources.Autoselect_disabled_due_to_member_declaration);
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExternAliasCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExternAliasCompletionProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/FunctionPointerUnmanagedCallingConventionCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/FunctionPointerUnmanagedCallingConventionCompletionProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 context.AddItems(completionItems);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         filterText: escapedName));
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     context.AddItems(snippetCompletionItems);
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         T, displayTextSuffix: "", CompletionItemRules.Default, glyph: Glyph.TypeParameter));
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 AddItems(inferredTypes, index.Value, completionContext, context.TargetToken.Parent.SpanStart);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 items.AddRange(GetAlwaysVisibleItems());
                 return items;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return SpecializedCollections.EmptyEnumerable<CompletionItem>();
             }

--- a/src/Features/CSharp/Portable/Debugging/CSharpBreakpointResolutionService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpBreakpointResolutionService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
 
                 return BreakpointResolutionResult.CreateSpanResult(document, span);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return null;
             }

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 return Do(tree, position, cancellationToken);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return null;
             }

--- a/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
+++ b/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
 
                 return new DebugDataTipInfo(expression.Span, textOpt);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return default;
             }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // nop
             }
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     ? GetPreselectedSymbolsAsync(context, position, options, cancellationToken)
                     : GetSymbolsAsync(context, position, options, cancellationToken);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.cs
+++ b/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Debugging
                 return members.Where(m => IsApplicable(m, parameterCount, cancellationToken)).
                     Select(CreateBreakpoint).ToImmutableArrayOrEmpty();
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return ImmutableArray<BreakpointResolutionResult>.Empty;
             }
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Debugging
                         return FindMembers(containers, nameParts.ToArray());
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return ImmutableArray<ISymbol>.Empty;
             }

--- a/src/Features/Core/Portable/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
 
                 return (document, data);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return default;
             }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (ex is not OperationCanceledException && project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.CrashOnAnalyzerException))
                     {
                         // report telemetry
-                        FatalError.Report(ex);
+                        FatalError.ReportAndPropagate(ex);
 
                         // force fail fast (the host might not crash when reporting telemetry):
                         FailFast.OnFatalException(ex);

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -278,10 +278,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 return ex =>
                 {
-                    if (project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.CrashOnAnalyzerException))
+                    if (ex is not OperationCanceledException && project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.CrashOnAnalyzerException))
                     {
-                        // if option is on, crash the host to get crash dump.
-                        FatalError.ReportUnlessCanceled(ex);
+                        // report telemetry
+                        FatalError.Report(ex);
+
+                        // force fail fast (the host might not crash when reporting telemetry):
+                        FailFast.OnFatalException(ex);
                     }
 
                     return true;

--- a/src/Features/Core/Portable/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/DocumentAnalysisExecutor.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (!AnalyzerHelper.AreEquivalent(rangeDiagnostics, wholeDiagnostics))
                 {
                     // otherwise, report non-fatal watson so that we can fix those cases
-                    FatalError.ReportWithoutCrash(new Exception("Bug in GetDiagnostics"));
+                    FatalError.ReportAndCatch(new Exception("Bug in GetDiagnostics"));
 
                     // make sure we hold onto these for debugging.
                     GC.KeepAlive(rangeDeclaractionDiagnostics);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 return null;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     // we only care about local diagnostics
                     return new DocumentAnalysisData(version, existingData.Items, diagnostics.ToImmutableArrayOrEmpty());
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     return new ProjectAnalysisData(project.Id, version, existingData.Result, result);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // check whether there is IDE specific project diagnostic analyzer
                 return await MergeProjectDiagnosticAnalyzerDiagnosticsAsync(project, ideAnalyzers, compilationWithAnalyzers?.Compilation, result, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // we couldn't reduce the set.
                 return await ComputeDiagnosticsAsync(compilationWithAnalyzers, project, ideAnalyzers, forcedAnalysis, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 return result;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     callbackTarget: null,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceled(ex))
+            catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex))
             {
                 // ignore all, this is fire and forget method
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     Debug.Assert(!_blockForData || containsFullResult);
                     return containsFullResult;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.OldResult, result.Result);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                     }
                 }
             }
-            catch (NullReferenceException e) when (FatalError.ReportWithoutCrash(e))
+            catch (NullReferenceException e) when (FatalError.ReportAndCatch(e))
             {
                 // We currently are seeing a strange null references crash in this code.  We have
                 // a strong belief that this is recoverable, but we'd like to know why it is 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -589,7 +589,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     lineEdits.AsImmutable(),
                     hasSemanticErrors: false);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // The same behavior as if there was a syntax error - we are unable to analyze the document. 
                 // We expect OOM to be thrown during the analysis if the number of top-level entities is too large.
@@ -1162,7 +1162,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     newActiveStatements[ordinal] = oldActiveStatements[ordinal].WithSpan(newText.Lines.GetLinePositionSpan(newSpan));
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 // Set the new spans of active statements overlapping the method body to match the old spans.
                 // Even though these might be now outside of the method body it's ok since we report a rude edit and don't allow to continue.

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     debugInfoReaderProvider.Dispose();
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match PDB: unexpected exception: {1}", sourceFilePath, e.Message);
             }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // for methods without custom debug info (https://github.com/dotnet/roslyn/issues/4138).
                     debugInfo = null;
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e)) // likely a bug in the compiler/debugger
+                catch (Exception e) when (FatalError.ReportAndCatch(e)) // likely a bug in the compiler/debugger
                 {
                     throw new InvalidDataException(e.Message, e);
                 }
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     return EditAndContinueMethodDebugInformation.Create(localSlots, lambdaMap);
                 }
-                catch (InvalidOperationException e) when (FatalError.ReportWithoutCrash(e)) // likely a bug in the compiler/debugger
+                catch (InvalidOperationException e) when (FatalError.ReportAndCatch(e)) // likely a bug in the compiler/debugger
                 {
                     // TODO: CustomDebugInfoReader should throw InvalidDataException
                     throw new InvalidDataException(e.Message, e);

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 return analysis.RudeEditErrors.SelectAsArray((e, t) => e.ToDiagnostic(t), tree);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return ImmutableArray<Diagnostic>.Empty;
             }
@@ -529,7 +529,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 return currentActiveStatements[baseActiveStatement.PrimaryDocumentOrdinal].Span;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return null;
             }
@@ -569,7 +569,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // If the document is out-of-sync the exception regions can't be determined.
                 return baseExceptionRegions.Spans.IsDefault ? (bool?)null : baseExceptionRegions.IsActiveStatementCovered;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return null;
             }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // Last committed solution reflects the state of the source that is in sync with the binaries that are loaded in the debuggee.
                 return CreateActiveStatementsMap(await activeStatementProvider(cancellationToken).ConfigureAwait(false));
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return new ActiveStatementsMap(
                     SpecializedCollections.EmptyReadOnlyDictionary<DocumentId, ImmutableArray<ActiveStatement>>(),
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 return result;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return ImmutableArray<ActiveStatementExceptionRegions>.Empty;
             }
@@ -445,7 +445,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                         return await analyzer.AnalyzeDocumentAsync(baseDocument, documentBaseActiveStatements, document, activeStatementSpans, cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                    catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 return false;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     allAddedSymbolResult,
                     activeStatementsInChangedDocuments.ToImmutableAndFree());
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -772,7 +772,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             {
                                 Emit();
                             }
-                            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                             {
                                 throw ExceptionUtilities.Unreachable;
                             }
@@ -893,7 +893,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     emitBaselines.ToImmutable(),
                     diagnostics.ToImmutable());
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 return false;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     allAddedSymbolResult,
                     activeStatementsInChangedDocuments.ToImmutableAndFree());
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -772,7 +772,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             {
                                 Emit();
                             }
-                            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+                            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                             {
                                 throw ExceptionUtilities.Unreachable;
                             }
@@ -893,7 +893,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     emitBaselines.ToImmutable(),
                     diagnostics.ToImmutable());
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
             // Some combination we didn't anticipate.  Can't do anything here.  Log the issue
             // and bail out.
-            FatalError.ReportWithoutCrash(new Exception($"extract method encountered unknown states: {key.ToString()}"));
+            FatalError.ReportAndCatch(new Exception($"extract method encountered unknown states: {key.ToString()}"));
 
             return false;
         }

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                                 useDecompiler = false;
                             }
                         }
-                        catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
                         {
                             useDecompiler = false;
                         }

--- a/src/Features/Core/Portable/SolutionCrawler/AbstractDocumentDifferenceService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/AbstractDocumentDifferenceService.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 return new DocumentDifferenceResult(InvocationReasons.DocumentChanged);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             // okay now we have work to do
                             await ProcessDocumentAsync(solution, Analyzers, workItem, documentCancellation).ConfigureAwait(false);
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 }
                             }
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // re-run just the body
                         await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, activeMember, reasons, c), cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                    catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }
@@ -354,14 +354,25 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         return null;
                     }
-                    catch (AggregateException e) when (CrashUnlessCanceled(e))
+                    catch (AggregateException e) when (ReportWithoutCrashUnlessAllCanceledAndPropagate(e))
                     {
                         return null;
                     }
-                    catch (Exception e) when (FatalError.Report(e))
+                    catch (Exception e) when (FatalError.ReportWithoutCrashAndPropagate(e))
                     {
                         // TODO: manage bad workers like what code actions does now
                         throw ExceptionUtilities.Unreachable;
+                    }
+
+                    static bool ReportWithoutCrashUnlessAllCanceledAndPropagate(AggregateException aggregate)
+                    {
+                        var flattened = aggregate.Flatten();
+                        if (flattened.InnerExceptions.All(e => e is OperationCanceledException))
+                        {
+                            return true;
+                        }
+
+                        return FatalError.ReportWithoutCrashAndPropagate(flattened);
                     }
                 }
 
@@ -391,18 +402,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     return $"Tick:{tick}, {documentOrProjectId}, Replaced:{replaced}";
-                }
-
-                private static bool CrashUnlessCanceled(AggregateException aggregate)
-                {
-                    var flattened = aggregate.Flatten();
-                    if (flattened.InnerExceptions.All(e => e is OperationCanceledException))
-                    {
-                        return true;
-                    }
-
-                    FatalError.Report(flattened);
-                    return false;
                 }
 
                 internal TestAccessor GetTestAccessor()

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // re-run just the body
                         await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, activeMember, reasons, c), cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                    catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         return null;
                     }
-                    catch (Exception e) when (FatalError.Report(e))
+                    catch (Exception e) when (FatalError.ReportAndPropagate(e))
                     {
                         // TODO: manage bad workers like what code actions does now
                         throw ExceptionUtilities.Unreachable;
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             return true;
                         }
 
-                        return FatalError.Report(flattened);
+                        return FatalError.ReportAndPropagate(flattened);
                     }
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // re-run just the body
                         await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, activeMember, reasons, c), cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                     {
                         throw ExceptionUtilities.Unreachable;
                     }
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         return null;
                     }
-                    catch (Exception e) when (FatalError.ReportWithoutCrashAndPropagate(e))
+                    catch (Exception e) when (FatalError.Report(e))
                     {
                         // TODO: manage bad workers like what code actions does now
                         throw ExceptionUtilities.Unreachable;
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             return true;
                         }
 
-                        return FatalError.ReportWithoutCrashAndPropagate(flattened);
+                        return FatalError.Report(flattened);
                     }
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 await ProcessProjectAsync(Analyzers, workItem, projectCancellation).ConfigureAwait(false);
                             }
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 }
                             }
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             // process the new document
                             await ProcessDocumentAsync(Analyzers, workItem, documentCancellation).ConfigureAwait(false);
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                             return false;
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 }
                             }
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 await Processor.RunAnalyzersAsync(reanalyzers, sourceDocument, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, null, reasons, c), cancellationToken).ConfigureAwait(false);
                             }
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                             SolutionCrawlerLogger.LogResetStates(Processor._logAggregator);
                         }
-                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                         {
                             throw ExceptionUtilities.Unreachable;
                         }

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Structure
 
                 ProvideBlockStructureWorker(context, syntaxRoot);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Structure
 
                 ProvideBlockStructureWorker(context, syntaxRoot);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
                         Range = ProtocolConversions.LinePositionToRange(linePosSpan),
                     };
                 }
-                catch (UriFormatException e) when (FatalError.ReportWithoutCrash(e))
+                catch (UriFormatException e) when (FatalError.ReportAndCatch(e))
                 {
                     // We might reach this point if the file path is formatted incorrectly.
                     return null;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // If the queue is asked to shut down between the start of the while loop, and the Dequeue call
                 // we could end up here, but we don't want to report an error. The Shutdown call will take care of things.
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 OnRequestServerShutdown($"Error occured processing queue: {e.Message}.");
             }

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 End If
 
                 context.IsExclusive = True
-            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
+            Catch e As Exception When FatalError.ReportAndCatchUnlessCanceled(e)
                 ' nop
             End Try
         End Function

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                         contextPosition:=position,
                         rules:=s_itemRules))
                 Next
-            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
+            Catch e As Exception When FatalError.ReportAndCatchUnlessCanceled(e)
                 ' nop
             End Try
         End Function

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -159,7 +159,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 End If
 
                 Return items
-            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
+            Catch e As Exception When FatalError.ReportAndCatchUnlessCanceled(e)
                 Return SpecializedCollections.EmptyEnumerable(Of CompletionItem)
             End Try
         End Function

--- a/src/Features/VisualBasic/Portable/Debugging/VisualBasicBreakpointService.vb
+++ b/src/Features/VisualBasic/Portable/Debugging/VisualBasicBreakpointService.vb
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Debugging
                 End If
 
                 Return BreakpointResolutionResult.CreateSpanResult(document, span)
-            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
+            Catch e As Exception When FatalError.ReportAndCatchUnlessCanceled(e)
                 Return Nothing
             End Try
         End Function

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                     return new InitializedRemoteService(remoteService, result);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         await host.OnProcessExitedAsync(Process).ConfigureAwait(false);
                     }
                 }
-                catch (Exception e) when (FatalError.Report(e))
+                catch (Exception e) when (FatalError.ReportAndPropagate(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 {
                     Console.OutputEncoding = Encoding.UTF8;
                 }
-                catch (IOException ex) when (FatalError.ReportWithoutCrash(ex))
+                catch (IOException ex) when (FatalError.ReportAndCatch(ex))
                 {
                     // Ignore this exception
                     // https://github.com/dotnet/roslyn/issues/47571

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 // The user reset the process during initialization. 
                 // The reset operation will recreate the process.
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 return initializedService.InitializationResult;
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Tools/ExternalAccess/FSharp/Editor/Shared/Utilities/FSharpClassificationTypeMap.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/Shared/Utilities/FSharpClassificationTypeMap.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor.Shared.Utilities
             var type = GetClassificationTypeWorker(name);
             if (type == null)
             {
-                FatalError.ReportWithoutCrash(new Exception($"classification type doesn't exist for {name}"));
+                FatalError.ReportAndCatch(new Exception($"classification type doesn't exist for {name}"));
             }
 
             return type ?? GetClassificationTypeWorker(ClassificationTypeNames.Text);

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     return new TempPECompilerService(this.Workspace.Services.GetService<IMetadataService>());
                 });
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 return GetDataTipTextImpl(pSpan, out pbstrText);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 return result;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/VisualStudio/Core/Def/Implementation/CallHierarchy/Finders/AbstractCallFinder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CallHierarchy/Finders/AbstractCallFinder.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
                 {
                     completionErrorMessage = EditorFeaturesResources.Canceled;
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                catch (Exception e) when (FatalError.ReportAndCatch(e))
                 {
                     completionErrorMessage = e.Message;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             {
                 // Cancellation is normal (during VS closing).  Just ignore.
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 // Otherwise report a watson for any other exception.  Don't bring down VS.  This is
                 // a BG service we don't want impacting the user experience.

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 var hr = vsShell.IsPackageInstalled(FxCopAnalyzersPackageGuid, out var installed);
                 if (ErrorHandler.Failed(hr))
                 {
-                    FatalError.ReportWithoutCrash(Marshal.GetExceptionForHR(hr));
+                    FatalError.ReportAndCatch(Marshal.GetExceptionForHR(hr));
 
                     // We set installed to ensure we don't go through this again next time a
                     // suggested action is called, and we don't want to continue if the shell

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.WorkspaceEventListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.WorkspaceEventListener.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 {
@@ -66,6 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 }
                 catch (Exception e) when (FatalError.Report(e))
                 {
+                    throw ExceptionUtilities.Unreachable;
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.WorkspaceEventListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.WorkspaceEventListener.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                     workspace.ApplyChangeToWorkspace(w =>
                         w.SetCurrentSolution(s => s.WithAnalyzerReferences(references), WorkspaceChangeKind.SolutionChanged));
                 }
-                catch (Exception e) when (FatalError.Report(e))
+                catch (Exception e) when (FatalError.ReportAndPropagate(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioManagedModuleUpdateProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioManagedModuleUpdateProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                 var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
                 return await _encService.HasChangesAsync(solution, activeStatementSpanProvider, sourceFilePath, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return true;
             }
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                 var (summary, deltas) = await _encService.EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
                 return new ManagedModuleUpdates(summary.ToModuleUpdateStatus(), deltas.SelectAsArray(ModuleUtilities.ToModuleUpdate).ToReadOnlyCollection());
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 _encService.ReportApplyChangesException(solution, e.Message);
                 return new ManagedModuleUpdates(ManagedModuleUpdateStatus.Blocked, ImmutableArray<DkmManagedModuleUpdate>.Empty.ToReadOnlyCollection());
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             {
                 _encService.CommitSolutionUpdate();
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
             }
         }
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             {
                 _encService.DiscardSolutionUpdate();
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             var hr = vsShell.IsPackageInstalled(ReSharperPackageGuid, out var extensionEnabled);
             if (ErrorHandler.Failed(hr))
             {
-                FatalError.ReportWithoutCrash(Marshal.GetExceptionForHR(hr));
+                FatalError.ReportAndCatch(Marshal.GetExceptionForHR(hr));
                 return;
             }
 
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
 
                 if (ErrorHandler.Failed(hr))
                 {
-                    FatalError.ReportWithoutCrash(Marshal.GetExceptionForHR(hr));
+                    FatalError.ReportAndCatch(Marshal.GetExceptionForHR(hr));
                     return;
                 }
 
@@ -319,7 +319,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 var hr = _oleCommandTarget.QueryStatus(ReSharperCommandGroup, (uint)cmds.Length, cmds, IntPtr.Zero);
                 if (ErrorHandler.Failed(hr))
                 {
-                    FatalError.ReportWithoutCrash(Marshal.GetExceptionForHR(hr));
+                    FatalError.ReportAndCatch(Marshal.GetExceptionForHR(hr));
                     await ShutdownAsync().ConfigureAwait(false);
 
                     return 0;
@@ -441,7 +441,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
 
                 if (ErrorHandler.Failed(hr))
                 {
-                    FatalError.ReportWithoutCrash(Marshal.GetExceptionForHR(hr));
+                    FatalError.ReportAndCatch(Marshal.GetExceptionForHR(hr));
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 _jsonRpc.Dispose();
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 // Swallow exceptions thrown by disposing our JsonRpc object. Disconnected events can potentially throw their own exceptions so
                 // we purposefully ignore all of those exceptions in an effort to shutdown gracefully.

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
                 if (!contextBuffer.ContentType.IsOfType(this.ContentTypeName))
                 {
-                    FatalError.ReportWithoutCrash(
+                    FatalError.ReportAndCatch(
                         new ArgumentException($"Expected content type {this.ContentTypeName} " +
                         $"but got buffer of content type {contextBuffer.ContentType}"));
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetLanguageID(pBuffer, iLine, iCol, out pguidLanguageID);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetLocationOfName(pszName, out pbstrMkDoc, out pspanLocation);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetNameOfLocation(pBuffer, iLine, iCol, out pbstrName, out piLineOffset);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetProximityExpressions(pBuffer, iLine, iCol, cLines, out ppEnum);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.IsMappedLocation(pBuffer, iLine, iCol);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.ResolveName(pszName, dwFlags, out ppNames);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
+            catch (Exception e) when (FatalError.ReportAndCatch(e) && false)
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
 
                 UpdateClassAndMemberVersions();
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 // make it crash VS on any exception
             }
@@ -535,7 +535,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             catch (OperationCanceledException)
             {
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Log/VisualStudioErrorLogger.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Log/VisualStudioErrorLogger.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Log
 
             if (ShouldReportCrashDumps(source))
             {
-                FatalError.ReportWithoutCrash(exception);
+                FatalError.ReportAndCatch(exception);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueryManager.cs
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
                 transaction.Complete();
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueryManager.cs
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
                 transaction.Complete();
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // If we got a PathTooLongException there's really nothing we can do about it; we will fail to read the file later which is fine
             if (!(e is PathTooLongException))
             {
-                return FatalError.ReportWithoutCrash(e);
+                return FatalError.ReportAndCatch(e);
             }
 
             // We'll always capture all exceptions regardless. If we don't, then the exception is captured by our lazy and will be potentially rethrown from

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 GC.SuppressFinalize(this);
             }
-            catch (Exception ex) when (FatalError.Report(ex))
+            catch (Exception ex) when (FatalError.ReportAndPropagate(ex))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Inter
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -154,6 +155,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
             catch (Exception ex) when (FatalError.Report(ex))
             {
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1204,7 +1204,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 if (document.FilePath == null)
                 {
-                    FatalError.ReportWithoutCrash(new Exception("Attempting to change the information of a document without a file path."));
+                    FatalError.ReportAndCatch(new Exception("Attempting to change the information of a document without a file path."));
                     return;
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectTelemetry/VisualStudioProjectTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectTelemetry/VisualStudioProjectTelemetryService.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectTelemetr
             {
                 // Cancellation is normal (during VS closing).  Just ignore.
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 // Otherwise report a watson for any other exception.  Don't bring down VS.  This is
                 // a BG service we don't want impacting the user experience.

--- a/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 return client;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return null;
             }

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
             {
                 // Cancellation is normal (during VS closing).  Just ignore.
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 // Otherwise report a watson for any other exception.  Don't bring down VS.  This is
                 // a BG service we don't want impacting the user experience.
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
                 var workQueue = await _workQueueSource.Task.ConfigureAwait(false);
                 workQueue.AddWork(new DocumentAndComments(documentId, infos));
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 // report NFW before returning back to the remote process
                 throw ExceptionUtilities.Unreachable;

--- a/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TodoComments/VisualStudioTodoCommentsService.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments
                 var workQueue = await _workQueueSource.Task.ConfigureAwait(false);
                 workQueue.AddWork(new DocumentAndComments(documentId, infos));
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 // report NFW before returning back to the remote process
                 throw ExceptionUtilities.Unreachable;

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 Debug.Assert(false, "Could not get the document moniker for an item from its hierarchy.");
                 if (!hierarchy.TryGetItemName(itemid, out filePath!))
                 {
-                    FatalError.Report(new InvalidOperationException("Failed to get document moniker for a contained document"));
+                    FatalError.ReportAndPropagate(new InvalidOperationException("Failed to get document moniker for a contained document"));
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 Debug.Assert(false, "Could not get the document moniker for an item from its hierarchy.");
                 if (!hierarchy.TryGetItemName(itemid, out filePath!))
                 {
-                    FatalError.Report(new System.Exception("Failed to get document moniker for a contained document"));
+                    FatalError.Report(new InvalidOperationException("Failed to get document moniker for a contained document"));
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonTraceListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonTraceListener.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
         private static void Exit(string message)
         {
-            FatalError.Report(new Exception(message));
+            FatalError.ReportAndPropagate(new Exception(message));
         }
 
         internal static void Install()

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     throw new ArgumentOutOfRangeException();
                 }
-                catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
                 {
                 }
 
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     throw new ArgumentOutOfRangeException();
                 }
-                catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
                 {
                 }
 
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     {
                         throw new ArgumentOutOfRangeException();
                     }
-                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
                     {
                     }
                 }
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     {
                         throw new ArgumentOutOfRangeException();
                     }
-                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
                     {
                     }
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     }
                 }
 
-                FatalError.ReportWithoutCrash(
+                FatalError.ReportAndCatch(
                     new InvalidOperationException($"Can't find an intersection. Visible spans count: {spans.Count}"));
 
                 return NoOpFormattingRule.Instance;

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             {
                 // These exceptions can happen when the nuget.config file is broken.
             }
-            catch (ArgumentException ae) when (FatalError.ReportWithoutCrash(ae))
+            catch (ArgumentException ae) when (FatalError.ReportAndCatch(ae))
             {
                 // This exception can happen when the nuget.config file is broken, e.g. invalid credentials.
                 // https://github.com/dotnet/roslyn/issues/40857
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 
                 // fall through.
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 dte.StatusBar.Text = string.Format(ServicesVSResources.Package_install_failed_colon_0, e.Message);
 
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 
                 // fall through.
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 dte.StatusBar.Text = string.Format(ServicesVSResources.Package_uninstall_failed_colon_0, e.Message);
 
@@ -390,7 +390,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 var metadata = installedPackages.FirstOrDefault(m => m.Id == packageName);
                 return metadata?.VersionString;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
             }
 
@@ -552,7 +552,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 
                 return new ProjectState(installedPackages.ToImmutableDictionary());
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
                 return null;
             }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -326,7 +326,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
                     // so guarding us from them
                     if (localRegistration != null)
                     {
-                        FatalError.ReportWithoutCrash(new InvalidOperationException("BulkFileOperation already exist"));
+                        FatalError.ReportAndCatch(new InvalidOperationException("BulkFileOperation already exist"));
                         return;
                     }
 

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.Telemetry;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 {
@@ -89,8 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                         EndScope<UserTaskEvent>(functionId, blockId, kvLogMessage, cancellationToken);
                         return;
                     default:
-                        FatalError.Report(new Exception($"unknown type: {kind}"));
-                        break;
+                        throw ExceptionUtilities.UnexpectedValue(kind);
                 }
             }
             catch
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             {
                 LogType.Trace => _session.StartOperation(eventName),
                 LogType.UserAction => _session.StartUserTask(eventName),
-                _ => (object)FatalError.Report(new Exception($"unknown type: {kind}")),
+                _ => throw ExceptionUtilities.UnexpectedValue(kind),
             };
         }
 

--- a/src/VisualStudio/Core/Def/Utilities/IVsEditorAdaptersFactoryServiceExtensions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsEditorAdaptersFactoryServiceExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Utilities
                     ? $"{nameof(contextDocumentId)} was null."
                     : $"{nameof(contextDocumentId)} was not null.";
 
-                FatalError.ReportWithoutCrash(new InvalidOperationException("Could not retrieve document. " + message));
+                FatalError.ReportAndCatch(new InvalidOperationException("Could not retrieve document. " + message));
 
                 return null;
             }

--- a/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionErrorHandler.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionErrorHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Setup
                 return;
             }
 
-            FatalError.Report(exception);
+            FatalError.ReportAndPropagate(exception);
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
@@ -479,7 +479,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
                     if (textBuffer == null)
                     {
                         // Text buffer is missing for opened Live Share document.
-                        FatalError.ReportWithoutCrash(new LiveShareTextBufferMissingException());
+                        FatalError.ReportAndCatch(new LiveShareTextBufferMissingException());
                         return;
                     }
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -76,6 +76,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                         Return New TempPECompilerFactory(workspace)
                     End Function)
             Catch ex As Exception When FatalError.ReportUnlessCanceled(ex)
+                Throw ExceptionUtilities.Unreachable
             End Try
         End Function
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                         Await JoinableTaskFactory.SwitchToMainThreadAsync(ct)
                         Return New TempPECompilerFactory(workspace)
                     End Function)
-            Catch ex As Exception When FatalError.ReportUnlessCanceled(ex)
+            Catch ex As Exception When FatalError.ReportAndPropagateUnlessCanceled(ex)
                 Throw ExceptionUtilities.Unreachable
             End Try
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -145,7 +145,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
                 Return VSConstants.S_OK
             Catch e As Exception When FatalError.Report(e)
-                Return VSConstants.S_OK
+                Throw ExceptionUtilities.Unreachable
             End Try
         End Function
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -144,7 +144,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 End If
 
                 Return VSConstants.S_OK
-            Catch e As Exception When FatalError.Report(e)
+            Catch e As Exception When FatalError.ReportAndPropagate(e)
                 Throw ExceptionUtilities.Unreachable
             End Try
         End Function

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
 
                     return newToken;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -934,7 +934,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
 
                 return conflicts.ToImmutableAndFree();
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -963,7 +963,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
 
                 return null;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 AddSemanticClassifications(semanticModel, textSpan, document.Project.Solution.Workspace, getNodeClassifiers, getTokenClassifiers, result, cancellationToken);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 data = ReadDiagnosticDataArray(reader, project, document, cancellationToken);
                 return true;
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceled(ex))
+            catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex))
             {
                 return false;
             }

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingFatalErrorAccessor.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingFatalErrorAccessor.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
     internal static class UnitTestingFatalErrorAccessor
     {
         public static bool ReportWithoutCrash(this Exception e)
-            => FatalError.ReportWithoutCrash(e);
+            => FatalError.ReportAndCatch(e);
 
         public static bool ReportWithoutCrashUnlessCanceled(this Exception e)
-            => FatalError.ReportWithoutCrashUnlessCanceled(e);
+            => FatalError.ReportAndCatchUnlessCanceled(e);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/DeclaredSymbolInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/DeclaredSymbolInfo.cs
@@ -201,7 +201,7 @@ $@"Invalid span in {nameof(DeclaredSymbolInfo)}.
 {nameof(this.Span)} = {this.Span}
 {nameof(root.FullSpan)} = {root.FullSpan}";
 
-                FatalError.ReportWithoutCrash(new InvalidOperationException(message));
+                FatalError.ReportAndCatch(new InvalidOperationException(message));
 
                 return null;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -181,7 +181,7 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
 {nameof(declaredSymbolInfo.Span)} = {declaredSymbolInfo.Span}
 {nameof(root.FullSpan)} = {root.FullSpan}";
 
-                                    FatalError.ReportWithoutCrash(new InvalidOperationException(message));
+                                    FatalError.ReportAndCatch(new InvalidOperationException(message));
                                 }
                             }
                         }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigDocumentOptionsProviderFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Options.EditorConfig
                     {
                         return editorConfigPersistence.TryGetOption(_options.AsNullable(), option.Option.Type, out value);
                     }
-                    catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                    catch (Exception e) when (FatalError.ReportAndCatch(e))
                     {
                         value = null;
                         return false;

--- a/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     throw new InvalidOperationException(
                         $"We should always be able to resolve a symbol back on the host side:\r\n{project.Name}\r\n{SymbolKeyData}\r\n{failureReason}");
                 }
-                catch (Exception ex) when (FatalError.ReportWithoutCrash(ex))
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex))
                 {
                     return null;
                 }

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     return conflictResolution;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     return conflictResolution.RelatedLocations.Any(r => r.Type == RelatedLocationType.PossiblyResolvableConflict);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -638,7 +638,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     return hasConflict;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -680,7 +680,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     var newSymbol = await SymbolFinder.FindSymbolAtPositionAsync(document, start, cancellationToken: _cancellationToken).ConfigureAwait(false);
                     return newSymbol;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -711,7 +711,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     await AddDocumentsWithPotentialConflictsAsync(documentsFromAffectedProjects).ConfigureAwait(false);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -751,7 +751,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                         }
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     return partiallyRenamedSolution;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 // A NullReferenceException is happening in this method, but the dumps do not
                 // contain information about this stack frame because this method is async and

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 var currentDocumentVersion = await currentDocument.GetSyntaxVersionAsync(cancellationToken).ConfigureAwait(false);
                 return !documentVersion.Equals(currentDocumentVersion);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Storage/AbstractPersistentStorageService.cs
+++ b/src/Workspaces/Core/Portable/Storage/AbstractPersistentStorageService.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Storage
                 {
                     // this was not a normal exception that we expected during DB open.
                     // Report this so we can try to address whatever is causing this.
-                    FatalError.ReportWithoutCrash(ex);
+                    FatalError.ReportAndCatch(ex);
                     IOUtilities.PerformIO(() => Directory.Delete(Path.GetDirectoryName(databaseFilePath), recursive: true));
                 }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis
                     return result;
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis
                     return text.GetTextChanges(oldText).ToList();
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis
                     return IncrementallyParse(newTextAndVersion, oldTreeAndVersion, cancellationToken);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis
                     return IncrementallyParse(newTextAndVersion, oldTreeAndVersion, cancellationToken);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -715,7 +715,7 @@ namespace Microsoft.CodeAnalysis
 
             // we time to time see (incremental) parsing bug where text <-> tree round tripping is broken.
             // send NFW for those cases
-            FatalError.ReportWithoutCrash(new Exception($"tree and text has different length {newTree.Length} vs {newText.Length}"));
+            FatalError.ReportAndCatch(new Exception($"tree and text has different length {newTree.Length} vs {newText.Length}"));
 
             // this will make sure that these variables are not thrown away in the dump
             GC.KeepAlive(newTreeContent);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis
                         new AnalyzerConfigDocumentChecksumCollection(analyzerConfigDocumentChecksums));
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis
                         new AnalyzerConfigDocumentChecksumCollection(analyzerConfigDocumentChecksums));
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -443,7 +443,7 @@ namespace Microsoft.CodeAnalysis
                         return compilation;
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis
                         }
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -551,7 +551,7 @@ namespace Microsoft.CodeAnalysis
                     // null and then we'll have to create a generator inside the finalization process.
                     return await FinalizeCompilationAsync(solution, compilation, new TrackedGeneratorDriver(null), cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis
                     WriteState(new FullDeclarationState(compilation, new TrackedGeneratorDriver(generatorDriver: null)), solutionServices);
                     return compilation;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis
                     var (compilation, generatorDriver) = await BuildDeclarationCompilationFromInProgressAsync(solution.Services, state, inProgressCompilation, cancellationToken).ConfigureAwait(false);
                     return await FinalizeCompilationAsync(solution, compilation, generatorDriver, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -642,7 +642,7 @@ namespace Microsoft.CodeAnalysis
 
                     return (inProgressCompilation, inProgressGeneratorDriver);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -766,7 +766,7 @@ namespace Microsoft.CodeAnalysis
 
                     return new CompilationInfo(compilation, hasSuccessfullyLoaded, generatorDriver.GeneratorDriver?.GetRunResult());
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -822,7 +822,7 @@ namespace Microsoft.CodeAnalysis
                         return await this.GetMetadataOnlyImageReferenceAsync(solution, projectReference, cancellationToken).ConfigureAwait(false);
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -886,7 +886,7 @@ namespace Microsoft.CodeAnalysis
                         return reference;
                     }
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SymbolToProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SymbolToProjectId.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis
                         throw new InvalidOperationException(
                             $"We should always be able to map a body symbol back to a document:\r\n{symbol.Kind}\r\n{symbol.Name}\r\n{syntaxTree.FilePath}\r\n{projectId}");
                     }
-                    catch (Exception ex) when (FatalError.ReportWithoutCrash(ex))
+                    catch (Exception ex) when (FatalError.ReportAndCatch(ex))
                     {
                     }
                 }
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis
                         throw new InvalidOperationException(
                             $"Syntax tree for a body symbol should map to the same project as the body symbol's assembly:\r\n{symbol.Kind}\r\n{symbol.Name}\r\n{syntaxTree.FilePath}\r\n{projectId}\r\n{documentId.ProjectId}");
                     }
-                    catch (Exception ex) when (FatalError.ReportWithoutCrash(ex))
+                    catch (Exception ex) when (FatalError.ReportAndCatch(ex))
                     {
                     }
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1669,7 +1669,7 @@ namespace Microsoft.CodeAnalysis
                     return currentPartialSolution;
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1795,7 +1795,7 @@ namespace Microsoft.CodeAnalysis
                 var tracker = this.GetCompilationTracker(projectReference.ProjectId);
                 return tracker.GetMetadataReferenceAsync(this, fromProject, projectReference, cancellationToken);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
                     return new SolutionStateChecksums(infoChecksum, optionsChecksum, new ProjectChecksumCollection(projectChecksums), analyzerReferenceChecksums);
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
                     return new SolutionStateChecksums(infoChecksum, optionsChecksum, new ProjectChecksumCollection(projectChecksums), analyzerReferenceChecksums);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                     return new DocumentStateChecksums(infoChecksum, textChecksum);
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                     return new DocumentStateChecksums(infoChecksum, textChecksum);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis
                     this.RaiseDocumentClosedEventAsync(newDoc); // don't wait for this
                 }
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis
                     this.RaiseDocumentClosedEventAsync(newDoc); // don't wait for this
                 }
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashAndPropagate(e))
+            catch (Exception e) when (FatalError.Report(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 {
                     a();
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // report telemetry event:
             Logger.Log(FunctionId.FeatureNotAvailable, $"{ServiceDescriptors.GetServiceName(typeof(TService))}: {exception.GetType()}: {exception.Message}");
 
-            return FatalError.ReportWithoutCrash(exception);
+            return FatalError.ReportAndCatch(exception);
         }
 
         private bool IsHostShuttingDown

--- a/src/Workspaces/Remote/Core/RemoteCallback.cs
+++ b/src/Workspaces/Remote/Core/RemoteCallback.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             // Indicates bug on client side or in serialization, report NFW and propagate the exception.
-            return FatalError.Report(exception);
+            return FatalError.ReportAndPropagate(exception);
         }
 
         private static Exception OnUnexpectedException(Exception exception, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/RemoteCallback.cs
+++ b/src/Workspaces/Remote/Core/RemoteCallback.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             // Indicates bug on client side or in serialization, report NFW and propagate the exception.
-            return FatalError.ReportWithoutCrashAndPropagate(exception);
+            return FatalError.Report(exception);
         }
 
         private static Exception OnUnexpectedException(Exception exception, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/RemoteEndPoint.cs
+++ b/src/Workspaces/Remote/Core/RemoteEndPoint.cs
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private static void ReportNonFatalWatson(Exception exception)
         {
-            FatalError.ReportWithoutCrash(exception);
+            FatalError.ReportAndCatch(exception);
         }
 
         private SoftCrashException CreateSoftCrashException(Exception ex, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 return new BrokeredServiceConnection<T>(proxy, _assetStorage, _errorReportingService, _shutdownCancellationService);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     ? SpecializedTasks.True
                     : SpecializedTasks.False;
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // even if our cancellation token is signaled. Do not report Watson in such cases to reduce noice.
                 if (!cancellationToken.IsCancellationRequested)
                 {
-                    FatalError.ReportWithoutCrash(e);
+                    FatalError.ReportAndCatch(e);
                 }
 
                 return true;
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 return new BrokeredServiceConnection<T>(proxy, _assetStorage, _errorReportingService, _shutdownCancellationService);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     ? SpecializedTasks.True
                     : SpecializedTasks.False;
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     using var writer = new ObjectWriter(stream, leaveOpen: false, cancellationToken);
                     RemoteHostAssetSerialization.WriteData(writer, singleAsset, assetMap, serializer, scopeId, checksums, cancellationToken);
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e, cancellationToken))
+                catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
                 {
                     // no-op
                 }
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
                 catch (Exception e)
                 {
-                    FatalError.ReportWithoutCrashUnlessCanceled(e, cancellationToken);
+                    FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken);
                     exception = e;
                 }
                 finally

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     return solution;
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     return solution;
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var workspace = new TemporaryWorkspace(Services.HostServices, WorkspaceKind.RemoteTemporaryWorkspace, solutionInfo, options);
                 return workspace.CurrentSolution;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(e))
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var workspace = new TemporaryWorkspace(Services.HostServices, WorkspaceKind.RemoteTemporaryWorkspace, solutionInfo, options);
                 return workspace.CurrentSolution;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 return await implementation(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 await implementation(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 return await implementation(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 await implementation(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 return await callAsync().ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 await callAsync().ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 return call();
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 call();
             }
-            catch (Exception ex) when (FatalError.ReportWithoutCrashUnlessCanceledAndPropagate(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 return await callAsync().ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 await callAsync().ConfigureAwait(false);
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 return call();
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 call();
             }
-            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex, cancellationToken))
+            catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -431,7 +431,7 @@ namespace Roslyn.Utilities
                 // because that token from the requester was cancelled.
                 throw ExceptionUtilities.Unreachable;
             }
-            catch (Exception e) when (FatalError.Report(e))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -382,52 +382,45 @@ namespace Roslyn.Utilities
         {
             var cancellationToken = computationToStart.CancellationTokenSource.Token;
 
+            // DO NOT ACCESS ANY FIELDS OR STATE BEYOND THIS POINT. Since this function
+            // runs unsynchronized, it's possible that during this function this request
+            // might be cancelled, and then a whole additional request might start and
+            // complete inline, and cache the result. By grabbing state before we check
+            // the cancellation token, we can be assured that we are only operating on
+            // a state that was complete.
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                    
+                var task = computationToStart.AsynchronousComputeFunction(cancellationToken);
 
-                // DO NOT ACCESS ANY FIELDS OR STATE BEYOND THIS POINT. Since this function
-                // runs unsynchronized, it's possible that during this function this request
-                // might be cancelled, and then a whole additional request might start and
-                // complete inline, and cache the result. By grabbing state before we check
-                // the cancellation token, we can be assured that we are only operating on
-                // a state that was complete.
-                try
+                // As an optimization, if the task is already completed, mark the 
+                // request as being completed as well.
+                //
+                // Note: we want to do this before we do the .ContinueWith below. That way, 
+                // when the async call to CompleteWithTask runs, it sees that we've already
+                // completed and can bail immediately. 
+                if (requestToCompleteSynchronously != null && task.IsCompleted)
                 {
-                    var task = computationToStart.AsynchronousComputeFunction(cancellationToken);
-
-                    // As an optimization, if the task is already completed, mark the 
-                    // request as being completed as well.
-                    //
-                    // Note: we want to do this before we do the .ContinueWith below. That way, 
-                    // when the async call to CompleteWithTask runs, it sees that we've already
-                    // completed and can bail immediately. 
-                    if (requestToCompleteSynchronously != null && task.IsCompleted)
+                    using (TakeLock(CancellationToken.None))
                     {
-                        using (TakeLock(CancellationToken.None))
-                        {
-                            task = GetCachedValueAndCacheThisValueIfNoneCached_NoLock(task);
-                        }
-
-                        requestToCompleteSynchronously.CompleteFromTask(task);
+                        task = GetCachedValueAndCacheThisValueIfNoneCached_NoLock(task);
                     }
 
-                    // We avoid creating a full closure just to pass the token along
-                    // Also, use TaskContinuationOptions.ExecuteSynchronously so that we inline 
-                    // the continuation if asynchronousComputeFunction completes synchronously
-                    task.ContinueWith(
-                        (t, s) => CompleteWithTask(t, ((CancellationTokenSource)s!).Token),
-                        computationToStart.CancellationTokenSource,
-                        cancellationToken,
-                        TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
+                    requestToCompleteSynchronously.CompleteFromTask(task);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
-                {
-                    throw ExceptionUtilities.Unreachable;
-                }
+
+                // We avoid creating a full closure just to pass the token along
+                // Also, use TaskContinuationOptions.ExecuteSynchronously so that we inline 
+                // the continuation if asynchronousComputeFunction completes synchronously
+                task.ContinueWith(
+                    (t, s) => CompleteWithTask(t, ((CancellationTokenSource)s!).Token),
+                    computationToStart.CancellationTokenSource,
+                    cancellationToken,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
             }
-            catch (OperationCanceledException oce) when (CrashIfCanceledWithDifferentToken(oce, cancellationToken))
+            catch (Exception e) when (ReportAndCatchUnlessCalceledWithDifferentToken(e, cancellationToken))
             {
                 // The underlying computation cancelled with the correct token, but we must ourselves ensure that the caller
                 // on our stack gets an OperationCanceledException thrown with the right token
@@ -440,14 +433,14 @@ namespace Roslyn.Utilities
             }
         }
 
-        private static bool CrashIfCanceledWithDifferentToken(OperationCanceledException exception, CancellationToken cancellationToken)
+        private static bool ReportAndCatchUnlessCalceledWithDifferentToken(Exception exception, CancellationToken cancellationToken)
         {
-            if (exception.CancellationToken != cancellationToken)
+            if (exception is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
             {
-                FatalError.Report(exception);
+                return true;
             }
 
-            return true;
+            return FatalError.Report(exception);
         }
 
         private void CompleteWithTask(Task<T> task, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
@@ -177,7 +177,7 @@ namespace Roslyn.Utilities
                         }
                     }
                 }
-                catch (Exception e) when (FatalError.Report(e))
+                catch (Exception e) when (FatalError.ReportAndPropagate(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
@@ -177,7 +177,7 @@ namespace Roslyn.Utilities
                         }
                     }
                 }
-                catch (Exception e) when (FatalError.ReportWithoutCrashAndPropagate(e))
+                catch (Exception e) when (FatalError.Report(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskExtensions.cs
@@ -205,7 +205,7 @@ namespace Roslyn.Utilities
                 {
                     return continuationFunction(t);
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -560,12 +560,12 @@ namespace Roslyn.Utilities
             //   ...
             // > ~67s     // switch to thread 67
             // > !dso     // dump stack objects
-            FatalError.ReportWithoutCrash(exception);
+            FatalError.ReportAndCatch(exception);
         }
 
         public static Task ReportNonFatalErrorAsync(this Task task)
         {
-            task.ContinueWith(p => FatalError.ReportWithoutCrashUnlessCanceled(p.Exception),
+            task.ContinueWith(p => FatalError.ReportAndCatchUnlessCanceled(p.Exception),
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskFactoryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskFactoryExtensions.cs
@@ -26,7 +26,7 @@ namespace Roslyn.Utilities
                 {
                     action();
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
@@ -44,7 +44,7 @@ namespace Roslyn.Utilities
                 {
                     return func();
                 }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 return null;
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }


### PR DESCRIPTION
Avoid crashing the host process when an unexpected exception is thrown. 

When an unexpected exception is thrown in ServiceHub process it needs to be propagated to the client so that we report actionable diagnostics in the log and in the info-bar. If the process is crashed via fail-fast we can't report good error. See e.g. https://github.com/dotnet/roslyn/issues/47234#issuecomment-699889772

**Proposal**

`ReportAndCatch`, `ReportAndCatchUnlessCanceled`

The caller declares it is able to recover from the exception at this call site (catches the exception - returns true).
This uses NonFatal handler - csc ignores it, VS/OOP reports non-fatal Watson
In the compiler this would only be used for exceptions from analyzers.

`ReportAndPropagate`, `ReportAndPropagateUnlessCanceled`

The caller declares it is not able to recover at this point and the exception needs to be propagated (returns false).
This uses Fatal handler - csc fail-fast, VS/OOP reports non-fatal Watson
We would never use fail fast in these handlers in VS/OOP. We could potentially have env variable/reg key that forces fatal watson for testing/manual investigations

Review strategy: commit by commit.