### PR TITLE
Avoid binding the world looking for target-typed new

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -638,6 +638,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             void CollectMatchingReferences(ISymbol originalUnreducedSymbolDefinition, SyntaxNode node,
                 ISyntaxFactsService syntaxFacts, ISemanticFactsService semanticFacts, ArrayBuilder<FinderLocation> locations)
             {
+                if (!syntaxFacts.IsImplicitObjectCreation(node))
+                {
+                    // Avoid binding unrelated nodes
+                    return;
+                }
+
                 var constructor = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
 
                 if (Matches(constructor, originalUnreducedSymbolDefinition))


### PR DESCRIPTION
Performance trace showed 12.7GB allocations in 30 seconds in calls to `GetSymbolInfo`.