### PR TITLE
Support running official build in dnceng

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -19,6 +19,22 @@ variables:
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
 
+  # To retrieve OptProf data we need to authenticate to the VS drop storage.
+  # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
+  - ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+    - name: _DevDivDropAccessToken
+      value: $(System.AccessToken)
+  # If the pipeline is running in dnceng:
+  # Get access token with $dn-bot-devdiv-drop-rw-code-rw from DotNet-VSTS-Infra-Access
+  # Get $dotnetfeed-storage-access-key-1 from DotNet-Blob-Feed
+  # Get $microsoft-symbol-server-pat and $symweb-symbol-server-pat from DotNet-Symbol-Server-Pats
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - group: DotNet-Blob-Feed
+    - group: DotNet-Symbol-Server-Pats
+    - group: DotNet-VSTS-Infra-Access
+    - name: _DevDivDropAccessToken
+      value: $(dn-bot-devdiv-drop-rw-code-rw)
+
 stages:
 - stage: build
   displayName: Build and Test
@@ -26,17 +42,34 @@ stages:
   jobs:
   - job: OfficialBuild
     displayName: Official Build
-    pool:
-      name: VSEng-MicroBuildVS2017
-      demands: 
-      - msbuild
-      - visualstudio
-      - DotNetFramework
     timeoutInMinutes: 360
+    # Conditionally set build pool so we can share this YAML when building with different pipeline (devdiv vs dnceng) 
+    pool:      
+      ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+        name: VSEng-MicroBuildVS2017
+        demands: 
+        - msbuild
+        - visualstudio
+        - DotNetFramework
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: NetCoreInternal-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre
 
-    steps:
+    steps:        
+    # Make sure our two pipelines generate builds with distinct build numbers to avoid confliction.
+    # i.e. DevDiv builds will have even rev# whereas dnceng builds will be odd.
+    - task: PowerShell@2
+      displayName: Update BuildNumber
+      inputs:
+        filePath: 'eng\update-build-number.ps1'
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven even'
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven odd'
+
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
+      condition: succeeded()
 
     - task: tagBuildOrRelease@0
       displayName: Tag official build
@@ -71,7 +104,10 @@ stages:
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
     - task: NuGetAuthenticate@0
       inputs:
-        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering
 
     - task: NuGetCommand@2
       displayName: Restore internal tools
@@ -86,6 +122,9 @@ stages:
       inputs:
         signType: $(SignType)
         zipSources: false
+        # If running in dnceng, we need to use a feed different from default
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
 
     - task: PowerShell@2
@@ -105,8 +144,8 @@ stages:
                    -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
                    -officialSourceBranchName $(SourceBranchName)
                    -officialIbcDrop $(IbcDrop)
+                   -officialVisualStudioDropAccessToken $(_DevDivDropAccessToken)
                    /p:RepositoryName=$(Build.Repository.Name)
-                   /p:VisualStudioDropAccessToken=$(System.AccessToken)
                    /p:VisualStudioDropName=$(VisualStudio.DropName)
                    /p:DotNetSignType=$(SignType)
                    /p:DotNetPublishToBlobFeed=true

--- a/eng/update-build-number.ps1
+++ b/eng/update-build-number.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+  [string]$buildNumber,
+  [string]$oddOrEven)
+
+# Build number is in the format of YYYYMMDD.R
+$buildNumberYYYYMMDD = $buildNumber.Substring(0, 8)
+$buildNumberRev = [int]($buildNumber.Substring(9))
+$updatedRev = $buildNumberRev
+
+if ($oddOrEven -eq 'odd') {
+  $updatedRev = $buildNumberRev * 2 -1
+}
+elseif ($oddOrEven -eq 'even') {
+  $updatedRev = $buildNumberRev * 2
+}
+
+$updatedBuildNumber = $buildNumberYYYYMMDD + '.' + $updatedRev
+Write-Host "Setting BuildNumber to $updatedBuildNumber"
+Write-Host "##vso[build.updatebuildnumber]$updatedBuildNumber"


### PR DESCRIPTION
The pipeline in dnceng is here:
https://dev.azure.com/dnceng/internal/_build?definitionId=327&_a=summary

The build isn't fully functional yet because of missing credentials for publishing, but the build and signing all work:
https://dev.azure.com/dnceng/internal/_build/results?buildId=853881&view=results

I have tested existing pipeline in devdiv to confirm I didn't break anything:
- With `SkipApplyOptimizationData` set to false:
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=4148443

- With `SkipApplyOptimizationData` set to true:
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=4148449

~~I will make a follow-up PR to make sure two pipeline will produce build with different build number and assembly version.~~

Update: 
Added [fix ](https://github.com/dotnet/roslyn/pull/48614/commits/f44cca890a97ab92f6b44da83865336569761167) for differentiating build numbers from two pipelines. The behevaior is the build will start with regular build number which will be updated once the task is executed (first task in the yaml). Tested in dnceng (odd rev# for dnceng and even for devdiv)
https://dev.azure.com/dnceng/internal/_build/results?buildId=855163&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=20450ecf-f450-5022-55ce-fcecb22663e6

@MattGal @tmat @jaredpar @dotnet/roslyn-infrastructure Please take a look