### PR TITLE
Make GreenNode.CreateList static

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -904,7 +904,7 @@ namespace Microsoft.CodeAnalysis
         public abstract SyntaxToken CreateSeparator<TNode>(SyntaxNode element) where TNode : SyntaxNode;
         public abstract bool IsTriviaWithEndOfLine(); // trivia node has end of line
 
-        public virtual GreenNode? CreateList(IEnumerable<GreenNode>? nodes, bool alwaysCreateListNode = false)
+        public static GreenNode? CreateList(IEnumerable<GreenNode>? nodes, bool alwaysCreateListNode = false)
         {
             if (nodes == null)
             {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return CreateList(list[0].Green, list);
+                return CreateList(list);
             }
         }
 
@@ -309,18 +309,6 @@ namespace Microsoft.CodeAnalysis
         }
 
         private static SyntaxList<TNode> CreateList(List<TNode> items)
-        {
-            if (items.Count == 0)
-            {
-                return default(SyntaxList<TNode>);
-            }
-            else
-            {
-                return CreateList(items[0].Green, items);
-            }
-        }
-
-        private static SyntaxList<TNode> CreateList(GreenNode creator, List<TNode> items)
         {
             if (items.Count == 0)
             {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxList<TNode>);
             }
 
-            var newGreen = creator.CreateList(items.Select(n => n.Green));
+            var newGreen = GreenNode.CreateList(items.Select(n => n.Green));
             return new SyntaxList<TNode>(newGreen!.CreateRed());
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -316,10 +316,10 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxNodeOrTokenList);
             }
 
-            var newGreen = creator.CreateList(items.Select(n => n.UnderlyingNode!))!;
+            var newGreen = GreenNode.CreateList(items.Select(n => n.UnderlyingNode!))!;
             if (newGreen.IsToken)
             {
-                newGreen = creator.CreateList(new[] { newGreen }, alwaysCreateListNode: true)!;
+                newGreen = GreenNode.CreateList(new[] { newGreen }, alwaysCreateListNode: true)!;
             }
 
             return new SyntaxNodeOrTokenList(newGreen.CreateRed(), 0);

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -306,10 +306,10 @@ namespace Microsoft.CodeAnalysis
 
             var nodes = this.ToList();
             nodes.InsertRange(index, nodesAndTokens);
-            return CreateList(nodes[0].UnderlyingNode!, nodes);
+            return CreateList(nodes);
         }
 
-        private static SyntaxNodeOrTokenList CreateList(GreenNode creator, List<SyntaxNodeOrToken> items)
+        private static SyntaxNodeOrTokenList CreateList(List<SyntaxNodeOrToken> items)
         {
             if (items.Count == 0)
             {
@@ -336,10 +336,9 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            var node = this[index];
             var nodes = this.ToList();
             nodes.RemoveAt(index);
-            return CreateList(node.UnderlyingNode!, nodes);
+            return CreateList(nodes);
         }
 
         /// <summary>
@@ -385,7 +384,7 @@ namespace Microsoft.CodeAnalysis
                 var nodes = this.ToList();
                 nodes.RemoveAt(index);
                 nodes.InsertRange(index, newNodesAndTokens);
-                return CreateList(nodeOrTokenInList.UnderlyingNode!, nodes);
+                return CreateList(nodes);
             }
 
             throw new ArgumentOutOfRangeException(nameof(nodeOrTokenInList));

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis
             var greenList = trivia?.Select(t => t.RequiredUnderlyingNode);
 
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(Node.CreateList(greenList)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(greenList)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis
             var greenList = trivia?.Select(t => t.RequiredUnderlyingNode);
 
             return Node != null
-                ? new SyntaxToken(null, Node.WithTrailingTrivia(Node.CreateList(greenList)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(greenList)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             Debug.Assert(list[0].Node is object);
-            return new SyntaxTokenList(null, list[0].Node!.CreateList(list.Select(n => n.RequiredNode)), 0, 0);
+            return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.RequiredNode)), 0, 0);
         }
 
         /// <summary>
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis
             var list = this.ToList();
             list.RemoveAt(index);
             Debug.Assert(Node is object);
-            return new SyntaxTokenList(null, Node.CreateList(list.Select(n => n.Node!)), 0, 0);
+            return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.Node!)), 0, 0);
         }
 
         /// <summary>
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis
                 list.RemoveAt(index);
                 list.InsertRange(index, newTokens);
                 Debug.Assert(Node is object);
-                return new SyntaxTokenList(null, Node.CreateList(list.Select(n => n.Node!)), 0, 0);
+                return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.Node!)), 0, 0);
             }
 
             throw new ArgumentOutOfRangeException(nameof(tokenInList));

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
@@ -361,7 +361,6 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            Debug.Assert(list[0].Node is object);
             return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.RequiredNode)), 0, 0);
         }
 
@@ -378,7 +377,6 @@ namespace Microsoft.CodeAnalysis
 
             var list = this.ToList();
             list.RemoveAt(index);
-            Debug.Assert(Node is object);
             return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.Node!)), 0, 0);
         }
 
@@ -425,7 +423,6 @@ namespace Microsoft.CodeAnalysis
                 var list = this.ToList();
                 list.RemoveAt(index);
                 list.InsertRange(index, newTokens);
-                Debug.Assert(Node is object);
                 return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.Node!)), 0, 0);
             }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis
 
             var list = this.ToList();
             list.RemoveAt(index);
-            return new SyntaxTriviaList(default(SyntaxToken), Node!.CreateList(list.Select(n => n.RequiredUnderlyingNode)), 0, 0);
+            return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list.Select(n => n.RequiredUnderlyingNode)), 0, 0);
         }
 
         /// <summary>
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis
                 var list = this.ToList();
                 list.RemoveAt(index);
                 list.InsertRange(index, newTrivia);
-                return new SyntaxTriviaList(default(SyntaxToken), Node!.CreateList(list.Select(n => n.RequiredUnderlyingNode)), 0, 0);
+                return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list.Select(n => n.RequiredUnderlyingNode)), 0, 0);
             }
 
             throw new ArgumentOutOfRangeException(nameof(triviaInList));


### PR DESCRIPTION
As discussed with @CyrusNajmabadi on [discord](https://discord.com/channels/143867839282020352/598678594750775301/765314698261692428) this PR makes GreenNode.CreateList static and adjusts all usages.

This done to simplify the method and remove the virtual call which should help performance somewhat, but I couldn't get perf numbers that could directly confirm this. 

I'm not sure whether members should also be reordered. I left them as is for now.