### PR TITLE
Avoid using the main thread within CodeAction.GetOperationsAsync

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -702,12 +702,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public override bool CanApplyParseOptionChange(ParseOptions oldOptions, ParseOptions newOptions, Project project)
             => true;
 
-        internal override async Task<bool> CanAddProjectReferenceAsync(ProjectId referencingProject, ProjectId referencedProject, CancellationToken cancellationToken)
+        internal override bool CanAddProjectReference(ProjectId referencingProject, ProjectId referencedProject)
         {
-            // VisualStudioWorkspace switches to the main thread for this call, so do the same thing here to catch tests
+            // VisualStudioWorkspace asserts the main thread for this call, so do the same thing here to catch tests
             // that fail to account for this possibility.
             var threadingContext = ExportProvider.GetExportedValue<IThreadingContext>();
-            await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+            Contract.ThrowIfFalse(threadingContext.HasMainThread && threadingContext.JoinableTaskContext.IsOnMainThread);
             return true;
         }
 

--- a/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
@@ -23,17 +24,6 @@ namespace Microsoft.CodeAnalysis.AddImport
                 Contract.ThrowIfFalse(fixData.Kind == AddImportFixKind.ReferenceAssemblySymbol);
             }
 
-            private Task<string?> ResolvePathAsync(CancellationToken cancellationToken)
-            {
-                var assemblyResolverService = OriginalDocument.Project.Solution.Workspace.Services.GetRequiredService<IFrameworkAssemblyPathResolver>();
-
-                return assemblyResolverService.ResolveAssemblyPathAsync(
-                    OriginalDocument.Project.Id,
-                    FixData.AssemblyReferenceAssemblyName,
-                    FixData.AssemblyReferenceFullyQualifiedTypeName,
-                    cancellationToken);
-            }
-
             protected override Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
                 => ComputeOperationsAsync(isPreview: true, cancellationToken);
 
@@ -45,21 +35,95 @@ namespace Microsoft.CodeAnalysis.AddImport
                 var newDocument = await GetUpdatedDocumentAsync(cancellationToken).ConfigureAwait(false);
                 var newProject = newDocument.Project;
 
