### PR TITLE
[LSP] Disable snippets in Nexus

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
@@ -240,6 +240,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
+            // Don't execute in cloud environment, should be handled by LSP
+            if (subjectBuffer.IsInCloudEnvironmentClientContext())
+            {
+                return false;
+            }
+
             var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
@@ -240,12 +240,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
-            // Don't execute in cloud environment, should be handled by LSP
-            if (subjectBuffer.IsInCloudEnvironmentClientContext())
-            {
-                return false;
-            }
-
             var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
@@ -304,6 +298,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         protected static bool AreSnippetsEnabled(EditorCommandArgs args)
         {
+            // Don't execute in cloud environment, should be handled by LSP
+            if (args.SubjectBuffer.IsInCloudEnvironmentClientContext())
+            {
+                return false;
+            }
+
             return args.SubjectBuffer.GetFeatureOnOffOption(InternalFeatureOnOffOptions.Snippets) &&
                 // TODO (https://github.com/dotnet/roslyn/issues/5107): enable in interactive
                 !(Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace) && workspace.Kind == WorkspaceKind.Interactive);


### PR DESCRIPTION
Possibly fixes snippet crash https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1231856. This bug only replicates in Nexus and not Liveshare. I was having a lot of trouble getting running RoslynDev hive on the Nexus client, so I thought it would be the most efficient to open this low-risk PR (since snippets shouldn't work yet in LSP anyway) and verify whether it fixes the problem once inserted into VS.