### PR TITLE
Use MEF for callback dispatcher discovery

### DIFF
--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -5,8 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.SymbolSearch;
 
@@ -22,8 +24,15 @@ namespace Microsoft.CodeAnalysis.AddImport
     /// back to VS, which will then bounce back out to OOP to perform the Nuget/ReferenceAssembly
     /// portion of the search.  Ideally we could keep this all OOP.
     /// </summary>
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteMissingImportDiscoveryService)), Shared]
     internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteMissingImportDiscoveryService.ICallback
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public RemoteMissingImportDiscoveryServiceCallbackDispatcher()
+        {
+        }
+
         private ISymbolSearchService GetService(RemoteServiceCallbackId callbackId)
             => (ISymbolSearchService)GetCallback(callbackId);
 

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -7,11 +7,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -45,8 +47,15 @@ namespace Microsoft.CodeAnalysis.FindUsages
             CancellationToken cancellationToken);
     }
 
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteFindUsagesService)), Shared]
     internal sealed class FindUsagesServerCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteFindUsagesService.ICallback
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FindUsagesServerCallbackDispatcher()
+        {
+        }
+
         private new FindUsagesServerCallback GetCallback(RemoteServiceCallbackId callbackId)
             => (FindUsagesServerCallback)base.GetCallback(callbackId);
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -29,18 +29,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         {
             private readonly IAsyncServiceProvider _vsServiceProvider;
             private readonly AsynchronousOperationListenerProvider _listenerProvider;
-            private readonly RemoteServiceCallbackDispatchers _callbackDispatchers;
+            private readonly RemoteServiceCallbackDispatcherRegistry _callbackDispatchers;
 
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
             public Factory(
                 SVsServiceProvider vsServiceProvider,
                 AsynchronousOperationListenerProvider listenerProvider,
-                [ImportMany] IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatchers.ExportMetadata>> callbackDispatchers)
+                [ImportMany] IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatcherRegistry.ExportMetadata>> callbackDispatchers)
             {
                 _vsServiceProvider = (IAsyncServiceProvider)vsServiceProvider;
                 _listenerProvider = listenerProvider;
-                _callbackDispatchers = new RemoteServiceCallbackDispatchers(callbackDispatchers);
+                _callbackDispatchers = new RemoteServiceCallbackDispatcherRegistry(callbackDispatchers);
             }
 
             [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
@@ -61,13 +61,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         private readonly AsyncLazy<RemoteHostClient?> _lazyClient;
         private readonly IAsyncServiceProvider _vsServiceProvider;
         private readonly AsynchronousOperationListenerProvider _listenerProvider;
-        private readonly RemoteServiceCallbackDispatchers _callbackDispatchers;
+        private readonly RemoteServiceCallbackDispatcherRegistry _callbackDispatchers;
 
         private VisualStudioRemoteHostClientProvider(
             HostWorkspaceServices services,
             IAsyncServiceProvider vsServiceProvider,
             AsynchronousOperationListenerProvider listenerProvider,
-            RemoteServiceCallbackDispatchers callbackDispatchers)
+            RemoteServiceCallbackDispatcherRegistry callbackDispatchers)
         {
             _services = services;
             _vsServiceProvider = vsServiceProvider;

--- a/src/Workspaces/Core/Portable/DesignerAttribute/IRemoteDesignerAttributeDiscoveryService.cs
+++ b/src/Workspaces/Core/Portable/DesignerAttribute/IRemoteDesignerAttributeDiscoveryService.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.DesignerAttribute
@@ -24,8 +27,15 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
         ValueTask StartScanningForDesignerAttributesAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellation);
     }
 
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteDesignerAttributeDiscoveryService)), Shared]
     internal sealed class RemoteDesignerAttributeDiscoveryCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteDesignerAttributeDiscoveryService.ICallback
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public RemoteDesignerAttributeDiscoveryCallbackDispatcher()
+        {
+        }
+
         private IDesignerAttributeListener GetLogService(RemoteServiceCallbackId callbackId)
             => (IDesignerAttributeListener)GetCallback(callbackId);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.CallbackDispatcher.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.CallbackDispatcher.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Composition;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Text;
 
