### PR TITLE
Add skipped regression test for asset synchronization failure

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Serialization;
@@ -16,15 +17,17 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
     /// </summary>
     internal sealed class SimpleAssetSource : IAssetSource
     {
+        private readonly ISerializerService _serializerService;
         private readonly IReadOnlyDictionary<Checksum, object> _map;
 
-        public SimpleAssetSource(IReadOnlyDictionary<Checksum, object> map)
+        public SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map)
         {
+            _serializerService = serializerService;
             _map = map;
         }
 
         public ValueTask<ImmutableArray<(Checksum, object)>> GetAssetsAsync(
-            int serviceId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
+            int serviceId, ISet<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
         {
             var results = new List<(Checksum, object)>();
 
@@ -32,7 +35,15 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
             {
                 if (_map.TryGetValue(checksum, out var data))
                 {
-                    results.Add((checksum, data));
+                    using var stream = new MemoryStream();
+                    using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+                    {
+                        _serializerService.Serialize(data, writer, cancellationToken);
+                    }
+
+                    stream.Position = 0;
+                    using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
+                    results.Add((checksum, deserializerService.Deserialize<object>(data.GetWellKnownSynchronizationKind(), reader, cancellationToken)));
                 }
                 else
                 {

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -132,7 +132,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             // Ensure remote workspace is in sync with normal workspace.
             var solution = workspace.CurrentSolution;
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution);
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
             await remoteWorkspace.UpdatePrimaryBranchSolutionAsync(assetProvider, solutionChecksum, solution.WorkspaceVersion, CancellationToken.None);
 
@@ -180,7 +180,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             }
         }
 
-        private static async Task<AssetProvider> GetAssetProviderAsync(Workspace remoteWorkspace, Solution solution, Dictionary<Checksum, object> map = null)
+        private static async Task<AssetProvider> GetAssetProviderAsync(Workspace workspace, Workspace remoteWorkspace, Solution solution, Dictionary<Checksum, object> map = null)
         {
             // make sure checksum is calculated
             await solution.State.GetChecksumAsync(CancellationToken.None);
@@ -190,7 +190,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var sessionId = 0;
             var storage = new SolutionAssetCache();
-            var assetSource = new SimpleAssetSource(map);
+            var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
             return new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
         }
@@ -210,7 +210,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var solution = workspace.CurrentSolution;
 
             // Ensure remote workspace is in sync with normal workspace.
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution);
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
             await remoteWorkspace.UpdatePrimaryBranchSolutionAsync(assetProvider, solutionChecksum, solution.WorkspaceVersion, CancellationToken.None);
 

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -40,7 +40,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             using var remoteWorkspace = CreateRemoteWorkspace();
 
             var solution = workspace.CurrentSolution;
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution);
 
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
             var synched = await remoteWorkspace.GetSolutionAsync(assetProvider, solutionChecksum, fromPrimaryBranch: false, workspaceVersion: -1, CancellationToken.None);
@@ -59,7 +59,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var solution = workspace.CurrentSolution;
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution);
 
             var synched = await remoteWorkspace.GetSolutionAsync(assetProvider, solutionChecksum, fromPrimaryBranch, solution.WorkspaceVersion, cancellationToken: CancellationToken.None);
             Assert.Equal(solutionChecksum, await synched.State.GetChecksumAsync(CancellationToken.None));
@@ -87,7 +87,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                     ProjectId.CreateNewId(), VersionStamp.Create(), "test", "test.dll", LanguageNames.CSharp,
                     filePath: filePath, outputFilePath: filePath));
 
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, workspace.CurrentSolution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, workspace.CurrentSolution);
 
             var solutionChecksum = await workspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None);
             var solution = await remoteWorkspace.GetSolutionAsync(assetProvider, solutionChecksum, fromPrimaryBranch: false, workspaceVersion: -1, CancellationToken.None);
@@ -116,7 +116,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                     ProjectId.CreateNewId(), VersionStamp.Create(), "test", "test.dll", LanguageNames.CSharp,
                     filePath: filePath, outputFilePath: filePath));
 
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, workspace.CurrentSolution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, workspace.CurrentSolution);
 
             var solutionChecksum = await workspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None);
             var solution = await remoteWorkspace.GetSolutionAsync(assetProvider, solutionChecksum, fromPrimaryBranch: false, workspaceVersion: -1, CancellationToken.None);
@@ -140,7 +140,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             using var remoteWorkspace = CreateRemoteWorkspace();
 
             var solution = workspace.CurrentSolution;
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution);
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
 
             var first = await remoteWorkspace.GetSolutionAsync(assetProvider, solutionChecksum, fromPrimaryBranch: false, workspaceVersion: -1, CancellationToken.None);
@@ -340,7 +340,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             // create solution service
             var solution = workspace.CurrentSolution;
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution);
 
             // update primary workspace
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
@@ -383,7 +383,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             // create solution service
             var solution1 = workspace.CurrentSolution;
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution1);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution1);
 
             var remoteSolution1 = await GetInitialOOPSolutionAsync(remoteWorkspace, assetProvider, solution1);
 
@@ -451,7 +451,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var map = new Dictionary<Checksum, object>();
 
             using var remoteWorkspace = CreateRemoteWorkspace();
-            var assetProvider = await GetAssetProviderAsync(remoteWorkspace, solution, map);
+            var assetProvider = await GetAssetProviderAsync(workspace, remoteWorkspace, solution, map);
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
 
             // update primary workspace
@@ -485,7 +485,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             newSolutionValidator?.Invoke(recoveredNewSolution);
         }
 
-        private static async Task<AssetProvider> GetAssetProviderAsync(RemoteWorkspace remoteWorkspace, Solution solution, Dictionary<Checksum, object> map = null)
+        private static async Task<AssetProvider> GetAssetProviderAsync(Workspace workspace, RemoteWorkspace remoteWorkspace, Solution solution, Dictionary<Checksum, object> map = null)
         {
             // make sure checksum is calculated
             await solution.State.GetChecksumAsync(CancellationToken.None);
@@ -495,7 +495,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var sessionId = 0;
             var storage = new SolutionAssetCache();
-            var assetSource = new SimpleAssetSource(map);
+            var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
             return new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
         }

--- a/src/Workspaces/CSharp/Portable/Serialization/CSharpOptionsSerializationService.cs
+++ b/src/Workspaces/CSharp/Portable/Serialization/CSharpOptionsSerializationService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Serialization
             WriteParseOptionsTo(options, writer, cancellationToken);
 
             var csharpOptions = (CSharpParseOptions)options;
-            writer.WriteInt32((int)csharpOptions.LanguageVersion);
+            writer.WriteInt32((int)csharpOptions.SpecifiedLanguageVersion);
             writer.WriteValue(options.PreprocessorSymbolNames.ToArray());
         }
 

--- a/src/Workspaces/VisualBasic/Portable/Serialization/VisualBasicOptionsSerializationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Serialization/VisualBasicOptionsSerializationService.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Serialization
             WriteParseOptionsTo(options, writer, cancellationToken)
 
             Dim vbOptions = DirectCast(options, VisualBasicParseOptions)
-            writer.WriteInt32(vbOptions.LanguageVersion)
+            writer.WriteInt32(vbOptions.SpecifiedLanguageVersion)
 
             writer.WriteInt32(vbOptions.PreprocessorSymbols.Length)
             For Each kv In vbOptions.PreprocessorSymbols


### PR DESCRIPTION
* Fixes failure to use correct MEF containers for access to `IGlobalOptionService` in test code
* Fixes failure to round trip `ParseOptions`
* Adds skipped regression test for synchronization failure described in #48564

See #48564