### PR TITLE
Optimize GreenNode.CreateList

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
         }
-        
+
         public SyntaxNode CreateRed()
         {
             return CreateRed(null, 0);

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -904,7 +904,7 @@ namespace Microsoft.CodeAnalysis
         public abstract SyntaxToken CreateSeparator<TNode>(SyntaxNode element) where TNode : SyntaxNode;
         public abstract bool IsTriviaWithEndOfLine(); // trivia node has end of line
 
-        public static GreenNode? CreateList<TFrom>(IReadOnlyList<TFrom>? list, Func<TFrom, GreenNode> select, bool alwaysCreateListNode = false)
+        public static GreenNode? CreateList<TFrom>(IReadOnlyList<TFrom>? list, Func<TFrom, GreenNode> select)
         {
             if (list == null)
             {
@@ -916,14 +916,7 @@ namespace Microsoft.CodeAnalysis
                 case 0:
                     return null;
                 case 1:
-                    if (alwaysCreateListNode)
-                    {
-                        goto default;
-                    }
-                    else
-                    {
-                        return select(list[0]);
-                    }
+                    return select(list[0]);
                 case 2:
                     return SyntaxList.List(select(list[0]), select(list[1]));
                 case 3:

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -903,12 +903,12 @@ namespace Microsoft.CodeAnalysis
 
         public abstract SyntaxToken CreateSeparator<TNode>(SyntaxNode element) where TNode : SyntaxNode;
         public abstract bool IsTriviaWithEndOfLine(); // trivia node has end of line
-        
+
         /*
          * There are 3 overloads of this, because most callers already know what they have is a List<T> and only transform it.
          * In those cases List<TFrom> performs much better.
          * In other cases, the type is unknown / is IEnumerable<T>, where we try to find the best match.
-         * There is another overload for IROList, since most collections already implement this, so checking for it will
+         * There is another overload for IReadOnlyList, since most collections already implement this, so checking for it will
          * perform better then copying to a List<T>, though not as good as List<T> directly.
          */
         public static GreenNode? CreateList<TFrom>(IEnumerable<TFrom>? enumerable, Func<TFrom, GreenNode> select)
@@ -933,15 +933,15 @@ namespace Microsoft.CodeAnalysis
                 case 3:
                     return SyntaxList.List(select(list[0]), select(list[1]), select(list[2]));
                 default:
-                {
-                    var array = new ArrayElement<GreenNode>[list.Count];
-                    for (int i = 0; i < array.Length; i++)
-                        array[i].Value = select(list[i]);
-                    return SyntaxList.List(array);
-                }
+                    {
+                        var array = new ArrayElement<GreenNode>[list.Count];
+                        for (int i = 0; i < array.Length; i++)
+                            array[i].Value = select(list[i]);
+                        return SyntaxList.List(array);
+                    }
             }
         }
-        
+
         public static GreenNode? CreateList<TFrom>(IReadOnlyList<TFrom> list, Func<TFrom, GreenNode> select)
         {
             switch (list.Count)
@@ -955,12 +955,12 @@ namespace Microsoft.CodeAnalysis
                 case 3:
                     return SyntaxList.List(select(list[0]), select(list[1]), select(list[2]));
                 default:
-                {
-                    var array = new ArrayElement<GreenNode>[list.Count];
-                    for (int i = 0; i < array.Length; i++)
-                        array[i].Value = select(list[i]);
-                    return SyntaxList.List(array);
-                }
+                    {
+                        var array = new ArrayElement<GreenNode>[list.Count];
+                        for (int i = 0; i < array.Length; i++)
+                            array[i].Value = select(list[i]);
+                        return SyntaxList.List(array);
+                    }
             }
         }
 

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -904,16 +904,14 @@ namespace Microsoft.CodeAnalysis
         public abstract SyntaxToken CreateSeparator<TNode>(SyntaxNode element) where TNode : SyntaxNode;
         public abstract bool IsTriviaWithEndOfLine(); // trivia node has end of line
 
