### PR TITLE
Add null check for _proximityExpressionsService

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -134,34 +134,38 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 using (Logger.LogBlock(FunctionId.Debugging_VsLanguageDebugInfo_GetProximityExpressions, CancellationToken.None))
                 {
                     VsEnumBSTR? enumBSTR = null;
-                    _waitIndicator.Wait(
-                        title: ServicesVSResources.Debugger,
-                        message: ServicesVSResources.Determining_autos,
-                        allowCancel: true,
-                        action: waitContext =>
+
+                    if (_proximityExpressionsService != null)
                     {
-                        var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
-
-                        if (textBuffer != null)
+                        _waitIndicator.Wait(
+                            title: ServicesVSResources.Debugger,
+                            message: ServicesVSResources.Determining_autos,
+                            allowCancel: true,
+                            action: waitContext =>
                         {
-                            var snapshot = textBuffer.CurrentSnapshot;
-                            var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
-                            if (nullablePoint.HasValue)
-                            {
-                                var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-                                if (document != null)
-                                {
-                                    var point = nullablePoint.Value;
-                                    var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
+                            var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
 
-                                    if (proximityExpressions != null)
+                            if (textBuffer != null)
+                            {
+                                var snapshot = textBuffer.CurrentSnapshot;
+                                var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
+                                if (nullablePoint.HasValue)
+                                {
+                                    var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                                    if (document != null)
                                     {
-                                        enumBSTR = new VsEnumBSTR(proximityExpressions);
+                                        var point = nullablePoint.Value;
+                                        var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
+
+                                        if (proximityExpressions != null)
+                                        {
+                                            enumBSTR = new VsEnumBSTR(proximityExpressions);
+                                        }
                                     }
                                 }
                             }
-                        }
-                    });
+                        });
+                    }
 
                     ppEnum = enumBSTR;
                     return ppEnum != null ? VSConstants.S_OK : VSConstants.E_FAIL;


### PR DESCRIPTION
All of the other services have null checks so we don't null ref if we're called without an underlying service. But this one is missing the check, and it's not implemented by TypeScript or F#.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1199127

**NOTE:** the first commit in this PR is annotating this type, the second one is actually fixing the bug. The first commit annotates it in a way that the compiler is then flagging the issue.