### PR TITLE
Null annotate VBCSCompiler

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal const string ResponseFileName = "csc.rsp";
 
         private readonly CommandLineDiagnosticFormatter _diagnosticFormatter;
-        private readonly string _tempDirectory;
+        private readonly string? _tempDirectory;
 
-        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
+        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
             : base(parser, responseFile, args, buildPaths, additionalReferenceDirectories, assemblyLoader)
         {
             _diagnosticFormatter = new CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);
@@ -37,8 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override Compilation? CreateCompilation(
             TextWriter consoleOutput,
-            TouchedFileLogger touchedFilesLogger,
-            ErrorLogger errorLogger,
+            TouchedFileLogger? touchedFilesLogger,
+            ErrorLogger? errorLogger,
             ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions,
             AnalyzerConfigOptionsResult globalConfigOptions)
         {
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var sourceFiles = Arguments.SourceFiles;
             var trees = new SyntaxTree?[sourceFiles.Length];
-            var normalizedFilePaths = new string[sourceFiles.Length];
+            var normalizedFilePaths = new string?[sourceFiles.Length];
             var diagnosticBag = DiagnosticBag.GetInstance();
 
             if (Arguments.CompilationOptions.ConcurrentBuild)
@@ -115,6 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (Arguments.TouchedFilesPath != null)
             {
+                Debug.Assert(touchedFilesLogger is object);
                 foreach (var path in uniqueFilePaths)
                 {
                     touchedFilesLogger.AddRead(path);
@@ -175,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref bool addedDiagnostics,
             CommandLineSourceFile file,
             DiagnosticBag diagnostics,
-            out string normalizedFilePath)
+            out string? normalizedFilePath)
         {
             var fileDiagnostics = new List<DiagnosticInfo>();
             var content = TryReadFileContent(file, fileDiagnostics, out normalizedFilePath);
@@ -232,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// entrypoint, then csc will produce "b.exe" and "b.pdb" in the output directory,
         /// with assembly name "b" and module name "b.exe" embedded in the file.
         /// </summary>
-        protected override string GetOutputFileName(Compilation compilation, CancellationToken cancellationToken)
+        protected override string? GetOutputFileName(Compilation compilation, CancellationToken cancellationToken)
         {
             if (Arguments.OutputFileName == null)
             {

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly CommandLineDiagnosticFormatter _diagnosticFormatter;
         private readonly string? _tempDirectory;
 
-        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
+        protected CSharpCompiler(CSharpCommandLineParser parser, string? responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
             : base(parser, responseFile, args, buildPaths, additionalReferenceDirectories, assemblyLoader)
         {
             _diagnosticFormatter = new CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -72,9 +72,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         public static BuildRequest Create(RequestLanguage language,
                                           IList<string> args,
-                                          string? workingDirectory = null,
-                                          string? tempDirectory = null,
-                                          string? compilerHash = null,
+                                          string workingDirectory,
+                                          string tempDirectory,
+                                          string compilerHash,
                                           string? keepAlive = null,
                                           string? libDirectory = null)
         {
@@ -90,15 +90,8 @@ Creating BuildRequest
             var requestLength = args.Count + 1 + (libDirectory == null ? 0 : 1);
             var requestArgs = new List<Argument>(requestLength);
 
-            if (workingDirectory != null)
-            {
-                requestArgs.Add(new Argument(ArgumentId.CurrentDirectory, 0, workingDirectory));
-            }
-
-            if (tempDirectory != null)
-            {
-                requestArgs.Add(new Argument(ArgumentId.TempDirectory, 0, tempDirectory));
-            }
+            requestArgs.Add(new Argument(ArgumentId.CurrentDirectory, 0, workingDirectory));
+            requestArgs.Add(new Argument(ArgumentId.TempDirectory, 0, tempDirectory));
 
             if (keepAlive != null)
             {

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             try
             {
-                var workingDir = CurrentDirectoryToUse();
+                string workingDir = CurrentDirectoryToUse();
                 string? tempDir = BuildServerConnection.GetTempPath(workingDir);
 
                 if (!UseSharedCompilation ||
@@ -505,9 +505,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                     var buildPaths = new BuildPathsAlt(
                         clientDir: clientDir,
+                        workingDir: workingDir,
                         // MSBuild doesn't need the .NET SDK directory
                         sdkDir: null,
-                        workingDir: workingDir,
                         tempDir: tempDir);
 
                     // Note: using ToolArguments here (the property) since

--- a/src/Compilers/Core/Portable/AdditionalTextFile.cs
+++ b/src/Compilers/Core/Portable/AdditionalTextFile.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
             _text = new Lazy<SourceText?>(ReadText);
         }
 
-        private SourceText ReadText()
+        private SourceText? ReadText()
         {
             var diagnostics = new List<DiagnosticInfo>();
             var text = _compiler.TryReadFileContent(_sourceFile, diagnostics);

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis
         /// Parses an editor config file text located at the given path. No parsing
         /// errors are reported. If any line contains a parse error, it is dropped.
         /// </summary>
-        public static AnalyzerConfig Parse(string text, string pathToFile)
+        public static AnalyzerConfig Parse(string text, string? pathToFile)
         {
             return Parse(SourceText.From(text), pathToFile);
         }
@@ -115,9 +115,9 @@ namespace Microsoft.CodeAnalysis
         /// Parses an editor config file text located at the given path. No parsing
         /// errors are reported. If any line contains a parse error, it is dropped.
         /// </summary>
-        public static AnalyzerConfig Parse(SourceText text, string pathToFile)
+        public static AnalyzerConfig Parse(SourceText text, string? pathToFile)
         {
-            if (!Path.IsPathRooted(pathToFile) || string.IsNullOrEmpty(Path.GetFileName(pathToFile)))
+            if (pathToFile is null || !Path.IsPathRooted(pathToFile) || string.IsNullOrEmpty(Path.GetFileName(pathToFile)))
             {
                 throw new ArgumentException("Must be an absolute path to an editorconfig file", nameof(pathToFile));
             }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.LoggingStrongNameProvider.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.LoggingStrongNameProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis
@@ -12,15 +10,15 @@ namespace Microsoft.CodeAnalysis
     {
         internal sealed class LoggingStrongNameFileSystem : StrongNameFileSystem
         {
-            private readonly TouchedFileLogger _loggerOpt;
+            private readonly TouchedFileLogger? _loggerOpt;
 
-            public LoggingStrongNameFileSystem(TouchedFileLogger logger, string tempPath)
-                : base(tempPath)
+            public LoggingStrongNameFileSystem(TouchedFileLogger? logger, string? customTempPath)
+                : base(customTempPath)
             {
                 _loggerOpt = logger;
             }
 
-            internal override bool FileExists(string fullPath)
+            internal override bool FileExists(string? fullPath)
             {
                 if (fullPath != null)
                 {

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis
             out ImmutableArray<DiagnosticAnalyzer> analyzers,
             out ImmutableArray<ISourceGenerator> generators);
 
-        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
+        public CommonCompiler(CommandLineParser parser, string? responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
         {
             IEnumerable<string> allArgs = args;
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -304,10 +304,11 @@ namespace Microsoft.CodeAnalysis
                     break;
                 }
 
+                Debug.Assert(normalizedPath is object);
                 var directory = Path.GetDirectoryName(normalizedPath) ?? normalizedPath;
                 var editorConfig = AnalyzerConfig.Parse(fileContent, normalizedPath);
 
-                if (!editorConfig.IsGlobal && directory is object)
+                if (!editorConfig.IsGlobal)
                 {
                     if (processedDirs.Contains(directory))
                     {
@@ -1063,6 +1064,7 @@ namespace Microsoft.CodeAnalysis
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // https://github.com/dotnet/roslyn/issues/48599
             string outputName = GetOutputFileName(compilation, cancellationToken)!;
             var finalPeFilePath = Arguments.GetOutputFilePath(outputName);
             var finalPdbFilePath = Arguments.GetPdbFilePath(outputName);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -39,15 +38,15 @@ namespace Microsoft.CodeAnalysis
         /// The path which contains mscorlib.  This can be null when specified by the user or running in a 
         /// CoreClr environment.
         /// </summary>
-        internal string SdkDirectory { get; }
+        internal string? SdkDirectory { get; }
 
         /// <summary>
         /// The temporary directory a compilation should use instead of <see cref="Path.GetTempPath"/>.  The latter
         /// relies on global state individual compilations should ignore.
         /// </summary>
-        internal string TempDirectory { get; }
+        internal string? TempDirectory { get; }
 
-        internal BuildPaths(string clientDir, string workingDir, string sdkDir, string tempDir)
+        internal BuildPaths(string clientDir, string workingDir, string? sdkDir, string? tempDir)
         {
             ClientDirectory = clientDir;
             WorkingDirectory = workingDir;
@@ -63,8 +62,6 @@ namespace Microsoft.CodeAnalysis
     {
         internal const int Failed = 1;
         internal const int Succeeded = 0;
-
-        private readonly string _clientDirectory;
 
         /// <summary>
         /// Fallback encoding that is lazily retrieved if needed. If <see cref="EncodedStringText.CreateFallbackEncoding"/> is
@@ -85,10 +82,10 @@ namespace Microsoft.CodeAnalysis
 
         private readonly HashSet<Diagnostic> _reportedDiagnostics = new HashSet<Diagnostic>();
 
-        public abstract Compilation CreateCompilation(
+        public abstract Compilation? CreateCompilation(
             TextWriter consoleOutput,
-            TouchedFileLogger touchedFilesLogger,
-            ErrorLogger errorLoggerOpt,
+            TouchedFileLogger? touchedFilesLogger,
+            ErrorLogger? errorLoggerOpt,
             ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions,
             AnalyzerConfigOptionsResult globalConfigOptions);
 
@@ -114,10 +111,9 @@ namespace Microsoft.CodeAnalysis
             out ImmutableArray<DiagnosticAnalyzer> analyzers,
             out ImmutableArray<ISourceGenerator> generators);
 
-        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
+        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
         {
             IEnumerable<string> allArgs = args;
-            _clientDirectory = buildPaths.ClientDirectory;
 
             Debug.Assert(null == responseFile || PathUtilities.IsAbsolute(responseFile));
             if (!SuppressDefaultResponseFile(args) && File.Exists(responseFile))
@@ -154,12 +150,13 @@ namespace Microsoft.CodeAnalysis
 
         internal static string GetProductVersion(Type type)
         {
-            string assemblyVersion = GetInformationalVersionWithoutHash(type);
-            string hash = GetShortCommitHash(type);
+            string? assemblyVersion = GetInformationalVersionWithoutHash(type);
+            string? hash = GetShortCommitHash(type);
             return $"{assemblyVersion} ({hash})";
         }
 
-        internal static string ExtractShortCommitHash(string hash)
+        [return: NotNullIfNotNull("hash")]
+        internal static string? ExtractShortCommitHash(string hash)
         {
             // leave "<developer build>" alone, but truncate SHA to 8 characters
             if (hash != null && hash.Length >= 8 && hash[0] != '<')
@@ -170,17 +167,19 @@ namespace Microsoft.CodeAnalysis
             return hash;
         }
 
-        private static string GetInformationalVersionWithoutHash(Type type)
+        private static string? GetInformationalVersionWithoutHash(Type type)
         {
             // The attribute stores a SemVer2-formatted string: `A.B.C(-...)?(+...)?`
             // We remove the section after the + (if any is present)
             return type.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0];
         }
 
-        private static string GetShortCommitHash(Type type)
+        private static string? GetShortCommitHash(Type type)
         {
             var hash = type.Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
-            return ExtractShortCommitHash(hash);
+            return hash is object
+                ? ExtractShortCommitHash(hash)
+                : null;
         }
 
         /// <summary>
@@ -191,7 +190,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Tool version identifier used for error logging.
         /// </summary>
-        internal Version GetAssemblyVersion()
+        internal Version? GetAssemblyVersion()
         {
             return Type.GetTypeInfo().Assembly.GetName().Version;
         }
@@ -206,7 +205,7 @@ namespace Microsoft.CodeAnalysis
             return (path, properties) => MetadataReference.CreateFromFile(path, properties);
         }
 
-        internal virtual MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger loggerOpt)
+        internal virtual MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger? loggerOpt)
         {
             var pathResolver = new RelativePathResolver(Arguments.ReferencePaths, Arguments.BaseDirectory);
             return new LoggingMetadataFileReferenceResolver(pathResolver, GetMetadataProvider(), loggerOpt);
@@ -217,7 +216,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal List<MetadataReference> ResolveMetadataReferences(
             List<DiagnosticInfo> diagnostics,
-            TouchedFileLogger touchedFiles,
+            TouchedFileLogger? touchedFiles,
             out MetadataReferenceResolver referenceDirectiveResolver)
         {
             var commandLineReferenceResolver = GetCommandLineMetadataReferenceResolver(touchedFiles);
@@ -244,10 +243,9 @@ namespace Microsoft.CodeAnalysis
         /// <param name="file">Source file information.</param>
         /// <param name="diagnostics">Storage for diagnostics.</param>
         /// <returns>File content or null on failure.</returns>
-        internal SourceText TryReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics)
+        internal SourceText? TryReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics)
         {
-            string discarded;
-            return TryReadFileContent(file, diagnostics, out discarded);
+            return TryReadFileContent(file, diagnostics, out _);
         }
 
         /// <summary>
@@ -257,7 +255,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="diagnostics">Storage for diagnostics.</param>
         /// <param name="normalizedFilePath">If given <paramref name="file"/> opens successfully, set to normalized absolute path of the file, null otherwise.</param>
         /// <returns>File content or null on failure.</returns>
-        internal SourceText TryReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics, out string normalizedFilePath)
+        internal SourceText? TryReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics, out string? normalizedFilePath)
         {
             var filePath = file.Path;
             try
@@ -290,7 +288,7 @@ namespace Microsoft.CodeAnalysis
         internal bool TryGetAnalyzerConfigSet(
             ImmutableArray<string> analyzerConfigPaths,
             DiagnosticBag diagnostics,
-            out AnalyzerConfigSet analyzerConfigSet)
+            [NotNullWhen(true)] out AnalyzerConfigSet? analyzerConfigSet)
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance(analyzerConfigPaths.Length);
 
@@ -301,7 +299,7 @@ namespace Microsoft.CodeAnalysis
                 // The editorconfig spec requires all paths use '/' as the directory separator.
                 // Since no known system allows directory separators as part of the file name,
                 // we can replace every instance of the directory separator with a '/'
-                string fileContent = TryReadFileContent(configPath, diagnostics, out string normalizedPath);
+                string? fileContent = TryReadFileContent(configPath, diagnostics, out string? normalizedPath);
                 if (fileContent is null)
                 {
                     // Error reading a file. Bail out and report error.
@@ -311,7 +309,7 @@ namespace Microsoft.CodeAnalysis
                 var directory = Path.GetDirectoryName(normalizedPath) ?? normalizedPath;
                 var editorConfig = AnalyzerConfig.Parse(fileContent, normalizedPath);
 
-                if (!editorConfig.IsGlobal)
+                if (!editorConfig.IsGlobal && directory is object)
                 {
                     if (processedDirs.Contains(directory))
                     {
@@ -344,7 +342,7 @@ namespace Microsoft.CodeAnalysis
         /// Returns the fallback encoding for parsing source files, if used, or null
         /// if not used
         /// </summary>
-        internal Encoding GetFallbackEncoding()
+        internal Encoding? GetFallbackEncoding()
         {
             if (_fallbackEncoding.IsValueCreated)
             {
@@ -357,7 +355,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Read a UTF-8 encoded file and return the text as a string.
         /// </summary>
-        private string TryReadFileContent(string filePath, DiagnosticBag diagnostics, out string normalizedPath)
+        private string? TryReadFileContent(string filePath, DiagnosticBag diagnostics, out string? normalizedPath)
         {
             try
             {
@@ -390,7 +388,7 @@ namespace Microsoft.CodeAnalysis
                 options: FileOptions.None);
         }
 
-        internal EmbeddedText TryReadEmbeddedFileContent(string filePath, DiagnosticBag diagnostics)
+        internal EmbeddedText? TryReadEmbeddedFileContent(string filePath, DiagnosticBag diagnostics)
         {
             try
             {
@@ -416,11 +414,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private ImmutableArray<EmbeddedText> AcquireEmbeddedTexts(Compilation compilation, DiagnosticBag diagnostics)
+        private ImmutableArray<EmbeddedText?> AcquireEmbeddedTexts(Compilation compilation, DiagnosticBag diagnostics)
         {
+            Debug.Assert(compilation.Options.SourceReferenceResolver is object);
             if (Arguments.EmbeddedFiles.IsEmpty)
             {
-                return ImmutableArray<EmbeddedText>.Empty;
+                return ImmutableArray<EmbeddedText?>.Empty;
             }
 
             var embeddedTreeMap = new Dictionary<string, SyntaxTree>(Arguments.EmbeddedFiles.Length);
@@ -447,11 +446,11 @@ namespace Microsoft.CodeAnalysis
                 ResolveEmbeddedFilesFromExternalSourceDirectives(tree, compilation.Options.SourceReferenceResolver, embeddedFileOrderedSet, diagnostics);
             }
 
-            var embeddedTextBuilder = ImmutableArray.CreateBuilder<EmbeddedText>(embeddedFileOrderedSet.Count);
+            var embeddedTextBuilder = ImmutableArray.CreateBuilder<EmbeddedText?>(embeddedFileOrderedSet.Count);
             foreach (var path in embeddedFileOrderedSet)
             {
-                SyntaxTree tree;
-                EmbeddedText text;
+                SyntaxTree? tree;
+                EmbeddedText? text;
 
                 if (embeddedTreeMap.TryGetValue(path, out tree))
                 {
@@ -518,7 +517,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>Returns true if there were any errors, false otherwise.</summary>
-        internal bool ReportDiagnostics(IEnumerable<Diagnostic> diagnostics, TextWriter consoleOutput, ErrorLogger errorLoggerOpt)
+        internal bool ReportDiagnostics(IEnumerable<Diagnostic> diagnostics, TextWriter consoleOutput, ErrorLogger? errorLoggerOpt)
         {
             bool hasErrors = false;
             foreach (var diag in diagnostics)
@@ -589,11 +588,11 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>Returns true if there were any errors, false otherwise.</summary>
-        private bool ReportDiagnostics(DiagnosticBag diagnostics, TextWriter consoleOutput, ErrorLogger errorLoggerOpt)
+        private bool ReportDiagnostics(DiagnosticBag diagnostics, TextWriter consoleOutput, ErrorLogger? errorLoggerOpt)
             => ReportDiagnostics(diagnostics.ToReadOnly(), consoleOutput, errorLoggerOpt);
 
         /// <summary>Returns true if there were any errors, false otherwise.</summary>
-        internal bool ReportDiagnostics(IEnumerable<DiagnosticInfo> diagnostics, TextWriter consoleOutput, ErrorLogger errorLoggerOpt)
+        internal bool ReportDiagnostics(IEnumerable<DiagnosticInfo> diagnostics, TextWriter consoleOutput, ErrorLogger? errorLoggerOpt)
             => ReportDiagnostics(diagnostics.Select(info => Diagnostic.Create(info)), consoleOutput, errorLoggerOpt);
 
         /// <summary>
@@ -636,7 +635,7 @@ namespace Microsoft.CodeAnalysis
             consoleOutput.WriteLine(DiagnosticFormatter.Format(diagnostic, Culture));
         }
 
-        public SarifErrorLogger GetErrorLogger(TextWriter consoleOutput, CancellationToken cancellationToken)
+        public SarifErrorLogger? GetErrorLogger(TextWriter consoleOutput, CancellationToken cancellationToken)
         {
             Debug.Assert(Arguments.ErrorLogOptions?.Path != null);
 
@@ -647,7 +646,7 @@ namespace Microsoft.CodeAnalysis
                                     FileAccess.Write,
                                     FileShare.ReadWrite | FileShare.Delete);
 
-            SarifErrorLogger logger;
+            SarifErrorLogger? logger;
             if (errorLog == null)
             {
                 Debug.Assert(diagnostics.HasAnyErrors());
@@ -657,7 +656,7 @@ namespace Microsoft.CodeAnalysis
             {
                 string toolName = GetToolName();
                 string compilerVersion = GetCompilerVersion();
-                Version assemblyVersion = GetAssemblyVersion();
+                Version assemblyVersion = GetAssemblyVersion() ?? new Version();
 
                 if (Arguments.ErrorLogOptions.SarifVersion == SarifVersion.Sarif1)
                 {
@@ -676,10 +675,10 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// csc.exe and vbc.exe entry point.
         /// </summary>
-        public virtual int Run(TextWriter consoleOutput, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual int Run(TextWriter consoleOutput, CancellationToken cancellationToken = default)
         {
             var saveUICulture = CultureInfo.CurrentUICulture;
-            SarifErrorLogger errorLogger = null;
+            SarifErrorLogger? errorLogger = null;
 
             try
             {
@@ -732,7 +731,7 @@ namespace Microsoft.CodeAnalysis
         /// <returns>A compilation that represents the original compilation with any additional, generated texts added to it.</returns>
         private protected virtual Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, ImmutableArray<AdditionalText> additionalTexts, DiagnosticBag generatorDiagnostics) { return input; }
 
-        private int RunCore(TextWriter consoleOutput, ErrorLogger errorLogger, CancellationToken cancellationToken)
+        private int RunCore(TextWriter consoleOutput, ErrorLogger? errorLogger, CancellationToken cancellationToken)
         {
             Debug.Assert(!Arguments.IsScriptRunner);
 
@@ -770,7 +769,7 @@ namespace Microsoft.CodeAnalysis
 
             var diagnostics = DiagnosticBag.GetInstance();
 
-            AnalyzerConfigSet analyzerConfigSet = null;
+            AnalyzerConfigSet? analyzerConfigSet = null;
             ImmutableArray<AnalyzerConfigOptionsResult> sourceFileAnalyzerConfigOptions = default;
             AnalyzerConfigOptionsResult globalConfigOptions = default;
 
@@ -792,7 +791,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            Compilation compilation = CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, sourceFileAnalyzerConfigOptions, globalConfigOptions);
+            Compilation? compilation = CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, sourceFileAnalyzerConfigOptions, globalConfigOptions);
             if (compilation == null)
             {
                 return Failed;
@@ -806,7 +805,7 @@ namespace Microsoft.CodeAnalysis
                 return Failed;
             }
 
-            ImmutableArray<EmbeddedText> embeddedTexts = AcquireEmbeddedTexts(compilation, diagnostics);
+            ImmutableArray<EmbeddedText?> embeddedTexts = AcquireEmbeddedTexts(compilation, diagnostics);
             if (ReportDiagnostics(diagnostics, consoleOutput, errorLogger))
             {
                 return Failed;
@@ -825,7 +824,7 @@ namespace Microsoft.CodeAnalysis
                 embeddedTexts,
                 diagnostics,
                 cancellationToken,
-                out CancellationTokenSource analyzerCts,
+                out CancellationTokenSource? analyzerCts,
                 out bool reportAnalyzer,
                 out var analyzerDriver);
 
@@ -855,6 +854,7 @@ namespace Microsoft.CodeAnalysis
             diagnostics.Free();
             if (reportAnalyzer)
             {
+                Debug.Assert(analyzerDriver is object);
                 ReportAnalyzerExecutionTime(consoleOutput, analyzerDriver, Culture, compilation.Options.ConcurrentBuild);
             }
 
@@ -908,19 +908,19 @@ namespace Microsoft.CodeAnalysis
         /// and analyzer output.
         /// </summary>
         private void CompileAndEmit(
-            TouchedFileLogger touchedFilesLogger,
+            TouchedFileLogger? touchedFilesLogger,
             ref Compilation compilation,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             ImmutableArray<ISourceGenerator> generators,
             ImmutableArray<AdditionalText> additionalTextFiles,
-            AnalyzerConfigSet analyzerConfigSet,
+            AnalyzerConfigSet? analyzerConfigSet,
             ImmutableArray<AnalyzerConfigOptionsResult> sourceFileAnalyzerConfigOptions,
-            ImmutableArray<EmbeddedText> embeddedTexts,
+            ImmutableArray<EmbeddedText?> embeddedTexts,
             DiagnosticBag diagnostics,
             CancellationToken cancellationToken,
-            out CancellationTokenSource analyzerCts,
+            out CancellationTokenSource? analyzerCts,
             out bool reportAnalyzer,
-            out AnalyzerDriver analyzerDriver)
+            out AnalyzerDriver? analyzerDriver)
         {
             analyzerCts = null;
             reportAnalyzer = false;
@@ -933,12 +933,13 @@ namespace Microsoft.CodeAnalysis
                 return;
             }
 
-            DiagnosticBag analyzerExceptionDiagnostics = null;
+            DiagnosticBag? analyzerExceptionDiagnostics = null;
             if (!analyzers.IsEmpty || !generators.IsEmpty)
             {
                 var analyzerConfigProvider = CompilerAnalyzerConfigOptionsProvider.Empty;
                 if (Arguments.AnalyzerConfigPaths.Length > 0)
                 {
+                    Debug.Assert(analyzerConfigSet is object);
                     analyzerConfigProvider = analyzerConfigProvider.WithGlobalOptions(new CompilerAnalyzerConfigOptions(analyzerConfigSet.GetOptionsForSourcePath(string.Empty).AnalyzerOptions));
 
                     // TODO(https://github.com/dotnet/roslyn/issues/31916): The compiler currently doesn't support
@@ -983,15 +984,15 @@ namespace Microsoft.CodeAnalysis
 
                             // embed the generated text and get analyzer options for it if needed
                             embeddedTextBuilder.Add(EmbeddedText.FromSource(tree.FilePath, sourceText));
-                            if (hasAnalyzerConfigs)
+                            if (analyzerOptionsBuilder is object)
                             {
-                                analyzerOptionsBuilder.Add(analyzerConfigSet.GetOptionsForSourcePath(tree.FilePath));
+                                analyzerOptionsBuilder.Add(analyzerConfigSet!.GetOptionsForSourcePath(tree.FilePath));
                             }
 
                             // write out the file if we have an output path
                             if (hasGeneratedOutputPath)
                             {
-                                var path = Path.Combine(Arguments.GeneratedFilesOutputDirectory, tree.FilePath);
+                                var path = Path.Combine(Arguments.GeneratedFilesOutputDirectory!, tree.FilePath);
                                 if (Directory.Exists(Arguments.GeneratedFilesOutputDirectory))
                                 {
                                     Directory.CreateDirectory(Path.GetDirectoryName(path));
@@ -1000,6 +1001,8 @@ namespace Microsoft.CodeAnalysis
                                 var fileStream = OpenFile(path, diagnostics, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
                                 if (fileStream is object)
                                 {
+                                    Debug.Assert(tree.Encoding is object);
+
                                     using var disposer = new NoThrowStreamDisposer(fileStream, path, diagnostics, MessageProvider);
                                     using var writer = new StreamWriter(fileStream, tree.Encoding);
 
@@ -1010,7 +1013,7 @@ namespace Microsoft.CodeAnalysis
                         }
 
                         embeddedTexts = embeddedTexts.AddRange(embeddedTextBuilder);
-                        if (hasAnalyzerConfigs)
+                        if (analyzerOptionsBuilder is object)
                         {
                             analyzerConfigProvider = UpdateAnalyzerConfigOptionsProvider(
                                analyzerConfigProvider,
@@ -1062,12 +1065,12 @@ namespace Microsoft.CodeAnalysis
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            string outputName = GetOutputFileName(compilation, cancellationToken);
+            string outputName = GetOutputFileName(compilation, cancellationToken)!;
             var finalPeFilePath = Arguments.GetOutputFilePath(outputName);
             var finalPdbFilePath = Arguments.GetPdbFilePath(outputName);
             var finalXmlFilePath = Arguments.DocumentationPath;
 
-            NoThrowStreamDisposer sourceLinkStreamDisposerOpt = null;
+            NoThrowStreamDisposer? sourceLinkStreamDisposerOpt = null;
 
             try
             {
@@ -1148,7 +1151,7 @@ namespace Microsoft.CodeAnalysis
                         {
                             // NOTE: as native compiler does, we generate the documentation file
                             // NOTE: 'in place', replacing the contents of the file if it exists
-                            NoThrowStreamDisposer xmlStreamDisposerOpt = null;
+                            NoThrowStreamDisposer? xmlStreamDisposerOpt = null;
 
                             if (finalXmlFilePath != null)
                             {
@@ -1242,7 +1245,7 @@ namespace Microsoft.CodeAnalysis
                         var peStreamProvider = new CompilerEmitStreamProvider(this, finalPeFilePath);
                         var pdbStreamProviderOpt = Arguments.EmitPdbFile ? new CompilerEmitStreamProvider(this, finalPdbFilePath) : null;
 
-                        string finalRefPeFilePath = Arguments.OutputRefFilePath;
+                        string? finalRefPeFilePath = Arguments.OutputRefFilePath;
                         var refPeStreamProviderOpt = finalRefPeFilePath != null ? new CompilerEmitStreamProvider(this, finalRefPeFilePath) : null;
 
                         RSAParameters? privateKeyOpt = null;
@@ -1325,7 +1328,7 @@ namespace Microsoft.CodeAnalysis
             AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
             => new Diagnostics.AnalyzerOptions(additionalTextFiles, analyzerConfigOptionsProvider);
 
-        private bool WriteTouchedFiles(DiagnosticBag diagnostics, TouchedFileLogger touchedFilesLogger, string finalXmlFilePath)
+        private bool WriteTouchedFiles(DiagnosticBag diagnostics, TouchedFileLogger? touchedFilesLogger, string? finalXmlFilePath)
         {
             if (Arguments.TouchedFilesPath != null)
             {
@@ -1347,7 +1350,7 @@ namespace Microsoft.CodeAnalysis
                     return false;
                 }
 
-                string filePath = null;
+                string? filePath = null;
                 try
                 {
                     filePath = readFilesPath;
@@ -1373,7 +1376,7 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
-        protected virtual ImmutableArray<AdditionalTextFile> ResolveAdditionalFilesFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger touchedFilesLogger)
+        protected virtual ImmutableArray<AdditionalTextFile> ResolveAdditionalFilesFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger? touchedFilesLogger)
         {
             var builder = ImmutableArray.CreateBuilder<AdditionalTextFile>();
 
@@ -1413,7 +1416,7 @@ namespace Microsoft.CodeAnalysis
                 string.Format(culture, "{0,8:<0.000}", 0.001) :
                 string.Format(culture, "{0,8:##0.000}", d);
             Func<int, string> getFormattedPercentage = i => string.Format("{0,5}", i < 1 ? "<1" : i.ToString());
-            Func<string, string> getFormattedAnalyzerName = s => "   " + s;
+            Func<string?, string> getFormattedAnalyzerName = s => "   " + s;
 
             // Table header
             var analyzerTimeColumn = string.Format("{0,8}", CodeAnalysisResources.AnalyzerExecutionTimeColumnHeader);
@@ -1459,7 +1462,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// C# has a special implementation that implements idiosyncratic behavior of csc.
         /// </remarks>
-        protected virtual string GetOutputFileName(Compilation compilation, CancellationToken cancellationToken)
+        protected virtual string? GetOutputFileName(Compilation compilation, CancellationToken cancellationToken)
         {
             return Arguments.OutputFileName;
         }
@@ -1472,9 +1475,10 @@ namespace Microsoft.CodeAnalysis
             get { return _fileOpen ?? ((path, mode, access, share) => new FileStream(path, mode, access, share)); }
             set { _fileOpen = value; }
         }
-        private Func<string, FileMode, FileAccess, FileShare, Stream> _fileOpen;
 
-        private Stream OpenFile(
+        private Func<string, FileMode, FileAccess, FileShare, Stream>? _fileOpen;
+
+        private Stream? OpenFile(
             string filePath,
             DiagnosticBag diagnostics,
             FileMode mode = FileMode.Open,
@@ -1493,7 +1497,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // internal for testing
-        internal static Stream GetWin32ResourcesInternal(
+        internal static Stream? GetWin32ResourcesInternal(
             CommonMessageProvider messageProvider,
             CommandLineArguments arguments,
             Compilation compilation,
@@ -1505,7 +1509,7 @@ namespace Microsoft.CodeAnalysis
             return stream;
         }
 
-        private static Stream GetWin32Resources(
+        private static Stream? GetWin32Resources(
             CommonMessageProvider messageProvider,
             CommandLineArguments arguments,
             Compilation compilation,
@@ -1516,9 +1520,9 @@ namespace Microsoft.CodeAnalysis
                 return OpenStream(messageProvider, arguments.Win32ResourceFile, arguments.BaseDirectory, messageProvider.ERR_CantOpenWin32Resource, diagnostics);
             }
 
-            using (Stream manifestStream = OpenManifestStream(messageProvider, compilation.Options.OutputKind, arguments, diagnostics))
+            using (Stream? manifestStream = OpenManifestStream(messageProvider, compilation.Options.OutputKind, arguments, diagnostics))
             {
-                using (Stream iconStream = OpenStream(messageProvider, arguments.Win32Icon, arguments.BaseDirectory, messageProvider.ERR_CantOpenWin32Icon, diagnostics))
+                using (Stream? iconStream = OpenStream(messageProvider, arguments.Win32Icon, arguments.BaseDirectory, messageProvider.ERR_CantOpenWin32Icon, diagnostics))
                 {
                     try
                     {
@@ -1534,21 +1538,21 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        private static Stream OpenManifestStream(CommonMessageProvider messageProvider, OutputKind outputKind, CommandLineArguments arguments, DiagnosticBag diagnostics)
+        private static Stream? OpenManifestStream(CommonMessageProvider messageProvider, OutputKind outputKind, CommandLineArguments arguments, DiagnosticBag diagnostics)
         {
             return outputKind.IsNetModule()
                 ? null
                 : OpenStream(messageProvider, arguments.Win32Manifest, arguments.BaseDirectory, messageProvider.ERR_CantOpenWin32Manifest, diagnostics);
         }
 
-        private static Stream OpenStream(CommonMessageProvider messageProvider, string path, string baseDirectory, int errorCode, DiagnosticBag diagnostics)
+        private static Stream? OpenStream(CommonMessageProvider messageProvider, string? path, string? baseDirectory, int errorCode, DiagnosticBag diagnostics)
         {
             if (path == null)
             {
                 return null;
             }
 
-            string fullPath = ResolveRelativePath(messageProvider, path, baseDirectory, diagnostics);
+            string? fullPath = ResolveRelativePath(messageProvider, path, baseDirectory, diagnostics);
             if (fullPath == null)
             {
                 return null;
@@ -1566,12 +1570,12 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        private static string ResolveRelativePath(CommonMessageProvider messageProvider, string path, string baseDirectory, DiagnosticBag diagnostics)
+        private static string? ResolveRelativePath(CommonMessageProvider messageProvider, string? path, string? baseDirectory, DiagnosticBag diagnostics)
         {
-            string fullPath = FileUtilities.ResolveRelativePath(path, baseDirectory);
+            string? fullPath = FileUtilities.ResolveRelativePath(path, baseDirectory);
             if (fullPath == null)
             {
-                diagnostics.Add(messageProvider.CreateDiagnostic(messageProvider.FTL_InvalidInputFileName, Location.None, path));
+                diagnostics.Add(messageProvider.CreateDiagnostic(messageProvider.FTL_InvalidInputFileName, Location.None, path ?? ""));
             }
 
             return fullPath;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         [return: NotNullIfNotNull("hash")]
-        internal static string? ExtractShortCommitHash(string hash)
+        internal static string? ExtractShortCommitHash(string? hash)
         {
             // leave "<developer build>" alone, but truncate SHA to 8 characters
             if (hash != null && hash.Length >= 8 && hash[0] != '<')
@@ -177,9 +177,7 @@ namespace Microsoft.CodeAnalysis
         private static string? GetShortCommitHash(Type type)
         {
             var hash = type.Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
-            return hash is object
-                ? ExtractShortCommitHash(hash)
-                : null;
+            return ExtractShortCommitHash(hash);
         }
 
         /// <summary>
@@ -1570,7 +1568,7 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        private static string? ResolveRelativePath(CommonMessageProvider messageProvider, string? path, string? baseDirectory, DiagnosticBag diagnostics)
+        private static string? ResolveRelativePath(CommonMessageProvider messageProvider, string path, string? baseDirectory, DiagnosticBag diagnostics)
         {
             string? fullPath = FileUtilities.ResolveRelativePath(path, baseDirectory);
             if (fullPath == null)

--- a/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -18,11 +16,11 @@ namespace Microsoft.CodeAnalysis
     internal class StrongNameFileSystem
     {
         internal static readonly StrongNameFileSystem Instance = new StrongNameFileSystem();
-        internal readonly string _tempPath;
+        internal readonly string? _customTempPath;
 
-        internal StrongNameFileSystem(string tempPath = null)
+        internal StrongNameFileSystem(string? customTempPath = null)
         {
-            _tempPath = tempPath;
+            _customTempPath = customTempPath;
         }
 
         internal virtual FileStream CreateFileStream(string filePath, FileMode fileMode, FileAccess fileAccess, FileShare fileShare)
@@ -36,12 +34,12 @@ namespace Microsoft.CodeAnalysis
             return File.ReadAllBytes(fullPath);
         }
 
-        internal virtual bool FileExists(string fullPath)
+        internal virtual bool FileExists(string? fullPath)
         {
             Debug.Assert(fullPath == null || PathUtilities.IsAbsolute(fullPath));
             return File.Exists(fullPath);
         }
 
-        internal virtual string GetTempPath() => _tempPath ?? Path.GetTempPath();
+        internal virtual string GetTempPath() => _customTempPath ?? Path.GetTempPath();
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
+++ b/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -19,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private static readonly ImmutableArray<string> s_defaultIgnorableReferenceNames = ImmutableArray.Create("mscorlib", "System", "Microsoft.CodeAnalysis", "netstandard");
 
-        public static bool Check(string baseDirectory, IEnumerable<CommandLineAnalyzerReference> analyzerReferences, IAnalyzerAssemblyLoader loader, IEnumerable<string> ignorableReferenceNames = null)
+        public static bool Check(string baseDirectory, IEnumerable<CommandLineAnalyzerReference> analyzerReferences, IAnalyzerAssemblyLoader loader, IEnumerable<string>? ignorableReferenceNames = null)
         {
             if (ignorableReferenceNames == null)
             {
@@ -48,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             foreach (var analyzerReference in analyzerReferences)
             {
-                string resolvedPath = FileUtilities.ResolveRelativePath(analyzerReference.FilePath, basePath: null, baseDirectory: baseDirectory, searchPaths: SpecializedCollections.EmptyEnumerable<string>(), fileExists: File.Exists);
+                string? resolvedPath = FileUtilities.ResolveRelativePath(analyzerReference.FilePath, basePath: null, baseDirectory: baseDirectory, searchPaths: SpecializedCollections.EmptyEnumerable<string>(), fileExists: File.Exists);
                 if (resolvedPath != null)
                 {
                     resolvedPath = FileUtilities.TryNormalizeAbsolutePath(resolvedPath);

--- a/src/Compilers/Server/VBCSCompiler/Assembly.cs
+++ b/src/Compilers/Server/VBCSCompiler/Assembly.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/Compilers/Server/VBCSCompiler/BuildProtocolUtil.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildProtocolUtil.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -19,9 +17,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         internal static RunRequest GetRunRequest(BuildRequest req)
         {
-            string currentDirectory;
-            string libDirectory;
-            string tempDirectory;
+            string? currentDirectory;
+            string? libDirectory;
+            string? tempDirectory;
             string[] arguments = GetCommandLineArguments(req, out currentDirectory, out tempDirectory, out libDirectory);
             string language = "";
             switch (req.Language)
@@ -37,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             return new RunRequest(language, currentDirectory, tempDirectory, libDirectory, arguments);
         }
 
-        internal static string[] GetCommandLineArguments(BuildRequest req, out string currentDirectory, out string tempDirectory, out string libDirectory)
+        internal static string[] GetCommandLineArguments(BuildRequest req, out string? currentDirectory, out string? tempDirectory, out string? libDirectory)
         {
             currentDirectory = null;
             libDirectory = null;
@@ -60,10 +58,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
                 else if (arg.ArgumentId == BuildProtocolConstants.ArgumentId.CommandLineArgument)
                 {
-                    int argIndex = arg.ArgumentIndex;
-                    while (argIndex >= commandLineArguments.Count)
-                        commandLineArguments.Add("");
-                    commandLineArguments[argIndex] = arg.Value;
+                    if (arg.Value is object)
+                    {
+                        int argIndex = arg.ArgumentIndex;
+                        while (argIndex >= commandLineArguments.Count)
+                            commandLineArguments.Add("");
+                        commandLineArguments[argIndex] = arg.Value;
+                    }
                 }
             }
 

--- a/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
             : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
         {
-            _metadataProvider = metadataProvider;
         }
 
         internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -18,8 +16,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
-        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(CSharpCommandLineParser.Default, buildPaths.ClientDirectory != null ? Path.Combine(buildPaths.ClientDirectory, ResponseFileName) : null, args, buildPaths, libDirectory, analyzerLoader)
+        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
+            : base(CSharpCommandLineParser.Default, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
@@ -17,7 +17,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
         internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(CSharpCommandLineParser.Default, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
+            : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
+        {
+            _metadataProvider = metadataProvider;
+        }
+
+        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
+            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, libDirectory, analyzerLoader)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/VBCSCompiler/DiagnosticListener.cs
+++ b/src/Compilers/Server/VBCSCompiler/DiagnosticListener.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO.Pipes;

--- a/src/Compilers/Server/VBCSCompiler/ICompilerServerHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/ICompilerServerHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Compilers/Server/VBCSCompiler/MemoryHelper.cs
+++ b/src/Compilers/Server/VBCSCompiler/MemoryHelper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CommandLine;

--- a/src/Compilers/Server/VBCSCompiler/MetadataCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/MetadataCache.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -38,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         private ImmutableArray<ModuleMetadata> GetAllModules(ModuleMetadata manifestModule, string assemblyDir)
         {
-            ArrayBuilder<ModuleMetadata> moduleBuilder = null;
+            ArrayBuilder<ModuleMetadata>? moduleBuilder = null;
 
             foreach (string moduleName in manifestModule.GetModuleNames())
             {
@@ -48,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     moduleBuilder.Add(manifestModule);
                 }
 
-                var module = CreateModuleMetadata(PathUtilities.CombineAbsoluteAndRelativePaths(assemblyDir, moduleName), prefetchEntireImage: false);
+                var module = CreateModuleMetadata(PathUtilities.CombineAbsoluteAndRelativePaths(assemblyDir, moduleName)!, prefetchEntireImage: false);
                 moduleBuilder.Add(module);
             }
 
@@ -60,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // Check if we have an entry in the dictionary.
             FileKey? fileKey = GetUniqueFileKey(fullPath);
 
-            Metadata metadata;
+            Metadata? metadata;
             if (fileKey.HasValue && _metadataCache.TryGetValue(fileKey.Value, out metadata) && metadata != null)
             {
                 return metadata;
@@ -74,10 +72,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
             else
             {
+                Debug.Assert(fileKey.HasValue);
                 var primaryModule = CreateModuleMetadata(fullPath, prefetchEntireImage: false);
 
                 // Get all the modules, and load them. Create an assembly metadata.
-                var allModules = GetAllModules(primaryModule, Path.GetDirectoryName(fullPath));
+                var allModules = GetAllModules(primaryModule, Path.GetDirectoryName(fullPath)!);
                 Metadata result = AssemblyMetadata.Create(allModules);
 
                 result = _metadataCache.GetOrAdd(fileKey.Value, result);
@@ -114,9 +113,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private static readonly MetadataAndSymbolCache s_mdCache = new MetadataAndSymbolCache();
 
+        public new string FilePath { get; }
+
         public CachingMetadataReference(string fullPath, MetadataReferenceProperties properties)
             : base(properties, fullPath)
         {
+            FilePath = fullPath;
         }
 
         protected override DocumentationProvider CreateDocumentationProvider()

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CommandLine;
 using System;
 using System.Collections.Specialized;

--- a/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
@@ -19,7 +19,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
         internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(VisualBasicCommandLineParser.Default, buildPaths.ClientDirectory != null ? Path.Combine(buildPaths.ClientDirectory, ResponseFileName) : null, args, buildPaths, libDirectory, analyzerLoader)
+            : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
+        {
+            _metadataProvider = metadataProvider;
+        }
+
+        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
+            : base(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, libDirectory, analyzerLoader)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -20,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
-        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
+        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
             : base(VisualBasicCommandLineParser.Default, buildPaths.ClientDirectory != null ? Path.Combine(buildPaths.ClientDirectory, ResponseFileName) : null, args, buildPaths, libDirectory, analyzerLoader)
         {
             _metadataProvider = metadataProvider;

--- a/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
             : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
         {
-            _metadataProvider = metadataProvider;
         }
 
         internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -342,17 +342,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void GetPipeNameForPathOptSlashes()
             {
                 var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
-                var name = BuildServerConnection.GetPipeNameForPathOpt(path);
-                Assert.Equal(name, BuildServerConnection.GetPipeNameForPathOpt(path));
-                Assert.Equal(name, BuildServerConnection.GetPipeNameForPathOpt(path + Path.DirectorySeparatorChar));
-                Assert.Equal(name, BuildServerConnection.GetPipeNameForPathOpt(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
+                var name = BuildServerConnection.GetPipeNameForPath(path);
+                Assert.Equal(name, BuildServerConnection.GetPipeNameForPath(path));
+                Assert.Equal(name, BuildServerConnection.GetPipeNameForPath(path + Path.DirectorySeparatorChar));
+                Assert.Equal(name, BuildServerConnection.GetPipeNameForPath(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
             }
 
             [Fact]
             public void GetPipeNameForPathOptLength()
             {
                 var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
-                var name = BuildServerConnection.GetPipeNameForPathOpt(path);
+                var name = BuildServerConnection.GetPipeNameForPath(path);
                 // We only have ~50 total bytes to work with on mac, so the base path must be small
                 Assert.Equal(43, name.Length);
             }

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -23,8 +23,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     internal static class ProtocolUtil
     {
-        internal const string DefaultWorkingDirectory = @"c:\code";
-
         internal static readonly BuildRequest EmptyCSharpBuildRequest = new BuildRequest(
             BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
@@ -42,10 +40,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             utf8output: false,
             output: string.Empty);
 
-        internal static BuildRequest CreateEmptyCSharpWithKeepAlive(TimeSpan keepAlive, string workingDirectory = null, string tempDirectory = null) => BuildRequest.Create(
+        internal static BuildRequest CreateEmptyCSharpWithKeepAlive(TimeSpan keepAlive, string workingDirectory, string tempDirectory = null) => BuildRequest.Create(
             RequestLanguage.CSharpCompile,
             Array.Empty<string>(),
-            workingDirectory ?? DefaultWorkingDirectory,
+            workingDirectory,
             tempDirectory ?? Path.GetTempPath(),
             compilerHash: BuildProtocolConstants.GetCommitHash(),
             keepAlive: keepAlive.TotalSeconds.ToString());

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     internal static class ProtocolUtil
     {
+        internal const string DefaultWorkingDirectory = @"c:\code";
+
         internal static readonly BuildRequest EmptyCSharpBuildRequest = new BuildRequest(
             BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
@@ -40,9 +42,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             utf8output: false,
             output: string.Empty);
 
-        internal static BuildRequest CreateEmptyCSharpWithKeepAlive(TimeSpan keepAlive) => BuildRequest.Create(
+        internal static BuildRequest CreateEmptyCSharpWithKeepAlive(TimeSpan keepAlive, string workingDirectory = null, string tempDirectory = null) => BuildRequest.Create(
             RequestLanguage.CSharpCompile,
             Array.Empty<string>(),
+            workingDirectory ?? DefaultWorkingDirectory,
+            tempDirectory ?? Path.GetTempPath(),
             compilerHash: BuildProtocolConstants.GetCommitHash(),
             keepAlive: keepAlive.TotalSeconds.ToString());
 

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -155,7 +155,7 @@ End Class
             expectedReads = new List<string>();
             expectedReads.AddRange(cmd.Arguments.MetadataReferences.Select(r => r.Reference));
 
-            if (cmd.Arguments is VisualBasicCommandLineArguments {  DefaultCoreLibraryReference: { } reference })
+            if (cmd.Arguments is VisualBasicCommandLineArguments { DefaultCoreLibraryReference: { } reference })
             {
                 expectedReads.Add(reference.Reference);
             }

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -48,13 +48,15 @@ class C
                 var source1 = Temp.CreateFile().WriteAllText(helloWorldCS).Path;
                 var touchedDir = Temp.CreateDirectory();
                 var touchedBase = Path.Combine(touchedDir.Path, "touched");
+                var clientDirectory = AppContext.BaseDirectory;
 
                 filelist.Add(source1);
                 var outWriter = new StringWriter();
                 var cmd = new CSharpCompilerServer(
                     CompilerServerHost.SharedAssemblyReferenceProvider,
+                    responseFile: null,
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
-                    new BuildPaths(null, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
+                    new BuildPaths(clientDirectory, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
                     s_libDirectory,
                     new TestAnalyzerAssemblyLoader());
 
@@ -92,8 +94,8 @@ class C
                                               out List<string> expectedReads,
                                               out List<string> expectedWrites)
         {
-            expectedReads = cmd.Arguments.MetadataReferences
-                .Select(r => r.Reference).ToList();
+            expectedReads = new List<string>();
+            expectedReads.AddRange(cmd.Arguments.MetadataReferences.Select(r => r.Reference));
 
             foreach (var file in cmd.Arguments.SourceFiles)
             {
@@ -111,6 +113,18 @@ class C
             List<string> expectedWrites,
             string touchedFilesBase)
         {
+            Console.WriteLine("Reads");
+            foreach (var s in expectedReads)
+            {
+                Console.WriteLine(s);
+            }
+
+            Console.WriteLine("Writes");
+            foreach (var s in expectedWrites)
+            {
+                Console.WriteLine(s);
+            }
+
             var touchedReadPath = touchedFilesBase + ".read";
             var touchedWritesPath = touchedFilesBase + ".write";
 

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -113,18 +113,6 @@ class C
             List<string> expectedWrites,
             string touchedFilesBase)
         {
-            Console.WriteLine("Reads");
-            foreach (var s in expectedReads)
-            {
-                Console.WriteLine(s);
-            }
-
-            Console.WriteLine("Writes");
-            foreach (var s in expectedWrites)
-            {
-                Console.WriteLine(s);
-            }
-
             var touchedReadPath = touchedFilesBase + ".read";
             var touchedWritesPath = touchedFilesBase + ".write";
 

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -17,6 +17,7 @@ using static Roslyn.Test.Utilities.SharedResourceHelpers;
 using System.Reflection;
 using Microsoft.CodeAnalysis.CompilerServer;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     {
         private static readonly string s_libDirectory = Environment.GetEnvironmentVariable("LIB");
         private readonly string _baseDirectory = TempRoot.Root;
-        private const string helloWorldCS = @"using System;
+        private const string HelloWorldCS = @"using System;
 
 class C
 {
@@ -34,10 +35,18 @@ class C
     }
 }";
 
+        private const string HelloWorldVB = @"Imports System
+Class C
+    Shared Sub Main(args As String())
+        Console.WriteLine(""Hello, world"")
+    End Sub
+End Class
+";
+
         [ConditionalFact(typeof(DesktopOnly))]
-        public void TrivialMetadataCaching()
+        public void CSharpTrivialMetadataCaching()
         {
-            List<String> filelist = new List<string>();
+            var filelist = new List<string>();
 
             // Do the following compilation twice.
             // The compiler server API should hold on to the mscorlib bits
@@ -45,7 +54,7 @@ class C
             // touched.
             for (int i = 0; i < 2; i++)
             {
-                var source1 = Temp.CreateFile().WriteAllText(helloWorldCS).Path;
+                var source1 = Temp.CreateFile().WriteAllText(HelloWorldCS).Path;
                 var touchedDir = Temp.CreateDirectory();
                 var touchedBase = Path.Combine(touchedDir.Path, "touched");
                 var clientDirectory = AppContext.BaseDirectory;
@@ -83,19 +92,73 @@ class C
             }
         }
 
+        [ConditionalFact(typeof(DesktopOnly))]
+        public void VisualBasicTrivialMetadataCaching()
+        {
+            var filelist = new List<string>();
+
+            // Do the following compilation twice.
+            // The compiler server API should hold on to the mscorlib bits
+            // in memory, but the file tracker should still map that it was
+            // touched.
+            for (int i = 0; i < 2; i++)
+            {
+                var source1 = Temp.CreateFile().WriteAllText(HelloWorldVB).Path;
+                var touchedDir = Temp.CreateDirectory();
+                var touchedBase = Path.Combine(touchedDir.Path, "touched");
+                var clientDirectory = AppContext.BaseDirectory;
+
+                filelist.Add(source1);
+                var outWriter = new StringWriter();
+                var cmd = new VisualBasicCompilerServer(
+                    CompilerServerHost.SharedAssemblyReferenceProvider,
+                    responseFile: null,
+                    new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
+                    new BuildPaths(clientDirectory, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
+                    s_libDirectory,
+                    new TestAnalyzerAssemblyLoader());
+
+                List<string> expectedReads;
+                List<string> expectedWrites;
+                BuildTouchedFiles(cmd,
+                                  Path.ChangeExtension(source1, "exe"),
+                                  out expectedReads,
+                                  out expectedWrites);
+
+                var exitCode = cmd.Run(outWriter);
+
+                Assert.Equal(string.Empty, outWriter.ToString().Trim());
+                Assert.Equal(0, exitCode);
+
+                AssertTouchedFilesEqual(expectedReads,
+                                        expectedWrites,
+                                        touchedBase);
+            }
+
+            foreach (string f in filelist)
+            {
+                CleanupAllGeneratedFiles(f);
+            }
+        }
+
         /// <summary>
         /// Builds the expected base of touched files.
         /// Adds a hook for temporary file creation as well,
         /// so this method must be called before the execution of
         /// Csc.Run.
         /// </summary>
-        private static void BuildTouchedFiles(CSharpCompiler cmd,
+        private static void BuildTouchedFiles(CommonCompiler cmd,
                                               string outputPath,
                                               out List<string> expectedReads,
                                               out List<string> expectedWrites)
         {
             expectedReads = new List<string>();
             expectedReads.AddRange(cmd.Arguments.MetadataReferences.Select(r => r.Reference));
+
+            if (cmd.Arguments is VisualBasicCommandLineArguments {  DefaultCoreLibraryReference: { } reference })
+            {
+                expectedReads.Add(reference.Reference);
+            }
 
             foreach (var file in cmd.Arguments.SourceFiles)
             {

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using Microsoft.CodeAnalysis.CommandLine;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System;
 using System.Collections.Generic;
@@ -19,8 +20,15 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
-    public class VBCSCompilerServerTests
+    public class VBCSCompilerServerTests : IDisposable
     {
+        public TempRoot TempRoot { get; } = new TempRoot();
+
+        public void Dispose()
+        {
+            TempRoot.Dispose();
+        }
+
         public class StartupTests : VBCSCompilerServerTests
         {
             [Fact]
@@ -278,11 +286,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 var compilerServerHost = new TestableCompilerServerHost((request, cancellationToken) => ProtocolUtil.EmptyBuildResponse);
                 using var serverData = await ServerUtil.CreateServer(compilerServerHost: compilerServerHost).ConfigureAwait(false);
+                var workingDirectory = TempRoot.CreateDirectory().Path;
 
                 for (var i = 0; i < connectionCount; i++)
                 {
                     var request = i + 1 >= connectionCount
-                        ? ProtocolUtil.CreateEmptyCSharpWithKeepAlive(TimeSpan.FromSeconds(3))
+                        ? ProtocolUtil.CreateEmptyCSharpWithKeepAlive(TimeSpan.FromSeconds(3), workingDirectory)
                         : ProtocolUtil.EmptyCSharpBuildRequest;
                     await serverData.SendAsync(request).ConfigureAwait(false);
                 }
@@ -318,7 +327,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
                 readyMre.Set();
 
-                await serverData.SendAsync(ProtocolUtil.CreateEmptyCSharpWithKeepAlive(TimeSpan.FromSeconds(3))).ConfigureAwait(false);
+                var workingDirectory = TempRoot.CreateDirectory().Path;
+                await serverData.SendAsync(ProtocolUtil.CreateEmptyCSharpWithKeepAlive(TimeSpan.FromSeconds(3), workingDirectory)).ConfigureAwait(false);
                 await Task.WhenAll(list).ConfigureAwait(false);
 
                 // Don't use Complete here because we want to see the server shutdown naturally

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// </summary>
         private static string GetPipeName(BuildPaths buildPaths)
         {
-            return BuildServerConnection.GetPipeNameForPathOpt(buildPaths.ClientDirectory);
+            return BuildServerConnection.GetPipeNameForPath(buildPaths.ClientDirectory);
         }
 
         private static IEnumerable<string> GetCommandLineArgs(IEnumerable<string> args)

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -51,9 +51,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// The temporary directory a compilation should use instead of <see cref="Path.GetTempPath"/>.  The latter
         /// relies on global state individual compilations should ignore.
         /// </summary>
-        internal string TempDirectory { get; }
+        internal string? TempDirectory { get; }
 
-        internal BuildPathsAlt(string clientDir, string workingDir, string? sdkDir, string tempDir)
+        internal BuildPathsAlt(string clientDir, string workingDir, string? sdkDir, string? tempDir)
         {
             ClientDirectory = clientDir;
             WorkingDirectory = workingDir;
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <summary>
         /// Determines if the compiler server is supported in this environment.
         /// </summary>
-        internal static bool IsCompilerServerSupported => GetPipeNameForPathOpt("") is object;
+        internal static bool IsCompilerServerSupported => GetPipeNameForPath("") is object;
 
         public static Task<BuildResponse> RunServerCompilationAsync(
             RequestLanguage language,
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             string? libEnvVariable,
             CancellationToken cancellationToken)
         {
-            var pipeNameOpt = sharedCompilationId ?? GetPipeNameForPathOpt(buildPaths.ClientDirectory);
+            var pipeNameOpt = sharedCompilationId ?? GetPipeNameForPath(buildPaths.ClientDirectory);
 
             return RunServerCompilationCoreAsync(
                 language,
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <returns>
         /// Null if not enough information was found to create a valid pipe name.
         /// </returns>
-        internal static string? GetPipeNameForPathOpt(string compilerExeDirectory)
+        internal static string? GetPipeNameForPath(string compilerExeDirectory)
         {
             // Prefix with username and elevation
             bool isAdmin = false;

--- a/src/Compilers/VisualBasic/Portable/Microsoft.CodeAnalysis.VisualBasic.vbproj
+++ b/src/Compilers/VisualBasic/Portable/Microsoft.CodeAnalysis.VisualBasic.vbproj
@@ -51,6 +51,7 @@
     <InternalsVisibleTo Include="vbc" />
     <InternalsVisibleTo Include="vbi" />
     <InternalsVisibleTo Include="VBCSCompiler" />
+    <InternalsVisibleTo Include="VBCSCompiler.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests" />

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -6,7 +6,6 @@ Imports System.Globalization
 Imports System.IO
 Imports System.Reflection
 Imports System.Runtime.InteropServices
-Imports Microsoft.CodeAnalysis.CompilerServer
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities.SharedResourceHelpers
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -155,48 +154,6 @@ End Class
 
             CleanupAllGeneratedFiles(sourcePath)
             CleanupAllGeneratedFiles(xml.Path)
-        End Sub
-
-        <Fact>
-        Public Sub TrivialMetadataCaching()
-            Dim folderList As New List(Of String)
-            Dim filelist As New List(Of String)
-
-            For i = 0 To 2 - 1
-                Dim source1 = Temp.CreateFile().WriteAllText(_helloWorldCS).Path
-                Dim touchedDir = Temp.CreateDirectory()
-                Dim touchedBase = Path.Combine(touchedDir.Path, "touched")
-                filelist.Add(source1)
-                folderList.Add(touchedDir.Path)
-
-                Dim outWriter = New StringWriter()
-                Dim cmd = New VisualBasicCompilerServer(
-                    CompilerServerHost.SharedAssemblyReferenceProvider,
-                    {"/nologo",
-                     "/touchedfiles:" + touchedBase,
-                     source1},
-                    New BuildPaths(Nothing, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
-                    s_libDirectory,
-                    New TestAnalyzerAssemblyLoader())
-                Dim expectedReads As List(Of String) = Nothing
-                Dim expectedWrites As List(Of String) = Nothing
-                BuildTouchedFiles(cmd,
-                                  Path.ChangeExtension(source1, "exe"),
-                                  expectedReads,
-                                  expectedWrites)
-
-                Dim exitCode = cmd.Run(outWriter, Nothing)
-                Assert.Equal(String.Empty, outWriter.ToString().Trim())
-                Assert.Equal(0, exitCode)
-
-                AssertTouchedFilesEqual(expectedReads,
-                                        expectedWrites,
-                                        touchedBase)
-            Next
-
-            For Each f In filelist
-                CleanupAllGeneratedFiles(f)
-            Next
         End Sub
 
         ''' <summary>


### PR DESCRIPTION
In attempting to clean up the logging code today I got stuck on a number
of cases where I was uncertain about `null` values. Decided to take the
time to finish `null` annotating this code base.