### PR TITLE
Remove active view infobars

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         ? string.Format(EditorFeaturesResources.Error_creating_instance_of_CodeFixProvider_0, lazyFixer.Metadata.Name)
                         : EditorFeaturesResources.Error_creating_instance_of_CodeFixProvider;
 
-                    errorReportingService.ShowErrorInfoInActiveView(
+                    errorReportingService.ShowGlobalErrorInfo(
                         message,
                         new InfoBarUI(
                             WorkspacesResources.Show_Stack_Trace,

--- a/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
+++ b/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor
                     {
                         base.HandleException(provider, exception);
 
-                        _errorReportingService?.ShowErrorInfoInActiveView(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled, provider.GetType().Name),
+                        _errorReportingService?.ShowGlobalErrorInfo(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled, provider.GetType().Name),
                             new InfoBarUI(WorkspacesResources.Show_Stack_Trace, InfoBarUI.UIKind.HyperLink, () => ShowDetailedErrorInfo(exception), closeAfterAction: false),
                             new InfoBarUI(WorkspacesResources.Enable, InfoBarUI.UIKind.Button, () =>
                             {

--- a/src/EditorFeatures/Core/Implementation/InfoBar/EditorInfoBarService.cs
+++ b/src/EditorFeatures/Core/Implementation/InfoBar/EditorInfoBarService.cs
@@ -21,9 +21,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         {
         }
 
-        public void ShowInfoBarInActiveView(string message, params InfoBarUI[] items)
-            => ShowInfoBarInGlobalView(message, items);
-
         public void ShowInfoBarInGlobalView(string message, params InfoBarUI[] items)
             => Logger.Log(FunctionId.Extension_InfoBar, message);
     }

--- a/src/EditorFeatures/Core/Implementation/InfoBar/EditorInfoBarService.cs
+++ b/src/EditorFeatures/Core/Implementation/InfoBar/EditorInfoBarService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         {
         }
 
-        public void ShowInfoBarInGlobalView(string message, params InfoBarUI[] items)
+        public void ShowInfoBar(string message, params InfoBarUI[] items)
             => Logger.Log(FunctionId.Extension_InfoBar, message);
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -15,9 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         public void ShowDetailedErrorInfo(Exception exception)
             => Logger.Log(FunctionId.Extension_Exception, exception.StackTrace);
 
-        public void ShowErrorInfoInActiveView(string message, params InfoBarUI[] items)
-            => ShowGlobalErrorInfo(message, items);
-
         public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
             => Logger.Log(FunctionId.Extension_Exception, message);
 

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 FxCopAnalyzersInstallLogger.Log("InfoBarShown");
 
                 var infoBarService = _workspace.Services.GetRequiredService<IInfoBarService>();
-                infoBarService.ShowInfoBarInGlobalView(
+                infoBarService.ShowInfoBar(
                     ServicesVSResources.Install_Microsoft_recommended_Roslyn_analyzers_which_provide_additional_diagnostics_and_fixes_for_common_API_design_security_performance_and_reliability_issues,
                     GetInfoBarUIItems().ToArray());
             }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             var message = ServicesVSResources.We_notice_you_suspended_0_Reset_keymappings_to_continue_to_navigate_and_refactor;
             KeybindingsResetLogger.Log("InfoBarShown");
             var infoBarService = _workspace.Services.GetRequiredService<IInfoBarService>();
-            infoBarService.ShowInfoBarInGlobalView(
+            infoBarService.ShowInfoBar(
                 string.Format(message, ReSharperExtensionName),
                 new InfoBarUI(title: ServicesVSResources.Reset_Visual_Studio_default_keymapping,
                               kind: InfoBarUI.UIKind.Button,

--- a/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
@@ -41,58 +41,28 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _listener = listenerProvider.GetListener(FeatureAttribute.InfoBar);
         }
 
-        public void ShowInfoBarInActiveView(string message, params InfoBarUI[] items)
-        {
-            ThisCanBeCalledOnAnyThread();
-            ShowInfoBar(activeView: true, message: message, items: items);
-        }
-
         public void ShowInfoBarInGlobalView(string message, params InfoBarUI[] items)
         {
             ThisCanBeCalledOnAnyThread();
-            ShowInfoBar(activeView: false, message: message, items: items);
-        }
 
-        private void ShowInfoBar(bool activeView, string message, params InfoBarUI[] items)
-        {
             // We can be called from any thread since errors can occur anywhere, however we can only construct and InfoBar from the UI thread.
             _foregroundNotificationService.RegisterNotification(() =>
             {
-                if (TryGetInfoBarData(activeView, out var infoBarHost))
+                if (TryGetInfoBarData(out var infoBarHost))
                 {
                     CreateInfoBar(infoBarHost, message, items);
                 }
-            }, _listener.BeginAsyncOperation(nameof(ShowInfoBar)));
+            }, _listener.BeginAsyncOperation(nameof(ShowInfoBarInGlobalView)));
         }
 
-        private bool TryGetInfoBarData(bool activeView, out IVsInfoBarHost infoBarHost)
+        private bool TryGetInfoBarData(out IVsInfoBarHost infoBarHost)
         {
             AssertIsForeground();
 
             infoBarHost = null;
 
-            if (activeView)
-            {
-                // We want to get whichever window is currently in focus (including toolbars) as we could have had an exception thrown from the error list
-                // or interactive window
-                if (!(_serviceProvider.GetService(typeof(SVsShellMonitorSelection)) is IVsMonitorSelection monitorSelectionService) ||
-                    ErrorHandler.Failed(monitorSelectionService.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_WindowFrame, out var value)))
-                {
-                    return false;
-                }
-
-                var frame = value as IVsWindowFrame;
-                if (ErrorHandler.Failed(frame.GetProperty((int)__VSFPROPID7.VSFPROPID_InfoBarHost, out var activeViewInfoBar)))
-                {
-                    return false;
-                }
-
-                infoBarHost = activeViewInfoBar as IVsInfoBarHost;
-                return infoBarHost != null;
-            }
-
             // global error info, show it on main window info bar
-            if (!(_serviceProvider.GetService(typeof(SVsShell)) is IVsShell shell) ||
+            if (_serviceProvider.GetService(typeof(SVsShell)) is not IVsShell shell ||
                 ErrorHandler.Failed(shell.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out var globalInfoBar)))
             {
                 return false;

--- a/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _listener = listenerProvider.GetListener(FeatureAttribute.InfoBar);
         }
 
-        public void ShowInfoBarInGlobalView(string message, params InfoBarUI[] items)
+        public void ShowInfoBar(string message, params InfoBarUI[] items)
         {
             ThisCanBeCalledOnAnyThread();
 
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     CreateInfoBar(infoBarHost, message, items);
                 }
-            }, _listener.BeginAsyncOperation(nameof(ShowInfoBarInGlobalView)));
+            }, _listener.BeginAsyncOperation(nameof(ShowInfoBar)));
         }
 
         private bool TryGetInfoBarData(out IVsInfoBarHost infoBarHost)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AnalyzerConfigDocumentAsSolutionItemHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AnalyzerConfigDocumentAsSolutionItemHandler.cs
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 {
                     _infoBarShownForCurrentSolution = true;
                     var infoBarService = _workspace.Services.GetRequiredService<IInfoBarService>();
-                    infoBarService.ShowInfoBarInGlobalView(
+                    infoBarService.ShowInfoBar(
                         ServicesVSResources.A_new_editorconfig_file_was_detected_at_the_root_of_your_solution_Would_you_like_to_make_it_a_solution_item,
                         GetInfoBarUIItems().ToArray());
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
@@ -21,9 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public string HostDisplayName => "Visual Studio";
 
-        public void ShowErrorInfoInActiveView(string message, params InfoBarUI[] items)
-            => _infoBarService.ShowInfoBarInActiveView(message, items);
-
         public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
             => _infoBarService.ShowInfoBarInGlobalView(message, items);
 

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         public string HostDisplayName => "Visual Studio";
 
         public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
-            => _infoBarService.ShowInfoBarInGlobalView(message, items);
+            => _infoBarService.ShowInfoBar(message, items);
 
         public void ShowDetailedErrorInfo(Exception exception)
         {

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -15,13 +15,6 @@ namespace Microsoft.CodeAnalysis.Extensions
         string HostDisplayName { get; }
 
         /// <summary>
-        /// Show error info in an active view.
-        ///
-        /// Different host can have different definition on what active view means.
-        /// </summary>
-        void ShowErrorInfoInActiveView(string message, params InfoBarUI[] items);
-
-        /// <summary>
         /// Show global error info.
         ///
         /// this kind error info should be something that affects whole roslyn such as

--- a/src/Workspaces/Core/Portable/ExtensionManager/IInfoBarService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IInfoBarService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Extensions
         /// <summary>
         /// Show global info bar
         /// </summary>
-        void ShowInfoBarInGlobalView(string message, params InfoBarUI[] items);
+        void ShowInfoBar(string message, params InfoBarUI[] items);
     }
 
     internal struct InfoBarUI

--- a/src/Workspaces/Core/Portable/ExtensionManager/IInfoBarService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IInfoBarService.cs
@@ -12,13 +12,6 @@ namespace Microsoft.CodeAnalysis.Extensions
     internal interface IInfoBarService : IWorkspaceService
     {
         /// <summary>
-        /// Show an info bar in the current active view.
-        ///
-        /// Different hosts can have different definitions on what active view means.
-        /// </summary>
-        void ShowInfoBarInActiveView(string message, params InfoBarUI[] items);
-
-        /// <summary>
         /// Show global info bar
         /// </summary>
         void ShowInfoBarInGlobalView(string message, params InfoBarUI[] items);

--- a/src/Workspaces/CoreTestUtilities/TestErrorReportingService.cs
+++ b/src/Workspaces/CoreTestUtilities/TestErrorReportingService.cs
@@ -27,9 +27,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public void ShowDetailedErrorInfo(Exception exception)
             => OnError(exception.Message);
 
-        public void ShowErrorInfoInActiveView(string message, params InfoBarUI[] items)
-            => OnError(message);
-
         public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
             => OnError(message);
 


### PR DESCRIPTION
Fixes #40993

Previous code used the active tool window or document window to show exceptions, but if exceptions come from navigation then they'd appear on the find in files, or find references tool windows, and if its possible for them to come from background processes, then who knows where they'd show. 

This change just makes us always use the global info bar, so its not confusing for the user.