### PR TITLE
Move VisualStudioTaskSchedulerProvider to the EditorFeatures layer

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/IThreadingContext.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/IThreadingContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/EditorFeatures/Core/Shared/Utilities/ThreadingContext.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ThreadingContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;

--- a/src/EditorFeatures/Core/Shared/Utilities/ThreadingContextTaskSchedulerProvider.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ThreadingContextTaskSchedulerProvider.cs
@@ -14,13 +14,13 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
     [ExportWorkspaceService(typeof(ITaskSchedulerProvider), ServiceLayer.Editor), Shared]
-    internal sealed class VisualStudioTaskSchedulerProvider : ITaskSchedulerProvider
+    internal sealed class ThreadingContextTaskSchedulerProvider : ITaskSchedulerProvider
     {
         public TaskScheduler CurrentContextScheduler { get; }
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioTaskSchedulerProvider(IThreadingContext threadingContext)
+        public ThreadingContextTaskSchedulerProvider(IThreadingContext threadingContext)
         {
             CurrentContextScheduler = threadingContext.HasMainThread
                 ? new JoinableTaskFactoryTaskScheduler(threadingContext.JoinableTaskFactory)

--- a/src/EditorFeatures/Core/Shared/Utilities/VisualStudioTaskSchedulerProvider.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VisualStudioTaskSchedulerProvider.cs
@@ -2,20 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Threading;
+using Roslyn.Utilities;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
-    [ExportWorkspaceService(typeof(ITaskSchedulerProvider), ServiceLayer.Host), Shared]
+    [ExportWorkspaceService(typeof(ITaskSchedulerProvider), ServiceLayer.Editor), Shared]
     internal sealed class VisualStudioTaskSchedulerProvider : ITaskSchedulerProvider
     {
         public TaskScheduler CurrentContextScheduler { get; }
@@ -34,7 +32,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             public override int MaximumConcurrencyLevel => 1;
 
-            protected override IEnumerable<Task> GetScheduledTasks() => null;
+            protected override IEnumerable<Task> GetScheduledTasks()
+                => SpecializedCollections.EmptyEnumerable<Task>();
 
             protected override void QueueTask(Task task)
             {

--- a/src/EditorFeatures/Core/Shared/Utilities/VisualStudioTaskSchedulerProvider.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VisualStudioTaskSchedulerProvider.cs
@@ -21,7 +21,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioTaskSchedulerProvider(IThreadingContext threadingContext)
-            => CurrentContextScheduler = new JoinableTaskFactoryTaskScheduler(threadingContext.JoinableTaskFactory);
+        {
+            CurrentContextScheduler = threadingContext.HasMainThread
+                ? new JoinableTaskFactoryTaskScheduler(threadingContext.JoinableTaskFactory)
+                : TaskScheduler.Default;
+        }
 
         private sealed class JoinableTaskFactoryTaskScheduler : TaskScheduler
         {


### PR DESCRIPTION
Prior to this change, tests in the EditorFeatures layer were using JTF through `IThreadingContext`, but didn't pull in a JTF-aware task scheduler provider because it was up in the Visual Studio layer. Moving the JTF-aware scheduler down to the EditorFeatures layer causes UseExportProviderAttribute.After to dispatch through JTF instead of trying to dispatch through XUnit's test synchronization context, which doesn't end up running on the WPF dispatcher.

Fixes #48644