-                // Now add the actual assembly reference.
-                if (!isPreview)
+                if (isPreview)
                 {
-                    var resolvedPath = await ResolvePathAsync(cancellationToken).ConfigureAwait(false);
-                    if (!string.IsNullOrWhiteSpace(resolvedPath))
-                    {
-                        var service = OriginalDocument.Project.Solution.Workspace.Services.GetRequiredService<IMetadataService>();
-                        var reference = service.GetReference(resolvedPath, MetadataReferenceProperties.Assembly);
-                        newProject = newProject.WithMetadataReferences(
-                            newProject.MetadataReferences.Concat(reference));
-                    }
+                    // If this is a preview, just return an ApplyChangesOperation for the updated document
+                    var operation = new ApplyChangesOperation(newProject.Solution);
+                    return SpecializedCollections.SingletonEnumerable<CodeActionOperation>(operation);
+                }
+                else
+                {
+                    // Otherwise return an operation that can apply the text changes and add the reference
+                    var operation = new AddAssemblyReferenceCodeActionOperation(
+                        FixData.AssemblyReferenceAssemblyName,
+                        FixData.AssemblyReferenceFullyQualifiedTypeName,
+                        newProject);
+                    return SpecializedCollections.SingletonEnumerable<CodeActionOperation>(operation);
+                }
+            }
+
+            private sealed class AddAssemblyReferenceCodeActionOperation : CodeActionOperation
+            {
+                private readonly string _assemblyReferenceAssemblyName;
+                private readonly string _assemblyReferenceFullyQualifiedTypeName;
+                private readonly Project _newProject;
+
+                public AddAssemblyReferenceCodeActionOperation(
+                    string assemblyReferenceAssemblyName,
+                    string assemblyReferenceFullyQualifiedTypeName,
+                    Project newProject)
+                {
+                    _assemblyReferenceAssemblyName = assemblyReferenceAssemblyName;
+                    _assemblyReferenceFullyQualifiedTypeName = assemblyReferenceFullyQualifiedTypeName;
+                    _newProject = newProject;
                 }
 
-                var operation = new ApplyChangesOperation(newProject.Solution);
-                return SpecializedCollections.SingletonEnumerable<CodeActionOperation>(operation);
+                internal override bool ApplyDuringTests => true;
+
+                public override void Apply(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    var operation = GetApplyChangesOperation(workspace, cancellationToken);
+                    if (operation is null)
+                        return;
+
+                    operation.Apply(workspace, cancellationToken);
+                }
+
+                internal override bool TryApply(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+                {
+                    var operation = GetApplyChangesOperation(workspace, cancellationToken);
+                    if (operation is null)
+                        return false;
+
+                    return operation.TryApply(workspace, progressTracker, cancellationToken);
+                }
+
+                private ApplyChangesOperation? GetApplyChangesOperation(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    var resolvedPath = ResolvePath(workspace, cancellationToken);
+                    if (string.IsNullOrWhiteSpace(resolvedPath))
+                        return null;
+
+                    var service = workspace.Services.GetRequiredService<IMetadataService>();
+                    var reference = service.GetReference(resolvedPath, MetadataReferenceProperties.Assembly);
+                    var newProject = _newProject.WithMetadataReferences(
+                        _newProject.MetadataReferences.Concat(reference));
+
+                    return new ApplyChangesOperation(newProject.Solution);
+                }
+
+                private string? ResolvePath(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    var resolvePathTask = ResolvePathAsync(workspace, cancellationToken);
+                    if (!resolvePathTask.IsCompleted)
+                    {
+                        // This code action cannot handle asynchronous calls that yield when called from the main thread
+                        return null;
+                    }
+
+                    return resolvePathTask.GetAwaiter().GetResult();
+                }
+
+                private Task<string?> ResolvePathAsync(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    var assemblyResolverService = workspace.Services.GetRequiredService<IFrameworkAssemblyPathResolver>();
+
+                    return assemblyResolverService.ResolveAssemblyPathAsync(
+                        _newProject.Id,
+                        _assemblyReferenceAssemblyName,
+                        _assemblyReferenceFullyQualifiedTypeName,
+                        cancellationToken);
+                }
             }
         }
     }

--- a/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 public override void Apply(Workspace workspace, CancellationToken cancellationToken)
                 {
-                    var operation = GetApplyChangesOperation(workspace, cancellationToken);
+                    var operation = GetApplyChangesOperation(workspace);
                     if (operation is null)
                         return;
 
@@ -81,16 +81,16 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 internal override bool TryApply(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
                 {
-                    var operation = GetApplyChangesOperation(workspace, cancellationToken);
+                    var operation = GetApplyChangesOperation(workspace);
                     if (operation is null)
                         return false;
 
                     return operation.TryApply(workspace, progressTracker, cancellationToken);
                 }
 
-                private ApplyChangesOperation? GetApplyChangesOperation(Workspace workspace, CancellationToken cancellationToken)
+                private ApplyChangesOperation? GetApplyChangesOperation(Workspace workspace)
                 {
-                    var resolvedPath = ResolvePath(workspace, cancellationToken);
+                    var resolvedPath = ResolvePath(workspace);
                     if (string.IsNullOrWhiteSpace(resolvedPath))
                         return null;
 
@@ -102,27 +102,14 @@ namespace Microsoft.CodeAnalysis.AddImport
                     return new ApplyChangesOperation(newProject.Solution);
                 }
 
-                private string? ResolvePath(Workspace workspace, CancellationToken cancellationToken)
-                {
-                    var resolvePathTask = ResolvePathAsync(workspace, cancellationToken);
-                    if (!resolvePathTask.IsCompleted)
-                    {
-                        // This code action cannot handle asynchronous calls that yield when called from the main thread
-                        return null;
-                    }
-
-                    return resolvePathTask.GetAwaiter().GetResult();
-                }
-
-                private Task<string?> ResolvePathAsync(Workspace workspace, CancellationToken cancellationToken)
+                private string? ResolvePath(Workspace workspace)
                 {
                     var assemblyResolverService = workspace.Services.GetRequiredService<IFrameworkAssemblyPathResolver>();
 
-                    return assemblyResolverService.ResolveAssemblyPathAsync(
+                    return assemblyResolverService.ResolveAssemblyPath(
                         _newProject.Id,
                         _assemblyReferenceAssemblyName,
-                        _assemblyReferenceFullyQualifiedTypeName,
-                        cancellationToken);
+                        _assemblyReferenceFullyQualifiedTypeName);
                 }
             }
         }

