### PR TITLE
Update sqlite experiment name.

### DIFF
--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -34,6 +34,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string TypeImportCompletion = "Roslyn.TypeImportCompletion";
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
         public const string TriggerCompletionInArgumentLists = "Roslyn.TriggerCompletionInArgumentLists";
-        public const string SQLiteInMemoryWriteCache = "Roslyn.SQLiteInMemoryWriteCache";
+        public const string SQLiteInMemoryWriteCache2 = "Roslyn.SQLiteInMemoryWriteCache2";
     }
 }

--- a/src/Workspaces/Core/Portable/Storage/PersistenceStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Storage/PersistenceStorageServiceFactory.cs
@@ -54,6 +54,6 @@ namespace Microsoft.CodeAnalysis.Storage
 
         private static bool UseInMemoryWriteCache(HostWorkspaceServices workspaceServices)
             => workspaceServices.Workspace.Options.GetOption(StorageOptions.SQLiteInMemoryWriteCache) ||
-               workspaceServices.GetService<IExperimentationService>()?.IsExperimentEnabled(WellKnownExperimentNames.SQLiteInMemoryWriteCache) == true;
+               workspaceServices.GetService<IExperimentationService>()?.IsExperimentEnabled(WellKnownExperimentNames.SQLiteInMemoryWriteCache2) == true;
     }
 }


### PR DESCRIPTION
We want to update this as the existing (disabled) code has an stability issue in it that will be exacerbated by all our OOP work.  We have fixed hte issue and will want to rerun the A/B test with the fix without pulling in people using the older version that doesn't have the fix.  We could try to do this by limiting the versions of VS that hte A/B test runs against. but this is just much simpler and ensures no one accidentally uses hte olde version.