### PR TITLE
Run integration tests on scouting queue

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCorePublic-Pool
-    queue: buildpool.windows.10.amd64.vs2019.pre.open
+    queue: $(queueName)
   strategy:
     maxParallel: 4
     matrix:


### PR DESCRIPTION
To increase the likelyhood that we will catch integration tests failures due to running on newer builds of VS, We will run integration tests for the master-vs-deps branch against the scouting queue daily and add this queue to our infrastructure dashboard. 

This PR parameterizes the queueName so we can specify the scouting queue from a separate pipeline.

CI running on scouting queue: https://dev.azure.com/dnceng/public/_build/results?buildId=860679&view=results