-        public static GreenNode? CreateList(IEnumerable<GreenNode>? nodes, bool alwaysCreateListNode = false)
+        public static GreenNode? CreateList<TFrom>(IReadOnlyList<TFrom>? list, Func<TFrom, GreenNode> select, bool alwaysCreateListNode = false)
         {
-            if (nodes == null)
+            if (list == null)
             {
                 return null;
             }
 
-            var list = nodes.ToArray();
-
-            switch (list.Length)
+            switch (list.Count)
             {
                 case 0:
                     return null;
@@ -924,17 +922,22 @@ namespace Microsoft.CodeAnalysis
                     }
                     else
                     {
-                        return list[0];
+                        return select(list[0]);
                     }
                 case 2:
-                    return SyntaxList.List(list[0], list[1]);
+                    return SyntaxList.List(select(list[0]), select(list[1]));
                 case 3:
-                    return SyntaxList.List(list[0], list[1], list[2]);
+                    return SyntaxList.List(select(list[0]), select(list[1]), select(list[2]));
                 default:
-                    return SyntaxList.List(list);
+                {
+                    var array = new ArrayElement<GreenNode>[list.Count];
+                    for (int i = 0; i < array.Length; i++)
+                        array[i].Value = select(list[i]);
+                    return SyntaxList.List(array);
+                }
             }
         }
-
+        
         public SyntaxNode CreateRed()
         {
             return CreateRed(null, 0);

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -904,7 +904,7 @@ namespace Microsoft.CodeAnalysis
         public abstract SyntaxToken CreateSeparator<TNode>(SyntaxNode element) where TNode : SyntaxNode;
         public abstract bool IsTriviaWithEndOfLine(); // trivia node has end of line
 
-        public static GreenNode? CreateList<TFrom>(IReadOnlyList<TFrom>? list, Func<TFrom, GreenNode> select)
+        public static GreenNode? CreateList<TFrom>(List<TFrom>? list, Func<TFrom, GreenNode> select)
         {
             if (list == null)
             {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxList<TNode>);
             }
 
-            var newGreen = GreenNode.CreateList(items, n => n.Green);
+            var newGreen = GreenNode.CreateList(items, static n => n.Green);
             return new SyntaxList<TNode>(newGreen!.CreateRed());
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxList<TNode>);
             }
 
-            var newGreen = GreenNode.CreateList(items.Select(n => n.Green));
+            var newGreen = GreenNode.CreateList(items, n => n.Green);
             return new SyntaxList<TNode>(newGreen!.CreateRed());
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
@@ -129,6 +129,15 @@ namespace Microsoft.CodeAnalysis
 
         internal int Position => _position;
 
+        internal GreenNode RequiredUnderlyingNode
+        {
+            get
+            {
+                Debug.Assert(UnderlyingNode is not null);
+                return UnderlyingNode;
+            }
+        }
+
         /// <summary>
         /// Determines whether this <see cref="SyntaxNodeOrToken"/> is wrapping a token.
         /// </summary>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -319,7 +319,10 @@ namespace Microsoft.CodeAnalysis
             var newGreen = GreenNode.CreateList(items, static n => n.RequiredUnderlyingNode)!;
             if (newGreen.IsToken)
             {
-                newGreen = Syntax.InternalSyntax.SyntaxList.List(new[] { newGreen });
+                newGreen = Syntax.InternalSyntax.SyntaxList.List(new[]
+                {
+                    new ArrayElement<GreenNode> {Value = newGreen}
+                });
             }
 
             return new SyntaxNodeOrTokenList(newGreen.CreateRed(), 0);

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -316,10 +316,10 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxNodeOrTokenList);
             }
 
-            var newGreen = GreenNode.CreateList(items.Select(n => n.UnderlyingNode!))!;
+            var newGreen = GreenNode.CreateList(items, n => n.UnderlyingNode!)!;
             if (newGreen.IsToken)
             {
-                newGreen = GreenNode.CreateList(new[] { newGreen }, alwaysCreateListNode: true)!;
+                newGreen = Syntax.InternalSyntax.SyntaxList.List(new[] { newGreen });
             }
 
             return new SyntaxNodeOrTokenList(newGreen.CreateRed(), 0);

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis
                 return default(SyntaxNodeOrTokenList);
             }
 
