### PR TITLE
Expose inline-hints through an external-access layer for F#.

### DIFF
--- a/src/Tools/ExternalAccess/FSharp/InlineHints/FSharpInlineHint.cs
+++ b/src/Tools/ExternalAccess/FSharp/InlineHints/FSharpInlineHint.cs
@@ -39,5 +39,4 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.InlineHints
         public Task<ImmutableArray<TaggedText>> GetDescriptionAsync(Document document, CancellationToken cancellationToken)
             => _getDescriptionAsync?.Invoke(document, cancellationToken) ?? SpecializedTasks.EmptyImmutableArray<TaggedText>();
     }
-
 }

--- a/src/Tools/ExternalAccess/FSharp/InlineHints/FSharpInlineHint.cs
+++ b/src/Tools/ExternalAccess/FSharp/InlineHints/FSharpInlineHint.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.InlineHints
+{
+    /// <inheritdoc cref="InlineHint"/>
+    internal readonly struct FSharpInlineHint
+    {
+        public readonly TextSpan Span;
+        public readonly ImmutableArray<TaggedText> DisplayParts;
+        private readonly Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? _getDescriptionAsync;
+
+        public FSharpInlineHint(
+            TextSpan span,
+            ImmutableArray<TaggedText> displayParts,
+            Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? getDescriptionAsync = null)
+        {
+            if (displayParts.Length == 0)
+                throw new ArgumentException($"{nameof(displayParts)} must be non-empty");
+
+            Span = span;
+            DisplayParts = displayParts;
+            _getDescriptionAsync = getDescriptionAsync;
+        }
+
+        /// <summary>
+        /// Gets a description for the inline hint, suitable to show when a user hovers over the editor adornment.  The
+        /// <paramref name="document"/> will represent the file at the time this hint was created.
+        /// </summary>
+        public Task<ImmutableArray<TaggedText>> GetDescriptionAsync(Document document, CancellationToken cancellationToken)
+            => _getDescriptionAsync?.Invoke(document, cancellationToken) ?? SpecializedTasks.EmptyImmutableArray<TaggedText>();
+    }
+
+}

--- a/src/Tools/ExternalAccess/FSharp/InlineHints/IFSharpInlineHintsService.cs
+++ b/src/Tools/ExternalAccess/FSharp/InlineHints/IFSharpInlineHintsService.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.InlineHints
+{
+    /// <inheritdoc cref="IInlineHintsService"/>
+    interface IFSharpInlineHintsService
+    {
+        /// <inheritdoc cref="IInlineHintsService.GetInlineHintsAsync"/>
+        Task<ImmutableArray<FSharpInlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Internal/InlineHints/FSharpInlineHintsService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/InlineHints/FSharpInlineHintsService.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.InlineHints;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.InlineHints
+{
+    [ExportLanguageService(typeof(IInlineHintsService), LanguageNames.FSharp), Shared]
+    internal class FSharpInlineHintsService : IInlineHintsService
+    {
+        private readonly IFSharpInlineHintsService? _service;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FSharpInlineHintsService(
+            [Import(AllowDefault = true)] IFSharpInlineHintsService? service)
+        {
+            _service = service;
+        }
+
+        public async Task<ImmutableArray<InlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+        {
+            if (_service == null)
+                return ImmutableArray<InlineHint>.Empty;
+
+            var hints = await _service.GetInlineHintsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+            return hints.SelectAsArray(h => new InlineHint(h.Span, h.DisplayParts, (d, c) => h.GetDescriptionAsync(d, c)));
+        }
+    }
+}


### PR DESCRIPTION
I followed hte pattern we have with IDocumentHighlightsService.