### PR TITLE
Fix UnmanagedCallingConventions test reliability

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -1199,17 +1199,17 @@ using System.Runtime.InteropServices;
 public unsafe class UnmanagedFunctionPointer 
 {{
     [UnmanagedFunctionPointer(CallingConvention.{enumConvention})]
-    private delegate string CombineStrings(string s1, string s2);
+    public delegate string CombineStrings(string s1, string s2);
     
     private static string CombineStringsImpl(string s1, string s2)
     {{
         return s1 + s2;
     }}
 
-    public static delegate* unmanaged[{unmanagedConvention}]<string, string, string> GetFuncPtr()
+    public static delegate* unmanaged[{unmanagedConvention}]<string, string, string> GetFuncPtr(out CombineStrings del)
     {{
-        var ptr = Marshal.GetFunctionPointerForDelegate((CombineStrings)CombineStringsImpl);
-        GC.KeepAlive(ptr);
+        del = CombineStringsImpl;
+        var ptr = Marshal.GetFunctionPointerForDelegate(del);
         return (delegate* unmanaged[{unmanagedConvention}]<string, string, string>)ptr;
     }}
 }}
@@ -1217,7 +1217,8 @@ class Caller
 {{
     public unsafe static void Main()
     {{
-        Call(UnmanagedFunctionPointer.GetFuncPtr());
+        Call(UnmanagedFunctionPointer.GetFuncPtr(out var del));
+        GC.KeepAlive(del);
     }}
 
     public unsafe static void Call(delegate* unmanaged[{unmanagedConvention}]<string, string, string> ptr)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -1285,17 +1285,17 @@ using System.Runtime.InteropServices;
 public unsafe class UnmanagedFunctionPointer 
 {
     [UnmanagedFunctionPointer(CallingConvention.FastCall)]
-    private delegate string CombineStrings(string s1, string s2);
+    public delegate string CombineStrings(string s1, string s2);
     
     private static string CombineStringsImpl(string s1, string s2)
     {
         return s1 + s2;
     }
 
-    public static delegate* unmanaged[Fastcall]<string, string, string> GetFuncPtr()
+    public static delegate* unmanaged[Fastcall]<string, string, string> GetFuncPtr(out CombineStrings del)
     {
-        var ptr = Marshal.GetFunctionPointerForDelegate((CombineStrings)CombineStringsImpl);
-        GC.KeepAlive(ptr);
+        del = CombineStringsImpl;
+        var ptr = Marshal.GetFunctionPointerForDelegate(del);
         return (delegate* unmanaged[Fastcall]<string, string, string>)ptr;
     }
 }
@@ -1303,7 +1303,8 @@ class Caller
 {
     public unsafe static void Main()
     {
-        Call(UnmanagedFunctionPointer.GetFuncPtr());
+        Call(UnmanagedFunctionPointer.GetFuncPtr(out var del));
+        GC.KeepAlive(del);
     }
 
     public unsafe static void Call(delegate* unmanaged[Fastcall]<string, string, string> ptr)
@@ -1355,20 +1356,20 @@ unsafe struct S
 unsafe class UnmanagedFunctionPointer
 {
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-    delegate int SingleParam(S* s);
+    public delegate int SingleParam(S* s);
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-    delegate int MultipleParams(S* s, int i);
+    public delegate int MultipleParams(S* s, int i);
     
-    public static delegate* unmanaged[Thiscall]<S*, int> GetFuncPtrSingleParam()
+    public static delegate* unmanaged[Thiscall]<S*, int> GetFuncPtrSingleParam(out SingleParam del)
     {
-        var ptr = Marshal.GetFunctionPointerForDelegate(new SingleParam(S.GetInt));
-        GC.KeepAlive(ptr);
+        del = S.GetInt;
+        var ptr = Marshal.GetFunctionPointerForDelegate(del);
         return (delegate* unmanaged[Thiscall]<S*, int>)ptr;
     }
-    public static delegate* unmanaged[Thiscall]<S*, int, int> GetFuncPtrMultipleParams()
+    public static delegate* unmanaged[Thiscall]<S*, int, int> GetFuncPtrMultipleParams(out MultipleParams del)
     {
-        var ptr = Marshal.GetFunctionPointerForDelegate(new MultipleParams(S.GetReturn));
-        GC.KeepAlive(ptr);
+        del = S.GetReturn;
+        var ptr = Marshal.GetFunctionPointerForDelegate(del);
         return (delegate* unmanaged[Thiscall]<S*, int, int>)ptr;
     }
 }
@@ -1385,61 +1386,71 @@ unsafe class C
     {
         S s = new S();
         s.i = 1;
-        var i = UnmanagedFunctionPointer.GetFuncPtrSingleParam()(&s);
+        var i = UnmanagedFunctionPointer.GetFuncPtrSingleParam(out var del)(&s);
         Console.Write(i);
+        GC.KeepAlive(del);
     }
 
     public static void TestMultiple()
     {
         S s = new S();
         s.i = 2;
-        var i = UnmanagedFunctionPointer.GetFuncPtrMultipleParams()(&s, 3);
+        var i = UnmanagedFunctionPointer.GetFuncPtrMultipleParams(out var del)(&s, 3);
         Console.Write(i);
+        GC.KeepAlive(del);
     }
 }", expectedOutput: @"15");
 
             verifier.VerifyIL("C.TestSingle()", @"
 {
-  // Code size       37 (0x25)
+  // Code size       45 (0x2d)
   .maxstack  2
   .locals init (S V_0, //s
-                delegate* unmanaged[Thiscall]<S*, int> V_1)
+                UnmanagedFunctionPointer.SingleParam V_1, //del
+                delegate* unmanaged[Thiscall]<S*, int> V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.1
   IL_000b:  stfld      ""int S.i""
-  IL_0010:  call       ""delegate* unmanaged[Thiscall]<S*, int> UnmanagedFunctionPointer.GetFuncPtrSingleParam()""
-  IL_0015:  stloc.1
-  IL_0016:  ldloca.s   V_0
-  IL_0018:  conv.u
-  IL_0019:  ldloc.1
-  IL_001a:  calli      ""delegate* unmanaged[Thiscall]<S*, int>""
-  IL_001f:  call       ""void System.Console.Write(int)""
-  IL_0024:  ret
+  IL_0010:  ldloca.s   V_1
+  IL_0012:  call       ""delegate* unmanaged[Thiscall]<S*, int> UnmanagedFunctionPointer.GetFuncPtrSingleParam(out UnmanagedFunctionPointer.SingleParam)""
+  IL_0017:  stloc.2
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  conv.u
+  IL_001b:  ldloc.2
+  IL_001c:  calli      ""delegate* unmanaged[Thiscall]<S*, int>""
+  IL_0021:  call       ""void System.Console.Write(int)""
+  IL_0026:  ldloc.1
+  IL_0027:  call       ""void System.GC.KeepAlive(object)""
+  IL_002c:  ret
 }
 ");
 
             verifier.VerifyIL("C.TestMultiple()", @"
 {
-  // Code size       38 (0x26)
+  // Code size       46 (0x2e)
   .maxstack  3
   .locals init (S V_0, //s
-                delegate* unmanaged[Thiscall]<S*, int, int> V_1)
+                UnmanagedFunctionPointer.MultipleParams V_1, //del
+                delegate* unmanaged[Thiscall]<S*, int, int> V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.2
   IL_000b:  stfld      ""int S.i""
-  IL_0010:  call       ""delegate* unmanaged[Thiscall]<S*, int, int> UnmanagedFunctionPointer.GetFuncPtrMultipleParams()""
-  IL_0015:  stloc.1
-  IL_0016:  ldloca.s   V_0
-  IL_0018:  conv.u
-  IL_0019:  ldc.i4.3
-  IL_001a:  ldloc.1
-  IL_001b:  calli      ""delegate* unmanaged[Thiscall]<S*, int, int>""
-  IL_0020:  call       ""void System.Console.Write(int)""
-  IL_0025:  ret
+  IL_0010:  ldloca.s   V_1
+  IL_0012:  call       ""delegate* unmanaged[Thiscall]<S*, int, int> UnmanagedFunctionPointer.GetFuncPtrMultipleParams(out UnmanagedFunctionPointer.MultipleParams)""
+  IL_0017:  stloc.2
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  conv.u
+  IL_001b:  ldc.i4.3
+  IL_001c:  ldloc.2
+  IL_001d:  calli      ""delegate* unmanaged[Thiscall]<S*, int, int>""
+  IL_0022:  call       ""void System.Console.Write(int)""
+  IL_0027:  ldloc.1
+  IL_0028:  call       ""void System.GC.KeepAlive(object)""
+  IL_002d:  ret
 }
 ");
         }
@@ -1582,20 +1593,20 @@ unsafe struct S
 unsafe class UnmanagedFunctionPointer
 {
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-    delegate IntWrapper SingleParam(S* s);
+    public delegate IntWrapper SingleParam(S* s);
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-    delegate ReturnWrapper MultipleParams(S* s, float f);
+    public delegate ReturnWrapper MultipleParams(S* s, float f);
     
-    public static delegate* unmanaged[Thiscall]<S*, IntWrapper> GetFuncPtrSingleParam()
+    public static delegate* unmanaged[Thiscall]<S*, IntWrapper> GetFuncPtrSingleParam(out SingleParam del)
     {
-        var ptr = Marshal.GetFunctionPointerForDelegate(new SingleParam(S.GetInt));
-        GC.KeepAlive(ptr);
+        del = S.GetInt;
+        var ptr = Marshal.GetFunctionPointerForDelegate(del);
         return (delegate* unmanaged[Thiscall]<S*, IntWrapper>)ptr;
     }
-    public static delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper> GetFuncPtrMultipleParams()
+    public static delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper> GetFuncPtrMultipleParams(out MultipleParams del)
     {
-        var ptr = Marshal.GetFunctionPointerForDelegate(new MultipleParams(S.GetReturn));
-        GC.KeepAlive(ptr);
+        del = S.GetReturn;
+        var ptr = Marshal.GetFunctionPointerForDelegate(del);
         return (delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper>)ptr;
     }
 }
@@ -1612,17 +1623,19 @@ unsafe class C
     {
         S s = new S();
         s.i = 1;
-        var intWrapper = UnmanagedFunctionPointer.GetFuncPtrSingleParam()(&s);
+        var intWrapper = UnmanagedFunctionPointer.GetFuncPtrSingleParam(out var del)(&s);
         Console.WriteLine(intWrapper.i);
+        GC.KeepAlive(del);
     }
 
     public static void TestMultiple()
     {
         S s = new S();
         s.i = 2;
-        var returnWrapper = UnmanagedFunctionPointer.GetFuncPtrMultipleParams()(&s, 3.5f);
+        var returnWrapper = UnmanagedFunctionPointer.GetFuncPtrMultipleParams(out var del)(&s, 3.5f);
         Console.Write(returnWrapper.i1);
         Console.Write(returnWrapper.f2);
+        GC.KeepAlive(del);
     }
 }", expectedOutput: @"
 1
@@ -1631,51 +1644,59 @@ unsafe class C
 
             verifier.VerifyIL("C.TestSingle()", @"
 {
-  // Code size       42 (0x2a)
+  // Code size       50 (0x32)
   .maxstack  2
   .locals init (S V_0, //s
-                delegate* unmanaged[Thiscall]<S*, IntWrapper> V_1)
+                UnmanagedFunctionPointer.SingleParam V_1, //del
+                delegate* unmanaged[Thiscall]<S*, IntWrapper> V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.1
   IL_000b:  stfld      ""int S.i""
-  IL_0010:  call       ""delegate* unmanaged[Thiscall]<S*, IntWrapper> UnmanagedFunctionPointer.GetFuncPtrSingleParam()""
-  IL_0015:  stloc.1
-  IL_0016:  ldloca.s   V_0
-  IL_0018:  conv.u
-  IL_0019:  ldloc.1
-  IL_001a:  calli      ""delegate* unmanaged[Thiscall]<S*, IntWrapper>""
-  IL_001f:  ldfld      ""int IntWrapper.i""
-  IL_0024:  call       ""void System.Console.WriteLine(int)""
-  IL_0029:  ret
+  IL_0010:  ldloca.s   V_1
+  IL_0012:  call       ""delegate* unmanaged[Thiscall]<S*, IntWrapper> UnmanagedFunctionPointer.GetFuncPtrSingleParam(out UnmanagedFunctionPointer.SingleParam)""
+  IL_0017:  stloc.2
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  conv.u
+  IL_001b:  ldloc.2
+  IL_001c:  calli      ""delegate* unmanaged[Thiscall]<S*, IntWrapper>""
+  IL_0021:  ldfld      ""int IntWrapper.i""
+  IL_0026:  call       ""void System.Console.WriteLine(int)""
+  IL_002b:  ldloc.1
+  IL_002c:  call       ""void System.GC.KeepAlive(object)""
+  IL_0031:  ret
 }
 ");
 
             verifier.VerifyIL("C.TestMultiple()", @"
 {
-  // Code size       58 (0x3a)
+  // Code size       66 (0x42)
   .maxstack  3
   .locals init (S V_0, //s
-                delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper> V_1)
+                UnmanagedFunctionPointer.MultipleParams V_1, //del
+                delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper> V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.2
   IL_000b:  stfld      ""int S.i""
-  IL_0010:  call       ""delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper> UnmanagedFunctionPointer.GetFuncPtrMultipleParams()""
-  IL_0015:  stloc.1
-  IL_0016:  ldloca.s   V_0
-  IL_0018:  conv.u
-  IL_0019:  ldc.r4     3.5
-  IL_001e:  ldloc.1
-  IL_001f:  calli      ""delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper>""
-  IL_0024:  dup
-  IL_0025:  ldfld      ""int ReturnWrapper.i1""
-  IL_002a:  call       ""void System.Console.Write(int)""
-  IL_002f:  ldfld      ""float ReturnWrapper.f2""
-  IL_0034:  call       ""void System.Console.Write(float)""
-  IL_0039:  ret
+  IL_0010:  ldloca.s   V_1
+  IL_0012:  call       ""delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper> UnmanagedFunctionPointer.GetFuncPtrMultipleParams(out UnmanagedFunctionPointer.MultipleParams)""
+  IL_0017:  stloc.2
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  conv.u
+  IL_001b:  ldc.r4     3.5
+  IL_0020:  ldloc.2
+  IL_0021:  calli      ""delegate* unmanaged[Thiscall]<S*, float, ReturnWrapper>""
+  IL_0026:  dup
+  IL_0027:  ldfld      ""int ReturnWrapper.i1""
+  IL_002c:  call       ""void System.Console.Write(int)""
+  IL_0031:  ldfld      ""float ReturnWrapper.f2""
+  IL_0036:  call       ""void System.Console.Write(float)""
+  IL_003b:  ldloc.1
+  IL_003c:  call       ""void System.GC.KeepAlive(object)""
+  IL_0041:  ret
 }");
         }
 


### PR DESCRIPTION
The test needs the `CombineStrings` instane to be alive through the
duration of the function pointer call. The `GC.KeepAlive` call though
was on the returned `IntPtr`. That is essentially a no-op cause it just
boxes to `object`. It doesn't actaully track the underlying `delegate`
instance.

Changed the code to track the `delegate` and push the `KeepAlive` after
the function pointer invocation.

closes #48641