### PR TITLE
Remove sign and pack from unit tests

### DIFF
--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -28,7 +28,7 @@ jobs:
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -pack -sign -publish -binaryLog 
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -publish -binaryLog 
 
     - task: PowerShell@2 
       displayName: Prepare Unit Tests


### PR DESCRIPTION
These aren't needed to run unit tests and they take up a significant
amount of time in the build jobs.