@@ -10,8 +13,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 {
     public static partial class SymbolFinder
     {
+        [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteSymbolFinderService)), Shared]
         internal sealed class CallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteSymbolFinderService.ICallback
         {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public CallbackDispatcher()
+            {
+            }
+
             private FindLiteralsServerCallback GetFindLiteralsCallback(RemoteServiceCallbackId callbackId)
                 => (FindLiteralsServerCallback)GetCallback(callbackId);
 

--- a/src/Workspaces/Core/Portable/ProjectTelemetry/IRemoteProjectTelemetryService.cs
+++ b/src/Workspaces/Core/Portable/ProjectTelemetry/IRemoteProjectTelemetryService.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.ProjectTelemetry
@@ -22,8 +25,15 @@ namespace Microsoft.CodeAnalysis.ProjectTelemetry
         ValueTask ComputeProjectTelemetryAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellation);
     }
 
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteProjectTelemetryService)), Shared]
     internal sealed class RemoteProjectTelemetryServiceCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteProjectTelemetryService.ICallback
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public RemoteProjectTelemetryServiceCallbackDispatcher()
+        {
+        }
+
         private IProjectTelemetryListener GetLogService(RemoteServiceCallbackId callbackId)
             => (IProjectTelemetryListener)GetCallback(callbackId);
 

