### PR TITLE
Update F1 Keywords to differentiate between semantics of default keyword

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -360,7 +360,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     return true;
                 }
 
-                if (token.Parent is DefaultExpressionSyntax || token.Parent is LiteralExpressionSyntax)
+                if (token.Parent is DefaultExpressionSyntax or LiteralExpressionSyntax)
                 {
                     text = Keyword("defaultvalue");
                     return true;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -358,11 +358,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 {
                     text = Keyword("defaultcase");
                     return true;
-                }
-
-                if (token.Parent is DefaultExpressionSyntax or LiteralExpressionSyntax)
-                {
-                    text = Keyword("defaultvalue");
+                } else {
+                    text = Keyword(token.Text);
                     return true;
                 }
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -358,6 +358,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     text = Keyword("defaultcase");
                     return true;
                 }
+
+                if (token.Parent is DefaultExpressionSyntax)
+                {
+                    text = Keyword("defaultvalue");
+                    return true;
+                }
             }
 
             if (token.IsKeyword())

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -359,7 +359,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     return true;
                 }
 
-                if (token.Parent is DefaultExpressionSyntax)
+                if (token.Parent is DefaultExpressionSyntax || token.Parent is LiteralExpressionSyntax)
                 {
                     text = Keyword("defaultvalue");
                     return true;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -352,7 +352,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 }
             }
 
-            if (token.IsKind(SyntaxKind.DefaultKeyword)) {
+            if (token.IsKind(SyntaxKind.DefaultKeyword))
+            {
                 if (token.Parent is DefaultSwitchLabelSyntax)
                 {
                     text = Keyword("defaultcase");

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -352,16 +352,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 }
             }
 
-            if (token.IsKind(SyntaxKind.DefaultKeyword))
-            {
-                if (token.Parent is DefaultSwitchLabelSyntax)
-                {
-                    text = Keyword("defaultcase");
-                    return true;
-                } else {
-                    text = Keyword(token.Text);
-                    return true;
-                }
+            if (token.IsKind(SyntaxKind.DefaultKeyword) && token.Parent is DefaultSwitchLabelSyntax) {
+                text = Keyword("defaultcase");
+                return true;
             }
 
             if (token.IsKeyword())

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -352,7 +352,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 }
             }
 
-            if (token.IsKind(SyntaxKind.DefaultKeyword) && token.Parent is DefaultSwitchLabelSyntax) {
+            if (token.IsKind(SyntaxKind.DefaultKeyword) && token.Parent is DefaultSwitchLabelSyntax)
+            {
                 text = Keyword("defaultcase");
                 return true;
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -352,6 +352,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 }
             }
 
+            if (token.IsKind(SyntaxKind.DefaultKeyword)) {
+                if (token.Parent is DefaultSwitchLabelSyntax)
+                {
+                    text = Keyword("defaultcase");
+                    return true;
+                }
+            }
+
             if (token.IsKeyword())
             {
                 text = Keyword(token.Text);

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -817,5 +817,113 @@ class C
     }
 }", "!");
         }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultSwitchCase()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1(int parameter)
+    {
+        switch(parameter) {
+            defa[||]ult:
+                parameter = default;
+                break;
+        }
+    }
+}", "defaultcase");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultValueInsideSwitch()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1(int parameter)
+    {
+        switch(parameter) {
+            default:
+                parameter = defa[||]ult;
+                break;
+        }
+    }
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultLiteralExpression()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    int field = defa[||]ult;
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultExpression()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    int field = defa[||]ult(int);
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultLiteralExpressionInOptionalParameter()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1(int parameter = defa[||]ult) {
+    }
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultExpressionInOptionalParameter()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1(int parameter = defa[||]ult(int)) {
+    }
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultLiteralExpressionInMethodCall()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1() {
+        M2(defa[||]ult);
+    }
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultExpressionInMethodCall()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1() {
+        M2(defa[||]ult(int));
+    }
+}", "defaultvalue");
+        }
     }
 }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -851,7 +851,7 @@ class C
                 break;
         }
     }
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -869,7 +869,7 @@ class C
                 break;
         }
     }
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -880,7 +880,7 @@ class C
 @"class C
 {
     int field = defa[||]ult;
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -891,7 +891,7 @@ class C
 @"class C
 {
     int field = defa[||]ult(int);
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -903,7 +903,7 @@ class C
 {
     void M1(int parameter = defa[||]ult) {
     }
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -915,7 +915,7 @@ class C
 {
     void M1(int parameter = defa[||]ult(int)) {
     }
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -928,7 +928,7 @@ class C
     void M1() {
         M2(defa[||]ult);
     }
-}", "defaultvalue");
+}", "default");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
@@ -941,7 +941,7 @@ class C
     void M1() {
         M2(defa[||]ult(int));
     }
-}", "defaultvalue");
+}", "default");
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -838,7 +838,7 @@ class C
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestDefaultValueInsideSwitch()
+        public async Task TestDefaultLiteralExpressionInsideSwitch()
         {
             await Test_KeywordAsync(
 @"class C
@@ -848,6 +848,24 @@ class C
         switch(parameter) {
             default:
                 parameter = defa[||]ult;
+                break;
+        }
+    }
+}", "defaultvalue");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestDefaultExpressionInsideSwitch()
+        {
+            await Test_KeywordAsync(
+@"class C
+{
+    void M1(int parameter)
+    {
+        switch(parameter) {
+            default:
+                parameter = defa[||]ult(int);
                 break;
         }
     }


### PR DESCRIPTION
This PR adds two separate `f1_keywords` for different semantics of the default keyword. This allows the F1 help to route to the appropriate page based on the context, rather than having to route to a generic default page.

The switch-statement version of `default` is detected by checking if the token is part of a `DefaultSwitchLabelSyntax`.

The default-value-expression version of `default` is detected by checking if  the token is part of:
* a `DefaultExpressionSyntax` (default operator)
* a `LiteralExpressionSyntax` (default literal expression)

Fixes part of #48392, dependent on dotnet/docs#20799

Related docs PR:
dotnet/docs#21034