### PR TITLE
IOperation Node Porting: Non-Leaf Non-Hierarchy Nodes Pt1

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseSystemHashCode/Analyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseSystemHashCode/Analyzer.cs
@@ -99,13 +99,13 @@ namespace Microsoft.CodeAnalysis.UseSystemHashCode
                 return null;
             }
 
-            if (!(statements[0] is IReturnOperation returnOperation))
+            if (!(statements[0] is IReturnOperation { ReturnedValue: { } returnedValue }))
             {
                 return null;
             }
 
             using var analyzer = new OperationDeconstructor(this, method, hashCodeVariable: null);
-            if (!analyzer.TryAddHashedSymbol(returnOperation.ReturnedValue, seenHash: false))
+            if (!analyzer.TryAddHashedSymbol(returnedValue, seenHash: false))
             {
                 return null;
             }
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.UseSystemHashCode
             // First statement has to be the declaration of the accumulator.
             // Last statement has to be the return of it.
             if (!(statements.First() is IVariableDeclarationGroupOperation varDeclStatement) ||
-                !(statements.Last() is IReturnOperation returnStatement))
+                !(statements.Last() is IReturnOperation { ReturnedValue: { } returnedValue }))
             {
                 return null;
             }
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.UseSystemHashCode
             }
 
             var hashCodeVariable = declarator.Symbol;
-            if (!(IsLocalReference(returnStatement.ReturnedValue, hashCodeVariable)))
+            if (!(IsLocalReference(returnedValue, hashCodeVariable)))
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -2039,16 +2039,18 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyBinaryPatternOperation(this, boundBinaryPattern, _semanticModel);
         }
 
