### PR TITLE
More error list performance improvements for build scenario

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -363,6 +363,7 @@ dotnet_diagnostic.{DisabledByDefaultAnalyzer.s_compilationRule.Id}.severity = wa
                 ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>>.Empty.Add(
                     document.Project.Id,
                     ImmutableArray.Create(DiagnosticData.Create(Diagnostic.Create(NoNameAnalyzer.s_syntaxRule, location), document.Project))),
+                new TaskQueue(service.Listener, TaskScheduler.Default),
                 onBuildCompleted: true,
                 CancellationToken.None);
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
@@ -7,36 +7,26 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal partial class DiagnosticAnalyzerService
     {
         /// <summary>
-        /// Initialize solution state for synchronizing build errors with live errors.
-        /// 
-        /// no cancellationToken since this can't be cancelled
-        /// </summary>
-        public Task InitializeSynchronizationStateWithBuildAsync(Solution solution, CancellationToken cancellationToken)
-        {
-            if (_map.TryGetValue(solution.Workspace, out var analyzer))
-            {
-                return analyzer.InitializeSynchronizationStateWithBuildAsync(solution, cancellationToken);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
         /// Synchronize build errors with live error.
-        /// 
-        /// no cancellationToken since this can't be cancelled
         /// </summary>
-        public Task SynchronizeWithBuildAsync(Workspace workspace, ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> diagnostics, bool onBuildCompleted, CancellationToken cancellationToken)
+        public Task SynchronizeWithBuildAsync(
+            Workspace workspace,
+            ImmutableDictionary<ProjectId,
+            ImmutableArray<DiagnosticData>> diagnostics,
+            TaskQueue postBuildTaskQueue,
+            bool onBuildCompleted,
+            CancellationToken cancellationToken)
         {
             if (_map.TryGetValue(workspace, out var analyzer))
             {
-                return analyzer.SynchronizeWithBuildAsync(diagnostics, onBuildCompleted, cancellationToken);
+                return analyzer.SynchronizeWithBuildAsync(diagnostics, postBuildTaskQueue, onBuildCompleted, cancellationToken);
             }
 
             return Task.CompletedTask;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
@@ -20,13 +20,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Workspace workspace,
             ImmutableDictionary<ProjectId,
             ImmutableArray<DiagnosticData>> diagnostics,
-            TaskQueue postBuildTaskQueue,
+            TaskQueue postBuildAndErrorListRefreshTaskQueue,
             bool onBuildCompleted,
             CancellationToken cancellationToken)
         {
             if (_map.TryGetValue(workspace, out var analyzer))
             {
-                return analyzer.SynchronizeWithBuildAsync(diagnostics, postBuildTaskQueue, onBuildCompleted, cancellationToken);
+                return analyzer.SynchronizeWithBuildAsync(diagnostics, postBuildAndErrorListRefreshTaskQueue, onBuildCompleted, cancellationToken);
             }
 
             return Task.CompletedTask;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -187,7 +187,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return builder.ToResult();
             }
 
-            public async Task SaveAsync(IPersistentStorageService persistentService, Project project, DiagnosticAnalysisResult result)
+            public Task SaveAsync(IPersistentStorageService persistentService, Project project, DiagnosticAnalysisResult result)
+                => SaveCoreAsync(project, result, persistentService);
+
+            public Task SaveInMemoryCacheAsync(Project project, DiagnosticAnalysisResult result)
+                => SaveCoreAsync(project, result, persistentService: null);
+
+            private async Task SaveCoreAsync(Project project, DiagnosticAnalysisResult result, IPersistentStorageService? persistentService)
             {
                 Contract.ThrowIfTrue(result.IsAggregatedForm);
                 Contract.ThrowIfNull(result.DocumentIds);
@@ -343,12 +349,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return builder.ToResult();
             }
 
-            private async Task SerializeAsync(IPersistentStorageService persistentService, DiagnosticDataSerializer serializer, Project project, TextDocument? document, object key, string stateKey, ImmutableArray<DiagnosticData> diagnostics)
+            private async Task SerializeAsync(IPersistentStorageService? persistentService, DiagnosticDataSerializer serializer, Project project, TextDocument? document, object key, string stateKey, ImmutableArray<DiagnosticData> diagnostics)
             {
                 Contract.ThrowIfFalse(document == null || document.Project == project);
 
                 // try to serialize it
-                if (await serializer.SerializeAsync(persistentService, project, document, stateKey, diagnostics, CancellationToken.None).ConfigureAwait(false))
+                if (persistentService != null &&
+                    await serializer.SerializeAsync(persistentService, project, document, stateKey, diagnostics, CancellationToken.None).ConfigureAwait(false))
                 {
                     // we succeeded saving it to persistent storage. remove it from in memory cache if it exists
                     RemoveInMemoryCacheEntry(key, stateKey);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -12,28 +12,21 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
-
-#if NETSTANDARD2_0
 using Roslyn.Utilities;
-#endif
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer
     {
-        public async Task InitializeSynchronizationStateWithBuildAsync(Solution solution, CancellationToken cancellationToken)
-        {
-            foreach (var project in solution.Projects)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var stateSets = _stateManager.CreateBuildOnlyProjectStateSet(project);
-                _ = await ProjectAnalysisData.CreateAsync(PersistentStorageService, project, stateSets, avoidLoadingData: false, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        public async Task SynchronizeWithBuildAsync(ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> buildDiagnostics, bool onBuildCompleted, CancellationToken cancellationToken)
+        public async Task SynchronizeWithBuildAsync(
+            ImmutableDictionary<ProjectId,
+            ImmutableArray<DiagnosticData>> buildDiagnostics,
+            TaskQueue postBuildTaskQueue,
+            bool onBuildCompleted,
+            CancellationToken cancellationToken)
         {
             var options = Workspace.Options;
 
@@ -59,27 +52,41 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         continue;
                     }
 
-                    // REVIEW: do build diagnostics include suppressed diagnostics?
                     var stateSets = _stateManager.CreateBuildOnlyProjectStateSet(project);
+                    var newResult = CreateAnalysisResults(project, stateSets, diagnostics);
 
-                    // We load data since we don't know right version.
-                    var oldAnalysisData = await ProjectAnalysisData.CreateAsync(PersistentStorageService, project, stateSets, avoidLoadingData: false, cancellationToken).ConfigureAwait(false);
-                    var newResult = CreateAnalysisResults(project, stateSets, oldAnalysisData, diagnostics);
-
+                    // PERF: Save the diagnostics into in-memory cache on the main thread.
+                    //       Saving them into persistent storage is expensive, so we invoke that operation on a separate task queue
+                    //       to ensure faster error list refresh.
                     foreach (var stateSet in stateSets)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
                         var state = stateSet.GetOrCreateProjectState(project.Id);
                         var result = GetResultOrEmpty(newResult, stateSet.Analyzer, project.Id, VersionStamp.Default);
-                        await state.SaveAsync(PersistentStorageService, project, result).ConfigureAwait(false);
+
+                        // Save into in-memory cache.
+                        await state.SaveInMemoryCacheAsync(project, result).ConfigureAwait(false);
+
+                        // Save into persistent storage on a separate post-build task queue.
+                        _ = postBuildTaskQueue.ScheduleTask(
+                                nameof(SynchronizeWithBuildAsync),
+                                async () => await state.SaveAsync(PersistentStorageService, project, result).ConfigureAwait(false),
+                                cancellationToken);
                     }
 
-                    // REVIEW: this won't handle active files. might need to tweak it later.
-                    RaiseProjectDiagnosticsIfNeeded(project, stateSets, oldAnalysisData.Result, newResult);
+                    // Raise diagnostic updated events after the new diagnostics have been stored into the in-memory cache.
+                    if (diagnostics.IsEmpty)
+                    {
+                        ClearAllDiagnostics(stateSets, projectId);
+                    }
+                    else
+                    {
+                        RaiseProjectDiagnosticsIfNeeded(project, stateSets, newResult);
+                    }
                 }
 
-                // Refresh diagnostics for open files after solution build completes.
+                // Refresh live diagnostics after solution build completes.
                 if (onBuildCompleted && PreferLiveErrorsOnOpenedFiles(options))
                 {
                     // Enqueue re-analysis of active document.
@@ -88,8 +95,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         AnalyzerService.Reanalyze(Workspace, documentIds: ImmutableArray.Create(activeDocument.Id), highPriority: true);
                     }
 
-                    // Enqueue re-analysis of open documents.
-                    AnalyzerService.Reanalyze(Workspace, documentIds: Workspace.GetOpenDocumentIds(), highPriority: true);
+                    // Enqueue remaining re-analysis on the task queue.
+                    _ = postBuildTaskQueue.ScheduleTask(nameof(SynchronizeWithBuildAsync), () =>
+                    {
+                        // Enqueue re-analysis of open documents.
+                        AnalyzerService.Reanalyze(Workspace, documentIds: Workspace.GetOpenDocumentIds());
+
+                        // Enqueue re-analysis of projects, if required.
+                        foreach (var projectsByLanguage in solution.Projects.GroupBy(p => p.Language))
+                        {
+                            if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(Workspace.Options, projectsByLanguage.Key) == BackgroundAnalysisScope.FullSolution)
+                            {
+                                AnalyzerService.Reanalyze(Workspace, projectsByLanguage.Select(p => p.Id));
+                            }
+                        }
+                    }, cancellationToken);
                 }
             }
         }
@@ -107,22 +127,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> CreateAnalysisResults(
-            Project project, ImmutableArray<StateSet> stateSets, ProjectAnalysisData oldAnalysisData, ImmutableArray<DiagnosticData> diagnostics)
+            Project project, ImmutableArray<StateSet> stateSets, ImmutableArray<DiagnosticData> diagnostics)
         {
             using var poolObject = SharedPools.Default<HashSet<string>>().GetPooledObject();
 
             var lookup = diagnostics.ToLookup(d => d.Id);
 
             var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, DiagnosticAnalysisResult>();
+            using var _ = PooledHashSet<DocumentId>.GetInstance(out var existingDocumentsInStateSet);
             foreach (var stateSet in stateSets)
             {
                 var descriptors = DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(stateSet.Analyzer);
+                var liveDiagnostics = ConvertToLiveDiagnostics(lookup, descriptors, poolObject.Object);
 
-                var liveDiagnostics = MergeDiagnostics(
-                    ConvertToLiveDiagnostics(lookup, descriptors, poolObject.Object),
-                    oldAnalysisData.GetResult(stateSet.Analyzer).GetAllDiagnostics());
+                // Ensure that all documents with diagnostics in the previous state set are added to the result.
+                existingDocumentsInStateSet.Clear();
+                stateSet.CollectDocumentsWithDiagnostics(project.Id, existingDocumentsInStateSet);
 
-                builder.Add(stateSet.Analyzer, DiagnosticAnalysisResult.CreateFromBuild(project, liveDiagnostics));
+                builder.Add(stateSet.Analyzer, DiagnosticAnalysisResult.CreateFromBuild(project, liveDiagnostics, existingDocumentsInStateSet));
             }
 
             return builder.ToImmutable();
@@ -133,26 +155,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         private static bool PreferLiveErrorsOnOpenedFiles(OptionSet options)
             => options.GetOption(InternalDiagnosticsOptions.PreferLiveErrorsOnOpenedFiles);
-
-        private static ImmutableArray<DiagnosticData> MergeDiagnostics(ImmutableArray<DiagnosticData> newDiagnostics, ImmutableArray<DiagnosticData> existingDiagnostics)
-        {
-            ImmutableArray<DiagnosticData>.Builder? builder = null;
-
-            if (newDiagnostics.Length > 0)
-            {
-                builder = ImmutableArray.CreateBuilder<DiagnosticData>();
-                builder.AddRange(newDiagnostics);
-            }
-
-            if (existingDiagnostics.Length > 0)
-            {
-                // retain hidden live diagnostics since it won't be comes from build.
-                builder ??= ImmutableArray.CreateBuilder<DiagnosticData>();
-                builder.AddRange(existingDiagnostics.Where(d => d.Severity == DiagnosticSeverity.Hidden));
-            }
-
-            return builder == null ? ImmutableArray<DiagnosticData>.Empty : builder.ToImmutable();
-        }
 
         private static ImmutableArray<DiagnosticData> ConvertToLiveDiagnostics(
             ILookup<string, DiagnosticData> lookup, ImmutableArray<DiagnosticDescriptor> descriptors, HashSet<string> seen)

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResult.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResult.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -101,13 +102,15 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 fromBuild: false);
         }
 
