### PR TITLE
No "implement implicitly" when class implements no interface

### DIFF
--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementImplicitlyTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementImplicitlyTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.ImplementInterface;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
@@ -205,6 +206,24 @@ class C : IGoo
 
     private void Goo1() { }
 }", index: SingleMember);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [WorkItem(48027, "https://github.com/dotnet/roslyn/issues/48027")]
+        public async Task TestSingleMemberNoInterface()
+        {
+            await TestMissingAsync(
+@"
+using System;
+using System.Collections;
+
+class C
+{
+    IEnumerator IEnumerable.[||]GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+}");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementImplicitlyTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementImplicitlyTests.cs
@@ -210,7 +210,7 @@ class C : IGoo
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         [WorkItem(48027, "https://github.com/dotnet/roslyn/issues/48027")]
-        public async Task TestSingleMemberNoInterface()
+        public async Task TestSingleMemberAndContainingTypeHasNoInterface()
         {
             await TestMissingAsync(
 @"

--- a/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
@@ -69,10 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             // member.  Interface member names are the expected names that people expect to see
             // (like "GetEnumerator"), instead of the auto-generated names that the compiler makes
             // like: "System.IEnumerable.GetEnumerator"
-            var interfaceImplementations = member.ExplicitOrImplicitInterfaceImplementations();
-            if (interfaceImplementations.Length == 0)
-                return;
-            directlyImplementedMembers.AddRange(member, interfaceImplementations);
+            directlyImplementedMembers.AddRange(member, member.ExplicitOrImplicitInterfaceImplementations());
 
             var codeAction = new MyCodeAction(
                 string.Format(Implement_0, member.ExplicitOrImplicitInterfaceImplementations().First().Name),

--- a/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
@@ -69,7 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             // member.  Interface member names are the expected names that people expect to see
             // (like "GetEnumerator"), instead of the auto-generated names that the compiler makes
             // like: "System.IEnumerable.GetEnumerator"
-            directlyImplementedMembers.AddRange(member, member.ExplicitOrImplicitInterfaceImplementations());
+            var interfaceImplementations = member.ExplicitOrImplicitInterfaceImplementations();
+            if (interfaceImplementations.Length == 0)
+                return;
+            directlyImplementedMembers.AddRange(member, interfaceImplementations);
 
             var codeAction = new MyCodeAction(
                 string.Format(Implement_0, member.ExplicitOrImplicitInterfaceImplementations().First().Name),


### PR DESCRIPTION
Fixes #48027

- If a method implements explicitly a method but its class implements no interface (and thus the code does not compile), don't suggest switching to an implicit implementation.