--- a/src/Workspaces/Core/Portable/Remote/ExportRemoteServiceCallbackDispatcherAttribute.cs
+++ b/src/Workspaces/Core/Portable/Remote/ExportRemoteServiceCallbackDispatcherAttribute.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class)]
+    internal sealed class ExportRemoteServiceCallbackDispatcherAttribute : ExportAttribute
+    {
+        public Type ServiceInterface { get; }
+
+        public ExportRemoteServiceCallbackDispatcherAttribute(Type serviceInterface)
+            : base(typeof(IRemoteServiceCallbackDispatcher))
+        {
+            Contract.ThrowIfFalse(serviceInterface.IsInterface);
+
+            ServiceInterface = serviceInterface;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackDispatcher.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackDispatcher.cs
@@ -4,38 +4,17 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Runtime.Serialization;
 using System.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
-    [DataContract]
-    internal readonly struct RemoteServiceCallbackId : IEquatable<RemoteServiceCallbackId>
+    internal interface IRemoteServiceCallbackDispatcher
     {
-        [DataMember(Order = 0)]
-        public readonly int Id;
-
-        public RemoteServiceCallbackId(int id)
-            => Id = id;
-
-        public override bool Equals(object? obj)
-            => obj is RemoteServiceCallbackId id && Equals(id);
-
-        public bool Equals(RemoteServiceCallbackId other)
-            => Id == other.Id;
-
-        public override int GetHashCode()
-            => Id;
-
-        public static bool operator ==(RemoteServiceCallbackId left, RemoteServiceCallbackId right)
-            => left.Equals(right);
-
-        public static bool operator !=(RemoteServiceCallbackId left, RemoteServiceCallbackId right)
-            => !(left == right);
+        RemoteServiceCallbackDispatcher.Handle CreateHandle(object? instance);
     }
 
-    internal abstract class RemoteServiceCallbackDispatcher
+    internal abstract class RemoteServiceCallbackDispatcher : IRemoteServiceCallbackDispatcher
     {
         internal readonly struct Handle : IDisposable
         {

--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackDispatchers.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackDispatchers.cs
@@ -9,7 +9,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
-    internal readonly struct RemoteServiceCallbackDispatchers
+    internal readonly struct RemoteServiceCallbackDispatcherRegistry
+
     {
         public sealed class ExportMetadata
         {
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private readonly ImmutableDictionary<Type, Lazy<IRemoteServiceCallbackDispatcher, ExportMetadata>> _callbackDispatchers;
 
-        public RemoteServiceCallbackDispatchers(IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, ExportMetadata>> dispatchers)
+        public RemoteServiceCallbackDispatcherRegistry(IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, ExportMetadata>> dispatchers)
             => _callbackDispatchers = dispatchers.ToImmutableDictionary(d => d.Metadata.ServiceInterface);
 
         public IRemoteServiceCallbackDispatcher GetDispatcher(Type serviceType)

--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackDispatchers.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackDispatchers.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    internal readonly struct RemoteServiceCallbackDispatchers
+    {
+        public sealed class ExportMetadata
+        {
+            public Type ServiceInterface { get; }
+
+            public ExportMetadata(IDictionary<string, object> data)
+            {
+                var serviceInterface = data.GetValueOrDefault(nameof(ExportRemoteServiceCallbackDispatcherAttribute.ServiceInterface));
+                Contract.ThrowIfNull(serviceInterface);
+                ServiceInterface = (Type)serviceInterface;
+            }
+        }
+
+        private readonly ImmutableDictionary<Type, Lazy<IRemoteServiceCallbackDispatcher, ExportMetadata>> _callbackDispatchers;
+
+        public RemoteServiceCallbackDispatchers(IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, ExportMetadata>> dispatchers)
+            => _callbackDispatchers = dispatchers.ToImmutableDictionary(d => d.Metadata.ServiceInterface);
+
+        public IRemoteServiceCallbackDispatcher GetDispatcher(Type serviceType)
+            => _callbackDispatchers[serviceType].Value;
+    }
+}

--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackId.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceCallbackId.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    [DataContract]
+    internal readonly struct RemoteServiceCallbackId : IEquatable<RemoteServiceCallbackId>
+    {
+        [DataMember(Order = 0)]
+        public readonly int Id;
+
+        public RemoteServiceCallbackId(int id)
+            => Id = id;
+
+        public override bool Equals(object? obj)
+            => obj is RemoteServiceCallbackId id && Equals(id);
+
+        public bool Equals(RemoteServiceCallbackId other)
+            => Id == other.Id;
+
+        public override int GetHashCode()
+            => Id;
+
+        public static bool operator ==(RemoteServiceCallbackId left, RemoteServiceCallbackId right)
+            => left.Equals(right);
+
+        public static bool operator !=(RemoteServiceCallbackId left, RemoteServiceCallbackId right)
+            => !(left == right);
+    }
+}

--- a/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchCallbackDispatcher.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchCallbackDispatcher.cs
@@ -4,14 +4,24 @@
 
 #nullable disable
 
+using System;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteSymbolSearchUpdateService)), Shared]
     internal sealed class SymbolSearchCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteSymbolSearchUpdateService.ICallback
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public SymbolSearchCallbackDispatcher()
+        {
+        }
+
         private ISymbolSearchLogService GetLogService(RemoteServiceCallbackId callbackId)
             => (ISymbolSearchLogService)GetCallback(callbackId);
 

--- a/src/Workspaces/Core/Portable/TodoComments/IRemoteTodoCommentsService.cs
+++ b/src/Workspaces/Core/Portable/TodoComments/IRemoteTodoCommentsService.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.TodoComments
@@ -23,8 +26,15 @@ namespace Microsoft.CodeAnalysis.TodoComments
         ValueTask ComputeTodoCommentsAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellation);
     }
 
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteTodoCommentsDiscoveryService)), Shared]
     internal sealed class RemoteTodoCommentsDiscoveryCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteTodoCommentsDiscoveryService.ICallback
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public RemoteTodoCommentsDiscoveryCallbackDispatcher()
+        {
+        }
+
         private ITodoCommentsListener GetLogService(RemoteServiceCallbackId callbackId)
             => (ITodoCommentsListener)GetCallback(callbackId);
 

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         }
 
         [Fact]