--- a/src/Features/Core/Portable/AddImport/CodeActions/MetadataSymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/MetadataSymbolReferenceCodeAction.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
@@ -21,14 +21,14 @@ namespace Microsoft.CodeAnalysis.AddImport
                 Contract.ThrowIfFalse(fixData.Kind == AddImportFixKind.MetadataSymbol);
             }
 
-            protected override Task<Project> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken)
+            protected override Task<CodeActionOperation?> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken)
             {
-                var projectWithReference = project.Solution.GetProject(FixData.PortableExecutableReferenceProjectId);
+                var projectWithReference = project.Solution.GetRequiredProject(FixData.PortableExecutableReferenceProjectId);
                 var reference = projectWithReference.MetadataReferences
                                                     .OfType<PortableExecutableReference>()
                                                     .First(pe => pe.FilePath == FixData.PortableExecutableReferenceFilePathToAdd);
 
-                return Task.FromResult(project.AddMetadataReference(reference));
+                return Task.FromResult<CodeActionOperation?>(new ApplyChangesOperation(project.AddMetadataReference(reference).Solution));
             }
         }
     }

--- a/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 public override void Apply(Workspace workspace, CancellationToken cancellationToken)
                 {
-                    if (!CanApply(workspace, cancellationToken))
+                    if (!CanApply(workspace))
                         return;
 
                     _applyOperation.Apply(workspace, cancellationToken);
@@ -73,26 +73,15 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 internal override bool TryApply(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
                 {
-                    if (!CanApply(workspace, cancellationToken))
+                    if (!CanApply(workspace))
                         return false;
 
                     return _applyOperation.TryApply(workspace, progressTracker, cancellationToken);
                 }
 
-                private bool CanApply(Workspace workspace, CancellationToken cancellationToken)
+                private bool CanApply(Workspace workspace)
                 {
-                    var canAddReferenceTask = workspace.CanAddProjectReferenceAsync(_referencingProject, _referencedProject, cancellationToken);
-                    if (!canAddReferenceTask.IsCompleted)
-                    {
-                        // This code action cannot handle asynchronous calls that yield when called from the main thread
-                        return false;
-                    }
-
-                    var canAddReference = canAddReferenceTask.GetAwaiter().GetResult();
-                    if (!canAddReference)
-                        return false;
-
-                    return true;
+                    return workspace.CanAddProjectReference(_referencingProject, _referencedProject);
                 }
             }
         }

--- a/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
@@ -31,22 +31,69 @@ namespace Microsoft.CodeAnalysis.AddImport
             private bool ShouldAddProjectReference()
                 => FixData.ProjectReferenceToAdd != null && FixData.ProjectReferenceToAdd != OriginalDocument.Project.Id;
 
