### PR TITLE
Don't set output path on empty output exe

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
@@ -48,12 +48,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                 VisualStudioProject.CompilationOutputAssemblyFilePath = filename;
             }
 
-            if (filename != null)
+            if (!string.IsNullOrEmpty(filename))
             {
                 VisualStudioProject.AssemblyName = Path.GetFileNameWithoutExtension(filename);
-            }
 
-            RefreshBinOutputPath();
+                RefreshBinOutputPath();
+            }
         }
 
         public void SetOutputFileType(OutputFileType fileType)

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -326,9 +326,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                         VisualStudioProject.CompilationOutputAssemblyFilePath = Nothing
                     End If
                 End If
-            End If
 
-            RefreshBinOutputPath()
+                RefreshBinOutputPath()
+            End If
 
             _runtimeLibraries = VisualStudioProjectOptionsProcessor.GetRuntimeLibraries(_compilerHost)
 


### PR DESCRIPTION
There were changes in the legacy project system that cause Roslyn to be initialized on a background thread with evaluation information when loading a project that does not have a design-time build cached. This initialization only contains file information and no switch information at all. There is a threading issue in that RefreshBinOutputPath calls the hierarchy to load evaluation properties which requires a marshal to the UI thread. This can create deadlocks. Since the background initialization will only ever be with evaluation information and that won't ever contain an exe name (that will come later and be handled properly), a simple fix is not to refresh the output path if the exe name is empty. My understanding is that this would be OK, but let me know if I'm wrong.