### PR TITLE
Update F1 keywords to detect `using static` combination

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -327,7 +327,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
                 case SyntaxKind.UsingKeyword when token.GetNextToken().IsKind(SyntaxKind.StaticKeyword):
                 case SyntaxKind.StaticKeyword when token.GetPreviousToken().IsKind(SyntaxKind.UsingKeyword):
-                    text = "usingstatic_CSharpKeyword";
+                    text = "using-static_CSharpKeyword";
                     return true;
             }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -324,6 +324,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 case SyntaxKind.InternalKeyword when ModifiersContains(token, syntaxFacts, SyntaxKind.ProtectedKeyword):
                     text = "protectedinternal_CSharpKeyword";
                     return true;
+
+                case SyntaxKind.UsingKeyword when token.GetNextToken().IsKind(SyntaxKind.StaticKeyword):
+                case SyntaxKind.StaticKeyword when token.GetPreviousToken().IsKind(SyntaxKind.UsingKeyword):
+                    text = "usingstatic_CSharpKeyword";
+                    return true;
             }
 
             text = null;

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1075,6 +1075,95 @@ class C
     delegate T MyDelegate<T>() where T : str[||]uct;
 }", "structconstraint");
         }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestUsingStaticOnUsingKeyword()
+        {
+            await Test_KeywordAsync(
+@"us[||]ing static namespace.Class;
+
+static class C
+{ 
+    static int Field;
+
+    static void Method() {}
+}", "using-static");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestNormalUsing()
+        {
+            await Test_KeywordAsync(
+@"us[||]ing namespace.Class;
+
+static class C
+{ 
+    static int Field;
+
+    static void Method() {}
+}", "using");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestUsingStaticOnStaticKeyword()
+        {
+            await Test_KeywordAsync(
+@"using sta[||]tic namespace.Class;
+
+static class C
+{ 
+    static int Field;
+
+    static void Method() {}
+}", "using-static");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStaticClass()
+        {
+            await Test_KeywordAsync(
+@"using static namespace.Class;
+
+sta[||]tic class C
+{ 
+    static int Field;
+
+    static void Method() {}
+}", "static");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStaticField()
+        {
+            await Test_KeywordAsync(
+@"using static namespace.Class;
+
+static class C
+{ 
+    sta[||]tic int Field;
+
+    static void Method() {}
+}", "static");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestStaticMethod()
+        {
+            await Test_KeywordAsync(
+@"using static namespace.Class;
+
+static class C
+{ 
+    static int Field;
+
+    sta[||]tic void Method() {}
+}", "static");
+        }
     }
 }
-


### PR DESCRIPTION
This PR makes the f1 keywords for the `using` and `static` keyword detect when they are used together.  If they are part of a `using static` directive, they will route to the `using static` page, rather than their normal keyword page.

Fixes part of dotnet/docs#20799

Related docs PR:
dotnet/docs#21125