-        internal void CallbackDispatchers()
+        public void CallbackDispatchers()
         {
             var hostServices = FeaturesTestCompositions.Features.WithTestHostParts(Testing.TestHost.OutOfProcess).GetHostServices();
             var callbackDispatchers = ((IMefHostExportProvider)hostServices).GetExports<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatchers.ExportMetadata>();

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         public void CallbackDispatchers()
         {
             var hostServices = FeaturesTestCompositions.Features.WithTestHostParts(Testing.TestHost.OutOfProcess).GetHostServices();
-            var callbackDispatchers = ((IMefHostExportProvider)hostServices).GetExports<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatchers.ExportMetadata>();
+            var callbackDispatchers = ((IMefHostExportProvider)hostServices).GetExports<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatcherRegistry.ExportMetadata>();
 
             var descriptorsWithCallbackServiceTypes = ServiceDescriptors.Descriptors.Where(d => d.Value.descriptor32.ClientInterface != null).Select(d => d.Key);
             var callbackDispatcherServiceTypes = callbackDispatchers.Select(d => d.Metadata.ServiceInterface);

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -31,11 +31,11 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
     {
         private readonly HostWorkspaceServices _workspaceServices;
         private readonly InProcRemoteServices _inprocServices;
-        private readonly RemoteServiceCallbackDispatchers _callbackDispatchers;
+        private readonly RemoteServiceCallbackDispatcherRegistry _callbackDispatchers;
         private readonly RemoteEndPoint _endPoint;
         private readonly TraceSource _logger;
 
-        public static async Task<RemoteHostClient> CreateAsync(HostWorkspaceServices services, RemoteServiceCallbackDispatchers callbackDispatchers, TraceListener? traceListener, RemoteHostTestData testData)
+        public static async Task<RemoteHostClient> CreateAsync(HostWorkspaceServices services, RemoteServiceCallbackDispatcherRegistry callbackDispatchers, TraceListener? traceListener, RemoteHostTestData testData)
         {
             var inprocServices = new InProcRemoteServices(services, traceListener, testData);
 
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         private InProcRemoteHostClient(
             HostWorkspaceServices services,
             InProcRemoteServices inprocServices,
-            RemoteServiceCallbackDispatchers callbackDispatchers,
+            RemoteServiceCallbackDispatcherRegistry callbackDispatchers,
             Stream stream)
         {
             _workspaceServices = services;

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         [ExportWorkspaceServiceFactory(typeof(IRemoteHostClientProvider), ServiceLayer.Test), Shared, PartNotDiscoverable]
         internal sealed class Factory : IWorkspaceServiceFactory
         {
-            private readonly RemoteServiceCallbackDispatchers _callbackDispatchers;
+            private readonly RemoteServiceCallbackDispatcherRegistry _callbackDispatchers;
 
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public Factory([ImportMany] IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatchers.ExportMetadata>> callbackDispatchers)
-                => _callbackDispatchers = new RemoteServiceCallbackDispatchers(callbackDispatchers);
+            public Factory([ImportMany] IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatcherRegistry.ExportMetadata>> callbackDispatchers)
+                => _callbackDispatchers = new RemoteServiceCallbackDispatcherRegistry(callbackDispatchers);
 
             public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
                 => new InProcRemoteHostClientProvider(workspaceServices, _callbackDispatchers);
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         public Type[]? AdditionalRemoteParts { get; }
         public TraceListener? TraceListener { get; set; }
 
-        public InProcRemoteHostClientProvider(HostWorkspaceServices services, RemoteServiceCallbackDispatchers callbackDispatchers)
+        public InProcRemoteHostClientProvider(HostWorkspaceServices services, RemoteServiceCallbackDispatcherRegistry callbackDispatchers)
         {
             _services = services;
 

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Threading;
@@ -19,14 +21,15 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         [ExportWorkspaceServiceFactory(typeof(IRemoteHostClientProvider), ServiceLayer.Test), Shared, PartNotDiscoverable]
         internal sealed class Factory : IWorkspaceServiceFactory
         {
+            private readonly RemoteServiceCallbackDispatchers _callbackDispatchers;
+
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public Factory()
-            {
-            }
+            public Factory([ImportMany] IEnumerable<Lazy<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatchers.ExportMetadata>> callbackDispatchers)
+                => _callbackDispatchers = new RemoteServiceCallbackDispatchers(callbackDispatchers);
 
             public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-                => new InProcRemoteHostClientProvider(workspaceServices);
+                => new InProcRemoteHostClientProvider(workspaceServices, _callbackDispatchers);
         }
 
         private sealed class WorkspaceManager : RemoteWorkspaceManager
@@ -52,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         public Type[]? AdditionalRemoteParts { get; }
         public TraceListener? TraceListener { get; set; }
 
-        public InProcRemoteHostClientProvider(HostWorkspaceServices services)
+        public InProcRemoteHostClientProvider(HostWorkspaceServices services, RemoteServiceCallbackDispatchers callbackDispatchers)
         {
             _services = services;
 
@@ -60,6 +63,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
             _lazyClient = new AsyncLazy<RemoteHostClient>(
                 cancellationToken => InProcRemoteHostClient.CreateAsync(
                     _services,
+                    callbackDispatchers,
                     TraceListener,
                     new RemoteHostTestData(_lazyManager.Value, isInProc: true)),
                 cacheResult: true);

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Threading;
@@ -46,9 +47,11 @@ namespace Microsoft.CodeAnalysis.Remote
         private readonly ServiceDescriptor _serviceDescriptor;
         private readonly ServiceBrokerClient _serviceBrokerClient;
         private readonly RemoteServiceCallbackDispatcher.Handle _callbackHandle;
+        private readonly IRemoteServiceCallbackDispatcher? _callbackDispatcher;
 
         public BrokeredServiceConnection(
             object? callbackTarget,
+            RemoteServiceCallbackDispatchers callbackDispatchers,
             ServiceBrokerClient serviceBrokerClient,
             SolutionAssetStorage solutionAssetStorage,
             IErrorReportingService? errorReportingService,
@@ -61,7 +64,12 @@ namespace Microsoft.CodeAnalysis.Remote
             _shutdownCancellationService = shutdownCancellationService;
 
             _serviceDescriptor = ServiceDescriptors.GetServiceDescriptor(typeof(TService), isRemoteHost64Bit);
-            _callbackHandle = _serviceDescriptor.CallbackDispatcher?.CreateHandle(callbackTarget) ?? default;
+
+            if (_serviceDescriptor.ClientInterface != null)
+            {
+                _callbackDispatcher = callbackDispatchers.GetDispatcher(typeof(TService));
+                _callbackHandle = _callbackDispatcher.CreateHandle(callbackTarget);
+            }
         }
 
         public override void Dispose()
@@ -76,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             var options = new ServiceActivationOptions
             {
-                ClientRpcTarget = _serviceDescriptor.CallbackDispatcher
+                ClientRpcTarget = _callbackDispatcher
             };
 
             var proxyRental = await _serviceBrokerClient.GetProxyAsync<TService>(_serviceDescriptor, options, cancellationToken).ConfigureAwait(false);
@@ -137,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public override async ValueTask<bool> TryInvokeAsync(Func<TService, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(_serviceDescriptor.CallbackDispatcher is not null);
+            Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
             try
             {
@@ -154,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Func<TService, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(_serviceDescriptor.CallbackDispatcher is not null);
+            Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
             try
             {
@@ -228,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public override async ValueTask<bool> TryInvokeAsync(Solution solution, Func<TService, PinnedSolutionInfo, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(_serviceDescriptor.CallbackDispatcher is not null);
+            Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
             try
             {
@@ -247,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Solution solution, Func<TService, PinnedSolutionInfo, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(_serviceDescriptor.CallbackDispatcher is not null);
+            Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
             try
             {

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public BrokeredServiceConnection(
             object? callbackTarget,
-            RemoteServiceCallbackDispatchers callbackDispatchers,
+            RemoteServiceCallbackDispatcherRegistry callbackDispatchers,
             ServiceBrokerClient serviceBrokerClient,
             SolutionAssetStorage solutionAssetStorage,
             IErrorReportingService? errorReportingService,

--- a/src/Workspaces/Remote/Core/ServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptor.cs
@@ -33,12 +33,9 @@ namespace Microsoft.CodeAnalysis.Remote
             ProtocolMajorVersion = 3
         }.GetFrozenCopy();
 
-        public readonly RemoteServiceCallbackDispatcher? CallbackDispatcher;
-
-        private ServiceDescriptor(ServiceMoniker serviceMoniker, Type? clientInterface, RemoteServiceCallbackDispatcher? callbackDispatcher)
+        private ServiceDescriptor(ServiceMoniker serviceMoniker, Type? clientInterface)
             : base(serviceMoniker, clientInterface, Formatters.MessagePack, MessageDelimiters.BigEndianInt32LengthHeader, s_multiplexingStreamOptions)
         {
-            CallbackDispatcher = callbackDispatcher;
         }
 
         private ServiceDescriptor(ServiceDescriptor copyFrom)
@@ -46,11 +43,11 @@ namespace Microsoft.CodeAnalysis.Remote
         {
         }
 
-        public static ServiceDescriptor CreateRemoteServiceDescriptor(string serviceName, Type? clientInterface, RemoteServiceCallbackDispatcher? callbackDispatcher)
-            => new ServiceDescriptor(new ServiceMoniker(serviceName), clientInterface, callbackDispatcher);
+        public static ServiceDescriptor CreateRemoteServiceDescriptor(string serviceName, Type? clientInterface)
+            => new ServiceDescriptor(new ServiceMoniker(serviceName), clientInterface);
 
         public static ServiceDescriptor CreateInProcServiceDescriptor(string serviceName)
-            => new ServiceDescriptor(new ServiceMoniker(serviceName), clientInterface: null, callbackDispatcher: null);
+            => new ServiceDescriptor(new ServiceMoniker(serviceName), clientInterface: null);
 
         protected override ServiceRpcDescriptor Clone()
             => new ServiceDescriptor(this);

--- a/src/Workspaces/Remote/Core/ServiceDescriptors.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptors.cs
@@ -40,16 +40,13 @@ namespace Microsoft.CodeAnalysis.Remote
         private const string InterfaceNamePrefix = "IRemote";
         private const string InterfaceNameSuffix = "Service";
 
-        // CONSIDER: The descriptors with callbacks currently depend on the feature implementations.
-        // To avoid this coupling we could moe the map from service type to callback dispatcher to IRemoteHostClientProvider and populate it via MEF.
-
         internal static readonly ImmutableDictionary<Type, (ServiceDescriptor descriptor32, ServiceDescriptor descriptor64)> Descriptors = ImmutableDictionary.CreateRange(new[]
         {
             CreateDescriptors(typeof(IRemoteAssetSynchronizationService)),
             CreateDescriptors(typeof(IRemoteAsynchronousOperationListenerService)),
-            CreateDescriptors(typeof(IRemoteTodoCommentsDiscoveryService), callbackInterface: typeof(IRemoteTodoCommentsDiscoveryService.ICallback), new RemoteTodoCommentsDiscoveryCallbackDispatcher()),
-            CreateDescriptors(typeof(IRemoteDesignerAttributeDiscoveryService), callbackInterface: typeof(IRemoteDesignerAttributeDiscoveryService.ICallback), new RemoteDesignerAttributeDiscoveryCallbackDispatcher()),
-            CreateDescriptors(typeof(IRemoteProjectTelemetryService), callbackInterface: typeof(IRemoteProjectTelemetryService.ICallback), new RemoteProjectTelemetryServiceCallbackDispatcher()),
+            CreateDescriptors(typeof(IRemoteTodoCommentsDiscoveryService), callbackInterface: typeof(IRemoteTodoCommentsDiscoveryService.ICallback)),
+            CreateDescriptors(typeof(IRemoteDesignerAttributeDiscoveryService), callbackInterface: typeof(IRemoteDesignerAttributeDiscoveryService.ICallback)),
+            CreateDescriptors(typeof(IRemoteProjectTelemetryService), callbackInterface: typeof(IRemoteProjectTelemetryService.ICallback)),
             CreateDescriptors(typeof(IRemoteDiagnosticAnalyzerService)),
             CreateDescriptors(typeof(IRemoteSemanticClassificationService)),
             CreateDescriptors(typeof(IRemoteSemanticClassificationCacheService)),
@@ -57,11 +54,11 @@ namespace Microsoft.CodeAnalysis.Remote
             CreateDescriptors(typeof(IRemoteEncapsulateFieldService)),
             CreateDescriptors(typeof(IRemoteRenamerService)),
             CreateDescriptors(typeof(IRemoteConvertTupleToStructCodeRefactoringService)),
-            CreateDescriptors(typeof(IRemoteSymbolFinderService), callbackInterface: typeof(IRemoteSymbolFinderService.ICallback), new SymbolFinder.CallbackDispatcher()),
-            CreateDescriptors(typeof(IRemoteFindUsagesService), callbackInterface: typeof(IRemoteFindUsagesService.ICallback), new FindUsagesServerCallbackDispatcher()),
+            CreateDescriptors(typeof(IRemoteSymbolFinderService), callbackInterface: typeof(IRemoteSymbolFinderService.ICallback)),
+            CreateDescriptors(typeof(IRemoteFindUsagesService), callbackInterface: typeof(IRemoteFindUsagesService.ICallback)),
             CreateDescriptors(typeof(IRemoteNavigateToSearchService)),
-            CreateDescriptors(typeof(IRemoteMissingImportDiscoveryService), callbackInterface: typeof(IRemoteMissingImportDiscoveryService.ICallback), new RemoteMissingImportDiscoveryServiceCallbackDispatcher()),
-            CreateDescriptors(typeof(IRemoteSymbolSearchUpdateService), callbackInterface: typeof(IRemoteSymbolSearchUpdateService.ICallback), new SymbolSearchCallbackDispatcher()),
+            CreateDescriptors(typeof(IRemoteMissingImportDiscoveryService), callbackInterface: typeof(IRemoteMissingImportDiscoveryService.ICallback)),
+            CreateDescriptors(typeof(IRemoteSymbolSearchUpdateService), callbackInterface: typeof(IRemoteSymbolSearchUpdateService.ICallback)),
             CreateDescriptors(typeof(IRemoteExtensionMethodImportCompletionService)),
             CreateDescriptors(typeof(IRemoteDependentTypeFinderService)),
             CreateDescriptors(typeof(IRemoteGlobalNotificationDeliveryService)),
@@ -81,14 +78,13 @@ namespace Microsoft.CodeAnalysis.Remote
         internal static string GetQualifiedServiceName(Type serviceInterface)
             => ServiceNamePrefix + GetServiceName(serviceInterface);
 
-        private static KeyValuePair<Type, (ServiceDescriptor, ServiceDescriptor)> CreateDescriptors(Type serviceInterface, Type? callbackInterface = null, RemoteServiceCallbackDispatcher? callbackDispatcher = null)
+        private static KeyValuePair<Type, (ServiceDescriptor, ServiceDescriptor)> CreateDescriptors(Type serviceInterface, Type? callbackInterface = null)
         {
             Contract.ThrowIfFalse(callbackInterface == null || callbackInterface.IsInterface);
-            Contract.ThrowIfFalse((callbackInterface == null) == (callbackDispatcher == null));
 
             var serviceName = GetQualifiedServiceName(serviceInterface);
-            var descriptor32 = ServiceDescriptor.CreateRemoteServiceDescriptor(serviceName, callbackInterface, callbackDispatcher);
-            var descriptor64 = ServiceDescriptor.CreateRemoteServiceDescriptor(serviceName + RemoteServiceName.Suffix64, callbackInterface, callbackDispatcher);
+            var descriptor32 = ServiceDescriptor.CreateRemoteServiceDescriptor(serviceName, callbackInterface);
+            var descriptor64 = ServiceDescriptor.CreateRemoteServiceDescriptor(serviceName + RemoteServiceName.Suffix64, callbackInterface);
             return new(serviceInterface, (descriptor32, descriptor64));
         }
 

--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private readonly ServiceBrokerClient _serviceBrokerClient;
         private readonly IErrorReportingService? _errorReportingService;
         private readonly IRemoteHostClientShutdownCancellationService? _shutdownCancellationService;
-        private readonly RemoteServiceCallbackDispatchers _callbackDispatchers;
+        private readonly RemoteServiceCallbackDispatcherRegistry _callbackDispatchers;
 
         private readonly ConnectionPools? _connectionPools;
 
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ServiceBrokerClient serviceBrokerClient,
             HubClient hubClient,
             Stream stream,
-            RemoteServiceCallbackDispatchers callbackDispatchers)
+            RemoteServiceCallbackDispatcherRegistry callbackDispatchers)
         {
             _connectionPools = new ConnectionPools(
                 connectionFactory: (serviceName, pool, cancellationToken) => CreateConnectionImplAsync(serviceName, callbackTarget: null, pool, cancellationToken),
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Remote
             HostWorkspaceServices services,
             AsynchronousOperationListenerProvider listenerProvider,
             IServiceBroker serviceBroker,
-            RemoteServiceCallbackDispatchers callbackDispatchers,
+            RemoteServiceCallbackDispatcherRegistry callbackDispatchers,
             CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.ServiceHubRemoteHostClient_CreateAsync, KeyValueLogMessage.NoProperty, cancellationToken))


### PR DESCRIPTION
Builds on top of https://github.com/dotnet/roslyn/pull/48543.

Instead of specifying callback dispatchers eagerly in ServiceDescriptors and thus introducing dependencies on feature implementations to the Remote.Workspace layer, we now import the dispatchers via MEF in the remote host client. Other than removing unwanted dependencies and eager initialization, this is necessary so that partner teams can use our RPC callback infrastructure.
