### PR TITLE
Remove custom handling of back and forward buttons

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Execute.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Execute.cs
@@ -7,7 +7,6 @@
 using System;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
@@ -40,10 +39,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     return ExecuteVisualStudio97(ref pguidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
                 }
-                else if (pguidCmdGroup == VSConstants.GUID_AppCommand)
-                {
-                    return ExecuteAppCommand(ref pguidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
-                }
                 else
                 {
                     return NextCommandTarget.Exec(ref pguidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
@@ -53,32 +48,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 this.CurrentlyExecutingCommand = default;
             }
-        }
-
-        private int ExecuteAppCommand(ref Guid pguidCmdGroup, uint commandId, uint executeInformation, IntPtr pvaIn, IntPtr pvaOut)
-        {
-            var result = VSConstants.S_OK;
-            var guidCmdGroup = pguidCmdGroup;
-            void executeNextCommandTarget()
-            {
-                result = NextCommandTarget.Exec(ref guidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
-            }
-
-            switch ((VSConstants.AppCommandCmdID)commandId)
-            {
-                case VSConstants.AppCommandCmdID.BrowserBackward:
-                    ExecuteBrowserBackward(executeNextCommandTarget);
-                    break;
-
-                case VSConstants.AppCommandCmdID.BrowserForward:
-                    ExecuteBrowserForward(executeNextCommandTarget);
-                    break;
-
-                default:
-                    return NextCommandTarget.Exec(ref pguidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
-            }
-
-            return result;
         }
 
         private int ExecuteVisualStudio97(ref Guid pguidCmdGroup, uint commandId, uint executeInformation, IntPtr pvaIn, IntPtr pvaOut)
@@ -137,35 +106,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 default:
                     return NextCommandTarget.Exec(ref pguidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
             }
-        }
-
-        private void ExecuteBrowserBackward(Action executeNextCommandTarget)
-            => ExecuteBrowserNavigationCommand(navigateBackward: true, executeNextCommandTarget);
-
-        private void ExecuteBrowserForward(Action executeNextCommandTarget)
-            => ExecuteBrowserNavigationCommand(navigateBackward: false, executeNextCommandTarget);
-
-        private void ExecuteBrowserNavigationCommand(bool navigateBackward, Action executeNextCommandTarget)
-        {
-            // We just want to delegate to the shell's NavigateBackward/Forward commands
-            System.IServiceProvider serviceProvider = ComponentModel.GetService<SVsServiceProvider>();
-            if (serviceProvider.GetService(typeof(SUIHostCommandDispatcher)) is IOleCommandTarget target)
-            {
-                var cmd = (uint)(navigateBackward ?
-                     VSConstants.VSStd97CmdID.ShellNavBackward :
-                     VSConstants.VSStd97CmdID.ShellNavForward);
-
-                var cmds = new[] { new OLECMD() { cmdf = 0, cmdID = cmd } };
-                var hr = target.QueryStatus(VSConstants.GUID_VSStandardCommandSet97, 1, cmds, IntPtr.Zero);
-                if (hr == VSConstants.S_OK && (cmds[0].cmdf & (uint)OLECMDF.OLECMDF_ENABLED) != 0)
-                {
-                    // ignore failure
-                    target.Exec(VSConstants.GUID_VSStandardCommandSet97, cmd, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero);
-                    return;
-                }
-            }
-
-            executeNextCommandTarget();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Query.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Query.cs
@@ -23,27 +23,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 return QueryVisualStudio2014Status(ref pguidCmdGroup, commandCount, prgCmds, commandText);
             }
-            else if (pguidCmdGroup == VSConstants.GUID_AppCommand)
-            {
-                return QueryAppCommandStatus(ref pguidCmdGroup, commandCount, prgCmds, commandText);
-            }
             else
             {
                 return NextCommandTarget.QueryStatus(ref pguidCmdGroup, commandCount, prgCmds, commandText);
-            }
-        }
-
-        private int QueryAppCommandStatus(ref Guid pguidCmdGroup, uint commandCount, OLECMD[] prgCmds, IntPtr commandText)
-        {
-            switch ((VSConstants.AppCommandCmdID)prgCmds[0].cmdID)
-            {
-                case VSConstants.AppCommandCmdID.BrowserBackward:
-                case VSConstants.AppCommandCmdID.BrowserForward:
-                    prgCmds[0].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
-                    return VSConstants.S_OK;
-
-                default:
-                    return NextCommandTarget.QueryStatus(ref pguidCmdGroup, commandCount, prgCmds, commandText);
             }
         }
 


### PR DESCRIPTION
This feature is provided by Visual Studio starting with 16.7 Preview 3.

🔗 https://developercommunity.visualstudio.com/content/problem/1064743/back-button-on-mouse-doesnt-work-when-navigatingop.html
🔗 [AB#1135868](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1135868)