### PR TITLE
Fix null-annotatation of ISerializerService.Deserialize

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Utilities
             => Debug.Assert(b, message);
 
         [Conditional("DEBUG")]
-        public static void AssertNotNull<T>([NotNull] T value) where T : class?
+        public static void AssertNotNull<T>([NotNull] T value)
         {
             Assert(value is object, "Unexpected null reference");
         }

--- a/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
@@ -43,7 +43,9 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
                     stream.Position = 0;
                     using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
-                    results.Add((checksum, deserializerService.Deserialize<object>(data.GetWellKnownSynchronizationKind(), reader, cancellationToken)));
+                    var asset = deserializerService.Deserialize<object>(data.GetWellKnownSynchronizationKind(), reader, cancellationToken);
+                    Contract.ThrowIfTrue(asset is null);
+                    results.Add((checksum, asset));
                 }
                 else
                 {

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -92,7 +92,9 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             using var reader = ObjectReader.TryGetReader(stream);
 
             // deserialize bits to object
-            return Serializer.Deserialize<T>(data.Kind, reader, CancellationToken.None);
+            var result = Serializer.Deserialize<T>(data.Kind, reader, CancellationToken.None);
+            Contract.ThrowIfNull(result);
+            return result;
         }
 
         public async Task<Solution> GetSolutionAsync(SolutionAssetStorage.Scope scope)

--- a/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
+++ b/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         void SerializeOptionSet(SerializableOptionSet options, ObjectWriter writer, CancellationToken cancellationToken);
 
-        T Deserialize<T>(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken);
+        T? Deserialize<T>(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken);
 
         Checksum CreateChecksum(object value, CancellationToken cancellationToken);
     }

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public static ImmutableArray<(Checksum, object)> ReadData(Stream stream, int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
-            Debug.Assert(checksums.Contains(Checksum.Null));
+            Debug.Assert(!checksums.Contains(Checksum.Null));
 
             using var _ = ArrayBuilder<(Checksum, object)>.GetInstance(out var results);
 

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -140,6 +140,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public static ImmutableArray<(Checksum, object)> ReadData(Stream stream, int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
+            Debug.Assert(checksums.Contains(Checksum.Null));
+
             using var _ = ArrayBuilder<(Checksum, object)>.GetInstance(out var results);
 
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
@@ -159,6 +161,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 // in service hub, cancellation means simply closed stream
                 var result = serializerService.Deserialize<object>(kind, reader, cancellationToken);
+
+                // we should not request null assets:
+                Debug.Assert(result != null);
 
                 results.Add((responseChecksum, result));
             }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,6 +35,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public override async Task<T> GetAssetAsync<T>(Checksum checksum, CancellationToken cancellationToken)
         {
+            Debug.Assert(checksum != Checksum.Null);
+
             if (_assetCache.TryGetAsset(checksum, out T asset))
             {
                 return asset;
@@ -112,6 +115,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async Task SynchronizeAssetsAsync(ISet<Checksum> checksums, CancellationToken cancellationToken)
         {
+            Debug.Assert(!checksums.Contains(Checksum.Null));
+
             using (Logger.LogBlock(FunctionId.AssetService_SynchronizeAssetsAsync, Checksum.GetChecksumsLogInfo, checksums, cancellationToken))
             {
                 var assets = await RequestAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);
@@ -125,6 +130,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private async Task<object> RequestAssetAsync(Checksum checksum, CancellationToken cancellationToken)
         {
+            Debug.Assert(checksum != Checksum.Null);
+
             using var _ = PooledHashSet<Checksum>.GetInstance(out var checksums);
             checksums.Add(checksum);
 
@@ -134,6 +141,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private async Task<ImmutableArray<(Checksum checksum, object value)>> RequestAssetsAsync(ISet<Checksum> checksums, CancellationToken cancellationToken)
         {
+            Debug.Assert(!checksums.Contains(Checksum.Null));
+
             if (checksums.Count == 0)
             {
                 return ImmutableArray<(Checksum, object)>.Empty;

--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Serialization;
@@ -123,6 +124,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private void AddIfNeeded(HashSet<Checksum> checksums, Checksum checksum)
         {
+            Debug.Assert(checksum != Checksum.Null);
+
             if (!_assetProvider.EnsureCacheEntryIfExists(checksum))
             {
                 checksums.Add(checksum);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -22,7 +22,7 @@ namespace Roslyn.Utilities
         /// all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull<T>([NotNull] T value) where T : class?
+        public static void ThrowIfNull<T>([NotNull] T value)
         {
             if (value is null)
             {
@@ -35,7 +35,7 @@ namespace Roslyn.Utilities
         /// all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull<T>([NotNull] T value, string message) where T : class?
+        public static void ThrowIfNull<T>([NotNull] T value, string message)
         {
             if (value is null)
             {


### PR DESCRIPTION
Remove `class?` constraint from `AssertNotNull` and `Contract.ThrowIfNull` to allow checking for null on unconstrained generic value.