### PR TITLE
Improve performance of nullable analysis of deeply nested lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4925,7 +4925,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (argumentsNoConversions[i] is BoundLambda lambda)
                     {
-                        VisitLambda(lambda, delegateTypeOpt: null, results[i].StateForLambda, disableDiagnostics: true);
+                        VisitLambda(lambda, delegateTypeOpt: null, results[i].StateForLambda);
                     }
                 }
             }
@@ -7350,7 +7350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private void VisitLambda(BoundLambda node, NamedTypeSymbol? delegateTypeOpt, Optional<LocalState> initialState = default, bool disableDiagnostics = false)
+        private void VisitLambda(BoundLambda node, NamedTypeSymbol? delegateTypeOpt, Optional<LocalState> initialState = default)
         {
             Debug.Assert(delegateTypeOpt?.IsDelegateType() != false);
 
@@ -7361,17 +7361,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SetUpdatedSymbol(node, node.Symbol, delegateTypeOpt!);
             }
 
-            var oldDisableDiagnostics = _disableDiagnostics;
-            _disableDiagnostics |= disableDiagnostics;
-
             AnalyzeLocalFunctionOrLambda(
                 node,
                 node.Symbol,
                 initialState.HasValue ? initialState.Value : State.Clone(),
                 delegateInvokeMethod,
                 useDelegateInvokeParameterTypes);
-
-            _disableDiagnostics = oldDisableDiagnostics;
         }
 
         private static bool UseDelegateInvokeParameterTypes(BoundLambda lambda, MethodSymbol? delegateInvokeMethod)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4918,8 +4918,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                // normally we delay visiting the lambda until we can visit it along with its conversion.
-                // since we can't visit its conversion here, or it doesn't have one, we dig back in and
+                // Normally we delay visiting the lambda until we can visit it along with its conversion.
+                // Since we can't visit its conversion here, or it doesn't have one, we dig back in and
                 // visit the lambda here to ensure all nodes have nullability info for public API
                 for (int i = 0; i < results.Length; i++)
                 {
@@ -7344,8 +7344,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLambda(BoundLambda node)
         {
-            // note: actual lambda analysis happens after this call, primarily in VisitConversion.
-            // here we just indicate that a lambda expression produces a non-null value.
+            // Note: actual lambda analysis happens after this call (primarily in VisitConversion).
+            // Here we just indicate that a lambda expression produces a non-null value.
             SetNotNullResult(node);
             return null;
         }


### PR DESCRIPTION
Fixes #48174

This reduces the build time of the [linked scenario](https://github.com/pranavkm/repro/blob/0970c67b7b166488145402f833f63ac27e452629/Class1.cs) from about 30 seconds to about 1 second. Multiple calls to VisitLambda have an exponential effect where a "top-level" lambda might get visited twice, but an inner lambda inside it gets visited 4 times, and a lambda inside that gets visited 8 times, and so on. (I think this is what's happening, anyway :smile:)

It turned out that [both my questions](https://github.com/dotnet/roslyn/issues/48174#issuecomment-707382381) were not very necessary at least for the scenario shared in the linked issue.

@cston @333fred would appreciate your review. I'm particularly wondering if this change might cause us to miss nullability info in public API in some error scenarios.