### PR TITLE
Update ExtractMethod to work correctly for records

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -4204,5 +4204,30 @@ class C
     }
 }");
         }
+
+        [WorkItem(48453, "https://github.com/dotnet/roslyn/issues/48453")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task TestInRecord()
+        {
+            await TestInRegularAndScript1Async(@"
+record Program
+{
+    int field;
+
+    public int this[int i] => [|this.field|];
+}",
+@"
+record Program
+{
+    int field;
+
+    public int this[int i] => {|Rename:GetField|}();
+
+    private int GetField()
+    {
+        return this.field;
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
@@ -377,6 +377,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return node.WithMembers(newMembers);
                 }
 
+                public override SyntaxNode VisitRecordDeclaration(RecordDeclarationSyntax node)
+                {
+                    if (node != ContainerOfStatementsOrFieldToReplace)
+                    {
+                        return base.VisitRecordDeclaration(node);
+                    }
+
+                    var newMembers = VisitList(ReplaceMembers(node.Members, global: false));
+                    return node.WithMembers(newMembers);
+                }
+
                 public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
                 {
                     if (node != ContainerOfStatementsOrFieldToReplace)

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
@@ -373,8 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                         return base.VisitClassDeclaration(node);
                     }
 
-                    var newMembers = VisitList(ReplaceMembers(node.Members, global: false));
-                    return node.WithMembers(newMembers);
+                    return GetUpdatedTypeDeclaration(node);
                 }
 
                 public override SyntaxNode VisitRecordDeclaration(RecordDeclarationSyntax node)
@@ -384,8 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                         return base.VisitRecordDeclaration(node);
                     }
 
-                    var newMembers = VisitList(ReplaceMembers(node.Members, global: false));
-                    return node.WithMembers(newMembers);
+                    return GetUpdatedTypeDeclaration(node);
                 }
 
                 public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
@@ -395,8 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                         return base.VisitStructDeclaration(node);
                     }
 
-                    var newMembers = VisitList(ReplaceMembers(node.Members, global: false));
-                    return node.WithMembers(newMembers);
+                    return GetUpdatedTypeDeclaration(node);
                 }
 
                 public override SyntaxNode VisitAccessorList(AccessorListSyntax node)
@@ -419,6 +416,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     }
 
                     var newMembers = VisitList(ReplaceMembers(node.Members, global: true));
+                    return node.WithMembers(newMembers);
+                }
+
+                private SyntaxNode GetUpdatedTypeDeclaration(TypeDeclarationSyntax node)
+                {
+                    var newMembers = VisitList(ReplaceMembers(node.Members, global: false));
                     return node.WithMembers(newMembers);
                 }
             }


### PR DESCRIPTION
Fixes #48453

Current behavior:

- Works well for classes.

    ![image](https://user-images.githubusercontent.com/31348972/95781303-cf427480-0ccd-11eb-8c09-7f63565d08be.png)

- *Partially* working for records (note the caller isn't updated).

    ![image](https://user-images.githubusercontent.com/31348972/95781345-ee410680-0ccd-11eb-8069-84108ae8f29c.png)
