### PR TITLE
Skip binary for determinism checking

### DIFF
--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -24,7 +24,10 @@ if ($help) {
 
 # List of binary names that should be skipped because they have a known issue that
 # makes them non-deterministic.  
-$script:skipList = @()
+$script:skipList = @(
+  # Added to work around https://github.com/dotnet/roslyn/issues/48417
+  "Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll"
+)
 
 function Run-Build([string]$rootDir, [string]$logFileName) {
   # Clean out the previous run


### PR DESCRIPTION
This adds Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll since right now that binary is impacted by https://github.com/dotnet/roslyn/issues/48417.