-            var newGreen = GreenNode.CreateList(items, n => n.UnderlyingNode!)!;
+            var newGreen = GreenNode.CreateList(items, static n => n.UnderlyingNode!)!;
             if (newGreen.IsToken)
             {
                 newGreen = Syntax.InternalSyntax.SyntaxList.List(new[] { newGreen });

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -491,7 +491,7 @@ namespace Microsoft.CodeAnalysis
         public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(GetList(trivia), t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(GetList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis
         public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             return Node != null
-                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(GetList(trivia), t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(GetList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis
             return this.WithLeadingTrivia((IEnumerable<SyntaxTrivia>?)trivia);
         }
 
-        private static IReadOnlyList<SyntaxTrivia>? GetList(IEnumerable<SyntaxTrivia>? trivia)
+        private static List<SyntaxTrivia>? GetList(IEnumerable<SyntaxTrivia>? trivia)
         {
             if (trivia is null)
                 return null;
@@ -480,8 +480,8 @@ namespace Microsoft.CodeAnalysis
             return trivia switch
             {
                 null => null,
-                IReadOnlyList<SyntaxTrivia> l => l,
-                _ => trivia.ToArray()
+                List<SyntaxTrivia> l => l,
+                _ => trivia.ToList()
             };
         }
         

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -473,14 +473,18 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Creates a new token from this token with the leading trivia specified..
+        /// Creates a new token from this token with the leading trivia specified.
         /// </summary>
         public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
-            var greenList = trivia?.Select(t => t.RequiredUnderlyingNode);
-
+            IReadOnlyList<SyntaxTrivia>? list = trivia switch
+            {
+                null => null,
+                IReadOnlyList<SyntaxTrivia> l => l,
+                _ => trivia.ToArray()
+            };
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(greenList)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(list, t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 
@@ -505,10 +509,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
-            var greenList = trivia?.Select(t => t.RequiredUnderlyingNode);
-
+            IReadOnlyList<SyntaxTrivia>? list = trivia switch
+            {
+                null => null,
+                IReadOnlyList<SyntaxTrivia> l => l,
+                _ => trivia.ToArray()
+            };
             return Node != null
-                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(greenList)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(list, t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -472,19 +472,26 @@ namespace Microsoft.CodeAnalysis
             return this.WithLeadingTrivia((IEnumerable<SyntaxTrivia>?)trivia);
         }
 
-        /// <summary>
-        /// Creates a new token from this token with the leading trivia specified.
-        /// </summary>
-        public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
+        private static IReadOnlyList<SyntaxTrivia>? GetList(IEnumerable<SyntaxTrivia>? trivia)
         {
-            IReadOnlyList<SyntaxTrivia>? list = trivia switch
+            if (trivia is null)
+                return null;
+
+            return trivia switch
             {
                 null => null,
                 IReadOnlyList<SyntaxTrivia> l => l,
                 _ => trivia.ToArray()
             };
+        }
+        
+        /// <summary>
+        /// Creates a new token from this token with the leading trivia specified.
+        /// </summary>
+        public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
+        {
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(list, t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(GetList(trivia), t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 
@@ -509,14 +516,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
-            IReadOnlyList<SyntaxTrivia>? list = trivia switch
-            {
-                null => null,
-                IReadOnlyList<SyntaxTrivia> l => l,
-                _ => trivia.ToArray()
-            };
             return Node != null
-                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(list, t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(GetList(trivia), t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -472,11 +472,8 @@ namespace Microsoft.CodeAnalysis
             return this.WithLeadingTrivia((IEnumerable<SyntaxTrivia>?)trivia);
         }
 
-        private static List<SyntaxTrivia>? GetList(IEnumerable<SyntaxTrivia>? trivia)
+        private static List<SyntaxTrivia>? AsList(IEnumerable<SyntaxTrivia>? trivia)
         {
-            if (trivia is null)
-                return null;
-
             return trivia switch
             {
                 null => null,
@@ -491,7 +488,7 @@ namespace Microsoft.CodeAnalysis
         public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(GetList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(AsList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 
@@ -517,7 +514,7 @@ namespace Microsoft.CodeAnalysis
         public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             return Node != null
-                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(GetList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(AsList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -472,23 +472,13 @@ namespace Microsoft.CodeAnalysis
             return this.WithLeadingTrivia((IEnumerable<SyntaxTrivia>?)trivia);
         }
 
-        private static List<SyntaxTrivia>? AsList(IEnumerable<SyntaxTrivia>? trivia)
-        {
-            return trivia switch
-            {
-                null => null,
-                List<SyntaxTrivia> l => l,
-                _ => trivia.ToList()
-            };
-        }
-        
         /// <summary>
         /// Creates a new token from this token with the leading trivia specified.
         /// </summary>
         public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(AsList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(GreenNode.CreateList(trivia, static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 
@@ -514,7 +504,7 @@ namespace Microsoft.CodeAnalysis
         public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             return Node != null
-                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(AsList(trivia), static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithTrailingTrivia(GreenNode.CreateList(trivia, static t => t.RequiredUnderlyingNode)), position: 0, index: 0)
                 : default(SyntaxToken);
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.RequiredNode)), 0, 0);
+            return new SyntaxTokenList(null, GreenNode.CreateList(list, n => n.RequiredNode), 0, 0);
         }
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis
 
             var list = this.ToList();
             list.RemoveAt(index);
-            return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.Node!)), 0, 0);
+            return new SyntaxTokenList(null, GreenNode.CreateList(list, n => n.Node!), 0, 0);
         }
 
         /// <summary>
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis
                 var list = this.ToList();
                 list.RemoveAt(index);
                 list.InsertRange(index, newTokens);
-                return new SyntaxTokenList(null, GreenNode.CreateList(list.Select(n => n.Node!)), 0, 0);
+                return new SyntaxTokenList(null, GreenNode.CreateList(list, n => n.Node!), 0, 0);
             }
 
             throw new ArgumentOutOfRangeException(nameof(tokenInList));

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return new SyntaxTokenList(null, GreenNode.CreateList(list, n => n.RequiredNode), 0, 0);
+            return new SyntaxTokenList(null, GreenNode.CreateList(list, static n => n.RequiredNode), 0, 0);
         }
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis
 
             var list = this.ToList();
             list.RemoveAt(index);
-            return new SyntaxTokenList(null, GreenNode.CreateList(list, n => n.Node!), 0, 0);
+            return new SyntaxTokenList(null, GreenNode.CreateList(list, static n => n.Node!), 0, 0);
         }
 
         /// <summary>
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis
                 var list = this.ToList();
                 list.RemoveAt(index);
                 list.InsertRange(index, newTokens);
-                return new SyntaxTokenList(null, GreenNode.CreateList(list, n => n.Node!), 0, 0);
+                return new SyntaxTokenList(null, GreenNode.CreateList(list, static n => n.Node!), 0, 0);
             }
 
             throw new ArgumentOutOfRangeException(nameof(tokenInList));

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis
 
             var list = this.ToList();
             list.RemoveAt(index);
-            return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list, n => n.RequiredUnderlyingNode), 0, 0);
+            return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list, static n => n.RequiredUnderlyingNode), 0, 0);
         }
 
         /// <summary>
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis
                 var list = this.ToList();
                 list.RemoveAt(index);
                 list.InsertRange(index, newTrivia);
