### PR TITLE
Generate ctor for target typed new

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1880,8 +1880,12 @@ Global
 		{2801F82B-78CE-4BAE-B06F-537574751E2E}.Release|x86.Build.0 = Release|x86
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|x86.Build.0 = Debug|Any CPU
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -4386,5 +4386,27 @@ namespace N {
     }
 }");
         }
+
+        [WorkItem(47928, "https://github.com/dotnet/roslyn/issues/47928")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestGenerateConstructorFromTargetTypedNew()
+        {
+            await TestInRegularAndScriptAsync(@"
+C c = new(0);
+
+public class C
+{
+}
+", @"
+C c = new(0);
+
+public class C
+{
+    public C(int v)
+    {
+    }
+}
+");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -4392,7 +4392,7 @@ namespace N {
         public async Task TestGenerateConstructorFromTargetTypedNew()
         {
             await TestInRegularAndScriptAsync(@"
-C c = new(0);
+C c = [||]new(0);
 
 public class C
 {

--- a/src/Features/CSharp/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
 
         protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
-            return node is ObjectCreationExpressionSyntax ||
+            return node is BaseObjectCreationExpressionSyntax ||
                    node is ConstructorInitializerSyntax ||
                    node is AttributeSyntax;
         }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -26,9 +26,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
     {
         protected abstract bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType);
         protected abstract bool IsSimpleNameGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
+        protected abstract bool IsTargetTypedNewGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract bool IsConstructorInitializerGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
 
         protected abstract bool TryInitializeSimpleNameGenerationState(SemanticDocument document, SyntaxNode simpleName, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
+        protected abstract bool TryInitializeTargetTypedNewGenerationState(SemanticDocument document, SyntaxNode implicitObjectCreation, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeConstructorInitializerGeneration(SemanticDocument document, SyntaxNode constructorInitializer, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeSimpleAttributeNameGenerationState(SemanticDocument document, SyntaxNode simpleName, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out ImmutableArray<TAttributeArgumentSyntax> attributeArguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract ImmutableArray<ParameterName> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TArgumentSyntax> arguments, IList<string> reservedNames, NamingRule parameterNamingRule, CancellationToken cancellationToken);

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -92,6 +92,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
             Return TypeOf node Is SimpleNameSyntax
         End Function
 
+        Protected Overrides Function IsTargetTypedNewGeneration(document As SemanticDocument, node As SyntaxNode, cancellationToken As CancellationToken) As Boolean
+            ' Target-typed new is C#-only concept.
+            Return False
+        End Function
+
         Protected Overrides Function TryInitializeSimpleNameGenerationState(
                 document As SemanticDocument,
                 node As SyntaxNode,
@@ -125,6 +130,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
             arguments = Nothing
             typeToGenerateIn = Nothing
             Return False
+        End Function
+
+        Protected Overrides Function TryInitializeTargetTypedNewGenerationState(document As SemanticDocument, simpleName As SyntaxNode, cancellationToken As CancellationToken, ByRef token As SyntaxToken, ByRef arguments As ImmutableArray(Of ArgumentSyntax), ByRef typeToGenerateIn As INamedTypeSymbol) As Boolean
+            ' This shouldn't be reachable because IsTargetTypedNewGeneration always returns False for VB.
+            Throw ExceptionUtilities.Unreachable
         End Function
 
         Protected Overrides Function TryInitializeSimpleAttributeNameGenerationState(


### PR DESCRIPTION
Currently this will crash. Will need to find a way to deal with delegated constructors.
The current implementation depends on retrieving the TypeSyntax and doing some logic on it. The implicit object creation doesn't have a TypeSyntax, so the implementation will need some updates to use semantic model.

I'll try to put more time on this to get it fixed.

Fixes #47928