### PR TITLE
Clarify the GetOutputFileName contract

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1457,7 +1457,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns the name With which the assembly should be output
+        /// Returns the name with which the assembly should be output
         /// </summary>
         protected abstract string GetOutputFileName(Compilation compilation, CancellationToken cancellationToken);
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1064,7 +1064,10 @@ namespace Microsoft.CodeAnalysis
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // https://github.com/dotnet/roslyn/issues/48599
+            // Given a compilation and a destination directory, determine three names:
+            //   1) The name with which the assembly should be output.
+            //   2) The path of the assembly/module file (default = destination directory + compilation output name).
+            //   3) The path of the pdb file (default = assembly/module path with ".pdb" extension).
             string outputName = GetOutputFileName(compilation, cancellationToken)!;
             var finalPeFilePath = Arguments.GetOutputFilePath(outputName);
             var finalPdbFilePath = Arguments.GetPdbFilePath(outputName);
@@ -1454,18 +1457,9 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Given a compilation and a destination directory, determine three names:
-        ///   1) The name with which the assembly should be output (default = null, which indicates that the compilation output name should be used).
-        ///   2) The path of the assembly/module file (default = destination directory + compilation output name).
-        ///   3) The path of the pdb file (default = assembly/module path with ".pdb" extension).
+        /// Returns the name With which the assembly should be output
         /// </summary>
-        /// <remarks>
-        /// C# has a special implementation that implements idiosyncratic behavior of csc.
-        /// </remarks>
-        protected virtual string? GetOutputFileName(Compilation compilation, CancellationToken cancellationToken)
-        {
-            return Arguments.OutputFileName;
-        }
+        protected abstract string GetOutputFileName(Compilation compilation, CancellationToken cancellationToken);
 
         /// <summary>
         /// Test hook for intercepting File.Open.

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             _additionalTextFiles = Nothing
             _tempDirectory = buildPaths.TempDirectory
 
-            Debug.Assert(Arguments.OutputFileName IsNot Nothing OrElse Arguments.Errors.Length > 0)
+            Debug.Assert(Arguments.OutputFileName IsNot Nothing OrElse Arguments.Errors.Length > 0 OrElse parser.IsScriptCommandLineParser)
         End Sub
 
         Private Function GetAdditionalTextFiles() As ImmutableArray(Of AdditionalTextFile)

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -28,6 +28,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             _diagnosticFormatter = New CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, AddressOf GetAdditionalTextFiles)
             _additionalTextFiles = Nothing
             _tempDirectory = buildPaths.TempDirectory
+
+            Debug.Assert(Arguments.OutputFileName IsNot Nothing OrElse Arguments.Errors.Length > 0)
         End Sub
 
         Private Function GetAdditionalTextFiles() As ImmutableArray(Of AdditionalTextFile)
@@ -172,6 +174,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      WithStrongNameProvider(Arguments.GetStrongNameProvider(loggingFileSystem)).
                      WithSourceReferenceResolver(sourceFileResolver).
                      WithSyntaxTreeOptionsProvider(syntaxTreeOptions))
+        End Function
+
+        Protected Overrides Function GetOutputFileName(compilation As Compilation, cancellationToken As CancellationToken) As String
+            ' The only case this is Nothing is when there are errors during parsing in which case this should never get called
+            Debug.Assert(Arguments.OutputFileName IsNot Nothing)
+            Return Arguments.OutputFileName
         End Function
 
         Private Sub PrintReferences(resolvedReferences As List(Of MetadataReference), consoleOutput As TextWriter)

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.CommandLine</RootNamespace>
     <LargeAddressAware>true</LargeAddressAware>
     <StartupObject>Microsoft.CodeAnalysis.VisualBasic.CommandLine.Program</StartupObject>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <UseAppHost>false</UseAppHost>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>


### PR DESCRIPTION
The `GetOutputFileName` consumption code requires the return to be
non-null yet the implementation appeared to allow `null` returns. This
change flips the return to be `string!` as well as reworking the code a
bit to make the guarantees the compilers are providing much clearer

closes #48599