-        public static DiagnosticAnalysisResult CreateFromBuild(Project project, ImmutableArray<DiagnosticData> diagnostics)
+        public static DiagnosticAnalysisResult CreateFromBuild(Project project, ImmutableArray<DiagnosticData> diagnostics, IEnumerable<DocumentId> initialDocuments)
         {
             // we can't distinguish locals and non locals from build diagnostics nor determine right snapshot version for the build.
             // so we put everything in as semantic local with default version. this lets us to replace those to live diagnostics when needed easily.
             var version = VersionStamp.Default;
 
             var documentIds = ImmutableHashSet.CreateBuilder<DocumentId>();
+            documentIds.AddRange(initialDocuments);
+
             var diagnosticsWithDocumentId = PooledDictionary<DocumentId, ArrayBuilder<DiagnosticData>>.GetInstance();
             var diagnosticsWithoutDocumentId = ArrayBuilder<DiagnosticData>.GetInstance();
 


### PR DESCRIPTION
**With this PR, error list refreshes almost instantaneously after build finishes on all manual test scenarios I have tried.**

**Recommend reviewing with whitespace diffs turned off**

This change removes one of the primary performance bottleneck in the build/live diagnostics de-dupe code path when user triggers a build: _reading and writing diagnostics into persistent storage as part of de-duping_.

- Current approach for build/live de-dupe: Once we have identified the build diagnostics that are supported in live analysis, we do the following:
   1. Load all existing diagnostics for each project being built (and all its documents) from the persistent storage.
   2. Merge the build diagnostics that are supported in live with the hidden severity existing diagnostics.
   3. Save the merged diagnostics into the persistent storage.
   4. Raise diagnostics updated events to update the diagnostics in error list and other diagnostic clients.

- New approach: Steps 1 to 3 above are the expensive ones. With this PR, we avoid these steps and instead do the following:
   1. Do not load existing diagnostics or attempt to merge existing hidden diagnostics with build diagnostics - computing hidden diagnostics for open file is pretty cheap, and is in fact already done via a separate re-analyze call for active document at end of the build.
   2. Store the build diagnostics that are supported in live in the InMemory cache, that takes precendence over persistent storage cache. This is much faster, almost instantaneous, and all the diagnostic clients will hit the InMemory cache and see no effective behavior change.
   3. Schedule a separate task on a post-build task queue to write the diagnostics in step 2. from the InMemory cache to persistent storage, also dropping them from in memory cache to reduce memory pressure. This change postpones this I/O step to be done after error list refresh, hence making the error list refresh almost instantaneous.
   4. Raise diagnostics updated events to update the diagnostics in error list and other diagnostic clients.