### PR TITLE
Add null check for _proximityExpressionsService

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Debugging;
+using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Text;
@@ -31,9 +29,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         {
             private readonly Guid _languageId;
             private readonly TLanguageService _languageService;
-            private readonly ILanguageDebugInfoService _languageDebugInfo;
-            private readonly IBreakpointResolutionService _breakpointService;
-            private readonly IProximityExpressionsService _proximityExpressionsService;
+            private readonly ILanguageDebugInfoService? _languageDebugInfo;
+            private readonly IBreakpointResolutionService? _breakpointService;
+            private readonly IProximityExpressionsService? _proximityExpressionsService;
             private readonly IWaitIndicator _waitIndicator;
 
             public VsLanguageDebugInfo(
@@ -59,20 +57,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return VSConstants.S_OK;
             }
 
-            public int GetLocationOfName(string pszName, out string pbstrMkDoc, out VsTextSpan pspanLocation)
+            public int GetLocationOfName(string pszName, out string? pbstrMkDoc, out VsTextSpan pspanLocation)
             {
                 pbstrMkDoc = null;
                 pspanLocation = default;
                 return VSConstants.E_NOTIMPL;
             }
 
-            public int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string pbstrName, out int piLineOffset)
+            public int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string? pbstrName, out int piLineOffset)
             {
                 using (Logger.LogBlock(FunctionId.Debugging_VsLanguageDebugInfo_GetNameOfLocation, CancellationToken.None))
                 {
-                    string name = null;
+                    string? name = null;
                     var lineOffset = 0;
-                    var succeeded = false;
 
                     if (_languageDebugInfo != null)
                     {
@@ -101,7 +98,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
                                         if (!debugLocationInfo.IsDefault)
                                         {
-                                            succeeded = true;
                                             name = debugLocationInfo.Name;
                                             lineOffset = debugLocationInfo.LineOffset;
                                         }
@@ -110,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                             }
                         });
 
-                        if (succeeded)
+                        if (name != null)
                         {
                             pbstrName = name;
                             piLineOffset = lineOffset;
@@ -126,13 +122,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 }
             }
 
-            public int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum)
+            public int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR? ppEnum)
             {
                 // NOTE(cyrusn): cLines is ignored.  This is to match existing dev10 behavior.
                 using (Logger.LogBlock(FunctionId.Debugging_VsLanguageDebugInfo_GetProximityExpressions, CancellationToken.None))
                 {
-                    VsEnumBSTR enumBSTR = null;
-                    var succeeded = false;
+                    VsEnumBSTR? enumBSTR = null;
                     _waitIndicator.Wait(
                         title: ServicesVSResources.Debugger,
                         message: ServicesVSResources.Determining_autos,
@@ -156,28 +151,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                                     if (proximityExpressions != null)
                                     {
                                         enumBSTR = new VsEnumBSTR(proximityExpressions);
-                                        succeeded = true;
                                     }
                                 }
                             }
                         }
                     });
 
-                    if (succeeded)
-                    {
-                        ppEnum = enumBSTR;
-                        return VSConstants.S_OK;
-                    }
-
-                    ppEnum = null;
-                    return VSConstants.E_FAIL;
+                    ppEnum = enumBSTR;
+                    return ppEnum != null ? VSConstants.S_OK : VSConstants.E_FAIL;
                 }
             }
 
             public int IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
                 => VSConstants.E_NOTIMPL;
 
-            public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName ppNames)
+            public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName? ppNames)
             {
                 using (Logger.LogBlock(FunctionId.Debugging_VsLanguageDebugInfo_ResolveName, CancellationToken.None))
                 {
@@ -191,8 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                         return VSConstants.S_FALSE;
                     }
 
-                    VsEnumDebugName enumName = null;
-                    var succeeded = false;
+                    VsEnumDebugName? enumName = null;
                     _waitIndicator.Wait(
                         title: ServicesVSResources.Debugger,
                         message: ServicesVSResources.Resolving_breakpoint_location,
@@ -212,19 +199,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                                 var debugNames = breakpoints.Select(bp => CreateDebugName(bp, solution, cancellationToken)).WhereNotNull().ToList();
 
                                 enumName = new VsEnumDebugName(debugNames);
-                                succeeded = true;
                             }
                         }
                     });
 
-                    if (succeeded)
-                    {
-                        ppNames = enumName;
-                        return VSConstants.S_OK;
-                    }
-
-                    ppNames = null;
-                    return VSConstants.E_NOTIMPL;
+                    ppNames = enumName;
+                    return ppNames != null ? VSConstants.S_OK : VSConstants.E_NOTIMPL;
                 }
             }
 
@@ -313,6 +293,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                             if (initialBreakpointSpan.Length > 0 && document.SupportsSyntaxTree)
                             {
                                 var tree = document.GetSyntaxTreeSynchronously(cancellationToken);
+                                Contract.ThrowIfNull(tree);
                                 if (tree.GetDiagnostics(cancellationToken).Any(d => d.Severity == DiagnosticSeverity.Error))
                                 {
                                     // Keep the span as is.

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -128,34 +128,38 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 using (Logger.LogBlock(FunctionId.Debugging_VsLanguageDebugInfo_GetProximityExpressions, CancellationToken.None))
                 {
                     VsEnumBSTR? enumBSTR = null;
-                    _waitIndicator.Wait(
-                        title: ServicesVSResources.Debugger,
-                        message: ServicesVSResources.Determining_autos,
-                        allowCancel: true,
-                        action: waitContext =>
+
+                    if (_proximityExpressionsService != null)
                     {
-                        var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
-
-                        if (textBuffer != null)
+                        _waitIndicator.Wait(
+                            title: ServicesVSResources.Debugger,
+                            message: ServicesVSResources.Determining_autos,
+                            allowCancel: true,
+                            action: waitContext =>
                         {
-                            var snapshot = textBuffer.CurrentSnapshot;
-                            var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
-                            if (nullablePoint.HasValue)
-                            {
-                                var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-                                if (document != null)
-                                {
-                                    var point = nullablePoint.Value;
-                                    var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
+                            var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
 
-                                    if (proximityExpressions != null)
+                            if (textBuffer != null)
+                            {
+                                var snapshot = textBuffer.CurrentSnapshot;
+                                var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
+                                if (nullablePoint.HasValue)
+                                {
+                                    var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                                    if (document != null)
                                     {
-                                        enumBSTR = new VsEnumBSTR(proximityExpressions);
+                                        var point = nullablePoint.Value;
+                                        var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
+
+                                        if (proximityExpressions != null)
+                                        {
+                                            enumBSTR = new VsEnumBSTR(proximityExpressions);
+                                        }
                                     }
                                 }
                             }
-                        }
-                    });
+                        });
+                    }
 
                     ppEnum = enumBSTR;
                     return ppEnum != null ? VSConstants.S_OK : VSConstants.E_FAIL;


### PR DESCRIPTION
All of the other services have null checks so we don't null ref if we're called without an underlying service. But this one is missing the check, and it's not implemented by TypeScript or F#.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1199127

**NOTE:** the first commit in this PR is annotating this type, the second one is actually fixing the bug. The first commit annotates it in a way that the compiler is then flagging the issue.

(This is a repeat of https://github.com/dotnet/roslyn/pull/48368 that got closed accidentally when the target branch was deleted.)