+#nullable enable
         private ISwitchOperation CreateBoundSwitchStatementOperation(BoundSwitchStatement boundSwitchStatement)
         {
+            IOperation value = Create(boundSwitchStatement.Expression);
+            ImmutableArray<ISwitchCaseOperation> cases = CreateFromArray<BoundSwitchSection, ISwitchCaseOperation>(boundSwitchStatement.SwitchSections);
             ImmutableArray<ILocalSymbol> locals = boundSwitchStatement.InnerLocals.GetPublicSymbols();
             ILabelSymbol exitLabel = boundSwitchStatement.BreakLabel.GetPublicSymbol();
             SyntaxNode syntax = boundSwitchStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundSwitchStatement.WasCompilerGenerated;
-            return new CSharpLazySwitchOperation(this, boundSwitchStatement, locals, exitLabel, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new SwitchOperation(locals, value, cases, exitLabel, _semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private ISwitchCaseOperation CreateBoundSwitchSectionOperation(BoundSwitchSection boundSwitchSection)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1676,14 +1676,17 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyForEachLoopOperation(this, boundForEachStatement, locals, continueLabel, exitLabel, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private ITryOperation CreateBoundTryStatementOperation(BoundTryStatement boundTryStatement)
         {
+            var body = (IBlockOperation)Create(boundTryStatement.TryBlock);
+            ImmutableArray<ICatchClauseOperation> catches = CreateFromArray<BoundCatchBlock, ICatchClauseOperation>(boundTryStatement.CatchBlocks);
+            var @finally = (IBlockOperation?)Create(boundTryStatement.FinallyBlockOpt);
             SyntaxNode syntax = boundTryStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundTryStatement.WasCompilerGenerated;
-            return new CSharpLazyTryOperation(this, boundTryStatement, exitLabel: null, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new TryOperation(body, catches, @finally, exitLabel: null, _semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private ICatchClauseOperation CreateBoundCatchBlockOperation(BoundCatchBlock boundCatchBlock)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1742,24 +1742,24 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = boundYieldReturnStatement.WasCompilerGenerated;
             return new ReturnOperation(returnedValue, OperationKind.YieldReturn, _semanticModel, syntax, isImplicit);
         }
-#nullable disable
 
         private ILockOperation CreateBoundLockStatementOperation(BoundLockStatement boundLockStatement)
         {
             // If there is no Enter2 method, then there will be no lock taken reference
             bool legacyMode = _semanticModel.Compilation.CommonGetWellKnownTypeMember(WellKnownMember.System_Threading_Monitor__Enter2) == null;
-            ILocalSymbol lockTakenSymbol =
+            ILocalSymbol? lockTakenSymbol =
                 legacyMode ? null : new SynthesizedLocal((_semanticModel.GetEnclosingSymbol(boundLockStatement.Syntax.SpanStart) as IMethodSymbol).GetSymbol(),
                                                          TypeWithAnnotations.Create(((CSharpCompilation)_semanticModel.Compilation).GetSpecialType(SpecialType.System_Boolean)),
                                                          SynthesizedLocalKind.LockTaken,
                                                          syntaxOpt: boundLockStatement.Argument.Syntax).GetPublicSymbol();
+            IOperation lockedValue = Create(boundLockStatement.Argument);
+            IOperation body = Create(boundLockStatement.Body);
             SyntaxNode syntax = boundLockStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundLockStatement.WasCompilerGenerated;
 
-            return new CSharpLazyLockOperation(this, boundLockStatement, lockTakenSymbol, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new LockOperation(lockedValue, body, lockTakenSymbol, _semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private IInvalidOperation CreateBoundBadStatementOperation(BoundBadStatement boundBadStatement)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1485,17 +1485,16 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyParameterInitializerOperation(this, value, boundParameterEqualsValue.Locals.GetPublicSymbols(), parameter, kind, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
+#nullable enable
         private IBlockOperation CreateBoundBlockOperation(BoundBlock boundBlock)
         {
+            ImmutableArray<IOperation> operations = CreateFromArray<BoundStatement, IOperation>(boundBlock.Statements);
             ImmutableArray<ILocalSymbol> locals = boundBlock.Locals.GetPublicSymbols();
             SyntaxNode syntax = boundBlock.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundBlock.WasCompilerGenerated;
-            return new CSharpLazyBlockOperation(this, boundBlock, locals, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new BlockOperation(operations, locals, _semanticModel, syntax, isImplicit);
         }
 
-#nullable enable
         private IBranchOperation CreateBoundContinueStatementOperation(BoundContinueStatement boundContinueStatement)
         {
             ILabelSymbol target = boundContinueStatement.Label.GetPublicSymbol();

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -33,7 +34,9 @@ namespace Microsoft.CodeAnalysis.Operations
             _cachedCreateInternal = CreateInternal;
         }
 
-        public IOperation Create(BoundNode boundNode)
+#nullable enable
+        [return: NotNullIfNotNull("boundNode")]
+        public IOperation? Create(BoundNode? boundNode)
         {
             if (boundNode == null)
             {
@@ -64,6 +67,7 @@ namespace Microsoft.CodeAnalysis.Operations
             }
             return builder.ToImmutableAndFree();
         }
+#nullable disable
 
         internal IOperation CreateInternal(BoundNode boundNode)
         {
@@ -1512,19 +1516,15 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = boundBreakStatement.WasCompilerGenerated;
             return new BranchOperation(target, branchKind, _semanticModel, syntax, isImplicit);
         }
-#nullable disable
 
         private IReturnOperation CreateBoundYieldBreakStatementOperation(BoundYieldBreakStatement boundYieldBreakStatement)
         {
-            BoundNode returnedValue = null;
+            IOperation? returnedValue = null;
             SyntaxNode syntax = boundYieldBreakStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundYieldBreakStatement.WasCompilerGenerated;
-            return new CSharpLazyReturnOperation(this, returnedValue, OperationKind.YieldBreak, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new ReturnOperation(returnedValue, OperationKind.YieldBreak, _semanticModel, syntax, isImplicit);
         }
 
-#nullable enable
         private IBranchOperation CreateBoundGotoStatementOperation(BoundGotoStatement boundGotoStatement)
         {
             ILabelSymbol target = boundGotoStatement.Label.GetPublicSymbol();
@@ -1726,25 +1726,23 @@ namespace Microsoft.CodeAnalysis.Operations
             return new CSharpLazyThrowOperation(this, thrownObject, _semanticModel, syntax, statementType, constantValue, isImplicit);
         }
 
+#nullable enable
         private IReturnOperation CreateBoundReturnStatementOperation(BoundReturnStatement boundReturnStatement)
         {
-            BoundNode returnedValue = boundReturnStatement.ExpressionOpt;
+            IOperation? returnedValue = Create(boundReturnStatement.ExpressionOpt);
             SyntaxNode syntax = boundReturnStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundReturnStatement.WasCompilerGenerated;
-            return new CSharpLazyReturnOperation(this, returnedValue, OperationKind.Return, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new ReturnOperation(returnedValue, OperationKind.Return, _semanticModel, syntax, isImplicit);
         }
 
         private IReturnOperation CreateBoundYieldReturnStatementOperation(BoundYieldReturnStatement boundYieldReturnStatement)
         {
-            BoundNode returnedValue = boundYieldReturnStatement.Expression;
+            IOperation returnedValue = Create(boundYieldReturnStatement.Expression);
             SyntaxNode syntax = boundYieldReturnStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundYieldReturnStatement.WasCompilerGenerated;
-            return new CSharpLazyReturnOperation(this, returnedValue, OperationKind.YieldReturn, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new ReturnOperation(returnedValue, OperationKind.YieldReturn, _semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private ILockOperation CreateBoundLockStatementOperation(BoundLockStatement boundLockStatement)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1860,27 +1860,24 @@ namespace Microsoft.CodeAnalysis.Operations
             return variableDeclaration;
         }
 
+#nullable enable
         private ILabeledOperation CreateBoundLabelStatementOperation(BoundLabelStatement boundLabelStatement)
         {
             ILabelSymbol label = boundLabelStatement.Label.GetPublicSymbol();
-            BoundNode statement = null;
             SyntaxNode syntax = boundLabelStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundLabelStatement.WasCompilerGenerated;
-            return new CSharpLazyLabeledOperation(this, statement, label, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new LabeledOperation(label, operation: null, _semanticModel, syntax, isImplicit);
         }
 
         private ILabeledOperation CreateBoundLabeledStatementOperation(BoundLabeledStatement boundLabeledStatement)
         {
             ILabelSymbol label = boundLabeledStatement.Label.GetPublicSymbol();
-            BoundNode labeledStatement = boundLabeledStatement.Body;
+            IOperation labeledStatement = Create(boundLabeledStatement.Body);
             SyntaxNode syntax = boundLabeledStatement.Syntax;
-            ITypeSymbol type = null;
-            ConstantValue constantValue = null;
             bool isImplicit = boundLabeledStatement.WasCompilerGenerated;
-            return new CSharpLazyLabeledOperation(this, labeledStatement, label, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new LabeledOperation(label, labeledStatement, _semanticModel, syntax, isImplicit);
         }
+#nullable disable
 
         private IExpressionStatementOperation CreateBoundExpressionStatementOperation(BoundExpressionStatement boundExpressionStatement)
         {

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -1218,29 +1218,6 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CSharpLazySwitchOperation : LazySwitchOperation
-    {
-        private readonly CSharpOperationFactory _operationFactory;
-        private readonly IBoundSwitchStatement _switchStatement;
-
-        internal CSharpLazySwitchOperation(CSharpOperationFactory operationFactory, IBoundSwitchStatement switchStatement, ImmutableArray<ILocalSymbol> locals, ILabelSymbol exitLabel, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit) :
-            base(locals, exitLabel, semanticModel, syntax, type, constantValue, isImplicit)
-        {
-            _operationFactory = operationFactory;
-            _switchStatement = switchStatement;
-        }
-
-        protected override IOperation CreateValue()
-        {
-            return _operationFactory.Create(_switchStatement.Value);
-        }
-
-        protected override ImmutableArray<ISwitchCaseOperation> CreateCases()
-        {
-            return _operationFactory.CreateFromArray<BoundStatementList, ISwitchCaseOperation>(_switchStatement.Cases);
-        }
-    }
-
     internal sealed class CSharpLazyTryOperation : LazyTryOperation
     {
         private readonly CSharpOperationFactory _operationFactory;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -1136,24 +1136,6 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CSharpLazyReturnOperation : LazyReturnOperation
-    {
-        private readonly CSharpOperationFactory _operationFactory;
-        private readonly BoundNode _returnedValue;
-
-        internal CSharpLazyReturnOperation(CSharpOperationFactory operationFactory, BoundNode returnedValue, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit) :
-            base(kind, semanticModel, syntax, type, constantValue, isImplicit)
-        {
-            _operationFactory = operationFactory;
-            _returnedValue = returnedValue;
-        }
-
-        protected override IOperation CreateReturnedValue()
-        {
-            return _operationFactory.Create(_returnedValue);
-        }
-    }
-
     internal sealed class CSharpLazySingleValueCaseClauseOperation : LazySingleValueCaseClauseOperation
     {
         private readonly CSharpOperationFactory _operationFactory;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -897,29 +897,6 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CSharpLazyLockOperation : LazyLockOperation
-    {
-        private readonly CSharpOperationFactory _operationFactory;
-        private readonly BoundLockStatement _lockStatement;
-
-        internal CSharpLazyLockOperation(CSharpOperationFactory operationFactory, BoundLockStatement lockStatement, ILocalSymbol lockTakenSymbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit) :
-            base(lockTakenSymbol, semanticModel, syntax, type, constantValue, isImplicit)
-        {
-            _operationFactory = operationFactory;
-            _lockStatement = lockStatement;
-        }
-
-        protected override IOperation CreateLockedValue()
-        {
-            return _operationFactory.Create(_lockStatement.Argument);
-        }
-
-        protected override IOperation CreateBody()
-        {
-            return _operationFactory.Create(_lockStatement.Body);
-        }
-    }
-
     internal sealed class CSharpLazyMethodReferenceOperation : LazyMethodReferenceOperation
     {
         private readonly CSharpOperationFactory _operationFactory;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -843,24 +843,6 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CSharpLazyLabeledOperation : LazyLabeledOperation
-    {
-        private readonly CSharpOperationFactory _operationFactory;
-        private readonly BoundNode _operation;
-
-        internal CSharpLazyLabeledOperation(CSharpOperationFactory operationFactory, BoundNode operation, ILabelSymbol label, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit) :
-            base(label, semanticModel, syntax, type, constantValue, isImplicit)
-        {
-            _operationFactory = operationFactory;
-            _operation = operation;
-        }
-
-        protected override IOperation CreateOperation()
-        {
-            return _operationFactory.Create(_operation);
-        }
-    }
-
     internal sealed class CSharpLazyAnonymousFunctionOperation : LazyAnonymousFunctionOperation
     {
         private readonly CSharpOperationFactory _operationFactory;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -1159,34 +1159,6 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CSharpLazyTryOperation : LazyTryOperation
-    {
-        private readonly CSharpOperationFactory _operationFactory;
-        private readonly BoundTryStatement _tryStatement;
-
-        internal CSharpLazyTryOperation(CSharpOperationFactory operationFactory, BoundTryStatement tryStatement, ILabelSymbol exitLabel, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit) :
-            base(exitLabel, semanticModel, syntax, type, constantValue, isImplicit)
-        {
-            _operationFactory = operationFactory;
-            _tryStatement = tryStatement;
-        }
-
-        protected override IBlockOperation CreateBody()
-        {
-            return (IBlockOperation)_operationFactory.Create(_tryStatement.TryBlock);
-        }
-
-        protected override ImmutableArray<ICatchClauseOperation> CreateCatches()
-        {
-            return _operationFactory.CreateFromArray<BoundCatchBlock, ICatchClauseOperation>(_tryStatement.CatchBlocks);
-        }
-
-        protected override IBlockOperation CreateFinally()
-        {
-            return (IBlockOperation)_operationFactory.Create(_tryStatement.FinallyBlockOpt);
-        }
-    }
-
     internal sealed class CSharpLazyTupleOperation : LazyTupleOperation
     {
         private readonly CSharpOperationFactory _operationFactory;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -350,24 +350,6 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CSharpLazyBlockOperation : LazyBlockOperation
-    {
-        private readonly CSharpOperationFactory _operationFactory;
-        private readonly BoundBlock _block;
-
-        internal CSharpLazyBlockOperation(CSharpOperationFactory operationFactory, BoundBlock block, ImmutableArray<ILocalSymbol> locals, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ConstantValue constantValue, bool isImplicit) :
-            base(locals, semanticModel, syntax, type, constantValue, isImplicit)
-        {
-            _operationFactory = operationFactory;
-            _block = block;
-        }
-
-        protected override ImmutableArray<IOperation> CreateOperations()
-        {
-            return _operationFactory.CreateFromArray<BoundStatement, IOperation>(_block.Statements);
-        }
-    }
-
     internal sealed class CSharpLazyCatchClauseOperation : LazyCatchClauseOperation
     {
         private readonly CSharpOperationFactory _operationFactory;

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void TestGetFlowGraphInvalidArgumentWithNonNullParent()
         {
             IOperation parent = new BlockOperation(ImmutableArray<IOperation>.Empty, ImmutableArray<ILocalSymbol>.Empty,
-                    semanticModel: null, syntax: null, type: null, constantValue: null, isImplicit: false);
+                    semanticModel: null, syntax: null, isImplicit: false);
 
             TestGetFlowGraphInvalidArgumentCore(argumentExceptionMessage: CodeAnalysisResources.NotARootOperation, parent);
         }
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             {
                 IBlockOperation block = new BlockOperation(
                     ImmutableArray<IOperation>.Empty, ImmutableArray<ILocalSymbol>.Empty,
-                    semanticModel: null, syntax: null, type: null, constantValue: null, isImplicit: false);
+                    semanticModel: null, syntax: null, isImplicit: false);
                 block = Operation.SetParentOperation(block, parent);
                 _ = ControlFlowGraph.Create(block);
             }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3389,6 +3389,7 @@ oneMoreTime:
             return FinishVisitingStatement(operation);
         }
 
+#nullable enable
         public override IOperation VisitTry(ITryOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -3405,7 +3406,7 @@ oneMoreTime:
                 return FinishVisitingStatement(operation);
             }
 
-            RegionBuilder tryAndFinallyRegion = null;
+            RegionBuilder? tryAndFinallyRegion = null;
             bool haveFinally = operation.Finally != null;
             if (haveFinally)
             {
@@ -3431,7 +3432,7 @@ oneMoreTime:
 
                 foreach (ICatchClauseOperation catchClause in operation.Catches)
                 {
-                    RegionBuilder filterAndHandlerRegion = null;
+                    RegionBuilder? filterAndHandlerRegion = null;
 
                     IOperation exceptionDeclarationOrExpression = catchClause.ExceptionDeclarationOrExpression;
                     IOperation filter = catchClause.Filter;
@@ -3525,7 +3526,6 @@ oneMoreTime:
             return FinishVisitingStatement(operation);
         }
 
-#nullable enable
         private void AddExceptionStore(ITypeSymbol exceptionType, IOperation exceptionDeclarationOrExpression)
         {
             if (exceptionDeclarationOrExpression != null)
@@ -3617,7 +3617,7 @@ oneMoreTime:
             AppendNewBlock(labeled);
         }
 
-        private BasicBlockBuilder GetLabeledOrNewBlock(ILabelSymbol labelOpt)
+        private BasicBlockBuilder GetLabeledOrNewBlock(ILabelSymbol? labelOpt)
         {
             if (labelOpt == null)
             {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3953,11 +3953,11 @@ oneMoreTime:
             // Microsoft.VisualBasic.CompilerServices.ObjectFlowControl.CheckForSyncLockOnValueType to ensure no value type is
             // used.
             // For simplicity, we will not synthesize this call because its presence is unlikely to affect graph analysis.
-            var baseLockStatement = (BaseLockOperation)operation;
+            var lockStatement = (LockOperation)operation;
 
             var lockRegion = new RegionBuilder(ControlFlowRegionKind.LocalLifetime,
-                                               locals: baseLockStatement.LockTakenSymbol != null ?
-                                                   ImmutableArray.Create(baseLockStatement.LockTakenSymbol) :
+                                               locals: lockStatement.LockTakenSymbol != null ?
+                                                   ImmutableArray.Create(lockStatement.LockTakenSymbol) :
                                                    ImmutableArray<ILocalSymbol>.Empty);
             EnterRegion(lockRegion);
 
@@ -3979,7 +3979,7 @@ oneMoreTime:
 
             if (legacyMode)
             {
-                Debug.Assert(baseLockStatement.LockTakenSymbol == null);
+                Debug.Assert(lockStatement.LockTakenSymbol == null);
                 enterMethod = (IMethodSymbol?)_compilation.CommonGetWellKnownTypeMember(WellKnownMember.System_Threading_Monitor__Enter)?.GetISymbol();
 
                 // Monitor.Enter($lock);
@@ -4013,10 +4013,10 @@ oneMoreTime:
             if (!legacyMode)
             {
                 // Monitor.Enter($lock, ref $lockTaken);
-                Debug.Assert(baseLockStatement.LockTakenSymbol is not null);
+                Debug.Assert(lockStatement.LockTakenSymbol is not null);
                 Debug.Assert(enterMethod is not null);
-                lockTaken = new LocalReferenceOperation(baseLockStatement.LockTakenSymbol, isDeclaration: true, semanticModel: null, lockedValue.Syntax,
-                                                         baseLockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
+                lockTaken = new LocalReferenceOperation(lockStatement.LockTakenSymbol, isDeclaration: true, semanticModel: null, lockedValue.Syntax,
+                                                         lockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
                 AddStatement(new InvocationOperation(enterMethod, instance: null, isVirtual: false,
                                                       ImmutableArray.Create<IArgumentOperation>(
                                                                 new ArgumentOperation(lockedValue,
@@ -4055,9 +4055,9 @@ oneMoreTime:
             if (!legacyMode)
             {
                 // if ($lockTaken)
-                Debug.Assert(baseLockStatement.LockTakenSymbol is not null);
-                IOperation condition = new LocalReferenceOperation(baseLockStatement.LockTakenSymbol, isDeclaration: false, semanticModel: null, lockedValue.Syntax,
-                                                                    baseLockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
+                Debug.Assert(lockStatement.LockTakenSymbol is not null);
+                IOperation condition = new LocalReferenceOperation(lockStatement.LockTakenSymbol, isDeclaration: false, semanticModel: null, lockedValue.Syntax,
+                                                                    lockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
                 ConditionalBranch(condition, jumpIfTrue: false, endOfFinally);
                 _currentBasicBlock = null;
             }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3561,7 +3561,6 @@ oneMoreTime:
                         isImplicit: true));
                 }
             }
-#nullable disable
         }
 
         public override IOperation VisitCatchClause(ICatchClauseOperation operation, int? captureIdForResult)
@@ -3577,7 +3576,7 @@ oneMoreTime:
             switch (operation.Kind)
             {
                 case OperationKind.YieldReturn:
-                    AddStatement(new ReturnOperation(returnedValue, OperationKind.YieldReturn, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
+                    AddStatement(new ReturnOperation(returnedValue, OperationKind.YieldReturn, semanticModel: null, operation.Syntax, IsImplicit(operation)));
                     break;
 
                 case OperationKind.YieldBreak:
@@ -3597,7 +3596,6 @@ oneMoreTime:
             return FinishVisitingStatement(operation);
         }
 
-#nullable enable
         public override IOperation VisitLabeled(ILabeledOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1336,6 +1336,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             _currentBasicBlock = null;
         }
 
+#nullable enable
         public override IOperation VisitBlock(IBlockOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -1346,6 +1347,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             return FinishVisitingStatement(operation);
         }
+#nullable disable
 
         private void StartVisitingStatement(IOperation operation)
         {
@@ -6962,6 +6964,7 @@ oneMoreTime:
             return GetCaptureReference(captureOutput, operation);
         }
 
+#nullable enable
         private void VisitUsingVariableDeclarationOperation(IUsingDeclarationOperation operation, ImmutableArray<IOperation> statements)
         {
             IOperation saveCurrentStatement = _currentStatement;
@@ -6974,8 +6977,6 @@ oneMoreTime:
                 locals: ImmutableArray<ILocalSymbol>.Empty,
                 ((Operation)operation).OwningSemanticModel,
                 operation.Syntax,
-                operation.Type,
-                operation.GetConstantValue(),
                 isImplicit: true);
 
             HandleUsingOperationParts(
@@ -6987,6 +6988,7 @@ oneMoreTime:
             FinishVisitingStatement(operation);
             _currentStatement = saveCurrentStatement;
         }
+#nullable disable
 
         public IOperation Visit(IOperation operation)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1408,6 +1408,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     return false;
             }
 
+#nullable enable
             bool visitPossibleUsingDeclarationInLabel(ILabeledOperation labelOperation)
             {
                 var savedCurrentStatement = _currentStatement;
@@ -1421,6 +1422,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 _currentStatement = savedCurrentStatement;
                 return visitedAll;
             }
+#nullable disable
         }
 
         internal override IOperation VisitWithStatement(IWithStatementOperation operation, int? captureIdForResult)
@@ -3595,6 +3597,7 @@ oneMoreTime:
             return FinishVisitingStatement(operation);
         }
 
+#nullable enable
         public override IOperation VisitLabeled(ILabeledOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -3623,7 +3626,7 @@ oneMoreTime:
                 return new BasicBlockBuilder(BasicBlockKind.Block);
             }
 
-            BasicBlockBuilder labeledBlock;
+            BasicBlockBuilder? labeledBlock;
 
             if (_labeledBlocks == null)
             {
@@ -3638,6 +3641,7 @@ oneMoreTime:
             _labeledBlocks.Add(labelOpt, labeledBlock);
             return labeledBlock;
         }
+#nullable disable
 
         public override IOperation VisitBranch(IBranchOperation operation, int? captureIdForResult)
         {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -5061,6 +5061,7 @@ oneMoreTime:
             return result;
         }
 
+#nullable enable
         public override IOperation VisitSwitch(ISwitchOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -5072,7 +5073,7 @@ oneMoreTime:
             var switchRegion = new RegionBuilder(ControlFlowRegionKind.LocalLifetime, locals: locals);
             EnterRegion(switchRegion);
 
-            BasicBlockBuilder defaultBody = null; // Adjusted in handleSection
+            BasicBlockBuilder? defaultBody = null; // Adjusted in handleSection
             BasicBlockBuilder @break = GetLabeledOrNewBlock(operation.ExitLabel);
 
             foreach (ISwitchCaseOperation section in operation.Cases)
@@ -5257,6 +5258,7 @@ oneMoreTime:
                 }
             }
         }
+#nullable disable
 
         private IOperation MakeNullable(IOperation operand, ITypeSymbol type)
         {

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         [return: NotNullIfNotNull("operation")]
-        public static T? SetParentOperation<T>(T? operation, IOperation parent) where T : IOperation
+        public static T? SetParentOperation<T>(T? operation, IOperation? parent) where T : IOperation
         {
             // explicit cast is not allowed, so using "as" instead
             (operation as Operation)?.SetParentOperation(parent);

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Operations;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.PooledObjects;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -159,7 +160,8 @@ namespace Microsoft.CodeAnalysis
             //Debug.Assert(result == s_unset || result == parent);
         }
 
-        public static T SetParentOperation<T>(T operation, IOperation parent) where T : IOperation
+        [return: NotNullIfNotNull("operation")]
+        public static T? SetParentOperation<T>(T? operation, IOperation parent) where T : IOperation
         {
             // explicit cast is not allowed, so using "as" instead
             (operation as Operation)?.SetParentOperation(parent);

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
     {
         protected static readonly IOperation s_unset = new EmptyOperation(semanticModel: null, syntax: null!, isImplicit: true);
         protected static readonly IBlockOperation s_unsetBlock = new BlockOperation(
-            operations: ImmutableArray<IOperation>.Empty, locals: default, semanticModel: null, syntax: null, type: null, constantValue: null, isImplicit: true);
+            operations: ImmutableArray<IOperation>.Empty, locals: default, semanticModel: null, syntax: null!, isImplicit: true);
         protected static readonly IArrayInitializerOperation s_unsetArrayInitializer = new ArrayInitializerOperation(
             elementValues: ImmutableArray<IOperation>.Empty, semanticModel: null, syntax: null, type: null, constantValue: null, isImplicit: true);
         protected static readonly IEventReferenceOperation s_unsetEventReference = new EventReferenceOperation(

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -41,11 +41,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new ConversionOperation(Visit(operation.Operand), ((BaseConversionOperation)operation).ConversionConvertible, operation.IsTryCast, operation.IsChecked, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitSwitch(ISwitchOperation operation, object argument)
-        {
-            return new SwitchOperation(operation.Locals, Visit(operation.Value), VisitArray(operation.Cases), operation.ExitLabel, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitSwitchCase(ISwitchCaseOperation operation, object argument)
         {
             return new SwitchCaseOperation(operation.Locals, ((BaseSwitchCaseOperation)operation).Condition, VisitArray(operation.Clauses), VisitArray(operation.Body), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -21,11 +21,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new NoneOperation(VisitArray(operation.Children.ToImmutableArray()), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.GetConstantValue(), operation.IsImplicit, operation.Type);
         }
 
-        public override IOperation VisitBlock(IBlockOperation operation, object argument)
-        {
-            return new BlockOperation(VisitArray(operation.Operations), operation.Locals, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitVariableDeclarationGroup(IVariableDeclarationGroupOperation operation, object argument)
         {
             return new VariableDeclarationGroupOperation(VisitArray(operation.Declarations), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -92,11 +92,6 @@ namespace Microsoft.CodeAnalysis.Operations
                                             ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitReturn(IReturnOperation operation, object argument)
-        {
-            return new ReturnOperation(Visit(operation.ReturnedValue), operation.Kind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitLock(ILockOperation operation, object argument)
         {
             var baseLockStatement = (BaseLockOperation)operation;

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -92,11 +92,6 @@ namespace Microsoft.CodeAnalysis.Operations
                                             ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitLabeled(ILabeledOperation operation, object argument)
-        {
-            return new LabeledOperation(operation.Label, Visit(operation.Operation), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitReturn(IReturnOperation operation, object argument)
         {
             return new ReturnOperation(Visit(operation.ReturnedValue), operation.Kind, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -92,12 +92,6 @@ namespace Microsoft.CodeAnalysis.Operations
                                             ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitLock(ILockOperation operation, object argument)
-        {
-            var baseLockStatement = (BaseLockOperation)operation;
-            return new LockOperation(Visit(operation.LockedValue), Visit(operation.Body), baseLockStatement.LockTakenSymbol, baseLockStatement.OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitTry(ITryOperation operation, object argument)
         {
             return new TryOperation(Visit(operation.Body), VisitArray(operation.Catches), Visit(operation.Finally), operation.ExitLabel, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -92,11 +92,6 @@ namespace Microsoft.CodeAnalysis.Operations
                                             ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
-        public override IOperation VisitTry(ITryOperation operation, object argument)
-        {
-            return new TryOperation(Visit(operation.Body), VisitArray(operation.Catches), Visit(operation.Finally), operation.ExitLabel, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
-        }
-
         public override IOperation VisitCatchClause(ICatchClauseOperation operation, object argument)
         {
             return new CatchClauseOperation(Visit(operation.ExceptionDeclarationOrExpression), operation.ExceptionType, operation.Locals, Visit(operation.Filter), Visit(operation.Handler), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -388,7 +388,7 @@
         </para>
       </summary>
     </Comments>
-    <Property Name="ReturnedValue" Type="IOperation">
+    <Property Name="ReturnedValue" Type="IOperation?">
       <Comments>
         <summary>Value to be returned.</summary>
       </Comments>

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -438,12 +438,12 @@
         <summary>Catch clauses of the try.</summary>
       </Comments>
     </Property>
-    <Property Name="Finally" Type="IBlockOperation">
+    <Property Name="Finally" Type="IBlockOperation?">
       <Comments>
         <summary>Finally handler of the try.</summary>
       </Comments>
     </Property>
-    <Property Name="ExitLabel" Type="ILabelSymbol">
+    <Property Name="ExitLabel" Type="ILabelSymbol?">
       <Comments>
         <summary>Exit label for the try. This will always be null for C#.</summary>
       </Comments>

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -415,7 +415,7 @@
         <summary>Body of the lock, to be executed while holding the lock.</summary>
       </Comments>
     </Property>
-    <Property Name="LockTakenSymbol" Type="ILocalSymbol" Internal="true"/>
+    <Property Name="LockTakenSymbol" Type="ILocalSymbol?" Internal="true"/>
   </Node>
   <Node Name="ITryOperation" Base="IOperation" ChildrenOrder="Body,Catches,Finally">
     <Comments>

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -333,7 +333,7 @@
         <summary>Label that can be the target of branches.</summary>
       </Comments>
     </Property>
-    <Property Name="Operation" Type="IOperation">
+    <Property Name="Operation" Type="IOperation?">
       <Comments>
         <summary>Operation that has been labeled. In VB, this is always null.</summary>
       </Comments>

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1019,12 +1019,12 @@ Namespace Microsoft.CodeAnalysis.Operations
 
         Private Function CreateBoundSelectStatementOperation(boundSelectStatement As BoundSelectStatement) As ISwitchOperation
             RecordParent(boundSelectStatement.ExprPlaceholderOpt, boundSelectStatement)
+            Dim value As IOperation = Create(boundSelectStatement.ExpressionStatement.Expression)
+            Dim cases As ImmutableArray(Of ISwitchCaseOperation) = CreateFromArray(Of BoundCaseBlock, ISwitchCaseOperation)(boundSelectStatement.CaseBlocks)
             Dim exitLabel As ILabelSymbol = boundSelectStatement.ExitLabel
             Dim syntax As SyntaxNode = boundSelectStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundSelectStatement.WasCompilerGenerated
-            Return New VisualBasicLazySwitchOperation(Me, boundSelectStatement, ImmutableArray(Of ILocalSymbol).Empty, exitLabel, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New SwitchOperation(ImmutableArray(Of ILocalSymbol).Empty, value, cases, exitLabel, _semanticModel, syntax, isImplicit)
         End Function
 
         Friend Function CreateBoundCaseBlockClauses(boundCaseBlock As BoundCaseBlock) As ImmutableArray(Of ICaseClauseOperation)

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1264,12 +1264,10 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundReturnStatementOperation(boundReturnStatement As BoundReturnStatement) As IReturnOperation
-            Dim returnedValue As BoundNode = boundReturnStatement.ExpressionOpt
+            Dim returnedValue As IOperation = Create(boundReturnStatement.ExpressionOpt)
             Dim syntax As SyntaxNode = boundReturnStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundReturnStatement.WasCompilerGenerated OrElse IsEndSubOrFunctionStatement(syntax)
-            Return New VisualBasicLazyReturnOperation(Me, returnedValue, OperationKind.Return, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New ReturnOperation(returnedValue, OperationKind.Return, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Shared Function IsEndSubOrFunctionStatement(syntax As SyntaxNode) As Boolean
@@ -1317,12 +1315,10 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundYieldStatementOperation(boundYieldStatement As BoundYieldStatement) As IReturnOperation
-            Dim returnedValue As BoundNode = boundYieldStatement.Expression
+            Dim returnedValue As IOperation = Create(boundYieldStatement.Expression)
             Dim syntax As SyntaxNode = boundYieldStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundYieldStatement.WasCompilerGenerated
-            Return New VisualBasicLazyReturnOperation(Me, returnedValue, OperationKind.YieldReturn, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New ReturnOperation(returnedValue, OperationKind.YieldReturn, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundLabelStatementOperation(boundLabelStatement As BoundLabelStatement) As ILabeledOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1238,12 +1238,11 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundBlockOperation(boundBlock As BoundBlock) As IBlockOperation
+            Dim operations As ImmutableArray(Of IOperation) = CreateFromArray(Of BoundStatement, IOperation)(boundBlock.Statements)
             Dim locals As ImmutableArray(Of ILocalSymbol) = boundBlock.Locals.As(Of ILocalSymbol)()
             Dim syntax As SyntaxNode = boundBlock.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundBlock.WasCompilerGenerated
-            Return New VisualBasicLazyBlockOperation(Me, boundBlock, locals, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New BlockOperation(operations, locals, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundBadStatementOperation(boundBadStatement As BoundBadStatement) As IInvalidOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1361,11 +1361,11 @@ Namespace Microsoft.CodeAnalysis.Operations
                                                     DirectCast(_semanticModel.Compilation.GetSpecialType(SpecialType.System_Boolean), TypeSymbol),
                                                     SynthesizedLocalKind.LockTaken,
                                                     syntaxOpt:=boundSyncLockStatement.LockExpression.Syntax))
+            Dim lockedValue as IOperation = Create(boundSyncLockStatement.LockExpression)
+            Dim body as IOperation = Create(boundSyncLockStatement.Body)
             Dim syntax As SyntaxNode = boundSyncLockStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundSyncLockStatement.WasCompilerGenerated
-            Return New VisualBasicLazyLockOperation(Me, boundSyncLockStatement, lockTakenSymbol, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New LockOperation(lockedValue, body, lockTakenSymbol, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundNoOpStatementOperation(boundNoOpStatement As BoundNoOpStatement) As IEmptyOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1207,12 +1207,13 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundTryStatementOperation(boundTryStatement As BoundTryStatement) As ITryOperation
+            Dim body As IBlockOperation = DirectCast(Create(boundTryStatement.TryBlock), IBlockOperation)
+            Dim catches As ImmutableArray(Of ICatchClauseOperation) = CreateFromArray(Of BoundCatchBlock, ICatchClauseOperation)(boundTryStatement.CatchBlocks)
+            Dim [finally] As IBlockOperation = DirectCast(Create(boundTryStatement.FinallyBlockOpt), IBlockOperation)
             Dim exitLabel As ILabelSymbol = boundTryStatement.ExitLabelOpt
             Dim syntax As SyntaxNode = boundTryStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundTryStatement.WasCompilerGenerated
-            Return New VisualBasicLazyTryOperation(Me, boundTryStatement, exitLabel, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New TryOperation(body, catches, [finally], exitLabel, _semanticModel, syntax, isImplicit)
         End Function
 
         Friend Function CreateBoundCatchBlockExceptionDeclarationOrExpression(boundCatchBlock As BoundCatchBlock) As IOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1327,12 +1327,10 @@ Namespace Microsoft.CodeAnalysis.Operations
 
         Private Function CreateBoundLabelStatementOperation(boundLabelStatement As BoundLabelStatement) As ILabeledOperation
             Dim label As ILabelSymbol = boundLabelStatement.Label
-            Dim statement As BoundNode = Nothing
+            Dim statement As IOperation = Nothing
             Dim syntax As SyntaxNode = boundLabelStatement.Syntax
-            Dim type As ITypeSymbol = Nothing
-            Dim constantValue As ConstantValue = Nothing
             Dim isImplicit As Boolean = boundLabelStatement.WasCompilerGenerated OrElse IsEndSubOrFunctionStatement(syntax)
-            Return New VisualBasicLazyLabeledOperation(Me, statement, label, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New LabeledOperation(label, statement, _semanticModel, syntax, isImplicit)
         End Function
 
         Private Function CreateBoundGotoStatementOperation(boundGotoStatement As BoundGotoStatement) As IBranchOperation

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
@@ -900,31 +900,6 @@ _operationFactory.CreateFromArray(Of BoundExpression, IOperation)(_boundForToLoo
         End Function
     End Class
 
-    Friend NotInheritable Class VisualBasicLazyTryOperation
-        Inherits LazyTryOperation
-
-        Private ReadOnly _operationFactory As VisualBasicOperationFactory
-        Private ReadOnly _tryStatement As BoundTryStatement
-
-        Friend Sub New(operationFactory As VisualBasicOperationFactory, tryStatement As BoundTryStatement, exitLabel As ILabelSymbol, semanticModel As SemanticModel, syntax As SyntaxNode, type As ITypeSymbol, constantValue As ConstantValue, isImplicit As Boolean)
-            MyBase.New(exitLabel, semanticModel, syntax, type, constantValue, isImplicit)
-            _operationFactory = operationFactory
-            _tryStatement = tryStatement
-        End Sub
-
-        Protected Overrides Function CreateBody() As IBlockOperation
-            Return DirectCast(_operationFactory.Create(_tryStatement.TryBlock), IBlockOperation)
-        End Function
-
-        Protected Overrides Function CreateCatches() As ImmutableArray(Of ICatchClauseOperation)
-            Return _operationFactory.CreateFromArray(Of BoundCatchBlock, ICatchClauseOperation)(_tryStatement.CatchBlocks)
-        End Function
-
-        Protected Overrides Function CreateFinally() As IBlockOperation
-            Return DirectCast(_operationFactory.Create(_tryStatement.FinallyBlockOpt), IBlockOperation)
-        End Function
-    End Class
-
     Friend NotInheritable Class VisualBasicLazyTupleOperation
         Inherits LazyTupleOperation
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
@@ -670,27 +670,6 @@ _operationFactory.CreateFromArray(Of BoundExpression, IOperation)(_boundForToLoo
         End Function
     End Class
 
-    Friend NotInheritable Class VisualBasicLazyLockOperation
-        Inherits LazyLockOperation
-
-        Private ReadOnly _operationFactory As VisualBasicOperationFactory
-        Private ReadOnly _lockStatement As BoundSyncLockStatement
-
-        Friend Sub New(operationFactory As VisualBasicOperationFactory, lockStatement As BoundSyncLockStatement, lockTakenSymbol As ILocalSymbol, semanticModel As SemanticModel, syntax As SyntaxNode, type As ITypeSymbol, constantValue As ConstantValue, isImplicit As Boolean)
-            MyBase.New(lockTakenSymbol, semanticModel, syntax, type, constantValue, isImplicit)
-            _operationFactory = operationFactory
-            _lockStatement = lockStatement
-        End Sub
-
-        Protected Overrides Function CreateLockedValue() As IOperation
-            Return _operationFactory.Create(_lockStatement.LockExpression)
-        End Function
-
-        Protected Overrides Function CreateBody() As IOperation
-            Return _operationFactory.Create(_lockStatement.Body)
-        End Function
-    End Class
-
     Friend NotInheritable Class VisualBasicLazyMethodReferenceOperation
         Inherits LazyMethodReferenceOperation
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
@@ -955,27 +955,6 @@ _operationFactory.CreateFromArray(Of BoundExpression, IOperation)(_boundForToLoo
         End Function
     End Class
 
-    Friend NotInheritable Class VisualBasicLazySwitchOperation
-        Inherits LazySwitchOperation
-
-        Private ReadOnly _operationFactory As VisualBasicOperationFactory
-        Private ReadOnly _selectStatement As BoundSelectStatement
-
-        Friend Sub New(operationFactory As VisualBasicOperationFactory, selectStatement As BoundSelectStatement, locals As ImmutableArray(Of ILocalSymbol), exitLabel As ILabelSymbol, semanticModel As SemanticModel, syntax As SyntaxNode, type As ITypeSymbol, constantValue As ConstantValue, isImplicit As Boolean)
-            MyBase.New(locals, exitLabel, semanticModel, syntax, type, constantValue, isImplicit)
-            _operationFactory = operationFactory
-            _selectStatement = selectStatement
-        End Sub
-
-        Protected Overrides Function CreateValue() As IOperation
-            Return _operationFactory.Create(_selectStatement.ExpressionStatement.Expression)
-        End Function
-
-        Protected Overrides Function CreateCases() As ImmutableArray(Of ISwitchCaseOperation)
-            Return _operationFactory.CreateFromArray(Of BoundCaseBlock, ISwitchCaseOperation)(_selectStatement.CaseBlocks)
-        End Function
-    End Class
-
     Friend NotInheritable Class VisualBasicLazyTryOperation
         Inherits LazyTryOperation
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
@@ -879,23 +879,6 @@ _operationFactory.CreateFromArray(Of BoundExpression, IOperation)(_boundForToLoo
         End Function
     End Class
 
-    Friend NotInheritable Class VisualBasicLazyReturnOperation
-        Inherits LazyReturnOperation
-
-        Private ReadOnly _operationFactory As VisualBasicOperationFactory
-        Private ReadOnly _returnedValue As BoundNode
-
-        Friend Sub New(operationFactory As VisualBasicOperationFactory, returnedValue As BoundNode, kind As OperationKind, semanticModel As SemanticModel, syntax As SyntaxNode, type As ITypeSymbol, constantValue As ConstantValue, isImplicit As Boolean)
-            MyBase.New(kind, semanticModel, syntax, type, constantValue, isImplicit)
-            _operationFactory = operationFactory
-            _returnedValue = returnedValue
-        End Sub
-
-        Protected Overrides Function CreateReturnedValue() As IOperation
-            Return _operationFactory.Create(_returnedValue)
-        End Function
-    End Class
-
     Friend NotInheritable Class VisualBasicLazySingleValueCaseClauseOperation
         Inherits LazySingleValueCaseClauseOperation
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
@@ -619,23 +619,6 @@ _operationFactory.CreateFromArray(Of BoundExpression, IOperation)(_boundForToLoo
         End Function
     End Class
 
-    Friend NotInheritable Class VisualBasicLazyLabeledOperation
-        Inherits LazyLabeledOperation
-
-        Private ReadOnly _operationFactory As VisualBasicOperationFactory
-        Private ReadOnly _operation As BoundNode
-
-        Friend Sub New(operationFactory As VisualBasicOperationFactory, operation As BoundNode, label As ILabelSymbol, semanticModel As SemanticModel, syntax As SyntaxNode, type As ITypeSymbol, constantValue As ConstantValue, isImplicit As Boolean)
-            MyBase.New(label, semanticModel, syntax, type, constantValue, isImplicit)
-            _operationFactory = operationFactory
-            _operation = operation
-        End Sub
-
-        Protected Overrides Function CreateOperation() As IOperation
-            Return _operationFactory.Create(_operation)
-        End Function
-    End Class
-
     Friend NotInheritable Class VisualBasicLazyAnonymousFunctionOperation
         Inherits LazyAnonymousFunctionOperation
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationNodes.vb
@@ -193,23 +193,6 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
     End Class
 
-    Friend NotInheritable Class VisualBasicLazyBlockOperation
-        Inherits LazyBlockOperation
-
-        Private ReadOnly _operationFactory As VisualBasicOperationFactory
-        Private ReadOnly _block As BoundBlock
-
-        Friend Sub New(operationFactory As VisualBasicOperationFactory, block As BoundBlock, locals As ImmutableArray(Of ILocalSymbol), semanticModel As SemanticModel, syntax As SyntaxNode, type As ITypeSymbol, constantValue As ConstantValue, isImplicit As Boolean)
-            MyBase.New(locals, semanticModel, syntax, type, constantValue, isImplicit)
-            _operationFactory = operationFactory
-            _block = block
-        End Sub
-
-        Protected Overrides Function CreateOperations() As ImmutableArray(Of IOperation)
-            Return _operationFactory.CreateFromArray(Of BoundStatement, IOperation)(_block.Statements)
-        End Function
-    End Class
-
     Friend NotInheritable Class VisualBasicLazyCatchClauseOperation
         Inherits LazyCatchClauseOperation
 

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
         private static ExpressionSyntax AsExpressionSyntax(IOperation operation)
             => operation switch
             {
-                IReturnOperation op => (ExpressionSyntax)op.ReturnedValue.Syntax,
+                IReturnOperation { ReturnedValue: { } value } => (ExpressionSyntax)value.Syntax,
                 IThrowOperation op => ThrowExpression((ExpressionSyntax)op.Exception.Syntax),
                 IBlockOperation op => AsExpressionSyntax(op.Operations.Single()),
                 var v => throw ExceptionUtilities.UnexpectedValue(v.Kind)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -27,7 +27,8 @@ namespace IOperationGenerator
             "IDiscardOperation",
             "IPlaceholderOperation",
             "IBlockOperation",
-            "ISwitchOperation"
+            "ISwitchOperation",
+            "ILabeledOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -29,7 +29,8 @@ namespace IOperationGenerator
             "IBlockOperation",
             "ISwitchOperation",
             "ILabeledOperation",
-            "IReturnOperation"
+            "IReturnOperation",
+            "ILockOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -25,7 +25,8 @@ namespace IOperationGenerator
             "ISizeOfOperation",
             "IOmittedArgumentOperation",
             "IDiscardOperation",
-            "IPlaceholderOperation"
+            "IPlaceholderOperation",
+            "IBlockOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -30,7 +30,8 @@ namespace IOperationGenerator
             "ISwitchOperation",
             "ILabeledOperation",
             "IReturnOperation",
-            "ILockOperation"
+            "ILockOperation",
+            "ITryOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -26,7 +26,8 @@ namespace IOperationGenerator
             "IOmittedArgumentOperation",
             "IDiscardOperation",
             "IPlaceholderOperation",
-            "IBlockOperation"
+            "IBlockOperation",
+            "ISwitchOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.PortedTypes.cs
@@ -28,7 +28,8 @@ namespace IOperationGenerator
             "IPlaceholderOperation",
             "IBlockOperation",
             "ISwitchOperation",
-            "ILabeledOperation"
+            "ILabeledOperation",
+            "IReturnOperation"
         };
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -1010,7 +1010,7 @@ namespace IOperationGenerator
             WriteLine("/// <summary>Deep clone given IOperation</summary>");
             WriteLine("public static T CloneOperation<T>(T operation) where T : IOperation => s_instance.Visit(operation);");
             WriteLine("public OperationCloner() { }");
-            WriteLine("private T Visit<T>(T node) where T : IOperation => (T)Visit(node, argument: null);");
+            WriteLine("private T Visit<T>(T node) where T : IOperation? => (T)Visit(node, argument: null);");
             WriteLine("public override IOperation DefaultVisit(IOperation operation, object? argument) => throw ExceptionUtilities.Unreachable;");
             WriteLine("private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray((n, @this) => @this.Visit(n), this);");
             WriteLine("private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray((n, @this) => (n.Item1, @this.Visit(n.Item2)), this);");

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -1143,8 +1143,14 @@ namespace IOperationGenerator
 
         private string GetSubName(string operationName) => operationName[1..^9];
 
-        private bool IsIOperationType(string typeName) => _typeMap.ContainsKey(typeName) ||
-                                                          (IsImmutableArray(typeName, out var innerType) && IsIOperationType(innerType));
+        private bool IsIOperationType(string typeName)
+        {
+            Debug.Assert(typeName.Length > 0);
+            return _typeMap.ContainsKey(getTypeName(typeName)) ||
+              (IsImmutableArray(typeName, out var innerType) && IsIOperationType(getTypeName(innerType)));
+
+            static string getTypeName(string typeName) => typeName[^1] == '?' ? typeName[..^1] : typeName;
+        }
 
         private static bool IsImmutableArray(string typeName, [NotNullWhen(true)] out string? arrayType)
         {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -408,7 +408,7 @@ namespace IOperationGenerator
             var lazyChildren = @"_lazyChildren";
             var hasType = false;
             var hasConstantValue = false;
-            var multipleValidKinds = (type.OperationKind?.Entries?.Where(e => e.EditorBrowsable != false).Count() ?? 0) > 1;
+            var multipleValidKinds = HasMultipleValidKinds(type);
 
             IEnumerable<Property>? baseProperties = null;
             if (_typeMap[type.Base] is { } baseNode)
@@ -629,6 +629,11 @@ namespace IOperationGenerator
 
                 return GetSubName(node.Name);
             }
+        }
+
+        private static bool HasMultipleValidKinds(AbstractNode type)
+        {
+            return (type.OperationKind?.Entries?.Where(e => e.EditorBrowsable != false).Count() ?? 0) > 1;
         }
 
         private void WriteClassOld(AbstractNode type)
@@ -1036,6 +1041,11 @@ namespace IOperationGenerator
                     {
                         Write($"{internalName}.{prop.Name}, ");
                     }
+                }
+
+                if (HasMultipleValidKinds(node))
+                {
+                    Write($"{internalName}.Kind, ");
                 }
 
                 Write($"{internalName}.OwningSemanticModel, {internalName}.Syntax, ");

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -429,7 +429,7 @@ namespace IOperationGenerator
             {
                 if (publicIOperationProps.Count != 0)
                 {
-                    WriteLine($"private IEnumerable<IOperation> {lazyChildren};");
+                    WriteLine($"private IEnumerable<IOperation>? {lazyChildren};");
                 }
 
                 hasType = node.HasType;
@@ -461,7 +461,14 @@ namespace IOperationGenerator
                     WriteLine($"var builder = ArrayBuilder<IOperation>.GetInstance({publicIOperationProps.Count});");
                     foreach (var prop in publicIOperationProps)
                     {
-                        WriteLine($"if ({prop.Name} is not null) builder.Add({prop.Name};");
+                        if (IsImmutableArray(prop.Type, out _))
+                        {
+                            WriteLine($"if (!{prop.Name}.IsEmpty) builder.AddRange({prop.Name});");
+                        }
+                        else
+                        {
+                            WriteLine($"if ({prop.Name} is not null) builder.Add({prop.Name});");
+                        }
                     }
 
                     WriteLine($"Interlocked.CompareExchange(ref {lazyChildren}, builder.ToImmutableAndFree(), null);");


### PR DESCRIPTION
This PR is the start of porting some of the IOperation nodes that are not leaf nodes. In these next PRs, I'm only going to be porting things that are not hierarchies in themselves: for example, IMemberReferenceOperation and it's children are a hierarchy in and unto themselves, but IBlockOperation is directly inherited from IOperation and has no subtypes. Again, commit-by-commit is highly recommended.