-            protected override async Task<Project> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken)
+            protected override Task<CodeActionOperation?> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken)
             {
                 if (!ShouldAddProjectReference())
                 {
-                    return project;
+                    return SpecializedTasks.Null<CodeActionOperation>();
                 }
 
-                if (!isPreview)
+                var projectWithAddedReference = project.AddProjectReference(new ProjectReference(FixData.ProjectReferenceToAdd));
+                var applyOperation = new ApplyChangesOperation(projectWithAddedReference.Solution);
+                if (isPreview)
                 {
-                    if (!await project.Solution.Workspace.CanAddProjectReferenceAsync(OriginalDocument.Project.Id, FixData.ProjectReferenceToAdd, cancellationToken).ConfigureAwait(false))
-                    {
-                        return project;
-                    }
+                    return Task.FromResult<CodeActionOperation?>(applyOperation);
                 }
 
-                return project.AddProjectReference(new ProjectReference(FixData.ProjectReferenceToAdd));
+                return Task.FromResult<CodeActionOperation?>(new AddProjectReferenceCodeActionOperation(OriginalDocument.Project.Id, FixData.ProjectReferenceToAdd, applyOperation));
+            }
+
+            private sealed class AddProjectReferenceCodeActionOperation : CodeActionOperation
+            {
+                private readonly ProjectId _referencingProject;
+                private readonly ProjectId _referencedProject;
+                private readonly ApplyChangesOperation _applyOperation;
+
+                public AddProjectReferenceCodeActionOperation(ProjectId referencingProject, ProjectId referencedProject, ApplyChangesOperation applyOperation)
+                {
+                    _referencingProject = referencingProject;
+                    _referencedProject = referencedProject;
+                    _applyOperation = applyOperation;
+                }
+
+                internal override bool ApplyDuringTests => true;
+
+                public override void Apply(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    if (!CanApply(workspace, cancellationToken))
+                        return;
+
+                    _applyOperation.Apply(workspace, cancellationToken);
+                }
+
+                internal override bool TryApply(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+                {
+                    if (!CanApply(workspace, cancellationToken))
+                        return false;
+
+                    return _applyOperation.TryApply(workspace, progressTracker, cancellationToken);
+                }
+
+                private bool CanApply(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    var canAddReferenceTask = workspace.CanAddProjectReferenceAsync(_referencingProject, _referencedProject, cancellationToken);
+                    if (!canAddReferenceTask.IsCompleted)
+                    {
+                        // This code action cannot handle asynchronous calls that yield when called from the main thread
+                        return false;
+                    }
+
+                    var canAddReference = canAddReferenceTask.GetAwaiter().GetResult();
+                    if (!canAddReference)
+                        return false;
+
+                    return true;
+                }
             }
         }
     }

--- a/src/Features/Core/Portable/AddImport/CodeActions/SymbolReference.SymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/SymbolReference.SymbolReferenceCodeAction.cs
@@ -54,8 +54,11 @@ namespace Microsoft.CodeAnalysis.AddImport
             {
                 var updatedDocument = await GetUpdatedDocumentAsync(cancellationToken).ConfigureAwait(false);
 
-                // Defer to subtype to add any p2p or metadata refs as appropriate.
-                return await UpdateProjectAsync(updatedDocument.Project, isPreview, cancellationToken).ConfigureAwait(false);
+                // Defer to subtype to add any p2p or metadata refs as appropriate. If no changes to project references
+                // are necessary, the call to 'UpdateProjectAsync' will return null, in which case we fall back to just
+                // returning the updated document with its text changes.
+                var updatedProject = await UpdateProjectAsync(updatedDocument.Project, isPreview, cancellationToken).ConfigureAwait(false);
+                return updatedProject ?? new ApplyChangesOperation(updatedDocument.Project.Solution);
             }
 
             protected abstract Task<CodeActionOperation?> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/AddImport/CodeActions/SymbolReference.SymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/SymbolReference.SymbolReferenceCodeAction.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
 {
@@ -31,32 +30,35 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             protected override async Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
             {
-                var changedSolution = await GetChangedSolutionAsync(isPreview: true, cancellationToken).ConfigureAwait(false);
-                if (changedSolution == null)
+                var operation = await GetChangeSolutionOperationAsync(isPreview: true, cancellationToken).ConfigureAwait(false);
+                if (operation is null)
                 {
                     return Array.Empty<CodeActionOperation>();
                 }
 
-                return new CodeActionOperation[] { new ApplyChangesOperation(changedSolution) };
+                return SpecializedCollections.SingletonEnumerable(operation);
             }
 
-            protected override Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+            protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
             {
-                return GetChangedSolutionAsync(isPreview: false, cancellationToken);
+                var operation = await GetChangeSolutionOperationAsync(isPreview: false, cancellationToken).ConfigureAwait(false);
+                if (operation is null)
+                {
+                    return Array.Empty<CodeActionOperation>();
+                }
+
+                return SpecializedCollections.SingletonEnumerable(operation);
             }
 
-            private async Task<Solution> GetChangedSolutionAsync(bool isPreview, CancellationToken cancellationToken)
+            private async Task<CodeActionOperation?> GetChangeSolutionOperationAsync(bool isPreview, CancellationToken cancellationToken)
             {
                 var updatedDocument = await GetUpdatedDocumentAsync(cancellationToken).ConfigureAwait(false);
 
                 // Defer to subtype to add any p2p or metadata refs as appropriate.
-                var updatedProject = await UpdateProjectAsync(updatedDocument.Project, isPreview, cancellationToken).ConfigureAwait(false);
-
-                var updatedSolution = updatedProject.Solution;
-                return updatedSolution;
+                return await UpdateProjectAsync(updatedDocument.Project, isPreview, cancellationToken).ConfigureAwait(false);
             }
 
-            protected abstract Task<Project> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken);
+            protected abstract Task<CodeActionOperation?> UpdateProjectAsync(Project project, bool isPreview, CancellationToken cancellationToken);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioFrameworkAssemblyPathResolverFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioFrameworkAssemblyPathResolverFactory.cs
@@ -7,8 +7,6 @@ using System.Composition;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Versioning;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
@@ -48,13 +46,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _serviceProvider = serviceProvider;
             }
 
