### PR TITLE
Only enforce Member/NotNullWhen on constants

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8617,8 +8617,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (node.OperatorKind)
             {
                 case UnaryOperatorKind.BoolLogicalNegation:
-                    VisitCondition(node.Operand);
-                    SetConditionalState(StateWhenFalse, StateWhenTrue);
+                    Visit(node.Operand);
+                    if (IsConditionalState)
+                        SetConditionalState(StateWhenFalse, StateWhenTrue);
                     resultType = adjustForLifting(ResultType);
                     break;
                 case UnaryOperatorKind.DynamicTrue:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -631,7 +631,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         foreach (var memberName in method.NotNullWhenFalseMembers)
                         {
-                            enforceMemberNotNullWhenIfAffected(returnStatement.Syntax, sense: true, method.ContainingType.GetMembers(memberName), pendingReturn.StateWhenFalse, pendingReturn.StateWhenTrue);
+                            enforceMemberNotNullWhenIfAffected(returnStatement.Syntax, sense: false, method.ContainingType.GetMembers(memberName), pendingReturn.StateWhenFalse, pendingReturn.StateWhenTrue);
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -609,10 +609,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void enforceMemberNotNullWhenForPendingReturn(PendingBranch pendingReturn, BoundReturnStatement returnStatement)
             {
-                if (pendingReturn.IsConditionalState)
+                if (returnStatement.ExpressionOpt is BoundExpression { ConstantValue: { IsBoolean: true, BooleanValue: bool value } })
                 {
-                    enforceMemberNotNullWhen(returnStatement.Syntax, sense: true, pendingReturn.StateWhenTrue);
-                    enforceMemberNotNullWhen(returnStatement.Syntax, sense: false, pendingReturn.StateWhenFalse);
+                    if (pendingReturn.IsConditionalState)
+                    {
+                        enforceMemberNotNullWhen(returnStatement.Syntax, sense: true, pendingReturn.StateWhenTrue);
+                        enforceMemberNotNullWhen(returnStatement.Syntax, sense: false, pendingReturn.StateWhenFalse);
+                    }
+                    else
+                    {
+                        enforceMemberNotNullWhen(returnStatement.Syntax, sense: value, pendingReturn.State);
+                    }
                 }
             }
 
@@ -763,12 +770,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var parameters = this.MethodParameters;
 
-                if (!parameters.IsEmpty)
+                if (!parameters.IsEmpty && returnStatement.ExpressionOpt is BoundExpression { ConstantValue: { IsBoolean: true, BooleanValue: bool value } })
                 {
                     if (pendingReturn.IsConditionalState)
                     {
                         enforceParameterNotNullWhen(returnStatement.Syntax, parameters, sense: true, stateWhen: pendingReturn.StateWhenTrue);
                         enforceParameterNotNullWhen(returnStatement.Syntax, parameters, sense: false, stateWhen: pendingReturn.StateWhenFalse);
+                    }
+                    else
+                    {
+                        enforceParameterNotNullWhen(returnStatement.Syntax, parameters, sense: value, stateWhen: pendingReturn.State);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8213,10 +8213,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void SplitIfBooleanConstant(BoundExpression node)
         {
-            if (node.ConstantValue is { IsBoolean: true })
+            if (node.ConstantValue is { IsBoolean: true, BooleanValue: bool booleanValue })
             {
                 Split();
-                if (node.ConstantValue.BooleanValue)
+                if (booleanValue)
                 {
                     StateWhenFalse = UnreachableState();
                 }


### PR DESCRIPTION
My previous PR (https://github.com/dotnet/roslyn/pull/46201) to relax enforcement of those conditional attribute on non-constants returns was incorrect. It relied on the state being conditional or not, but (1) we split the state for non-constant values (`!expr` and method invocations involving attributes), and (2) we don't split the state for constant values.
~~This PR corrects that, by directly checking for the return having a constant value.~~

Update: this PR now only enforced those warnings if the target of the attribute (ie. parameter or member) has a different state in the two branches of analysis of the return statement. This allows to warn on statements that we can analyze like `return !TryGetValue(..., out p);` or `return p != null;`, while avoiding annoying warnings on `return M();` or `return TryGetValue(..., out _);`.

Fixes https://github.com/dotnet/roslyn/issues/48126
Original issue: https://github.com/dotnet/roslyn/issues/44080