### PR TITLE
Remove unused method

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -69,12 +69,6 @@ namespace Roslyn.Test.Utilities
                 Contract.ThrowIfNull(_currentSolution);
                 return _currentSolution.GetDocuments(documentUri);
             }
-
-            public ImmutableArray<TextDocument> GetTextDocuments(Uri documentUri)
-            {
-                Contract.ThrowIfNull(_currentSolution);
-                return _currentSolution.GetTextDocuments(documentUri);
-            }
         }
 
         private class TestSpanMapperProvider : IDocumentServiceProvider

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -29,11 +29,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return GetDocuments<Document>(solution, documentUri, (s, i) => s.GetRequiredDocument(i));
         }
 
-        public static ImmutableArray<TextDocument> GetTextDocuments(this Solution solution, Uri documentUri)
-        {
-            return GetDocuments<TextDocument>(solution, documentUri, (s, i) => s.GetRequiredTextDocument(i));
-        }
-
         private static ImmutableArray<T> GetDocuments<T>(this Solution solution, Uri documentUri, Func<Solution, DocumentId, T> getDocument) where T : TextDocument
         {
             // TODO: we need to normalize this. but for now, we check both absolute and local path
@@ -68,11 +63,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return GetDocuments<Document>(solutionProvider, uri, (s, u, c) => s.GetDocuments(u), clientName);
         }
 
-        public static ImmutableArray<TextDocument> GetTextDocuments(this ILspSolutionProvider solutionProvider, Uri uri, string? clientName)
-        {
-            return GetDocuments<TextDocument>(solutionProvider, uri, (s, u, c) => s.GetTextDocuments(u), clientName);
-        }
-
         private static ImmutableArray<T> GetDocuments<T>(this ILspSolutionProvider solutionProvider, Uri uri, Func<ILspSolutionProvider, Uri, string?, ImmutableArray<T>> getDocuments, string? clientName) where T : TextDocument
         {
             var documents = getDocuments(solutionProvider, uri, clientName);
@@ -99,11 +89,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static Document? GetDocument(this ILspSolutionProvider solutionProvider, TextDocumentIdentifier documentIdentifier, string? clientName = null)
         {
             return GetDocument<Document>(solutionProvider, documentIdentifier, (s, d, c) => s.GetDocuments(d, c), clientName);
-        }
-
-        public static TextDocument? GetTextDocument(this ILspSolutionProvider solutionProvider, TextDocumentIdentifier documentIdentifier, string? clientName = null)
-        {
-            return GetDocument<TextDocument>(solutionProvider, documentIdentifier, (s, d, c) => s.GetTextDocuments(d, c), clientName);
         }
 
         private static T? GetDocument<T>(this ILspSolutionProvider solutionProvider, TextDocumentIdentifier documentIdentifier, Func<ILspSolutionProvider, Uri, string?, ImmutableArray<T>> getDocuments, string? clientName = null) where T : TextDocument

--- a/src/Features/LanguageServer/Protocol/ILspSolutionProvider.cs
+++ b/src/Features/LanguageServer/Protocol/ILspSolutionProvider.cs
@@ -18,14 +18,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         ImmutableArray<Document> GetDocuments(Uri documentUri);
 
         /// <summary>
-        /// Finds the workspace and solution containing the specified document URI
-        /// and returns the text documents in that context.
-        /// </summary>
-        /// <param name="documentUri">the document's file path URI.</param>
-        /// <returns>the text documents in the correct workspace and solution context</returns>
-        ImmutableArray<TextDocument> GetTextDocuments(Uri documentUri);
-
-        /// <summary>
         /// Return the latest solution from the main workspace that we know about.
         /// </summary>
         Solution GetCurrentSolutionForMainWorkspace();

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLspSolutionProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLspSolutionProvider.cs
@@ -43,18 +43,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 
             return documents;
         }
-
-        public ImmutableArray<TextDocument> GetTextDocuments(Uri documentUri)
-        {
-            // First check the VS workspace for matching documents.
-            var documents = _visualStudioWorkspace.CurrentSolution.GetTextDocuments(documentUri);
-            if (documents.IsEmpty)
-            {
-                // If there's none in the VS workspace, then check the misc files workspace.
-                documents = _miscellaneousFilesWorkspace.CurrentSolution.GetTextDocuments(documentUri);
-            }
-
-            return documents;
-        }
     }
 }


### PR DESCRIPTION
I couldn't see why this existed.

Also its weird because the Extensions class had a method that called a method on ILspSolutionProvider that called an extension method in the Extensions class.

If the build fails, or someone tells me why this is needed, I will abandon this PR faster than you can possibly image.