### PR TITLE
Fix crash in Extract Method

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractMethod;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -154,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 : await doc.GetSyntaxRootAsync();
         }
 
-        protected static async Task TestSelectionAsync(string codeWithMarker, bool expectedFail = false, CSharpParseOptions parseOptions = null)
+        protected static async Task TestSelectionAsync(string codeWithMarker, bool expectedFail = false, CSharpParseOptions parseOptions = null, TextSpan? textSpanOverride = null)
         {
             using var workspace = TestWorkspace.CreateCSharp(codeWithMarker, parseOptions: parseOptions);
             var testDocument = workspace.Documents.Single();
@@ -166,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var options = await document.GetOptionsAsync(CancellationToken.None);
 
             var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);
-            var validator = new CSharpSelectionValidator(semanticDocument, namedSpans["b"].Single(), options);
+            var validator = new CSharpSelectionValidator(semanticDocument, textSpanOverride ?? namedSpans["b"].Single(), options);
             var result = await validator.GetValidSelectionAsync(CancellationToken.None);
 
             Assert.True(expectedFail ? result.Status.Failed() : result.Status.Succeeded());

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/SelectionValidatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/SelectionValidatorTests.cs
@@ -6,6 +6,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1666,6 +1667,23 @@ class B
     public int Length { get; set; }
 }";
             await TestSelectionAsync(code);
+        }
+
+        [WorkItem(1228916, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1228916")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task DontCrashPastEndOfLine()
+        {
+            //                    11 1
+            //          012345678901 2
+            var code = "class C { }\r\n";
+
+            // Markup parsing doesn't produce the right spans here, so supply one ourselves.
+            // Can be removed when https://github.com/dotnet/roslyn-sdk/issues/637 is fixed
+
+            // This span covers just the "\n"
+            var span = new TextSpan(12, 1);
+
+            await TestSelectionAsync(code, expectedFail: true, textSpanOverride: span);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
@@ -454,6 +454,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             // get previous line
             Contract.ThrowIfFalse(line.LineNumber > 0);
             var previousLine = text.Lines[line.LineNumber - 1];
+
+            // if the span is past the end of the line (ie, in whitespace) then
+            // return to the end of the line including whitespace
+            if (textSpan.Start > previousLine.End)
+            {
+                return TextSpan.FromBounds(textSpan.Start, previousLine.EndIncludingLineBreak);
+            }
+
             return TextSpan.FromBounds(textSpan.Start, previousLine.End);
         }
 


### PR DESCRIPTION
Fixes [AB#1228916](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1228916)

The repro is much simpler than what the issue says, just press Ctrl+F, turn on regex, and type "\n" in the search box.

Doesn't repro in VB.