### PR TITLE
Make sure to yield when waiting in SetActiveTreeAnalysisTaskAsync

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/ConfiguredYieldAwaitable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConfiguredYieldAwaitable.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// A custom awaiter that supports <see cref="YieldAwaitableExtensions.ConfigureAwait"/> for
+    /// <see cref="Task.Yield"/>.
+    /// </summary>
+    internal readonly struct ConfiguredYieldAwaitable
+    {
+        private readonly YieldAwaitable _awaitable;
+        private readonly bool _continueOnCapturedContext;
+
+        public ConfiguredYieldAwaitable(YieldAwaitable awaitable, bool continueOnCapturedContext)
+        {
+            _awaitable = awaitable;
+            _continueOnCapturedContext = continueOnCapturedContext;
+        }
+
+        public ConfiguredYieldAwaiter GetAwaiter()
+            => new ConfiguredYieldAwaiter(_awaitable.GetAwaiter(), _continueOnCapturedContext);
+
+        public readonly struct ConfiguredYieldAwaiter
+            : INotifyCompletion, ICriticalNotifyCompletion
+        {
+            private static readonly WaitCallback s_runContinuation =
+                static continuation => ((Action)continuation!)();
+
+            private readonly YieldAwaitable.YieldAwaiter _awaiter;
+            private readonly bool _continueOnCapturedContext;
+
+            public ConfiguredYieldAwaiter(YieldAwaitable.YieldAwaiter awaiter, bool continueOnCapturedContext)
+            {
+                _awaiter = awaiter;
+                _continueOnCapturedContext = continueOnCapturedContext;
+            }
+
+            public bool IsCompleted => _awaiter.IsCompleted;
+
+            public void GetResult()
+                => _awaiter.GetResult();
+
+            public void OnCompleted(Action continuation)
+            {
+                if (_continueOnCapturedContext)
+                {
+                    // Pass through to the YieldAwaiter, which always continues on the captured context
+                    _awaiter.OnCompleted(continuation);
+                }
+                else
+                {
+                    // Schedule the continuation directly on the thread pool
+                    ThreadPool.QueueUserWorkItem(s_runContinuation, continuation);
+                }
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                if (_continueOnCapturedContext)
+                {
+                    // Pass through to the YieldAwaiter, which always continues on the captured context
+                    _awaiter.UnsafeOnCompleted(continuation);
+                }
+                else
+                {
+                    // Schedule the continuation directly on the thread pool
+                    ThreadPool.UnsafeQueueUserWorkItem(s_runContinuation, continuation);
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/YieldAwaitableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/YieldAwaitableExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Roslyn.Utilities
+{
+    internal static class YieldAwaitableExtensions
+    {
+        /// <summary>
+        /// Implements <c>ConfigureAwait(bool)</c> for <see cref="Task.Yield"/>. The resulting behavior in asynchronous code
+        /// is the same as one would expect for <see cref="Task.ConfigureAwait(bool)"/>.
+        /// </summary>
+        /// <param name="awaitable">The awaitable provided by <see cref="Task.Yield"/>.</param>
+        /// <param name="continueOnCapturedContext"><inheritdoc cref="Task.ConfigureAwait(bool)"/></param>
+        /// <returns>An object used to await this yield.</returns>
+        public static ConfiguredYieldAwaitable ConfigureAwait(this YieldAwaitable awaitable, bool continueOnCapturedContext)
+        {
+            return new ConfiguredYieldAwaitable(awaitable, continueOnCapturedContext);
+        }
+    }
+}


### PR DESCRIPTION
This change attempts to resolve a livelock scenario observed once locally and twice in timed-out integration tests. In this scenario, one thread is spinning in `SetActiveTreeAnalysisTaskAsync` while `_concurrentTreeTaskTokensOpt` contains a completed task.

⚠️  This change assumes that the reason a completed task appears in `_concurrentTreeTaskTokensOpt` is the continuation which removes it is scheduled but never executes. I have not ruled out the possibility of a case where `ClearExecutingTask` either fails to execute, or fails to remove the impacted task when executed. If such a case occurs, then this pull request might not fix the problem (though it likely would still improve the performance).

🔗 Heap dump **ServiceHub.RoslynCodeAnalysisService-16.dmp** was taken during this scenario and is available in the build artifacts attached to https://dev.azure.com/dnceng/public/_build/results?buildId=843262.