### PR TITLE
IOperation Node Porting: Leaf Nodes

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -2124,6 +2124,7 @@ namespace Microsoft.CodeAnalysis.Operations
             return Create(boundRangeVariable.Value);
         }
 
+#nullable enable
         private IOperation CreateBoundDiscardExpressionOperation(BoundDiscardExpression boundNode)
         {
             return new DiscardOperation(
@@ -2131,9 +2132,9 @@ namespace Microsoft.CodeAnalysis.Operations
                 _semanticModel,
                 boundNode.Syntax,
                 boundNode.GetPublicTypeSymbol(),
-                boundNode.ConstantValue,
                 isImplicit: boundNode.WasCompilerGenerated);
         }
+#nullable disable
 
         private IOperation CreateFromEndIndexExpressionOperation(BoundFromEndIndexExpression boundIndex)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -639,14 +639,16 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ParameterReferenceOperation(parameter, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         internal ILiteralOperation CreateBoundLiteralOperation(BoundLiteral boundLiteral, bool @implicit = false)
         {
             SyntaxNode syntax = boundLiteral.Syntax;
-            ITypeSymbol type = boundLiteral.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundLiteral.ConstantValue;
+            ITypeSymbol? type = boundLiteral.GetPublicTypeSymbol();
+            ConstantValue? constantValue = boundLiteral.ConstantValue;
             bool isImplicit = boundLiteral.WasCompilerGenerated || @implicit;
             return new LiteralOperation(_semanticModel, syntax, type, constantValue, isImplicit);
         }
+#nullable disable
 
         private IAnonymousObjectCreationOperation CreateBoundAnonymousObjectCreationExpressionOperation(BoundAnonymousObjectCreationExpression boundAnonymousObjectCreationExpression)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1529,14 +1529,14 @@ namespace Microsoft.CodeAnalysis.Operations
             return new BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IEmptyOperation CreateBoundNoOpStatementOperation(BoundNoOpStatement boundNoOpStatement)
         {
             SyntaxNode syntax = boundNoOpStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundNoOpStatement.WasCompilerGenerated;
-            return new EmptyOperation(_semanticModel, syntax, type, constantValue, isImplicit);
+            return new EmptyOperation(_semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private IConditionalOperation CreateBoundIfStatementOperation(BoundIfStatement boundIfStatement)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -631,17 +631,16 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyEventAssignmentOperation(this, boundEventAssignmentOperator, adds, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IParameterReferenceOperation CreateBoundParameterOperation(BoundParameter boundParameter)
         {
             IParameterSymbol parameter = boundParameter.ParameterSymbol.GetPublicSymbol();
             SyntaxNode syntax = boundParameter.Syntax;
-            ITypeSymbol type = boundParameter.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundParameter.ConstantValue;
+            ITypeSymbol? type = boundParameter.GetPublicTypeSymbol();
             bool isImplicit = boundParameter.WasCompilerGenerated;
-            return new ParameterReferenceOperation(parameter, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new ParameterReferenceOperation(parameter, _semanticModel, syntax, type, isImplicit);
         }
 
-#nullable enable
         internal ILiteralOperation CreateBoundLiteralOperation(BoundLiteral boundLiteral, bool @implicit = false)
         {
             SyntaxNode syntax = boundLiteral.Syntax;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -410,14 +410,15 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
+#nullable enable
         private IPlaceholderOperation CreateBoundDeconstructValuePlaceholderOperation(BoundDeconstructValuePlaceholder boundDeconstructValuePlaceholder)
         {
             SyntaxNode syntax = boundDeconstructValuePlaceholder.Syntax;
-            ITypeSymbol type = boundDeconstructValuePlaceholder.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundDeconstructValuePlaceholder.ConstantValue;
+            ITypeSymbol? type = boundDeconstructValuePlaceholder.GetPublicTypeSymbol();
             bool isImplicit = boundDeconstructValuePlaceholder.WasCompilerGenerated;
-            return new PlaceholderOperation(PlaceholderKind.Unspecified, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new PlaceholderOperation(PlaceholderKind.Unspecified, _semanticModel, syntax, type, isImplicit);
         }
+#nullable disable
 
         private IDeconstructionAssignmentOperation CreateBoundDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator boundDeconstructionAssignmentOperator)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1127,10 +1127,11 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyArrayInitializerOperation(this, boundArrayInitialization, _semanticModel, syntax, constantValue, isImplicit);
         }
 
+#nullable enable
         private IDefaultValueOperation CreateBoundDefaultLiteralOperation(BoundDefaultLiteral boundDefaultLiteral)
         {
             SyntaxNode syntax = boundDefaultLiteral.Syntax;
-            ConstantValue constantValue = boundDefaultLiteral.ConstantValue;
+            ConstantValue? constantValue = boundDefaultLiteral.ConstantValue;
             bool isImplicit = boundDefaultLiteral.WasCompilerGenerated;
             return new DefaultValueOperation(_semanticModel, syntax, type: null, constantValue, isImplicit);
         }
@@ -1138,13 +1139,12 @@ namespace Microsoft.CodeAnalysis.Operations
         private IDefaultValueOperation CreateBoundDefaultExpressionOperation(BoundDefaultExpression boundDefaultExpression)
         {
             SyntaxNode syntax = boundDefaultExpression.Syntax;
-            ITypeSymbol type = boundDefaultExpression.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundDefaultExpression.ConstantValue;
+            ITypeSymbol? type = boundDefaultExpression.GetPublicTypeSymbol();
+            ConstantValue? constantValue = boundDefaultExpression.ConstantValue;
             bool isImplicit = boundDefaultExpression.WasCompilerGenerated;
             return new DefaultValueOperation(_semanticModel, syntax, type, constantValue, isImplicit);
         }
 
-#nullable enable
         private IInstanceReferenceOperation CreateBoundBaseReferenceOperation(BoundBaseReference boundBaseReference)
         {
             InstanceReferenceKind referenceKind = InstanceReferenceKind.ContainingTypeInstance;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -494,13 +494,14 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
+#nullable enable
         internal IOperation CreateBoundLocalOperation(BoundLocal boundLocal, bool createDeclaration = true)
         {
             ILocalSymbol local = boundLocal.LocalSymbol.GetPublicSymbol();
             bool isDeclaration = boundLocal.DeclarationKind != BoundLocalDeclarationKind.None;
             SyntaxNode syntax = boundLocal.Syntax;
-            ITypeSymbol type = boundLocal.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundLocal.ConstantValue;
+            ITypeSymbol? type = boundLocal.GetPublicTypeSymbol();
+            ConstantValue? constantValue = boundLocal.ConstantValue;
             bool isImplicit = boundLocal.WasCompilerGenerated;
             if (isDeclaration && syntax is DeclarationExpressionSyntax declarationExpressionSyntax)
             {
@@ -512,6 +513,7 @@ namespace Microsoft.CodeAnalysis.Operations
             }
             return new LocalReferenceOperation(local, isDeclaration, _semanticModel, syntax, type, constantValue, isImplicit);
         }
+#nullable disable
 
         internal IOperation CreateBoundFieldAccessOperation(BoundFieldAccess boundFieldAccess, bool createDeclaration = true)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1089,17 +1089,18 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyIsTypeOperation(this, valueOperand, typeOperand, isNegated, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private ISizeOfOperation CreateBoundSizeOfOperatorOperation(BoundSizeOfOperator boundSizeOfOperator)
         {
-            ITypeSymbol typeOperand = boundSizeOfOperator.SourceType.GetPublicTypeSymbol();
+            ITypeSymbol? typeOperand = boundSizeOfOperator.SourceType.GetPublicTypeSymbol();
+            Debug.Assert(typeOperand is not null);
             SyntaxNode syntax = boundSizeOfOperator.Syntax;
-            ITypeSymbol type = boundSizeOfOperator.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundSizeOfOperator.ConstantValue;
+            ITypeSymbol? type = boundSizeOfOperator.GetPublicTypeSymbol();
+            ConstantValue? constantValue = boundSizeOfOperator.ConstantValue;
             bool isImplicit = boundSizeOfOperator.WasCompilerGenerated;
             return new SizeOfOperation(typeOperand, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
-#nullable enable
         private ITypeOfOperation CreateBoundTypeOfOperatorOperation(BoundTypeOfOperator boundTypeOfOperator)
         {
             ITypeSymbol? typeOperand = boundTypeOfOperator.SourceType.GetPublicTypeSymbol();

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1144,25 +1144,25 @@ namespace Microsoft.CodeAnalysis.Operations
             return new DefaultValueOperation(_semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IInstanceReferenceOperation CreateBoundBaseReferenceOperation(BoundBaseReference boundBaseReference)
         {
             InstanceReferenceKind referenceKind = InstanceReferenceKind.ContainingTypeInstance;
             SyntaxNode syntax = boundBaseReference.Syntax;
-            ITypeSymbol type = boundBaseReference.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundBaseReference.ConstantValue;
+            ITypeSymbol? type = boundBaseReference.GetPublicTypeSymbol();
             bool isImplicit = boundBaseReference.WasCompilerGenerated;
-            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit);
         }
 
         private IInstanceReferenceOperation CreateBoundThisReferenceOperation(BoundThisReference boundThisReference)
         {
             InstanceReferenceKind referenceKind = InstanceReferenceKind.ContainingTypeInstance;
             SyntaxNode syntax = boundThisReference.Syntax;
-            ITypeSymbol type = boundThisReference.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundThisReference.ConstantValue;
+            ITypeSymbol? type = boundThisReference.GetPublicTypeSymbol();
             bool isImplicit = boundThisReference.WasCompilerGenerated;
-            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit);
         }
+#nullable disable
 
         private IOperation CreateBoundAssignmentOperatorOrMemberInitializerOperation(BoundAssignmentOperator boundAssignmentOperator)
         {
@@ -1415,15 +1415,16 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyAddressOfOperation(this, reference, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IInstanceReferenceOperation CreateBoundImplicitReceiverOperation(BoundImplicitReceiver boundImplicitReceiver)
         {
             InstanceReferenceKind referenceKind = InstanceReferenceKind.ImplicitReceiver;
             SyntaxNode syntax = boundImplicitReceiver.Syntax;
-            ITypeSymbol type = boundImplicitReceiver.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundImplicitReceiver.ConstantValue;
+            ITypeSymbol? type = boundImplicitReceiver.GetPublicTypeSymbol();
             bool isImplicit = boundImplicitReceiver.WasCompilerGenerated;
-            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit);
         }
+#nullable disable
 
         private IConditionalAccessOperation CreateBoundConditionalAccessOperation(BoundConditionalAccess boundConditionalAccess)
         {
@@ -2175,6 +2176,7 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyPropertySubpatternOperation(this, subpattern, matchedType, syntax, _semanticModel);
         }
 
+#nullable enable
         internal IOperation CreatePropertySubpatternMember(Symbol symbol, ITypeSymbol matchedType, SyntaxNode syntax)
         {
             var nameSyntax = (syntax is SubpatternSyntax subpatSyntax ? subpatSyntax.NameColon?.Name : null) ?? syntax;
@@ -2185,14 +2187,14 @@ namespace Microsoft.CodeAnalysis.Operations
                     {
                         var constantValue = field.GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
                         var receiver = new InstanceReferenceOperation(
-                            InstanceReferenceKind.PatternInput, _semanticModel, nameSyntax, matchedType, constantValue, isImplicit: true);
+                            InstanceReferenceKind.PatternInput, _semanticModel, nameSyntax, matchedType, isImplicit: true);
                         return new FieldReferenceOperation(
                             field.GetPublicSymbol(), isDeclaration: false, receiver, _semanticModel, nameSyntax, field.Type.GetPublicSymbol(), constantValue, isImplicit: isImplicit);
                     }
                 case PropertySymbol property:
                     {
                         var receiver = new InstanceReferenceOperation(
-                            InstanceReferenceKind.PatternInput, _semanticModel, nameSyntax, matchedType, constantValue: null, isImplicit: true);
+                            InstanceReferenceKind.PatternInput, _semanticModel, nameSyntax, matchedType, isImplicit: true);
                         return new PropertyReferenceOperation(
                             property.GetPublicSymbol(), ImmutableArray<IArgumentOperation>.Empty, receiver, _semanticModel, nameSyntax, property.Type.GetPublicSymbol(),
                             constantValue: null, isImplicit: isImplicit);
@@ -2208,10 +2210,9 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             InstanceReferenceKind referenceKind = InstanceReferenceKind.ImplicitReceiver;
             SyntaxNode syntax = placeholder.Syntax;
-            ITypeSymbol type = placeholder.GetPublicTypeSymbol();
-            ConstantValue constantValue = placeholder.ConstantValue;
+            ITypeSymbol? type = placeholder.GetPublicTypeSymbol();
             bool isImplicit = placeholder.WasCompilerGenerated;
-            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1099,15 +1099,17 @@ namespace Microsoft.CodeAnalysis.Operations
             return new SizeOfOperation(typeOperand, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private ITypeOfOperation CreateBoundTypeOfOperatorOperation(BoundTypeOfOperator boundTypeOfOperator)
         {
-            ITypeSymbol typeOperand = boundTypeOfOperator.SourceType.GetPublicTypeSymbol();
+            ITypeSymbol? typeOperand = boundTypeOfOperator.SourceType.GetPublicTypeSymbol();
+            Debug.Assert(typeOperand is not null);
             SyntaxNode syntax = boundTypeOfOperator.Syntax;
-            ITypeSymbol type = boundTypeOfOperator.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundTypeOfOperator.ConstantValue;
+            ITypeSymbol? type = boundTypeOfOperator.GetPublicTypeSymbol();
             bool isImplicit = boundTypeOfOperator.WasCompilerGenerated;
-            return new TypeOfOperation(typeOperand, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new TypeOfOperation(typeOperand, _semanticModel, syntax, type, isImplicit);
         }
+#nullable disable
 
         private IArrayCreationOperation CreateBoundArrayCreationOperation(BoundArrayCreation boundArrayCreation)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1436,14 +1436,15 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyConditionalAccessOperation(this, boundConditionalAccess, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IConditionalAccessInstanceOperation CreateBoundConditionalReceiverOperation(BoundConditionalReceiver boundConditionalReceiver)
         {
             SyntaxNode syntax = boundConditionalReceiver.Syntax;
-            ITypeSymbol type = boundConditionalReceiver.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundConditionalReceiver.ConstantValue;
+            ITypeSymbol? type = boundConditionalReceiver.GetPublicTypeSymbol();
             bool isImplicit = boundConditionalReceiver.WasCompilerGenerated;
-            return new ConditionalAccessInstanceOperation(_semanticModel, syntax, type, constantValue, isImplicit);
+            return new ConditionalAccessInstanceOperation(_semanticModel, syntax, type, isImplicit);
         }
+#nullable disable
 
         private IFieldInitializerOperation CreateBoundFieldEqualsValueOperation(BoundFieldEqualsValue boundFieldEqualsValue)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1486,15 +1486,14 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyBlockOperation(this, boundBlock, locals, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IBranchOperation CreateBoundContinueStatementOperation(BoundContinueStatement boundContinueStatement)
         {
             ILabelSymbol target = boundContinueStatement.Label.GetPublicSymbol();
             BranchKind branchKind = BranchKind.Continue;
             SyntaxNode syntax = boundContinueStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundContinueStatement.WasCompilerGenerated;
-            return new BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit);
         }
 
         private IBranchOperation CreateBoundBreakStatementOperation(BoundBreakStatement boundBreakStatement)
@@ -1502,11 +1501,10 @@ namespace Microsoft.CodeAnalysis.Operations
             ILabelSymbol target = boundBreakStatement.Label.GetPublicSymbol();
             BranchKind branchKind = BranchKind.Break;
             SyntaxNode syntax = boundBreakStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundBreakStatement.WasCompilerGenerated;
-            return new BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private IReturnOperation CreateBoundYieldBreakStatementOperation(BoundYieldBreakStatement boundYieldBreakStatement)
         {
@@ -1518,18 +1516,16 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyReturnOperation(this, returnedValue, OperationKind.YieldBreak, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IBranchOperation CreateBoundGotoStatementOperation(BoundGotoStatement boundGotoStatement)
         {
             ILabelSymbol target = boundGotoStatement.Label.GetPublicSymbol();
             BranchKind branchKind = BranchKind.GoTo;
             SyntaxNode syntax = boundGotoStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundGotoStatement.WasCompilerGenerated;
-            return new BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit);
         }
 
-#nullable enable
         private IEmptyOperation CreateBoundNoOpStatementOperation(BoundNoOpStatement boundNoOpStatement)
         {
             SyntaxNode syntax = boundNoOpStatement.Syntax;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -33,8 +33,10 @@ namespace Microsoft.CodeAnalysis.Operations
             return ImmutableArray.Create(statement);
         }
 
+#nullable enable
         private IInstanceReferenceOperation CreateImplicitReceiver(SyntaxNode syntax, TypeSymbol type) =>
-            new InstanceReferenceOperation(InstanceReferenceKind.ImplicitReceiver, _semanticModel, syntax, type.GetPublicSymbol(), constantValue: null, isImplicit: true);
+            new InstanceReferenceOperation(InstanceReferenceKind.ImplicitReceiver, _semanticModel, syntax, type.GetPublicSymbol(), isImplicit: true);
+#nullable disable
 
         internal IArgumentOperation CreateArgumentOperation(ArgumentKind kind, IParameterSymbol parameter, BoundExpression expression)
         {
@@ -365,6 +367,7 @@ namespace Microsoft.CodeAnalysis.Operations
             return builder.ToImmutableAndFree();
         }
 
+#nullable enable
         internal ImmutableArray<IOperation> GetAnonymousObjectCreationInitializers(
             ImmutableArray<BoundExpression> arguments,
             ImmutableArray<BoundAnonymousPropertyDeclaration> declarations,
@@ -390,12 +393,11 @@ namespace Microsoft.CodeAnalysis.Operations
                         semanticModel: _semanticModel,
                         syntax: syntax,
                         type: type,
-                        constantValue: null,
                         isImplicit: true);
 
                 // Find matching declaration for the current argument.
                 PropertySymbol property = AnonymousTypeManager.GetAnonymousTypeProperty(type.GetSymbol<NamedTypeSymbol>(), i);
-                BoundAnonymousPropertyDeclaration anonymousProperty = getDeclaration(declarations, property, ref currentDeclarationIndex);
+                BoundAnonymousPropertyDeclaration? anonymousProperty = getDeclaration(declarations, property, ref currentDeclarationIndex);
                 if (anonymousProperty is null)
                 {
                     // No matching declaration, synthesize a property reference to be assigned.
@@ -424,7 +426,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 }
 
                 var assignmentSyntax = value.Syntax?.Parent ?? syntax;
-                ITypeSymbol assignmentType = target.Type;
+                ITypeSymbol? assignmentType = target.Type;
                 bool isRef = false;
                 var assignment = new SimpleAssignmentOperation(isRef, target, value, _semanticModel, assignmentSyntax, assignmentType, value.GetConstantValue(), isImplicitAssignment);
                 builder.Add(assignment);
@@ -433,7 +435,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Debug.Assert(currentDeclarationIndex == declarations.Length);
             return builder.ToImmutableAndFree();
 
-            static BoundAnonymousPropertyDeclaration getDeclaration(ImmutableArray<BoundAnonymousPropertyDeclaration> declarations, PropertySymbol currentProperty, ref int currentDeclarationIndex)
+            static BoundAnonymousPropertyDeclaration? getDeclaration(ImmutableArray<BoundAnonymousPropertyDeclaration> declarations, PropertySymbol currentProperty, ref int currentDeclarationIndex)
             {
                 if (currentDeclarationIndex >= declarations.Length)
                 {

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -1359,7 +1359,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (
             Member: 
               IFieldReferenceOperation: System.Int32 D.X (Static) (OperationKind.FieldReference, Type: System.Int32, Constant: 3, IsInvalid) (Syntax: 'X')
                 Instance Receiver: 
-                  IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: D, Constant: 3, IsInvalid, IsImplicit) (Syntax: 'X')
+                  IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: D, IsInvalid, IsImplicit) (Syntax: 'X')
             Pattern: 
               IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var x') (InputType: ?, NarrowedType: ?, DeclaredSymbol: ?? x, MatchesNull: True)
 ";

--- a/src/Compilers/Core/Portable/Generated/FlowAnalysis.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/FlowAnalysis.Generated.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -1878,6 +1878,7 @@ namespace Microsoft.CodeAnalysis.Operations
     {
     }
     #nullable disable
+    #nullable enable
     /// <summary>
     /// Represents an operation that gets <see cref="System.Type" /> for the given <see cref="TypeOperand" />.
     /// <para>
@@ -1901,6 +1902,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         ITypeSymbol TypeOperand { get; }
     }
+    #nullable disable
     /// <summary>
     /// Represents an operation to compute the size of a given type.
     /// <para>
@@ -6402,18 +6404,24 @@ namespace Microsoft.CodeAnalysis.Operations
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitDefaultValue(this, argument);
     }
     #nullable disable
-    internal sealed partial class TypeOfOperation : OperationOld, ITypeOfOperation
+    #nullable enable
+    internal sealed partial class TypeOfOperation : Operation, ITypeOfOperation
     {
-        internal TypeOfOperation(ITypeSymbol typeOperand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.TypeOf, semanticModel, syntax, type, constantValue, isImplicit)
+        internal TypeOfOperation(ITypeSymbol typeOperand, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
         {
             TypeOperand = typeOperand;
+            Type = type;
         }
         public ITypeSymbol TypeOperand { get; }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.TypeOf;
         public override void Accept(OperationVisitor visitor) => visitor.VisitTypeOf(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitTypeOf(this, argument);
     }
+    #nullable disable
     internal sealed partial class SizeOfOperation : OperationOld, ISizeOfOperation
     {
         internal SizeOfOperation(ITypeSymbol typeOperand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9181,6 +9189,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (DefaultValueOperation)operation;
             return new DefaultValueOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitTypeOf(ITypeOfOperation operation, object? argument)
+        {
+            var internalOperation = (TypeOfOperation)operation;
+            return new TypeOfOperation(internalOperation.TypeOperand, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -1858,6 +1858,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation Target { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents a default value operation.
     /// <para>
@@ -1876,6 +1877,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IDefaultValueOperation : IOperation
     {
     }
+    #nullable disable
     /// <summary>
     /// Represents an operation that gets <see cref="System.Type" /> for the given <see cref="TypeOperand" />.
     /// <para>
@@ -6383,14 +6385,23 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class DefaultValueOperation : OperationOld, IDefaultValueOperation
+    #nullable enable
+    internal sealed partial class DefaultValueOperation : Operation, IDefaultValueOperation
     {
-        internal DefaultValueOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.DefaultValue, semanticModel, syntax, type, constantValue, isImplicit) { }
+        internal DefaultValueOperation(SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, ConstantValue? constantValue, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
+        {
+            OperationConstantValue = constantValue;
+            Type = type;
+        }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue { get; }
+        public override OperationKind Kind => OperationKind.DefaultValue;
         public override void Accept(OperationVisitor visitor) => visitor.VisitDefaultValue(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitDefaultValue(this, argument);
     }
+    #nullable disable
     internal sealed partial class TypeOfOperation : OperationOld, ITypeOfOperation
     {
         internal TypeOfOperation(ITypeSymbol typeOperand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9165,6 +9176,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (ConditionalAccessInstanceOperation)operation;
             return new ConditionalAccessInstanceOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitDefaultValue(IDefaultValueOperation operation, object? argument)
+        {
+            var internalOperation = (DefaultValueOperation)operation;
+            return new DefaultValueOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -792,6 +792,7 @@ namespace Microsoft.CodeAnalysis.Operations
         bool IsDeclaration { get; }
     }
     #nullable disable
+    #nullable enable
     /// <summary>
     /// Represents a reference to a parameter.
     /// <para>
@@ -815,6 +816,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IParameterSymbol Parameter { get; }
     }
+    #nullable disable
     /// <summary>
     /// Represents a reference to a member of a class, struct, or interface.
     /// <para>
@@ -4736,18 +4738,24 @@ namespace Microsoft.CodeAnalysis.Operations
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitLocalReference(this, argument);
     }
     #nullable disable
-    internal sealed partial class ParameterReferenceOperation : OperationOld, IParameterReferenceOperation
+    #nullable enable
+    internal sealed partial class ParameterReferenceOperation : Operation, IParameterReferenceOperation
     {
-        internal ParameterReferenceOperation(IParameterSymbol parameter, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.ParameterReference, semanticModel, syntax, type, constantValue, isImplicit)
+        internal ParameterReferenceOperation(IParameterSymbol parameter, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
         {
             Parameter = parameter;
+            Type = type;
         }
         public IParameterSymbol Parameter { get; }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.ParameterReference;
         public override void Accept(OperationVisitor visitor) => visitor.VisitParameterReference(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitParameterReference(this, argument);
     }
+    #nullable disable
     internal abstract partial class BaseMemberReferenceOperation : OperationOld, IMemberReferenceOperation
     {
         protected BaseMemberReferenceOperation(OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9124,6 +9132,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (LocalReferenceOperation)operation;
             return new LocalReferenceOperation(internalOperation.Local, internalOperation.IsDeclaration, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitParameterReference(IParameterReferenceOperation operation, object? argument)
+        {
+            var internalOperation = (ParameterReferenceOperation)operation;
+            return new ParameterReferenceOperation(internalOperation.Parameter, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -571,6 +571,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IStopOperation : IOperation
     {
     }
+    #nullable enable
     /// <summary>
     /// Represents an operation that stops the execution of code abruptly.
     /// <para>
@@ -589,6 +590,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IEndOperation : IOperation
     {
     }
+    #nullable disable
     /// <summary>
     /// Represents an operation for raising an event.
     /// <para>
@@ -4415,14 +4417,19 @@ namespace Microsoft.CodeAnalysis.Operations
         public override void Accept(OperationVisitor visitor) => visitor.VisitStop(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitStop(this, argument);
     }
-    internal sealed partial class EndOperation : OperationOld, IEndOperation
+    #nullable enable
+    internal sealed partial class EndOperation : Operation, IEndOperation
     {
-        internal EndOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.End, semanticModel, syntax, type, constantValue, isImplicit) { }
+        internal EndOperation(SemanticModel? semanticModel, SyntaxNode syntax, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit) { }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type => null;
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.End;
         public override void Accept(OperationVisitor visitor) => visitor.VisitEnd(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitEnd(this, argument);
     }
+    #nullable disable
     internal abstract partial class BaseRaiseEventOperation : OperationOld, IRaiseEventOperation
     {
         internal BaseRaiseEventOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9070,6 +9077,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (EmptyOperation)operation;
             return new EmptyOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitEnd(IEndOperation operation, object? argument)
+        {
+            var internalOperation = (EndOperation)operation;
+            return new EndOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -2811,6 +2811,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation Initializer { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents a discard operation.
     /// <para>
@@ -2832,6 +2833,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IDiscardSymbol DiscardSymbol { get; }
     }
+    #nullable disable
     /// <summary>
     /// Represents a coalesce assignment operation with a target and a conditionally-evaluated value:
     /// (1) <see cref="IAssignmentOperation.Target" /> is evaluated for null. If it is null, <see cref="IAssignmentOperation.Value" /> is evaluated and assigned to target.
@@ -7976,18 +7978,24 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class DiscardOperation : OperationOld, IDiscardOperation
+    #nullable enable
+    internal sealed partial class DiscardOperation : Operation, IDiscardOperation
     {
-        internal DiscardOperation(IDiscardSymbol discardSymbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.Discard, semanticModel, syntax, type, constantValue, isImplicit)
+        internal DiscardOperation(IDiscardSymbol discardSymbol, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
         {
             DiscardSymbol = discardSymbol;
+            Type = type;
         }
         public IDiscardSymbol DiscardSymbol { get; }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.Discard;
         public override void Accept(OperationVisitor visitor) => visitor.VisitDiscardOperation(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitDiscardOperation(this, argument);
     }
+    #nullable disable
     internal sealed partial class FlowCaptureReferenceOperation : OperationOld, IFlowCaptureReferenceOperation
     {
         internal FlowCaptureReferenceOperation(CaptureId id, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9223,6 +9231,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (OmittedArgumentOperation)operation;
             return new OmittedArgumentOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitDiscardOperation(IDiscardOperation operation, object? argument)
+        {
+            var internalOperation = (DiscardOperation)operation;
+            return new DiscardOperation(internalOperation.DiscardSymbol, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -1486,6 +1486,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation WhenNotNull { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents the value of a conditionally-accessed operation within <see cref="IConditionalAccessOperation.WhenNotNull" />.
     /// For a conditional access operation of the form <c>someExpr?.Member</c>, this operation is used as the InstanceReceiver for the right operation <c>Member</c>.
@@ -1507,6 +1508,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IConditionalAccessInstanceOperation : IOperation
     {
     }
+    #nullable disable
     /// <summary>
     /// Represents an interpolated string.
     /// <para>
@@ -5926,14 +5928,22 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class ConditionalAccessInstanceOperation : OperationOld, IConditionalAccessInstanceOperation
+    #nullable enable
+    internal sealed partial class ConditionalAccessInstanceOperation : Operation, IConditionalAccessInstanceOperation
     {
-        internal ConditionalAccessInstanceOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.ConditionalAccessInstance, semanticModel, syntax, type, constantValue, isImplicit) { }
+        internal ConditionalAccessInstanceOperation(SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
+        {
+            Type = type;
+        }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.ConditionalAccessInstance;
         public override void Accept(OperationVisitor visitor) => visitor.VisitConditionalAccessInstance(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitConditionalAccessInstance(this, argument);
     }
+    #nullable disable
     internal abstract partial class BaseInterpolatedStringOperation : OperationOld, IInterpolatedStringOperation
     {
         internal BaseInterpolatedStringOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9150,6 +9160,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (InstanceReferenceOperation)operation;
             return new InstanceReferenceOperation(internalOperation.ReferenceKind, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitConditionalAccessInstance(IConditionalAccessInstanceOperation operation, object? argument)
+        {
+            var internalOperation = (ConditionalAccessInstanceOperation)operation;
+            return new ConditionalAccessInstanceOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -3131,6 +3131,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IObjectOrCollectionInitializerOperation Initializer { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents a general placeholder when no more specific kind of placeholder is available.
     /// A placeholder is an expression whose meaning is inferred from context.
@@ -3143,6 +3144,7 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         PlaceholderKind PlaceholderKind { get; }
     }
+    #nullable disable
     /// <summary>
     /// Represents a reference through a pointer.
     /// <para>
@@ -8749,18 +8751,24 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class PlaceholderOperation : OperationOld, IPlaceholderOperation
+    #nullable enable
+    internal sealed partial class PlaceholderOperation : Operation, IPlaceholderOperation
     {
-        internal PlaceholderOperation(PlaceholderKind placeholderKind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.None, semanticModel, syntax, type, constantValue, isImplicit)
+        internal PlaceholderOperation(PlaceholderKind placeholderKind, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
         {
             PlaceholderKind = placeholderKind;
+            Type = type;
         }
         public PlaceholderKind PlaceholderKind { get; }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.None;
         public override void Accept(OperationVisitor visitor) => visitor.VisitPlaceholder(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitPlaceholder(this, argument);
     }
+    #nullable disable
     internal abstract partial class BasePointerIndirectionReferenceOperation : OperationOld, IPointerIndirectionReferenceOperation
     {
         internal BasePointerIndirectionReferenceOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9236,6 +9244,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (DiscardOperation)operation;
             return new DiscardOperation(internalOperation.DiscardSymbol, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+        }
+        internal override IOperation VisitPlaceholder(IPlaceholderOperation operation, object? argument)
+        {
+            var internalOperation = (PlaceholderOperation)operation;
+            return new PlaceholderOperation(internalOperation.PlaceholderKind, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -2086,6 +2086,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation Expression { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents an argument value that has been omitted in an invocation.
     /// <para>
@@ -2104,6 +2105,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IOmittedArgumentOperation : IOperation
     {
     }
+    #nullable disable
     /// <summary>
     /// Represents an initializer for a field, property, parameter or a local variable declaration.
     /// <para>
@@ -6753,14 +6755,22 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class OmittedArgumentOperation : OperationOld, IOmittedArgumentOperation
+    #nullable enable
+    internal sealed partial class OmittedArgumentOperation : Operation, IOmittedArgumentOperation
     {
-        internal OmittedArgumentOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.OmittedArgument, semanticModel, syntax, type, constantValue, isImplicit) { }
+        internal OmittedArgumentOperation(SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
+        {
+            Type = type;
+        }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.OmittedArgument;
         public override void Accept(OperationVisitor visitor) => visitor.VisitOmittedArgument(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitOmittedArgument(this, argument);
     }
+    #nullable disable
     internal abstract partial class BaseSymbolInitializerOperation : OperationOld, ISymbolInitializerOperation
     {
         protected BaseSymbolInitializerOperation(ImmutableArray<ILocalSymbol> locals, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9208,6 +9218,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (SizeOfOperation)operation;
             return new SizeOfOperation(internalOperation.TypeOperand, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitOmittedArgument(IOmittedArgumentOperation operation, object? argument)
+        {
+            var internalOperation = (OmittedArgumentOperation)operation;
+            return new OmittedArgumentOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -553,6 +553,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </remarks>
         IBlockOperation IgnoredBody { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents an operation to stop or suspend execution of code.
     /// <para>
@@ -571,6 +572,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IStopOperation : IOperation
     {
     }
+    #nullable disable
     #nullable enable
     /// <summary>
     /// Represents an operation that stops the execution of code abruptly.
@@ -4409,14 +4411,19 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class StopOperation : OperationOld, IStopOperation
+    #nullable enable
+    internal sealed partial class StopOperation : Operation, IStopOperation
     {
-        internal StopOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.Stop, semanticModel, syntax, type, constantValue, isImplicit) { }
+        internal StopOperation(SemanticModel? semanticModel, SyntaxNode syntax, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit) { }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type => null;
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.Stop;
         public override void Accept(OperationVisitor visitor) => visitor.VisitStop(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitStop(this, argument);
     }
+    #nullable disable
     #nullable enable
     internal sealed partial class EndOperation : Operation, IEndOperation
     {
@@ -9077,6 +9084,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (EmptyOperation)operation;
             return new EmptyOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitStop(IStopOperation operation, object? argument)
+        {
+            var internalOperation = (StopOperation)operation;
+            return new StopOperation(internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.IsImplicit);
         }
         public override IOperation VisitEnd(IEndOperation operation, object? argument)
         {

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -1232,6 +1232,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IArrayInitializerOperation Initializer { get; }
     }
+    #nullable enable
     /// <summary>
     /// Represents an implicit/explicit reference to an instance.
     /// <para>
@@ -1257,6 +1258,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         InstanceReferenceKind ReferenceKind { get; }
     }
+    #nullable disable
     /// <summary>
     /// Represents an operation that tests if a value is of a specific type.
     /// <para>
@@ -5489,18 +5491,24 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
     }
-    internal sealed partial class InstanceReferenceOperation : OperationOld, IInstanceReferenceOperation
+    #nullable enable
+    internal sealed partial class InstanceReferenceOperation : Operation, IInstanceReferenceOperation
     {
-        internal InstanceReferenceOperation(InstanceReferenceKind referenceKind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.InstanceReference, semanticModel, syntax, type, constantValue, isImplicit)
+        internal InstanceReferenceOperation(InstanceReferenceKind referenceKind, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
         {
             ReferenceKind = referenceKind;
+            Type = type;
         }
         public InstanceReferenceKind ReferenceKind { get; }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue => null;
+        public override OperationKind Kind => OperationKind.InstanceReference;
         public override void Accept(OperationVisitor visitor) => visitor.VisitInstanceReference(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitInstanceReference(this, argument);
     }
+    #nullable disable
     internal abstract partial class BaseIsTypeOperation : OperationOld, IIsTypeOperation
     {
         internal BaseIsTypeOperation(ITypeSymbol typeOperand, bool isNegated, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9137,6 +9145,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (ParameterReferenceOperation)operation;
             return new ParameterReferenceOperation(internalOperation.Parameter, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitInstanceReference(IInstanceReferenceOperation operation, object? argument)
+        {
+            var internalOperation = (InstanceReferenceOperation)operation;
+            return new InstanceReferenceOperation(internalOperation.ReferenceKind, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -1903,6 +1903,7 @@ namespace Microsoft.CodeAnalysis.Operations
         ITypeSymbol TypeOperand { get; }
     }
     #nullable disable
+    #nullable enable
     /// <summary>
     /// Represents an operation to compute the size of a given type.
     /// <para>
@@ -1925,6 +1926,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         ITypeSymbol TypeOperand { get; }
     }
+    #nullable disable
     /// <summary>
     /// Represents an operation that creates a pointer value by taking the address of a reference.
     /// <para>
@@ -6422,18 +6424,25 @@ namespace Microsoft.CodeAnalysis.Operations
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitTypeOf(this, argument);
     }
     #nullable disable
-    internal sealed partial class SizeOfOperation : OperationOld, ISizeOfOperation
+    #nullable enable
+    internal sealed partial class SizeOfOperation : Operation, ISizeOfOperation
     {
-        internal SizeOfOperation(ITypeSymbol typeOperand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
-            : base(OperationKind.SizeOf, semanticModel, syntax, type, constantValue, isImplicit)
+        internal SizeOfOperation(ITypeSymbol typeOperand, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, ConstantValue? constantValue, bool isImplicit)
+            : base(semanticModel, syntax, isImplicit)
         {
             TypeOperand = typeOperand;
+            OperationConstantValue = constantValue;
+            Type = type;
         }
         public ITypeSymbol TypeOperand { get; }
         public override IEnumerable<IOperation> Children => Array.Empty<IOperation>();
+        public override ITypeSymbol? Type { get; }
+        internal override ConstantValue? OperationConstantValue { get; }
+        public override OperationKind Kind => OperationKind.SizeOf;
         public override void Accept(OperationVisitor visitor) => visitor.VisitSizeOf(this);
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.VisitSizeOf(this, argument);
     }
+    #nullable disable
     internal abstract partial class BaseAddressOfOperation : OperationOld, IAddressOfOperation
     {
         internal BaseAddressOfOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit)
@@ -9194,6 +9203,11 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             var internalOperation = (TypeOfOperation)operation;
             return new TypeOfOperation(internalOperation.TypeOperand, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+        }
+        public override IOperation VisitSizeOf(ISizeOfOperation operation, object? argument)
+        {
+            var internalOperation = (SizeOfOperation)operation;
+            return new SizeOfOperation(internalOperation.TypeOperand, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
         }
     }
     #nullable disable

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.ImplicitInstanceInfo.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.ImplicitInstanceInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -22,17 +20,17 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             /// <summary>
             /// Holds the current object instance being initialized if we're visiting an object initializer.
             /// </summary>
-            public IOperation ImplicitInstance { get; }
+            public IOperation? ImplicitInstance { get; }
 
             /// <summary>
             /// Holds the current anonymous type instance being initialized if we're visiting an anonymous object initializer.
             /// </summary>
-            public INamedTypeSymbol AnonymousType { get; }
+            public INamedTypeSymbol? AnonymousType { get; }
 
             /// <summary>
             /// Holds the captured values for initialized anonymous type properties in an anonymous object initializer.
             /// </summary>
-            public PooledDictionary<IPropertySymbol, IOperation> AnonymousTypePropertyValues { get; }
+            public PooledDictionary<IPropertySymbol, IOperation>? AnonymousTypePropertyValues { get; }
 
             public ImplicitInstanceInfo(IOperation currentImplicitInstance)
             {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6566,10 +6566,12 @@ oneMoreTime:
                                                      operation.Kind, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
+#nullable enable
         public override IOperation VisitDiscardOperation(IDiscardOperation operation, int? captureIdForResult)
         {
-            return new DiscardOperation(operation.DiscardSymbol, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new DiscardOperation(operation.DiscardSymbol, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
+#nullable disable
 
         public override IOperation VisitDiscardPattern(IDiscardPatternOperation pat, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6356,10 +6356,12 @@ oneMoreTime:
             return new SizeOfOperation(operation.TypeOperand, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
+#nullable enable
         public override IOperation VisitStop(IStopOperation operation, int? captureIdForResult)
         {
-            return new StopOperation(semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new StopOperation(semanticModel: null, operation.Syntax, IsImplicit(operation));
         }
+#nullable disable
 
         public override IOperation VisitIsType(IIsTypeOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3137,7 +3137,8 @@ oneMoreTime:
                    MakeInvalidOperation(ITypeSymbolHelpers.GetNullableUnderlyingType(value.Type), value);
         }
 
-        public override IOperation VisitConditionalAccess(IConditionalAccessOperation operation, int? captureIdForResult)
+#nullable enable
+        public override IOperation? VisitConditionalAccess(IConditionalAccessOperation operation, int? captureIdForResult)
         {
             SpillEvalStack();
 
@@ -3175,7 +3176,7 @@ oneMoreTime:
             {
                 testExpression = currentConditionalAccess.Operation;
                 SyntaxNode testExpressionSyntax = testExpression.Syntax;
-                ITypeSymbol testExpressionType = testExpression.Type;
+                ITypeSymbol? testExpressionType = testExpression.Type;
 
                 PushOperand(Visit(testExpression));
                 SpillEvalStack();
@@ -3221,6 +3222,7 @@ oneMoreTime:
 
                 if (_currentStatement != operation)
                 {
+                    Debug.Assert(_currentStatement is not null);
                     var expressionStatement = (IExpressionStatementOperation)_currentStatement;
                     result = new ExpressionStatementOperation(result, semanticModel: null, expressionStatement.Syntax,
                                                      expressionStatement.Type, expressionStatement.GetConstantValue(),
@@ -3268,6 +3270,7 @@ oneMoreTime:
 
                 SyntaxNode defaultValueSyntax = (operation.Operation == testExpression ? testExpression : operation).Syntax;
 
+                Debug.Assert(operation.Type is not null);
                 AddStatement(new FlowCaptureOperation(resultCaptureId,
                                              defaultValueSyntax,
                                              new DefaultValueOperation(semanticModel: null, defaultValueSyntax, operation.Type,
@@ -3282,7 +3285,6 @@ oneMoreTime:
             }
         }
 
-#nullable enable
         public override IOperation VisitConditionalAccessInstance(IConditionalAccessInstanceOperation operation, int? captureIdForResult)
         {
             Debug.Assert(_currentConditionalAccessInstance != null);
@@ -6616,10 +6618,12 @@ oneMoreTime:
             return new ConversionOperation(Visit(operation.Operand), ((BaseConversionOperation)operation).ConversionConvertible, operation.IsTryCast, operation.IsChecked, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
+#nullable enable
         public override IOperation VisitDefaultValue(IDefaultValueOperation operation, int? captureIdForResult)
         {
             return new DefaultValueOperation(semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
+#nullable disable
 
         public override IOperation VisitIsPattern(IIsPatternOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3282,6 +3282,7 @@ oneMoreTime:
             }
         }
 
+#nullable enable
         public override IOperation VisitConditionalAccessInstance(IConditionalAccessInstanceOperation operation, int? captureIdForResult)
         {
             Debug.Assert(_currentConditionalAccessInstance != null);
@@ -3289,6 +3290,7 @@ oneMoreTime:
             _currentConditionalAccessInstance = null;
             return result;
         }
+#nullable disable
 
         public override IOperation VisitExpressionStatement(IExpressionStatementOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -5839,6 +5839,7 @@ oneMoreTime:
             return MakeInvalidOperation(operation.Syntax, operation.Type, ImmutableArray<IOperation>.Empty);
         }
 
+#nullable enable
         public override IOperation VisitAnonymousObjectCreation(IAnonymousObjectCreationOperation operation, int? captureIdForResult)
         {
             if (operation.Initializers.IsEmpty)
@@ -5848,7 +5849,9 @@ oneMoreTime:
             }
 
             ImplicitInstanceInfo savedCurrentImplicitInstance = _currentImplicitInstance;
+            Debug.Assert(operation.Type is not null);
             _currentImplicitInstance = new ImplicitInstanceInfo((INamedTypeSymbol)operation.Type);
+            Debug.Assert(_currentImplicitInstance.AnonymousTypePropertyValues is not null);
 
             SpillEvalStack();
 
@@ -5867,7 +5870,7 @@ oneMoreTime:
                 Debug.Assert(((IInstanceReferenceOperation)propertyReference.Instance).ReferenceKind == InstanceReferenceKind.ImplicitReceiver);
 
                 var visitedPropertyInstance = new InstanceReferenceOperation(InstanceReferenceKind.ImplicitReceiver, semanticModel: null,
-                    propertyReference.Instance.Syntax, propertyReference.Instance.Type, propertyReference.Instance.GetConstantValue(), IsImplicit(propertyReference.Instance));
+                    propertyReference.Instance.Syntax, propertyReference.Instance.Type, IsImplicit(propertyReference.Instance));
                 IOperation visitedTarget = new PropertyReferenceOperation(propertyReference.Property, ImmutableArray<IArgumentOperation>.Empty, visitedPropertyInstance,
                     semanticModel: null, propertyReference.Syntax, propertyReference.Type, propertyReference.GetConstantValue(), IsImplicit(propertyReference));
                 IOperation visitedValue = visitAndCaptureInitializer(propertyReference.Property, simpleAssignment.Value);
@@ -5903,6 +5906,7 @@ oneMoreTime:
                 return captured;
             }
         }
+#nullable disable
 
         public override IOperation VisitLocalFunction(ILocalFunctionOperation operation, int? captureIdForResult)
         {
@@ -6009,6 +6013,7 @@ oneMoreTime:
             }
         }
 
+#nullable enable
         public override IOperation VisitInstanceReference(IInstanceReferenceOperation operation, int? captureIdForResult)
         {
             if (operation.ReferenceKind == InstanceReferenceKind.ImplicitReceiver)
@@ -6028,10 +6033,10 @@ oneMoreTime:
             }
             else
             {
-                return new InstanceReferenceOperation(operation.ReferenceKind, semanticModel: null, operation.Syntax, operation.Type,
-                                                       operation.GetConstantValue(), IsImplicit(operation));
+                return new InstanceReferenceOperation(operation.ReferenceKind, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
             }
         }
+#nullable disable
 
         public override IOperation VisitDynamicInvocation(IDynamicInvocationOperation operation, int? captureIdForResult)
         {
@@ -6392,7 +6397,6 @@ oneMoreTime:
             VisitInitializer(rewrittenTarget: parameterRef, initializer: operation);
             return FinishVisitingStatement(operation);
         }
-#nullable disable
 
         public override IOperation VisitFieldInitializer(IFieldInitializerOperation operation, int? captureIdForResult)
         {
@@ -6400,10 +6404,10 @@ oneMoreTime:
 
             foreach (IFieldSymbol fieldSymbol in operation.InitializedFields)
             {
-                IInstanceReferenceOperation instance = fieldSymbol.IsStatic ?
+                IInstanceReferenceOperation? instance = fieldSymbol.IsStatic ?
                     null :
                     new InstanceReferenceOperation(InstanceReferenceKind.ContainingTypeInstance, semanticModel: null,
-                        operation.Syntax, fieldSymbol.ContainingType, constantValue: null, isImplicit: true);
+                        operation.Syntax, fieldSymbol.ContainingType, isImplicit: true);
                 var fieldRef = new FieldReferenceOperation(fieldSymbol, isDeclaration: false, instance, semanticModel: null,
                     operation.Syntax, fieldSymbol.Type, constantValue: null, isImplicit: true);
                 VisitInitializer(rewrittenTarget: fieldRef, initializer: operation);
@@ -6421,7 +6425,7 @@ oneMoreTime:
                 var instance = propertySymbol.IsStatic ?
                     null :
                     new InstanceReferenceOperation(InstanceReferenceKind.ContainingTypeInstance, semanticModel: null,
-                        operation.Syntax, propertySymbol.ContainingType, constantValue: null, isImplicit: true);
+                        operation.Syntax, propertySymbol.ContainingType, isImplicit: true);
 
                 ImmutableArray<IArgumentOperation> arguments;
                 if (!propertySymbol.Parameters.IsEmpty)
@@ -6451,6 +6455,7 @@ oneMoreTime:
 
             return FinishVisitingStatement(operation);
         }
+#nullable disable
 
         private void VisitInitializer(IOperation rewrittenTarget, ISymbolInitializerOperation initializer)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6359,10 +6359,12 @@ oneMoreTime:
                                                 operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
+#nullable enable
         public override IOperation VisitTypeOf(ITypeOfOperation operation, int? captureIdForResult)
         {
-            return new TypeOfOperation(operation.TypeOperand, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new TypeOfOperation(operation.TypeOperand, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
+#nullable disable
 
         public override IOperation VisitParenthesized(IParenthesizedOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6576,10 +6576,12 @@ oneMoreTime:
             return new DiscardPatternOperation(pat.InputType, pat.NarrowedType, semanticModel: null, pat.Syntax, IsImplicit(pat));
         }
 
+#nullable enable
         public override IOperation VisitOmittedArgument(IOmittedArgumentOperation operation, int? captureIdForResult)
         {
-            return new OmittedArgumentOperation(semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new OmittedArgumentOperation(semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
+#nullable disable
 
         internal override IOperation VisitPlaceholder(IPlaceholderOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6583,7 +6583,6 @@ oneMoreTime:
         {
             return new OmittedArgumentOperation(semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
-#nullable disable
 
         internal override IOperation VisitPlaceholder(IPlaceholderOperation operation, int? captureIdForResult)
         {
@@ -6616,7 +6615,7 @@ oneMoreTime:
             }
 
             Debug.Fail("All placeholders should be handled above. Have we introduced a new scenario where placeholders are used?");
-            return new PlaceholderOperation(operation.PlaceholderKind, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new PlaceholderOperation(operation.PlaceholderKind, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
         public override IOperation VisitConversion(IConversionOperation operation, int? captureIdForResult)

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6293,13 +6293,13 @@ oneMoreTime:
             return new LocalReferenceOperation(operation.Local, operation.IsDeclaration, semanticModel: null, operation.Syntax,
                                                 operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
-#nullable disable
 
         public override IOperation VisitParameterReference(IParameterReferenceOperation operation, int? captureIdForResult)
         {
             return new ParameterReferenceOperation(operation.Parameter, semanticModel: null, operation.Syntax,
-                                                    operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+                                                   operation.Type, IsImplicit(operation));
         }
+#nullable disable
 
         public override IOperation VisitFieldReference(IFieldReferenceOperation operation, int? captureIdForResult)
         {
@@ -6382,15 +6382,17 @@ oneMoreTime:
             return new IsTypeOperation(Visit(operation.ValueOperand), operation.TypeOperand, operation.IsNegated, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
+#nullable enable
         public override IOperation VisitParameterInitializer(IParameterInitializerOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
 
             var parameterRef = new ParameterReferenceOperation(operation.Parameter, semanticModel: null,
-                operation.Syntax, operation.Parameter.Type, constantValue: null, isImplicit: true);
+                operation.Syntax, operation.Parameter.Type, isImplicit: true);
             VisitInitializer(rewrittenTarget: parameterRef, initializer: operation);
             return FinishVisitingStatement(operation);
         }
+#nullable disable
 
         public override IOperation VisitFieldInitializer(IFieldInitializerOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6376,12 +6376,12 @@ oneMoreTime:
             return new AwaitOperation(Visit(operation.Operation), semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
+#nullable enable
         public override IOperation VisitSizeOf(ISizeOfOperation operation, int? captureIdForResult)
         {
             return new SizeOfOperation(operation.TypeOperand, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
-#nullable enable
         public override IOperation VisitStop(IStopOperation operation, int? captureIdForResult)
         {
             return new StopOperation(semanticModel: null, operation.Syntax, IsImplicit(operation));

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -17,8 +17,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal abstract class Operation : IOperation
     {
-        protected static readonly IOperation s_unset = new EmptyOperation(
-            semanticModel: null, syntax: null, type: null, constantValue: null, isImplicit: true);
+        protected static readonly IOperation s_unset = new EmptyOperation(semanticModel: null, syntax: null!, isImplicit: true);
         protected static readonly IBlockOperation s_unsetBlock = new BlockOperation(
             operations: ImmutableArray<IOperation>.Empty, locals: default, semanticModel: null, syntax: null, type: null, constantValue: null, isImplicit: true);
         protected static readonly IArrayInitializerOperation s_unsetArrayInitializer = new ArrayInitializerOperation(

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -112,11 +112,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new BranchOperation(operation.Target, operation.BranchKind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitEmpty(IEmptyOperation operation, object argument)
-        {
-            return new EmptyOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitReturn(IReturnOperation operation, object argument)
         {
             return new ReturnOperation(Visit(operation.ReturnedValue), operation.Kind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -256,11 +256,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new IsTypeOperation(Visit(operation.ValueOperand), operation.TypeOperand, operation.IsNegated, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitSizeOf(ISizeOfOperation operation, object argument)
-        {
-            return new SizeOfOperation(operation.TypeOperand, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitAnonymousFunction(IAnonymousFunctionOperation operation, object argument)
         {
             return new AnonymousFunctionOperation(operation.Symbol, Visit(operation.Body), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -200,11 +200,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ConditionalAccessOperation(Visit(operation.WhenNotNull), Visit(operation.Operation), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        internal override IOperation VisitPlaceholder(IPlaceholderOperation operation, object argument)
-        {
-            return new PlaceholderOperation(operation.PlaceholderKind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitUnaryOperator(IUnaryOperation operation, object argument)
         {
             return new UnaryOperation(operation.OperatorKind, Visit(operation.Operand), operation.IsLifted, operation.IsChecked, operation.OperatorMethod, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -205,11 +205,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ConditionalAccessOperation(Visit(operation.WhenNotNull), Visit(operation.Operation), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitConditionalAccessInstance(IConditionalAccessInstanceOperation operation, object argument)
-        {
-            return new ConditionalAccessInstanceOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         internal override IOperation VisitPlaceholder(IPlaceholderOperation operation, object argument)
         {
             return new PlaceholderOperation(operation.PlaceholderKind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -175,11 +175,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ArrayElementReferenceOperation(Visit(operation.ArrayReference), VisitArray(operation.Indices), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitInstanceReference(IInstanceReferenceOperation operation, object argument)
-        {
-            return new InstanceReferenceOperation(operation.ReferenceKind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitFieldReference(IFieldReferenceOperation operation, object argument)
         {
             return new FieldReferenceOperation(operation.Field, operation.IsDeclaration, Visit(operation.Instance), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -165,11 +165,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ArgumentOperation(Visit(operation.Value), operation.ArgumentKind, operation.Parameter, baseArgument.InConversionConvertibleOpt, baseArgument.OutConversionConvertibleOpt, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.IsImplicit);
         }
 
-        public override IOperation VisitOmittedArgument(IOmittedArgumentOperation operation, object argument)
-        {
-            return new OmittedArgumentOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitArrayElementReference(IArrayElementReferenceOperation operation, object argument)
         {
             return new ArrayElementReferenceOperation(Visit(operation.ArrayReference), VisitArray(operation.Indices), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -261,11 +261,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new SizeOfOperation(operation.TypeOperand, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitTypeOf(ITypeOfOperation operation, object argument)
-        {
-            return new TypeOfOperation(operation.TypeOperand, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitAnonymousFunction(IAnonymousFunctionOperation operation, object argument)
         {
             return new AnonymousFunctionOperation(operation.Symbol, Visit(operation.Body), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -497,12 +497,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new MethodBodyOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, Visit(operation.BlockBody), Visit(operation.ExpressionBody));
         }
 
-        public override IOperation VisitDiscardOperation(IDiscardOperation operation, object argument)
-        {
-            return new DiscardOperation(
-                operation.DiscardSymbol, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitDiscardPattern(IDiscardPatternOperation operation, object argument)
         {
             return new DiscardPatternOperation(operation.InputType, operation.NarrowedType, operation.SemanticModel, operation.Syntax, operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -159,11 +159,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new StopOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitEnd(IEndOperation operation, object argument)
-        {
-            return new EndOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitInvocation(IInvocationOperation operation, object argument)
         {
             return new InvocationOperation(operation.TargetMethod, Visit(operation.Instance), operation.IsVirtual, VisitArray(operation.Arguments), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -302,11 +302,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new DelegateCreationOperation(Visit(operation.Target), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitLiteral(ILiteralOperation operation, object argument)
-        {
-            return new LiteralOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitAwait(IAwaitOperation operation, object argument)
         {
             return new AwaitOperation(Visit(operation.Operation), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -397,11 +397,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new DynamicIndexerAccessOperation(Visit(operation.Operation), VisitArray(operation.Arguments), ((HasDynamicArgumentsExpression)operation).ArgumentNames, ((HasDynamicArgumentsExpression)operation).ArgumentRefKinds, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitDefaultValue(IDefaultValueOperation operation, object argument)
-        {
-            return new DefaultValueOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitTypeParameterObjectCreation(ITypeParameterObjectCreationOperation operation, object argument)
         {
             return new TypeParameterObjectCreationOperation(Visit(operation.Initializer), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -175,11 +175,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ArrayElementReferenceOperation(Visit(operation.ArrayReference), VisitArray(operation.Indices), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitLocalReference(ILocalReferenceOperation operation, object argument)
-        {
-            return new LocalReferenceOperation(operation.Local, operation.IsDeclaration, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitParameterReference(IParameterReferenceOperation operation, object argument)
         {
             return new ParameterReferenceOperation(operation.Parameter, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -107,11 +107,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new LabeledOperation(operation.Label, Visit(operation.Operation), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitBranch(IBranchOperation operation, object argument)
-        {
-            return new BranchOperation(operation.Target, operation.BranchKind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitReturn(IReturnOperation operation, object argument)
         {
             return new ReturnOperation(Visit(operation.ReturnedValue), operation.Kind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -154,11 +154,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new WithStatementOperation(Visit(operation.Body), Visit(operation.Value), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitStop(IStopOperation operation, object argument)
-        {
-            return new StopOperation(((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitInvocation(IInvocationOperation operation, object argument)
         {
             return new InvocationOperation(operation.TargetMethod, Visit(operation.Instance), operation.IsVirtual, VisitArray(operation.Arguments), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -175,11 +175,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ArrayElementReferenceOperation(Visit(operation.ArrayReference), VisitArray(operation.Indices), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitParameterReference(IParameterReferenceOperation operation, object argument)
-        {
-            return new ParameterReferenceOperation(operation.Parameter, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitInstanceReference(IInstanceReferenceOperation operation, object argument)
         {
             return new InstanceReferenceOperation(operation.ReferenceKind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -2,62 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Operations
 {
-    internal sealed class OperationCloner : OperationVisitor<object, IOperation>
+    internal sealed partial class OperationCloner : OperationVisitor<object?, IOperation>
+#nullable disable
     {
-        private static readonly OperationCloner s_instance = new OperationCloner();
-
-        /// <summary>
-        /// Deep clone given IOperation
-        /// </summary>
-        public static T CloneOperation<T>(T operation) where T : IOperation
-        {
-            return s_instance.Visit(operation);
-        }
-
-        private OperationCloner()
-        {
-        }
-
-        private T Visit<T>(T node) where T : IOperation
-        {
-            return (T)Visit(node, argument: null);
-        }
-
         public IOperation Visit(IOperation operation)
         {
             return Visit(operation, argument: null);
         }
 
-        public override IOperation DefaultVisit(IOperation operation, object argument)
-        {
-            // this should never reach, otherwise, there is missing override for IOperation type
-            throw ExceptionUtilities.Unreachable;
-        }
-
         internal override IOperation VisitNoneOperation(IOperation operation, object argument)
         {
             return new NoneOperation(VisitArray(operation.Children.ToImmutableArray()), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.GetConstantValue(), operation.IsImplicit, operation.Type);
-        }
-
-        private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation
-        {
-            // clone the array
-            return nodes.SelectAsArray(n => Visit(n));
-        }
-
-        private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation
-        {
-            // clone the array
-            return nodes.SelectAsArray(n => (n.Item1, Visit(n.Item2)));
         }
 
         public override IOperation VisitBlock(IBlockOperation operation, object argument)

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1363,7 +1363,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IConditionalAccessInstanceOperation" Base="IOperation">
+  <Node Name="IConditionalAccessInstanceOperation" Base="IOperation" HasType="true">
     <Comments>
       <summary>
         Represents the value of a conditionally-accessed operation within <see cref="IConditionalAccessOperation.WhenNotNull" />.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1138,7 +1138,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IInstanceReferenceOperation" Base="IOperation">
+  <Node Name="IInstanceReferenceOperation" Base="IOperation" HasType="true">
     <Comments>
       <summary>
         Represents an implicit/explicit reference to an instance.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -577,7 +577,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="ILiteralOperation" Base="IOperation">
+  <Node Name="ILiteralOperation" Base="IOperation" HasType="true" HasConstantValue="true">
     <Comments>
       <summary>
         Represents a textual literal numeric, string, etc.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -724,7 +724,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IParameterReferenceOperation" Base="IOperation">
+  <Node Name="IParameterReferenceOperation" Base="IOperation" HasType="true">
     <Comments>
       <summary>
         Represents a reference to a parameter.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1676,7 +1676,7 @@
       </summary>
     </Comments>
   </Node>
-  <Node Name="ITypeOfOperation" Base="IOperation">
+  <Node Name="ITypeOfOperation" Base="IOperation" HasType="true">
     <Comments>
       <summary>
         Represents an operation that gets <see cref="System.Type" /> for the given <see cref="TypeOperand" />.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -699,7 +699,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="ILocalReferenceOperation" Base="IOperation">
+  <Node Name="ILocalReferenceOperation" Base="IOperation" HasType="true" HasConstantValue="true">
     <Comments>
       <summary>
         Represents a reference to a declared local variable.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -2861,7 +2861,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IPlaceholderOperation" Base="IOperation" Internal="true">
+  <Node Name="IPlaceholderOperation" Base="IOperation" Internal="true" HasType="true">
     <Comments>
       <summary>
         Represents a general placeholder when no more specific kind of placeholder is available.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1693,7 +1693,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="ISizeOfOperation" Base="IOperation">
+  <Node Name="ISizeOfOperation" Base="IOperation" HasType="true" HasConstantValue="true">
     <Comments>
       <summary>
         Represents an operation to compute the size of a given type.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1845,7 +1845,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IOmittedArgumentOperation" Base="IOperation">
+  <Node Name="IOmittedArgumentOperation" Base="IOperation" HasType="true">
     <Comments>
       <summary>
         Represents an argument value that has been omitted in an invocation.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1665,7 +1665,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IDefaultValueOperation" Base="IOperation">
+  <Node Name="IDefaultValueOperation" Base="IOperation" HasType="true" HasConstantValue="true">
     <Comments>
       <summary>
         Represents a default value operation.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -2506,7 +2506,7 @@
       </Comments>
     </Property>
   </Node>
-  <Node Name="IDiscardOperation" Base="IOperation" VisitorName="VisitDiscardOperation">
+  <Node Name="IDiscardOperation" Base="IOperation" VisitorName="VisitDiscardOperation" HasType="true">
     <Comments>
       <summary>
         Represents a discard operation.

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -468,9 +468,8 @@ Namespace Microsoft.CodeAnalysis.Operations
         Private Function CreateBoundOmittedArgumentOperation(boundOmittedArgument As BoundOmittedArgument) As IOmittedArgumentOperation
             Dim syntax As SyntaxNode = boundOmittedArgument.Syntax
             Dim type As ITypeSymbol = boundOmittedArgument.Type
-            Dim constantValue As ConstantValue = boundOmittedArgument.ConstantValueOpt
             Dim isImplicit As Boolean = boundOmittedArgument.WasCompilerGenerated
-            Return New OmittedArgumentOperation(_semanticModel, syntax, type, constantValue, isImplicit)
+            Return New OmittedArgumentOperation(_semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundParenthesizedOperation(boundParenthesized As BoundParenthesized) As IParenthesizedOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1395,10 +1395,8 @@ Namespace Microsoft.CodeAnalysis.Operations
 
         Private Function CreateBoundStopStatementOperation(boundStopStatement As BoundStopStatement) As IStopOperation
             Dim syntax As SyntaxNode = boundStopStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundStopStatement.WasCompilerGenerated
-            Return New StopOperation(_semanticModel, syntax, type, constantValue, isImplicit)
+            Return New StopOperation(_semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundEndStatementOperation(boundEndStatement As BoundEndStatement) As IEndOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -747,9 +747,8 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim typeOperand As ITypeSymbol = boundGetType.SourceType.Type
             Dim syntax As SyntaxNode = boundGetType.Syntax
             Dim type As ITypeSymbol = boundGetType.Type
-            Dim constantValue As ConstantValue = boundGetType.ConstantValueOpt
             Dim isImplicit As Boolean = boundGetType.WasCompilerGenerated
-            Return New TypeOfOperation(typeOperand, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New TypeOfOperation(typeOperand, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundLateInvocationOperation(boundLateInvocation As BoundLateInvocation) As IOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1350,30 +1350,24 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim target As ILabelSymbol = boundGotoStatement.Label
             Dim branchKind As BranchKind = BranchKind.GoTo
             Dim syntax As SyntaxNode = boundGotoStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundGotoStatement.WasCompilerGenerated
-            Return New BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundContinueStatementOperation(boundContinueStatement As BoundContinueStatement) As IBranchOperation
             Dim target As ILabelSymbol = boundContinueStatement.Label
             Dim branchKind As BranchKind = BranchKind.Continue
             Dim syntax As SyntaxNode = boundContinueStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundContinueStatement.WasCompilerGenerated
-            Return New BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundExitStatementOperation(boundExitStatement As BoundExitStatement) As IBranchOperation
             Dim target As ILabelSymbol = boundExitStatement.Label
             Dim branchKind As BranchKind = BranchKind.Break
             Dim syntax As SyntaxNode = boundExitStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundExitStatement.WasCompilerGenerated
-            Return New BranchOperation(target, branchKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundSyncLockStatementOperation(boundSyncLockStatement As BoundSyncLockStatement) As ILockOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1403,10 +1403,8 @@ Namespace Microsoft.CodeAnalysis.Operations
 
         Private Function CreateBoundEndStatementOperation(boundEndStatement As BoundEndStatement) As IEndOperation
             Dim syntax As SyntaxNode = boundEndStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundEndStatement.WasCompilerGenerated
-            Return New EndOperation(_semanticModel, syntax, type, constantValue, isImplicit)
+            Return New EndOperation(_semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundWithStatementOperation(boundWithStatement As BoundWithStatement) As IWithStatementOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -972,7 +972,6 @@ Namespace Microsoft.CodeAnalysis.Operations
         Private Function CreateBoundRValuePlaceholderOperation(boundRValuePlaceholder As BoundRValuePlaceholder) As IOperation
             Dim syntax As SyntaxNode = boundRValuePlaceholder.Syntax
             Dim type As ITypeSymbol = boundRValuePlaceholder.Type
-            Dim constantValue As ConstantValue = boundRValuePlaceholder.ConstantValueOpt
             Dim isImplicit As Boolean = boundRValuePlaceholder.WasCompilerGenerated
 
             Dim knownParent As BoundNode = TryGetParent(boundRValuePlaceholder)
@@ -1006,7 +1005,7 @@ Namespace Microsoft.CodeAnalysis.Operations
                 End Select
             End If
 
-            Return New PlaceholderOperation(placeholderKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New PlaceholderOperation(placeholderKind, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundIfStatementOperation(boundIfStatement As BoundIfStatement) As IConditionalOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -883,9 +883,8 @@ Namespace Microsoft.CodeAnalysis.Operations
         Private Function CreateBoundConditionalAccessReceiverPlaceholderOperation(boundConditionalAccessReceiverPlaceholder As BoundConditionalAccessReceiverPlaceholder) As IConditionalAccessInstanceOperation
             Dim syntax As SyntaxNode = boundConditionalAccessReceiverPlaceholder.Syntax
             Dim type As ITypeSymbol = boundConditionalAccessReceiverPlaceholder.Type
-            Dim constantValue As ConstantValue = boundConditionalAccessReceiverPlaceholder.ConstantValueOpt
             Dim isImplicit As Boolean = boundConditionalAccessReceiverPlaceholder.WasCompilerGenerated
-            Return New ConditionalAccessInstanceOperation(_semanticModel, syntax, type, constantValue, isImplicit)
+            Return New ConditionalAccessInstanceOperation(_semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundParameterOperation(boundParameter As BoundParameter) As IParameterReferenceOperation
@@ -989,7 +988,7 @@ Namespace Microsoft.CodeAnalysis.Operations
                         ' to get the expression being conditionally accessed, and return an IConditionalAccessInstanceOperation
                         ' instead of a PlaceholderOperation
                         syntax = If(TryCast(syntax, ConditionalAccessExpressionSyntax)?.Expression, syntax)
-                        Return New ConditionalAccessInstanceOperation(_semanticModel, syntax, type, constantValue, isImplicit)
+                        Return New ConditionalAccessInstanceOperation(_semanticModel, syntax, type, isImplicit)
 
                     Case BoundKind.SelectStatement
                         placeholderKind = PlaceholderKind.SwitchOperationExpression

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -393,27 +393,24 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim referenceKind As InstanceReferenceKind = InstanceReferenceKind.ContainingTypeInstance
             Dim syntax As SyntaxNode = boundMeReference.Syntax
             Dim type As ITypeSymbol = boundMeReference.Type
-            Dim constantValue As ConstantValue = boundMeReference.ConstantValueOpt
             Dim isImplicit As Boolean = boundMeReference.WasCompilerGenerated
-            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundMyBaseReferenceOperation(boundMyBaseReference As BoundMyBaseReference) As IInstanceReferenceOperation
             Dim referenceKind As InstanceReferenceKind = InstanceReferenceKind.ContainingTypeInstance
             Dim syntax As SyntaxNode = boundMyBaseReference.Syntax
             Dim type As ITypeSymbol = boundMyBaseReference.Type
-            Dim constantValue As ConstantValue = boundMyBaseReference.ConstantValueOpt
             Dim isImplicit As Boolean = boundMyBaseReference.WasCompilerGenerated
-            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundMyClassReferenceOperation(boundMyClassReference As BoundMyClassReference) As IInstanceReferenceOperation
             Dim referenceKind As InstanceReferenceKind = InstanceReferenceKind.ContainingTypeInstance
             Dim syntax As SyntaxNode = boundMyClassReference.Syntax
             Dim type As ITypeSymbol = boundMyClassReference.Type
-            Dim constantValue As ConstantValue = boundMyClassReference.ConstantValueOpt
             Dim isImplicit As Boolean = boundMyClassReference.WasCompilerGenerated
-            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Friend Function CreateBoundLiteralOperation(boundLiteral As BoundLiteral, Optional implicit As Boolean = False) As ILiteralOperation
@@ -839,18 +836,16 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim referenceKind As InstanceReferenceKind = InstanceReferenceKind.ImplicitReceiver
             Dim syntax As SyntaxNode = boundWithLValueExpressionPlaceholder.Syntax
             Dim type As ITypeSymbol = boundWithLValueExpressionPlaceholder.Type
-            Dim constantValue As ConstantValue = boundWithLValueExpressionPlaceholder.ConstantValueOpt
             Dim isImplicit As Boolean = boundWithLValueExpressionPlaceholder.WasCompilerGenerated
-            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundWithRValueExpressionPlaceholder(boundWithRValueExpressionPlaceholder As BoundWithRValueExpressionPlaceholder) As IInstanceReferenceOperation
             Dim referenceKind As InstanceReferenceKind = InstanceReferenceKind.ImplicitReceiver
             Dim syntax As SyntaxNode = boundWithRValueExpressionPlaceholder.Syntax
             Dim type As ITypeSymbol = boundWithRValueExpressionPlaceholder.Type
-            Dim constantValue As ConstantValue = boundWithRValueExpressionPlaceholder.ConstantValueOpt
             Dim isImplicit As Boolean = boundWithRValueExpressionPlaceholder.WasCompilerGenerated
-            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New InstanceReferenceOperation(referenceKind, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundEventAccessOperation(boundEventAccess As BoundEventAccess) As IEventReferenceOperation
@@ -1584,7 +1579,6 @@ Namespace Microsoft.CodeAnalysis.Operations
                 _semanticModel,
                 syntax,
                 propertySym.ContainingType,
-                constantValue:=Nothing,
                 isImplicit:=True)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1396,7 +1396,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim type As ITypeSymbol = Nothing
             Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundNoOpStatement.WasCompilerGenerated
-            Return New EmptyOperation(_semanticModel, syntax, type, constantValue, isImplicit)
+            Return New EmptyOperation(_semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundStopStatementOperation(boundStopStatement As BoundStopStatement) As IStopOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -897,9 +897,8 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim parameter As IParameterSymbol = boundParameter.ParameterSymbol
             Dim syntax As SyntaxNode = boundParameter.Syntax
             Dim type As ITypeSymbol = boundParameter.Type
-            Dim constantValue As ConstantValue = boundParameter.ConstantValueOpt
             Dim isImplicit As Boolean = boundParameter.WasCompilerGenerated
-            Return New ParameterReferenceOperation(parameter, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New ParameterReferenceOperation(parameter, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundLocalOperation(boundLocal As BoundLocal) As IOperation

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -12,7 +12,8 @@ namespace IOperationGenerator
         private static readonly HashSet<string> PortedTypes = new HashSet<string>()
         {
             "IEmptyOperation",
-            "IBranchOperation"
+            "IBranchOperation",
+            "IEndOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -21,7 +21,8 @@ namespace IOperationGenerator
             "IInstanceReferenceOperation",
             "IConditionalAccessInstanceOperation",
             "IDefaultValueOperation",
-            "ITypeOfOperation"
+            "ITypeOfOperation",
+            "ISizeOfOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -17,7 +17,8 @@ namespace IOperationGenerator
             "IStopOperation",
             "ILiteralOperation",
             "ILocalReferenceOperation",
-            "IParameterReferenceOperation"
+            "IParameterReferenceOperation",
+            "IInstanceReferenceOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -19,7 +19,8 @@ namespace IOperationGenerator
             "ILocalReferenceOperation",
             "IParameterReferenceOperation",
             "IInstanceReferenceOperation",
-            "IConditionalAccessInstanceOperation"
+            "IConditionalAccessInstanceOperation",
+            "IDefaultValueOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -11,6 +11,7 @@ namespace IOperationGenerator
     {
         private static readonly HashSet<string> PortedTypes = new HashSet<string>()
         {
+            "IEmptyOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -13,7 +13,8 @@ namespace IOperationGenerator
         {
             "IEmptyOperation",
             "IBranchOperation",
-            "IEndOperation"
+            "IEndOperation",
+            "IStopOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -22,7 +22,8 @@ namespace IOperationGenerator
             "IConditionalAccessInstanceOperation",
             "IDefaultValueOperation",
             "ITypeOfOperation",
-            "ISizeOfOperation"
+            "ISizeOfOperation",
+            "IOmittedArgumentOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -24,7 +24,8 @@ namespace IOperationGenerator
             "ITypeOfOperation",
             "ISizeOfOperation",
             "IOmittedArgumentOperation",
-            "IDiscardOperation"
+            "IDiscardOperation",
+            "IPlaceholderOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -23,7 +23,8 @@ namespace IOperationGenerator
             "IDefaultValueOperation",
             "ITypeOfOperation",
             "ISizeOfOperation",
-            "IOmittedArgumentOperation"
+            "IOmittedArgumentOperation",
+            "IDiscardOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -18,7 +18,8 @@ namespace IOperationGenerator
             "ILiteralOperation",
             "ILocalReferenceOperation",
             "IParameterReferenceOperation",
-            "IInstanceReferenceOperation"
+            "IInstanceReferenceOperation",
+            "IConditionalAccessInstanceOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -11,7 +11,8 @@ namespace IOperationGenerator
     {
         private static readonly HashSet<string> PortedTypes = new HashSet<string>()
         {
-            "IEmptyOperation"
+            "IEmptyOperation",
+            "IBranchOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -20,7 +20,8 @@ namespace IOperationGenerator
             "IParameterReferenceOperation",
             "IInstanceReferenceOperation",
             "IConditionalAccessInstanceOperation",
-            "IDefaultValueOperation"
+            "IDefaultValueOperation",
+            "ITypeOfOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -15,7 +15,8 @@ namespace IOperationGenerator
             "IBranchOperation",
             "IEndOperation",
             "IStopOperation",
-            "ILiteralOperation"
+            "ILiteralOperation",
+            "ILocalReferenceOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -14,7 +14,8 @@ namespace IOperationGenerator
             "IEmptyOperation",
             "IBranchOperation",
             "IEndOperation",
-            "IStopOperation"
+            "IStopOperation",
+            "ILiteralOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -16,7 +16,8 @@ namespace IOperationGenerator
             "IEndOperation",
             "IStopOperation",
             "ILiteralOperation",
-            "ILocalReferenceOperation"
+            "ILocalReferenceOperation",
+            "IParameterReferenceOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.Verifier.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.Verifier.cs
@@ -56,6 +56,24 @@ namespace IOperationGenerator
                 if (node.SkipChildrenGeneration || node.SkipClassGeneration)
                     continue;
 
+                if (node.HasTypeText is not (null or "true" or "false"))
+                {
+                    Console.WriteLine($"{node.Name} has unexpected value for {nameof(Node.HasType)}: {node.HasTypeText}");
+                    error = true;
+                }
+
+                if (node.HasConstantValueText is not (null or "true" or "false"))
+                {
+                    Console.WriteLine($"{node.Name} has unexpected value for {nameof(Node.HasConstantValue)}: {node.HasConstantValueText}");
+                    error = true;
+                }
+
+                if (node.HasConstantValue && !node.HasType)
+                {
+                    Console.WriteLine($"{node.Name} is marked as having a constant value without having a type");
+                    error = true;
+                }
+
                 var properties = GetAllGeneratedIOperationProperties(node).Where(p => !p.IsInternal).Select(p => p.Name).ToList();
 
                 if (properties.Count < 2)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -440,7 +440,7 @@ namespace IOperationGenerator
                 node = null!;
             }
 
-            writeConstructor(type.IsAbstract ? "protected" : "internal", @class, allProps, baseProperties, type, hasType, multipleValidKinds, hasConstantValue);
+            writeConstructor(type.IsAbstract ? "protected" : "internal", @class, allProps, baseProperties, type, hasType, hasConstantValue, multipleValidKinds);
 
             foreach (var property in type.Properties.Where(p => !p.SkipGeneration))
             {
@@ -569,7 +569,7 @@ namespace IOperationGenerator
 
                     if (hasConstantValue)
                     {
-                        WriteLine("OperationConstant = constantValue;");
+                        WriteLine("OperationConstantValue = constantValue;");
                     }
 
                     if (hasType)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -1011,7 +1011,7 @@ namespace IOperationGenerator
                 if (!PortedTypes.Contains(node.Name)) continue;
 
                 string nameMinusI = node.Name[1..];
-                WriteLine($"public override IOperation {GetVisitorName(node)}({node.Name} operation, object? argument)");
+                WriteLine($"{(node.IsInternal ? "internal" : "public")} override IOperation {GetVisitorName(node)}({node.Name} operation, object? argument)");
                 Brace();
                 WriteLine($"var {internalName} = ({nameMinusI})operation;");
                 Write($"return new {nameMinusI}(");

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -425,7 +425,7 @@ namespace IOperationGenerator
 
             writeClassHeader(type.IsAbstract ? "abstract" : "sealed", @class, @base, type.Name);
 
-            if (type is Node node)
+            if (type is Node and var node)
             {
                 if (publicIOperationProps.Count != 0)
                 {
@@ -437,7 +437,7 @@ namespace IOperationGenerator
             }
             else
             {
-                node = null!;
+                node = null;
             }
 
             writeConstructor(type.IsAbstract ? "protected" : "internal", @class, allProps, baseProperties, type, hasType, hasConstantValue, multipleValidKinds);
@@ -605,7 +605,6 @@ namespace IOperationGenerator
             {
                 WriteLine($"public override void Accept(OperationVisitor visitor) => visitor.{visitorName}(this);");
                 WriteLine($"public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument) => visitor.{visitorName}(this, argument);");
-
             }
 
             string getKind(Node node)
@@ -1008,7 +1007,10 @@ namespace IOperationGenerator
             {
                 const string internalName = "internalOperation";
 
-                if (!PortedTypes.Contains(node.Name)) continue;
+                if (!PortedTypes.Contains(node.Name))
+                {
+                    continue;
+                }
 
                 string nameMinusI = node.Name[1..];
                 WriteLine($"{(node.IsInternal ? "internal" : "public")} override IOperation {GetVisitorName(node)}({node.Name} operation, object? argument)");

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Model.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Model.cs
@@ -79,6 +79,14 @@ namespace IOperationGenerator
         public string? ChildrenOrder;
 
         public override bool IsAbstract => false;
+
+        [XmlAttribute(AttributeName = "HasType")]
+        public string HasTypeText;
+        public bool HasType => HasTypeText == "true";
+
+        [XmlAttribute(AttributeName = "HasConstantValue")]
+        public string HasConstantValueText;
+        public bool HasConstantValue => HasConstantValueText == "true";
     }
 
     public class Kind

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Program.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Program.cs
@@ -29,7 +29,7 @@ using (var reader = XmlReader.Create(inFileName, new XmlReaderSettings { DtdProc
 
 if (tree is null)
 {
-    Console.WriteLine("Derserialize returned null.");
+    Console.WriteLine("Deserialize returned null.");
     return 1;
 }
 


### PR DESCRIPTION
This is part 1 of the actual implementation step of porting IOperation nodes to the new non-lazy format. In this PR I've done all the leaf nodes. Commit-by-commit is _highly_ recommended here: the first two commits might be best reviewed together, but everything else should definitely be reviewed one commit at a time. Generally, if I found a bug in my initial writer implementation when I got to a specific node pattern that I had not seen prior, I fixed the writer inline with that commit, rather than going back and redoing all the work if it did not affect the generation of previous nodes. There are a couple of bugs in there with respect to nodes that have children, but that code is fixed up and will be exercised in the next PR. @dotnet/roslyn-compiler for review.
