### PR TITLE
Add null vsix entries to publish data to unblock older builds

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -116,6 +116,7 @@
       "nugetKind": "PerBuildPreRelease",
       "version": "2.10.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev15.9" ],
       "vsBranch": "rel/d15.9",
       "vsMajorVersion": 15
@@ -124,6 +125,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.0.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.0" ],
       "vsBranch": "rel/d16.0",
       "vsMajorVersion": 16
@@ -132,6 +134,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.1.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.1" ],
       "vsBranch": "rel/d16.1",
       "vsMajorVersion": 16
@@ -140,6 +143,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.2.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.2" ],
       "vsBranch": "rel/d16.2",
       "vsMajorVersion": 16
@@ -148,6 +152,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.3.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.3" ],
       "vsBranch": "rel/d16.3",
       "vsMajorVersion": 16
@@ -156,6 +161,7 @@
       "nugetKind": ["Shipping"],
       "version": "3.4.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.4" ],
       "vsBranch": "rel/d16.4",
       "vsMajorVersion": 16
@@ -164,6 +170,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.5.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.5", "dev16.5p4" ],
       "vsBranch": "rel/d16.5",
       "vsMajorVersion": 16
@@ -172,6 +179,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.6.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.6", "dev16.6p3" ],
       "vsBranch": "rel/d16.6",
       "vsMajorVersion": 16
@@ -180,6 +188,7 @@
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.7.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dev16.7", "dev16.7p4" ],
       "vsBranch": "rel/d16.7",
       "vsMajorVersion": 16
@@ -187,6 +196,7 @@
     "release/dev16.8-vs-deps": {
       "nugetKind": [ "Shipping", "NonShipping" ],
       "version": "3.8.*",
+      "vsix": null,
       "packageFeeds": "default",
       "channels": [ "dev16.8p4" ],
       "vsBranch": "rel/d16.8",
@@ -204,6 +214,7 @@
       "nugetKind": "PerBuildPreRelease",
       "version": "2.6.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn-nonnull/api/v2/package" ],
+      "vsix": null,
       "channels": [ "nonnull" ],
       "vsBranch": "lab/d16.1stg",
       "vsMajorVersion": 16
@@ -212,6 +223,7 @@
       "nugetKind": "PerBuildPreRelease",
       "version": "2.8.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "dataflow" ],
       "vsBranch": "lab/d16.1stg",
       "vsMajorVersion": 16
@@ -220,6 +232,7 @@
       "nugetKind": [ "Shipping", "NonShipping" ],
       "version": "3.1.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "razorSupport2" ],
       "vsBranch": "lab/d16.1stg",
       "vsMajorVersion": 16
@@ -228,6 +241,7 @@
       "nugetKind": [ "Shipping", "NonShipping" ],
       "version": "3.4.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "compilerNext" ],
       "vsBranch": "main",
       "vsMajorVersion": 16
@@ -237,6 +251,7 @@
       "version": "3.8.*",
       "packageFeeds": "arcade",
       "channels": [ "UsedAssemblyReferences" ],
+      "vsix": null,
       "vsBranch": "main",
       "vsMajorVersion": 16
     },
@@ -244,6 +259,7 @@
       "nugetKind": [ "Shipping", "NonShipping" ],
       "version": "3.3.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": null,
       "channels": [ "unitTesting" ],
       "vsBranch": "rel/d16.5",
       "vsMajorVersion": 16


### PR DESCRIPTION
The 16.8 signed build is failing because the vsix entry is missing from the publish data configuration. This PR adds back null vsix entries so that builds can complete.