### PR TITLE
Add support for `init` accessor in debugging

### DIFF
--- a/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.cs
@@ -305,6 +305,21 @@ class Class
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingProximityExpressions)]
+        [WorkItem(48504, "https://github.com/dotnet/roslyn/issues/48504")]
+        public async Task TestValueInPropertyInit()
+        {
+            await TestTryDoAsync(@"
+class Class
+{
+    string Name
+    {
+        get { return """"; }
+        init { $$ }
+    }
+}", "this", "value");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DebuggingProximityExpressions)]
         public async Task TestValueInEventAdd()
         {
             await TestTryDoAsync(@"

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -3819,6 +3819,20 @@ $$    using ([|var vv = goo()|])
         }
 
         [Fact]
+        [WorkItem(48504, "https://github.com/dotnet/roslyn/issues/48504")]
+        public void OnPropertyAccessor5()
+        {
+            TestSpan(
+@"class C
+{
+  int Goo
+  {
+    [|in$$it;|]
+  }
+}");
+        }
+
+        [Fact]
         public void OnProperty1()
         {
             TestSpan(

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.Worker.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.Worker.cs
@@ -59,7 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             private void AddValueExpression()
             {
                 // If we're in a setter/adder/remover then add "value".
-                if (_parentStatement.GetAncestorOrThis<AccessorDeclarationSyntax>().IsKind(SyntaxKind.SetAccessorDeclaration, SyntaxKind.AddAccessorDeclaration, SyntaxKind.RemoveAccessorDeclaration))
+                if (_parentStatement.GetAncestorOrThis<AccessorDeclarationSyntax>().IsKind(
+                    SyntaxKind.SetAccessorDeclaration, SyntaxKind.InitAccessorDeclaration, SyntaxKind.AddAccessorDeclaration, SyntaxKind.RemoveAccessorDeclaration))
                 {
                     _expressions.Add("value");
                 }

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -208,6 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                 case SyntaxKind.UnknownAccessorDeclaration:


### PR DESCRIPTION
Fixes #48504

This fixes two things:

1. The issue mentioned in #48504:

    ![image](https://user-images.githubusercontent.com/31348972/95747644-119d8e80-0c99-11eb-909a-d56e29606d00.png)

2. The absence of `value` in `autos` window (mentioned in https://github.com/dotnet/roslyn/issues/48504#issuecomment-706778340 with screenshots before fixing):

    After fix:

    
    ![image](https://user-images.githubusercontent.com/31348972/95749483-ec5e4f80-0c9b-11eb-928d-64be1a062995.png)
