### PR TITLE
Do not reduce digit separators in VB pretty listing

### DIFF
--- a/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests.cs
@@ -2033,13 +2033,15 @@ End Module
 
         [Fact]
         [WorkItem(14034, "https://github.com/dotnet/roslyn/issues/14034")]
+        [WorkItem(48492, "https://github.com/dotnet/roslyn/issues/48492")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
-        public async Task ReduceIntegersWithDigitSeparators()
+        public async Task DoNotReduceDigitSeparators()
         {
             var source = @"
 Module Module1
     Sub Main()
         Dim x = 100_000
+        Dim y = 100_000.0F
     End Sub
 End Module
 ";

--- a/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests.cs
@@ -2042,6 +2042,7 @@ Module Module1
     Sub Main()
         Dim x = 100_000
         Dim y = 100_000.0F
+        Dim z = 100_000.0D
     End Sub
 End Module
 ";

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
@@ -44,6 +44,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
             Public Overrides Function VisitLiteralExpression(node As LiteralExpressionSyntax) As SyntaxNode
                 Dim newNode = DirectCast(MyBase.VisitLiteralExpression(node), LiteralExpressionSyntax)
                 Dim literal As SyntaxToken = newNode.Token
+                Const digitSeparator = "_"c
 
                 ' Pretty list floating and decimal literals.
                 Select Case literal.Kind
@@ -55,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                         Dim value As Double = 0
                         Dim valueText As String = GetFloatLiteralValueString(literal, value) + GetTypeCharString(literal.GetTypeCharacter())
 
-                        If value = 0 Then
+                        If value = 0 OrElse valueText.Contains(digitSeparator) Then
                             ' Overflow/underflow case or zero literal, skip pretty listing.
                             Return newNode
                         End If
@@ -70,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                         Dim idText = literal.GetIdentifierText()
                         Dim value = DirectCast(literal.Value, Decimal)
 
-                        If value = 0 Then
+                        If value = 0 OrElse idText.Contains(digitSeparator) Then
                             ' Overflow/underflow case or zero literal, skip pretty listing.
                             Return newNode
                         End If
@@ -96,7 +97,6 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
 
                         Dim base = literal.GetBase()
 
-                        Const digitSeparator = "_"c
                         If Not base.HasValue OrElse idText.Contains(digitSeparator) Then
                             Return newNode
                         End If

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                         Dim value As Double = 0
                         Dim valueText As String = GetFloatLiteralValueString(literal, value) + GetTypeCharString(literal.GetTypeCharacter())
 
-                        If value = 0 OrElse valueText.Contains(digitSeparator) Then
+                        If value = 0 OrElse idText.Contains(digitSeparator) Then
                             ' Overflow/underflow case or zero literal, skip pretty listing.
                             Return newNode
                         End If


### PR DESCRIPTION
This was originally fixed for integers in https://github.com/dotnet/roslyn/pull/14291, but the PR missed the case for doubles and floats.

Fixes #48492