-            public async Task<string?> ResolveAssemblyPathAsync(
+            public string? ResolveAssemblyPath(
                 ProjectId projectId,
                 string assemblyName,
-                string? fullyQualifiedTypeName,
-                CancellationToken cancellationToken)
+                string? fullyQualifiedTypeName)
             {
-                await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                AssertIsForeground();
 
                 var assembly = ResolveAssembly(projectId, assemblyName);
                 if (assembly != null)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1428,9 +1428,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public void EnsureEditableDocuments(params DocumentId[] documents)
             => this.EnsureEditableDocuments((IEnumerable<DocumentId>)documents);
 
-        internal override async Task<bool> CanAddProjectReferenceAsync(ProjectId referencingProject, ProjectId referencedProject, CancellationToken cancellationToken)
+        internal override bool CanAddProjectReference(ProjectId referencingProject, ProjectId referencedProject)
         {
-            await _foregroundObject.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            _foregroundObject.AssertIsForeground();
 
             if (!TryGetHierarchy(referencingProject, out var referencingHierarchy) ||
                 !TryGetHierarchy(referencedProject, out var referencedHierarchy))

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/FrameworkAssemblyPathResolverFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/FrameworkAssemblyPathResolverFactory.cs
@@ -4,10 +4,7 @@
 
 using System;
 using System.Composition;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Host
 {
@@ -34,10 +31,10 @@ namespace Microsoft.CodeAnalysis.Host
             //    return false;
             //}
 
-            public Task<string?> ResolveAssemblyPathAsync(ProjectId projectId, string assemblyName, string? fullyQualifiedTypeName, CancellationToken cancellationToken)
+            public string? ResolveAssemblyPath(ProjectId projectId, string assemblyName, string? fullyQualifiedTypeName)
             {
                 // Assembly path resolution not supported at the default workspace level.
-                return SpecializedTasks.Null<string>();
+                return null;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IFrameworkAssemblyPathResolver.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IFrameworkAssemblyPathResolver.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.CodeAnalysis.Host
 {
     /// <summary>
@@ -22,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Host
         /// exist in the assembly.</param>
         /// <param name="projectId">The project context to search within.</param>
         /// <param name="assemblyName">The name of the assembly to try to resolve.</param>
-        Task<string?> ResolveAssemblyPathAsync(ProjectId projectId, string assemblyName, string? fullyQualifiedName, CancellationToken cancellationToken);
+        string? ResolveAssemblyPath(ProjectId projectId, string assemblyName, string? fullyQualifiedName);
 
         // bool CanResolveType(ProjectId projectId, string assemblyName, string fullyQualifiedTypeName);
     }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1161,8 +1161,8 @@ namespace Microsoft.CodeAnalysis
         /// Returns <see langword="true"/> if a reference to referencedProject can be added to
         /// referencingProject.  <see langword="false"/> otherwise.
         /// </summary>
-        internal virtual Task<bool> CanAddProjectReferenceAsync(ProjectId referencingProject, ProjectId referencedProject, CancellationToken cancellationToken)
-            => SpecializedTasks.False;
+        internal virtual bool CanAddProjectReference(ProjectId referencingProject, ProjectId referencedProject)
+            => false;
 
         /// <summary>
         /// Apply changes made to a solution back to the workspace.


### PR DESCRIPTION
Preview operations are not allowed to use the main thread, but final code fix applications are allowed to as part of the `CodeActionOperation`.

Fixes #48679