### PR TITLE
Update F1 keywords to disambiguate `class`

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -357,6 +357,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 text = Keyword("defaultcase");
                 return true;
             }
+            
+            if (token.IsKind(SyntaxKind.ClassKeyword)) {
+                if (token.Parent is ClassDeclarationSyntax) {
+                    text = "class_CSharpKeyword";
+                    return true;
+                }
+
+                if (token.Parent is ClassOrStructConstraintSyntax) {
+                    text = "classconstraint_CSharpKeyword";
+                    return true;
+                }
+            }
 
             if (token.IsKeyword())
             {

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -359,13 +359,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
             
             if (token.IsKind(SyntaxKind.ClassKeyword)) {
-                if (token.Parent is ClassDeclarationSyntax) {
-                    text = "class_CSharpKeyword";
-                    return true;
-                }
-
                 if (token.Parent is ClassOrStructConstraintSyntax) {
                     text = "classconstraint_CSharpKeyword";
+                    return true;
+                } else {
+                    text = "class_CSharpKeyword";
                     return true;
                 }
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -358,7 +358,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
-            if (token.IsKind(SyntaxKind.ClassKeyword) && token.Parent is ClassOrStructConstraintSyntax) {
+            if (token.IsKind(SyntaxKind.ClassKeyword) && token.Parent is ClassOrStructConstraintSyntax)
+            {
                 text = Keyword("classconstraint");
                 return true;
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -364,6 +364,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
+            if (token.IsKind(SyntaxKind.StructKeyword) && token.Parent is ClassOrStructConstraintSyntax)
+            {
+                text = Keyword("structconstraint");
+                return true;
+            }
+
             if (token.IsKeyword())
             {
                 text = Keyword(token.Text);

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -357,15 +357,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 text = Keyword("defaultcase");
                 return true;
             }
-            
-            if (token.IsKind(SyntaxKind.ClassKeyword)) {
-                if (token.Parent is ClassOrStructConstraintSyntax) {
-                    text = Keyword("classconstraint");
-                    return true;
-                } else {
-                    text = Keyword("class");
-                    return true;
-                }
+
+            if (token.IsKind(SyntaxKind.ClassKeyword) && token.Parent is ClassOrStructConstraintSyntax) {
+                text = Keyword("classconstraint");
+                return true;
             }
 
             if (token.IsKeyword())

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -360,10 +360,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             
             if (token.IsKind(SyntaxKind.ClassKeyword)) {
                 if (token.Parent is ClassOrStructConstraintSyntax) {
-                    text = "classconstraint_CSharpKeyword";
+                    text = Keyword("classconstraint");
                     return true;
                 } else {
-                    text = "class_CSharpKeyword";
+                    text = Keyword("class");
                     return true;
                 }
             }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1009,6 +1009,72 @@ class C
     delegate T MyDelegate<T>() where T : cla[||]ss;
 }", "classconstraint");
         }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestOuterStructDeclaration()
+        {
+            await Test_KeywordAsync(
+@"str[||]uct OuterStruct<T> where T : struct
+{ 
+    struct InnerStruct<T> where T : struct { }
+}", "struct");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestInnerStructDeclaration()
+        {
+            await Test_KeywordAsync(
+@"struct OuterStruct<T> where T : struct
+{ 
+    str[||]uct InnerStruct<T> where T : struct { }
+}", "struct");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStructConstraintInOuterStruct()
+        {
+            await Test_KeywordAsync(
+@"struct OuterStruct<T> where T : str[||]uct
+{ 
+    struct InnerStruct<T> where T : struct { }
+}", "structconstraint");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStructConstraintInInnerStruct()
+        {
+            await Test_KeywordAsync(
+@"struct OuterStruct<T> where T : struct
+{ 
+    struct InnerStruct<T> where T : str[||]uct { }
+}", "structconstraint");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStructConstraintInGenericMethod()
+        {
+            await Test_KeywordAsync(
+@"struct C
+{ 
+    void M1<T>() where T : str[||]uct { }
+}", "structconstraint");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStructConstraintInGenericDelegate()
+        {
+            await Test_KeywordAsync(
+@"struct C
+{ 
+    delegate T MyDelegate<T>() where T : str[||]uct;
+}", "structconstraint");
+        }
     }
 }
 

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -943,5 +943,72 @@ class C
     }
 }", "default");
         }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestOuterClassDeclaration()
+        {
+            await Test_KeywordAsync(
+@"cla[||]ss OuterClass<T> where T : class
+{ 
+    class InnerClass<T> where T : class { }
+}", "class");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestInnerClassDeclaration()
+        {
+            await Test_KeywordAsync(
+@"class OuterClass<T> where T : class
+{ 
+    cla[||]ss InnerClass<T> where T : class { }
+}", "class");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestClassConstraintInOuterClass()
+        {
+            await Test_KeywordAsync(
+@"class OuterClass<T> where T : cla[||]ss
+{ 
+    class InnerClass<T> where T : class { }
+}", "classconstraint");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestClassConstraintInInnerClass()
+        {
+            await Test_KeywordAsync(
+@"class OuterClass<T> where T : class
+{ 
+    class InnerClass<T> where T : cla[||]ss { }
+}", "classconstraint");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestClassConstraintInGenericMethod()
+        {
+            await Test_KeywordAsync(
+@"class C
+{ 
+    void M1<T>() where T : cla[||]ss { }
+}", "classconstraint");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestClassConstraintInGenericDelegate()
+        {
+            await Test_KeywordAsync(
+@"class C
+{ 
+    delegate T MyDelegate<T>() where T : cla[||]ss;
+}", "classconstraint");
+        }
     }
 }
+


### PR DESCRIPTION
This PR makes the f1 keywords for the `class` keyword be context-specific.  If it appears in a generic constraint clause, it will route to the `where-generic-type-constraint` page, otherwise it will continue to go to the class declaration page.

Fixes part of dotnet/docs#20799

Related docs PR:
dotnet/docs#21037