### PR TITLE
Avoid realizing the entire solution snapshot in the Sql layer.

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_BulkPopulateIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_BulkPopulateIds.cs
@@ -37,12 +37,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                 BulkPopulateProjectIds(connection, bulkLoadSnapshot.State, projectState, fetchStringTable);
         }
 
-        private void BulkPopulateProjectIds(SqlConnection connection, SolutionState? bulkLoadSolution, ProjectState? bulkLoadProject, bool fetchStringTable)
+        private void BulkPopulateProjectIds(SqlConnection connection, SolutionState bulkLoadSolution, ProjectState bulkLoadProject, bool fetchStringTable)
         {
-            // Can only bulk populate if we were given a snapshot we can walk to grab data from.
-            if (bulkLoadProject == null)
-                return;
-
             // Ensure that only one caller is trying to bulk populate a project at a time.
             var gate = _projectBulkPopulatedLock.GetOrAdd(bulkLoadProject.Id, _ => new object());
             lock (gate)
@@ -71,7 +67,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                     }
                 }
 
-                if (!BulkPopulateProjectIdsWorker(connection, bulkLoadSolution!, bulkLoadProject))
+                if (!BulkPopulateProjectIdsWorker(connection, bulkLoadSolution, bulkLoadProject))
                 {
                     // Something went wrong.  Try to bulk populate this project later.
                     return;

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentIds.cs
@@ -29,7 +29,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // This will only be expensive the first time we do this.  But will save
             // us from tons of back-and-forth as any BG analyzer processes all the
             // documents in a solution.
-            BulkPopulateProjectIds(connection, bulkLoadSnapshot?.Project.Solution.State, bulkLoadSnapshot?.Project.State, fetchStringTable: true);
+            if (bulkLoadSnapshot != null)
+                BulkPopulateProjectIds(connection, bulkLoadSnapshot.Project.Solution.State, bulkLoadSnapshot.Project.State, fetchStringTable: true);
 
             var documentId = TryGetDocumentId(connection, documentKey);
             var nameId = TryGetStringId(connection, name);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentIds.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // This will only be expensive the first time we do this.  But will save
             // us from tons of back-and-forth as any BG analyzer processes all the
             // documents in a solution.
-            BulkPopulateProjectIds(connection, bulkLoadSnapshot?.Project, fetchStringTable: true);
+            BulkPopulateProjectIds(connection, bulkLoadSnapshot?.Project.Solution.State, bulkLoadSnapshot?.Project.State, fetchStringTable: true);
 
             var documentId = TryGetDocumentId(connection, documentKey);
             var nameId = TryGetStringId(connection, name);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectIds.cs
@@ -29,7 +29,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // This will only be expensive the first time we do this.  But will save
             // us from tons of back-and-forth as any BG analyzer processes all the
             // documents in a solution.
-            BulkPopulateProjectIds(connection, bulkLoadSnapshot?.Solution.State, bulkLoadSnapshot?.State, fetchStringTable: true);
+            if (bulkLoadSnapshot != null)
+                BulkPopulateProjectIds(connection, bulkLoadSnapshot.Solution.State, bulkLoadSnapshot.State, fetchStringTable: true);
 
             var projectId = TryGetProjectId(connection, project);
             var nameId = TryGetStringId(connection, name);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectIds.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // This will only be expensive the first time we do this.  But will save
             // us from tons of back-and-forth as any BG analyzer processes all the
             // documents in a solution.
-            BulkPopulateProjectIds(connection, bulkLoadSnapshot, fetchStringTable: true);
+            BulkPopulateProjectIds(connection, bulkLoadSnapshot?.Solution.State, bulkLoadSnapshot?.State, fetchStringTable: true);
 
             var projectId = TryGetProjectId(connection, project);
             var nameId = TryGetStringId(connection, name);

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/ProjectKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/ProjectKey.cs
@@ -32,7 +32,10 @@ namespace Microsoft.CodeAnalysis.PersistentStorage
         }
 
         public static explicit operator ProjectKey(Project project)
-            => new((SolutionKey)project.Solution, project.Id, project.FilePath, project.Name);
+            => ToProjectKey(project.Solution.State, project.State);
+
+        public static ProjectKey ToProjectKey(SolutionState solutionState, ProjectState projectState)
+            => new((SolutionKey)solutionState, projectState.Id, projectState.FilePath, projectState.Name);
 
         public SerializableProjectKey Dehydrate()
             => new(Solution.Dehydrate(), Id, FilePath, Name);

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/SolutionKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/SolutionKey.cs
@@ -29,7 +29,10 @@ namespace Microsoft.CodeAnalysis.PersistentStorage
         }
 
         public static explicit operator SolutionKey(Solution solution)
-            => new(solution.Id, solution.FilePath, solution.BranchId == solution.Workspace.PrimaryBranchId);
+            => (SolutionKey)solution.State;
+
+        public static explicit operator SolutionKey(SolutionState solutionState)
+            => new(solutionState.Id, solutionState.FilePath, solutionState.BranchId == solutionState.Workspace.PrimaryBranchId);
 
         public SerializableSolutionKey Dehydrate()
             => new(Id, FilePath, IsPrimaryBranch);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/48597.

All the data we need is in the realized green snapshot tree.  So we can just walk that instead of forcing the creation of the entire red tree.