### PR TITLE
Fix the dotted line for multiline condition in else if

### DIFF
--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -79,7 +80,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
 
         private static TextSpan GetHintSpan(BlockSyntax node)
         {
-            var start = node.Parent.Span.Start;
+            var parent = node.Parent;
+            if (parent.IsKind(SyntaxKind.IfStatement) && parent.IsParentKind(SyntaxKind.ElseClause))
+            {
+                parent = parent.Parent;
+            }
+
+            var start = parent.Span.Start;
             var end = GetEnd(node);
             return TextSpan.FromBounds(start, end);
         }


### PR DESCRIPTION
Fixes #45682

I don't like the way I fixed this tbh.

From reading the existing code, the bug *should* exist even for single-line conditions, but that's *not* the case.
Actually, the following existing test shows that:

https://github.com/dotnet/roslyn/blob/cf55f3a58e47298426fa971d3bd9d8857c746c65/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs#L287-L302

the start of the hint is at the "else" part.
There should be some modifications on the hint span somewhere, and that *unknown* place should be where the fix is included.