### PR TITLE
Process lsp diagnostic requests serially to prevent state corruption

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly AsyncQueue<QueueItem> _queue;
         private readonly CancellationTokenSource _cancelSource;
 
+        public CancellationToken CancellationToken => _cancelSource.Token;
+
         /// <summary>
         /// Raised when the execution queue has failed, or the solution state its tracking is in an unknown state
         /// and so the only course of action is to shutdown the server so that the client re-connects and we can

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -11,12 +11,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Client;
@@ -41,6 +40,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         private readonly AbstractRequestHandlerProvider _requestHandlerProvider;
         private readonly Workspace _workspace;
         private readonly RequestExecutionQueue _queue;
+
+        /// <summary>
+        /// Work queue responsible for receiving notifications about diagnostic updates and publishing those to
+        /// interested parties.
+        /// </summary>
+        private readonly AsyncBatchingWorkQueue<DocumentId> _diagnosticsWorkQueue;
 
         private VSClientCapabilities _clientCapabilities;
         private bool _shuttingDown;
@@ -68,12 +73,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             _diagnosticService = diagnosticService;
             _listener = listenerProvider.GetListener(FeatureAttribute.LanguageServer);
             _clientName = clientName;
-            _diagnosticService.DiagnosticsUpdated += DiagnosticService_DiagnosticsUpdated;
 
             _clientCapabilities = new VSClientCapabilities();
 
             _queue = new RequestExecutionQueue(solutionProvider);
             _queue.RequestServerShutdown += RequestExecutionQueue_Errored;
+
+            // Dedupe on DocumentId.  If we hear about the same document multiple times, we only need to process that id once.
+            _diagnosticsWorkQueue = new AsyncBatchingWorkQueue<DocumentId>(
+                TimeSpan.FromMilliseconds(250),
+                ProcessDiagnosticUpdatedBatchAsync,
+                EqualityComparer<DocumentId>.Default,
+                _listener,
+                _queue.CancellationToken);
+            _diagnosticService.DiagnosticsUpdated += DiagnosticService_DiagnosticsUpdated;
         }
 
         public bool Running => !_shuttingDown && !_jsonRpc.IsDisposed;
@@ -100,19 +113,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         }
 
         [JsonRpcMethod(Methods.InitializedName)]
-        public async Task InitializedAsync()
+        public Task InitializedAsync()
         {
             // Publish diagnostics for all open documents immediately following initialization.
             var solution = _workspace.CurrentSolution;
             var openDocuments = _workspace.GetOpenDocumentIds();
             foreach (var documentId in openDocuments)
-            {
-                var document = solution.GetDocument(documentId);
-                if (document != null)
-                {
-                    await PublishDiagnosticsAsync(document).ConfigureAwait(false);
-                }
-            }
+                DiagnosticService_DiagnosticsUpdated(solution, documentId);
+
+            return Task.CompletedTask;
         }
 
         [JsonRpcMethod(Methods.ShutdownName)]
@@ -263,27 +272,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             => _requestHandlerProvider.ExecuteRequestAsync<DocumentOnAutoInsertParams, DocumentOnAutoInsertResponseItem[]>(_queue, MSLSPMethods.OnAutoInsertName,
                 autoInsertParams, _clientCapabilities, _clientName, cancellationToken);
 
-        private void DiagnosticService_DiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)
+        private void DiagnosticService_DiagnosticsUpdated(object _, DiagnosticsUpdatedArgs e)
+            => DiagnosticService_DiagnosticsUpdated(e.Solution, e.DocumentId);
+
+        private void DiagnosticService_DiagnosticsUpdated(Solution? solution, DocumentId? documentId)
         {
             // LSP doesn't support diagnostics without a document. So if we get project level diagnostics without a document, ignore them.
-            if (e.DocumentId != null && e.Solution != null)
+            if (documentId != null && solution != null)
             {
-                var document = e.Solution.GetDocument(e.DocumentId);
+                var document = solution.GetDocument(documentId);
                 if (document == null || document.FilePath == null)
-                {
                     return;
-                }
 
                 // Only publish document diagnostics for the languages this provider supports.
                 if (document.Project.Language != CodeAnalysis.LanguageNames.CSharp && document.Project.Language != CodeAnalysis.LanguageNames.VisualBasic)
-                {
                     return;
-                }
 
-                // LSP does not currently support publishing diagnostics incrementally, so we re-publish all diagnostics.
-                var asyncToken = _listener.BeginAsyncOperation(nameof(PublishDiagnosticsAsync));
-                Task.Run(() => PublishDiagnosticsAsync(document))
-                    .CompletesAsyncOperation(asyncToken);
+                _diagnosticsWorkQueue.AddWork(document.Id);
             }
         }
 
@@ -348,10 +353,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         private static readonly Comparer<Uri> s_uriComparer = Comparer<Uri>.Create((uri1, uri2)
             => Uri.Compare(uri1, uri2, UriComponents.AbsoluteUri, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase));
 
-        internal async Task PublishDiagnosticsAsync(Document document)
+        private async Task ProcessDiagnosticUpdatedBatchAsync(ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
+        {
+            var solution = _workspace.CurrentSolution;
+            foreach (var documentId in documentIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var document = solution.GetDocument(documentId);
+                if (document != null)
+                    await PublishDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // Internal for testing purposes.
+        internal async Task PublishDiagnosticsAsync(Document document, CancellationToken cancellationToken)
         {
             // Retrieve all diagnostics for the current document grouped by their actual file uri.
-            var fileUriToDiagnostics = await GetDiagnosticsAsync(document, CancellationToken.None).ConfigureAwait(false);
+            var fileUriToDiagnostics = await GetDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
 
             // Get the list of file uris with diagnostics (for the document).
             // We need to join the uris from current diagnostics with those previously published

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -367,7 +367,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
             // Triggers language server to send notifications.
             foreach (var document in documentsToPublish)
             {
-                await languageServer.PublishDiagnosticsAsync(document).ConfigureAwait(false);
+                await languageServer.PublishDiagnosticsAsync(document, CancellationToken.None).ConfigureAwait(false);
             }
 
             // Waits for all notifications to be recieved.


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1193692.

Necessary until we move over to pull diagnostics.