### PR TITLE
Fix gap in error handling in request queue

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {
                 OnRequestServerShutdown($"Error occurred processing queue: {e.Message}.");
-                
+
                 if (work.CallbackAsync != null)
                 {
                     // We've shut down and cancelled any work that was in the queue, but if this exception


### PR DESCRIPTION
Found while testing didChange stuff when I accidentally introduced a null ref in the `MergeChanges` method :D

This only really affected test code, which directly awaits the `HandleRequestAsync` method. In the real world the LSP client would have (presumably) stopped waiting for a response when the connection with the server was closed.