### PR TITLE
Use an iterative wait in DiagnosticTaggerWrapper

### DIFF
--- a/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
@@ -97,11 +97,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
         public async Task WaitForTags()
         {
-            await _listenerProvider.GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
-            await _listenerProvider.GetWaiter(FeatureAttribute.SolutionCrawler).ExpeditedWaitAsync();
-            await _listenerProvider.GetWaiter(FeatureAttribute.DiagnosticService).ExpeditedWaitAsync();
-            await _listenerProvider.GetWaiter(FeatureAttribute.ErrorSquiggles).ExpeditedWaitAsync();
-            await _listenerProvider.GetWaiter(FeatureAttribute.Classification).ExpeditedWaitAsync();
+            await _listenerProvider.WaitAllDispatcherOperationAndTasksAsync(
+                _workspace,
+                FeatureAttribute.Workspace,
+                FeatureAttribute.SolutionCrawler,
+                FeatureAttribute.DiagnosticService,
+                FeatureAttribute.ErrorSquiggles,
+                FeatureAttribute.Classification);
         }
     }
 }


### PR DESCRIPTION
This change ensures asynchronous operations in "earlier" stages which are triggered by later stages still cause the test to wait for full completion. The wait is complete when reaching a state where no pending tasks are in any category of interest.

Fixes #48671