### PR TITLE
Clean up build configuration

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1217,15 +1217,13 @@ Global
 		{CEA80C83-5848-4FF6-B4E8-CEEE9482E4AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CEA80C83-5848-4FF6-B4E8-CEEE9482E4AA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2801F82B-78CE-4BAE-B06F-537574751E2E}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2801F82B-78CE-4BAE-B06F-537574751E2E}.Debug|Any CPU.Build.0 = Debug|x86
 		{2801F82B-78CE-4BAE-B06F-537574751E2E}.Release|Any CPU.ActiveCfg = Release|x86
+		{2801F82B-78CE-4BAE-B06F-537574751E2E}.Release|Any CPU.Build.0 = Release|x86
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Debug|x86.Build.0 = Debug|Any CPU
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|x86.ActiveCfg = Release|Any CPU
-		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Remove references to non-existent 'x86' solution platform
* Make sure to build 'BuildActionTelemetryTable' project