-                return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list, n => n.RequiredUnderlyingNode), 0, 0);
+                return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list, static n => n.RequiredUnderlyingNode), 0, 0);
             }
 
             throw new ArgumentOutOfRangeException(nameof(triviaInList));

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis
 
             var list = this.ToList();
             list.RemoveAt(index);
-            return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list.Select(n => n.RequiredUnderlyingNode)), 0, 0);
+            return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list, n => n.RequiredUnderlyingNode), 0, 0);
         }
 
         /// <summary>
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis
                 var list = this.ToList();
                 list.RemoveAt(index);
                 list.InsertRange(index, newTrivia);
-                return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list.Select(n => n.RequiredUnderlyingNode)), 0, 0);
+                return new SyntaxTriviaList(default(SyntaxToken), GreenNode.CreateList(list, n => n.RequiredUnderlyingNode), 0, 0);
             }
 
             throw new ArgumentOutOfRangeException(nameof(triviaInList));


### PR DESCRIPTION
This PR improves the performance of GreenNode.CreateList.
This is part of a larger goal to improve NormalizeWhitespace performance, the benchmark below tests NormalizeWhitespace performance of real-world generated C# source (~116k loc when normalized).
Benchmark:
|   Method |    Mean |    Error |   StdDev |      Gen 0 |      Gen 1 | Gen 2 | Allocated |
|--------- |--------:|---------:|---------:|-----------:|-----------:|------:|----------:|
| Baseline | 5.806 s | 0.0556 s | 0.0493 s | 74000.0000 | 18000.0000 |     - | 591.82 MB |
| New      | 5.595 s | 0.1072 s | 0.1731 s | 49000.0000 | 13000.0000 |     - | 393.68 MB |

Tested on Net5.0 RC2 with the Benchmark runtime being .NET Core 3.1.8

I also investigated a couple of other approaches (ImmutableArray + SelectAsArray, GetEnumerator directly) but this one came out on top.
Thanks for the help @333fred and @CyrusNajmabadi 😄 

Benchmark Files (drop into IdeCoreBenchmarks for testing):
[normalization-sample.txt](https://github.com/dotnet/roslyn/files/5373857/normalization-sample.txt)
[NormalizeWhitespaceBenchmark.cs](https://github.com/dotnet/roslyn/files/5373859/NormalizeWhitespaceBenchmark.txt)