### PR TITLE
Warn on uninitialized fields for struct constructor with `: this()` clause

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -444,7 +444,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             this.Diagnostics.Clear();
             this.regionPlace = RegionPlace.Before;
-            makeNotNullMembersMaybeNull();
             if (!_isSpeculative)
             {
                 ParameterSymbol methodThisParameter = MethodThisParameter;
@@ -454,6 +453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     EnterParameter(methodThisParameter, methodThisParameter.TypeWithAnnotations);
                 }
 
+                makeNotNullMembersMaybeNull();
                 // We need to create a snapshot even of the first node, because we want to have the state of the initial parameters.
                 _snapshotBuilderOpt?.TakeIncrementalSnapshot(methodMainNode, State);
             }

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -736,9 +736,9 @@ hasBucket:
 
         public struct Enumerator
         {
-            private readonly Stack<AvlNode> _stack;
+            private readonly Stack<AvlNode>? _stack;
             private Node? _next;
-            private Node _current;
+            private Node? _current;
 
             public Enumerator(SmallDictionary<K, V> dict)
                 : this()
@@ -761,7 +761,7 @@ hasBucket:
                 }
             }
 
-            public KeyValuePair<K, V> Current => new KeyValuePair<K, V>(_current.Key, _current.Value);
+            public KeyValuePair<K, V> Current => new KeyValuePair<K, V>(_current!.Key, _current!.Value);
 
             public bool MoveNext()
             {
@@ -791,7 +791,7 @@ hasBucket:
             {
                 if (child != null)
                 {
-                    _stack.Push(child);
+                    _stack!.Push(child);
                 }
             }
         }

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -515,9 +515,9 @@ hasBucket:
 
             public struct Enumerator
             {
-                private readonly Stack<AvlNode> _stack;
+                private readonly Stack<AvlNode>? _stack;
                 private Node? _next;
-                private Node _current;
+                private Node? _current;
 
                 public Enumerator(SmallDictionary<K, V> dict)
                     : this()
@@ -538,7 +538,7 @@ hasBucket:
                     }
                 }
 
-                public K Current => _current.Key;
+                public K Current => _current!.Key;
 
                 public bool MoveNext()
                 {
@@ -568,7 +568,7 @@ hasBucket:
                 {
                     if (child != null)
                     {
-                        _stack.Push(child);
+                        _stack!.Push(child);
                     }
                 }
             }
@@ -630,9 +630,9 @@ hasBucket:
 
             public struct Enumerator
             {
-                private readonly Stack<AvlNode> _stack;
+                private readonly Stack<AvlNode>? _stack;
                 private Node? _next;
-                private Node _current;
+                private Node? _current;
 
                 public Enumerator(SmallDictionary<K, V> dict)
                     : this()
@@ -655,7 +655,7 @@ hasBucket:
                     }
                 }
 
-                public V Current => _current.Value;
+                public V Current => _current!.Value;
 
                 public bool MoveNext()
                 {
@@ -685,7 +685,7 @@ hasBucket:
                 {
                     if (child != null)
                     {
-                        _stack.Push(child);
+                        _stack!.Push(child);
                     }
                 }
             }

--- a/src/Workspaces/Core/Portable/Rename/ConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictResolution.cs
@@ -37,8 +37,10 @@ namespace Microsoft.CodeAnalysis.Rename
         private readonly ImmutableDictionary<DocumentId, ImmutableArray<ComplexifiedSpan>> _documentToComplexifiedSpansMap;
         private readonly ImmutableDictionary<DocumentId, ImmutableArray<RelatedLocation>> _documentToRelatedLocationsMap;
 
+#nullable disable warnings
         public ConflictResolution(string errorMessage) : this()
             => ErrorMessage = errorMessage;
+#nullable enable warnings
 
         public ConflictResolution(
             Solution oldSolution,


### PR DESCRIPTION
Closes #48574

Basically, entering the `this` parameter caused the declared state to be written to the slots for the struct fields, so we need to `makeNotNullMembersMaybeNull()` after the `EnterParameter`, not before. I think it also makes more sense to move the call into the `!_isSpeculative` block, since in speculative analysis we should just load a snapshot that already has the "state before we call base.Scan()" plugged into it. (if I'm reading the code right @333fred.)

I think we should revisit the way we populate state when assigning to variables of struct types eventually (to solve #47596, for example).

@dotnet/roslyn-compiler for review please