### PR TITLE
Run Rich Nav index on every push to master

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -1,12 +1,6 @@
-trigger: none
+trigger:
+- master
 pr: none
-
-schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight (UTC) RichNav indexer run
-  branches:
-    include:
-    - master
 
 jobs:
 - job: RichCodeNav_Indexing


### PR DESCRIPTION
Remove scheduled Rich Navigation build and instead index on every iteration of master. 