### PR TITLE
Fix link

### DIFF
--- a/.github/ISSUE_TEMPLATE/analyzer-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/analyzer-suggestion.md
@@ -22,4 +22,4 @@ Any more additional information you would like to add.
 
 **Documentation requirements:**
 
-When this analyzer is implemented, it must be documented by following the steps at [Documentation for IDE CodeStyle analyzers](../../docs/contributing/Documentation for IDE CodeStyle analyzers.md).
+When this analyzer is implemented, it must be documented by following the steps at [Documentation for IDE CodeStyle analyzers](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Documentation%20for%20IDE%20CodeStyle%20analyzers.md).


### PR DESCRIPTION
Noticed in https://github.com/dotnet/roslyn/issues/48621 that the link isn't clickable.