### PR TITLE
Disallow completion keywords after numeric literal

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AsKeywordRecommenderTests.cs
@@ -195,7 +195,7 @@ class C {
 
         [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterNumericLiteral()
+        public async Task TestMissingAfterNumericLiteral()
         {
             await VerifyAbsenceAsync(
 @"
@@ -204,6 +204,36 @@ class C
     void M()
     {
         var x = 1$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralAndDot()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1.$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralDotAndSpace()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1. $$
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/AsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AsKeywordRecommenderTests.cs
@@ -192,5 +192,20 @@ class C {
     void M() {
         Action b = () => {} $$");
         }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNumericLiteral()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1$$
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
@@ -254,5 +254,20 @@ class C {
     void M() {
         Action b = () => {} $$");
         }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNumericLiteral()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1$$
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
@@ -257,7 +257,7 @@ class C {
 
         [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterNumericLiteral()
+        public async Task TestMissingAfterNumericLiteral()
         {
             await VerifyAbsenceAsync(
 @"
@@ -266,6 +266,36 @@ class C
     void M()
     {
         var x = 1$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralAndDot()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1.$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralDotAndSpace()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1. $$
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
@@ -201,7 +201,7 @@ class C {
 
         [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterNumericLiteral()
+        public async Task TestMissingAfterNumericLiteral()
         {
             await VerifyAbsenceAsync(
 @"
@@ -210,6 +210,36 @@ class C
     void M()
     {
         var x = 1$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralAndDot()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1.$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralDotAndSpace()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1. $$
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
@@ -198,5 +198,20 @@ class C {
     void M() {
         Action b = () => {} $$");
         }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNumericLiteral()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1$$
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
@@ -199,5 +199,20 @@ class C {
     void M() {
         Action b = () => {} $$");
         }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterNumericLiteral()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1$$
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
@@ -202,7 +202,7 @@ class C {
 
         [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterNumericLiteral()
+        public async Task TestMissingAfterNumericLiteral()
         {
             await VerifyAbsenceAsync(
 @"
@@ -211,6 +211,36 @@ class C
     void M()
     {
         var x = 1$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralAndDot()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1.$$
+    }
+}");
+        }
+
+        [WorkItem(48573, "https://github.com/dotnet/roslyn/issues/48573")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMissingAfterNumericLiteralDotAndSpace()
+        {
+            await VerifyAbsenceAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = 1. $$
     }
 }");
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2791,8 +2791,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            // Not if the position is *within* a numeric literal
-            if (token.IsKind(SyntaxKind.NumericLiteralToken) && token.Span.Contains(position))
+            // Not if the position is a numeric literal
+            if (token.IsKind(SyntaxKind.NumericLiteralToken))
             {
                 return false;
             }


### PR DESCRIPTION
Fixes #48573

'as', 'with', 'is', and 'switch' are already filtered out after numeric literals via Roslyn's AsyncCompletion layer, but LSP doesn't go through that layer. This explicitly prohibits these keywords from ever being a completion option after numeric literals, which should fix things for LSP/Razor.

Thanks to Gen and David B for helping brainstorm the ideal solution for this problem :D