### PR TITLE
Fix - Editor has variable name casing issue in ElseIf statement issue #48745

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -205,7 +205,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     ' possible that there is semantic content in this block.
                     ' In VB some constructs are not "Blocks"  in the same way that they are in C#, but can contain multiple statements.
                     ' IsExecutableBlock maps the semantics of VB to match C# Block.
-                    ' If we are in what C# would define as a block we want to do semantic formatting
+                    ' If we are in what C# would define as a block we want to do semantic formatting for the statement and
+                    ' syntactic formating for the rest
 
                     ' Below defines the entire scope of the edit that possibility needs indenting changed
                     formattingInfo.UseSemantics = finalSpanStart <= startingStatementInfo.MatchingBlockConstruct.SpanStart

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -140,13 +140,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             End Try
         End Sub
 
+        ''' <summary>
+        ''' UseSemantics is set when the entire SpanToFormat should be formatted using semantics,
+        ''' otherwise SpanToFormat will be syntacticly formatted (ex. spacing fixed).
+        ''' If SpanToSemanticFormat is not Nothing it will be semantically formatted before SpanToFormat,
+        ''' SpanToSemanticFormat will be a single statement.
+        ''' </summary>
         Private Structure FormattingInfo
-            ' This is the original flag to enable semantic formating on a span
+#Disable Warning IDE1006 ' Naming Styles
             Public UseSemantics As Boolean
-            ' This is the total span to format, the span may or may not be semantically formated
             Public SpanToFormat As SnapshotSpan
-            ' This is a span that will always be semantically formated
             Public SpanToSemanticFormat? As SnapshotSpan
+#Enable Warning IDE1006 ' Naming Styles
         End Structure
 
         Private Sub FormatSpan(isExplicitFormat As Boolean, dirtyRegion As SnapshotSpan, spanToFormat As SnapshotSpan, useSemantics As Boolean, cancellationToken As CancellationToken)

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -128,6 +128,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     End If
 
                     Dim tree As SyntaxTree
+                    Dim startLineNumber As Integer
+                    Dim startCharIndex As Integer
+                    Dim endLineNumber As Integer
+                    Dim endCharIndex As Integer
                     Dim useSemantics = info.UseStatementSemanticFormatting AndAlso Not isExplicitFormat
                     If useSemantics AndAlso Not isExplicitFormat Then
                         ' Avoid using semantics for formatting extremely large dirty spans without an explicit request
@@ -136,10 +140,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                         ' differencing in designer cases along with measurements of a pathological example demonstrated
                         ' at 14000 lines. We expect Windows Forms designer formatting operations to run in under ~15
                         ' seconds on average current hardware when nearing the threshold.
-                        Dim startLineNumber = 0
-                        Dim startCharIndex = 0
-                        Dim endLineNumber = 0
-                        Dim endCharIndex = 0
                         info.StatementSpanToSemanticFormat.GetLinesAndCharacters(startLineNumber, startCharIndex, endLineNumber, endCharIndex)
                         If endLineNumber - startLineNumber > 7000 Then
                             useSemantics = False
@@ -151,10 +151,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     useSemantics = info.UseSemantics AndAlso Not info.UseStatementSemanticFormatting
                     If useSemantics AndAlso Not isExplicitFormat Then
                         ' same comment at above
-                        Dim startLineNumber = 0
-                        Dim startCharIndex = 0
-                        Dim endLineNumber = 0
-                        Dim endCharIndex = 0
                         info.SpanToFormat.GetLinesAndCharacters(startLineNumber, startCharIndex, endLineNumber, endCharIndex)
                         If endLineNumber - startLineNumber > 7000 Then
                             useSemantics = False

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -191,7 +191,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 
                 If startingStatementInfo.MatchingBlockConstruct IsNot Nothing Then
                     ' If we're expanding backwards because of editing an end construct, we don't wan to run
-                    ' expensive semantic formatting checks.  We really just want to fix up indentation.
+                    ' expensive semantic formatting checks.  We really just want to fix up indentation unless we are in a VB block.
+                    ' In VB some constructs are not "Blocks" in the same way that they are in C#, IsExecutableBlock maps the semantics
+                    ' of VB to match C# Block.
                     formattingInfo.UseSemantics = (finalSpanStart <= startingStatementInfo.MatchingBlockConstruct.SpanStart) OrElse startingStatementInfo.MatchingBlockConstruct.Parent.IsExecutableBlock
 
                     finalSpanStart = Math.Min(finalSpanStart, startingStatementInfo.MatchingBlockConstruct.SpanStart)

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -192,7 +192,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 If startingStatementInfo.MatchingBlockConstruct IsNot Nothing Then
                     ' If we're expanding backwards because of editing an end construct, we don't wan to run
                     ' expensive semantic formatting checks.  We really just want to fix up indentation.
-                    formattingInfo.UseSemantics = finalSpanStart <= startingStatementInfo.MatchingBlockConstruct.SpanStart
+                    formattingInfo.UseSemantics = (finalSpanStart <= startingStatementInfo.MatchingBlockConstruct.SpanStart) OrElse startingStatementInfo.MatchingBlockConstruct.Parent.IsExecutableBlock
 
                     finalSpanStart = Math.Min(finalSpanStart, startingStatementInfo.MatchingBlockConstruct.SpanStart)
                 End If

--- a/src/EditorFeatures/VisualBasic/LineCommit/ContainingStatementInfo.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/ContainingStatementInfo.vb
@@ -108,7 +108,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             End If
 
             Dim containingStatement = token.GetAncestors(Of StatementSyntax) _
-                                           .Where(Function(a) Not TypeOf a Is LambdaHeaderSyntax) _
+                                           .Where(Function(a) TypeOf a IsNot LambdaHeaderSyntax) _
                                            .FirstOrDefault()
 
             Dim containingTypeStatement = TryCast(containingStatement, TypeStatementSyntax)

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -1134,9 +1134,8 @@ End Class
             End Using
         End Sub
 
-        ' Remove Skip to debug issue and when fixed
         <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
-        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.LineCommit)>
         Public Sub TestCaseChangeInDoLoop()
             Using testData = CommitTestData.Create(
                 <Workspace>
@@ -1171,9 +1170,8 @@ End Class
             End Using
         End Sub
 
-        ' Remove Skip to debug issue and when fixed
         <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
-        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.LineCommit)>
         Public Sub TestCaseChangeInElseIf()
             Using testData = CommitTestData.Create(
                 <Workspace>
@@ -1210,9 +1208,8 @@ End Class
             End Using
         End Sub
 
-        ' Remove Skip to debug issue and when fixed
         <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
-        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.LineCommit)>
         Public Sub TestCaseChangeInFor()
             Using testData = CommitTestData.Create(
                 <Workspace>
@@ -1284,7 +1281,7 @@ End Class
         End Sub
 
         <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
-        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.LineCommit)>
         Public Sub TestCaseChangeInTry()
             Using testData = CommitTestData.Create(
                 <Workspace>

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -821,7 +821,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        
+
     End Sub
 End Module|]</Document>
                     </Project>
@@ -1133,5 +1133,194 @@ End Class
                 Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
             End Using
         End Sub
+
+        ' Remove Skip to debug issue and when fixed
+        <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
+        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub TestCaseChangeInDoLoop()
+            Using testData = CommitTestData.Create(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Sub S()
+        Dim Test = 1
+        Do
+            ' While fixed but Test not
+        Loop while test = 1$$
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>)
+
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.MoveLineDown(False)
+                Dim expected = <Code>
+Class C
+    Sub S()
+        Dim Test = 1
+        Do
+            ' While fixed but Test not
+        Loop While Test = 1
+
+    End Sub
+End Class
+</Code>
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        ' Remove Skip to debug issue and when fixed
+        <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
+        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub TestCaseChangeInElseIf()
+            Using testData = CommitTestData.Create(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Sub S()
+        Dim Test = 1
+        If Test = 1 Then
+
+        ElseIf test = 2 Then$$
+        End If
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>)
+
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.MoveLineDown(False)
+                Dim expected = <Code>
+Class C
+    Sub S()
+        Dim Test = 1
+        If Test = 1 Then
+
+        ElseIf Test = 2 Then
+
+        End If
+    End Sub
+End Class
+</Code>
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        ' Remove Skip to debug issue and when fixed
+        <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
+        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub TestCaseChangeInFor()
+            Using testData = CommitTestData.Create(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Sub S()
+        Dim Test = 1
+        For Test = 0 To 10
+        Next test$$
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>)
+
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.MoveLineDown(False)
+                Dim expected = <Code>
+Class C
+    Sub S()
+        Dim Test = 1
+        For Test = 0 To 10
+        Next Test
+
+    End Sub
+End Class
+</Code>
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub TestCaseChangeInIfAndElseIf()
+            Using testData = CommitTestData.Create(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Sub S()
+        Dim Test = 1
+        If test = 1 Then$$
+        ElseIf test = 2 Then
+
+        End If
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>)
+
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.MoveLineDown(False)
+                Dim expected = <Code>
+Class C
+    Sub S()
+        Dim Test = 1
+        If Test = 1 Then
+
+        ElseIf Test = 2 Then
+
+        End If
+    End Sub
+End Class
+</Code>
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        <WorkItem(9999, "https://github.com/dotnet/roslyn/issues/48745")>
+        <WpfFact(Skip:="This test will fail"), Trait(Traits.Feature, Traits.Features.LineCommit)>
+        Public Sub TestCaseChangeInTry()
+            Using testData = CommitTestData.Create(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Class C
+    Sub S()
+        Dim Test = 1
+        Try
+            ' When fixed but Test not
+        Catch ex As Exception when test = 1$$
+        End Try
+    End Sub
+End Class
+</Document>
+                    </Project>
+                </Workspace>)
+
+                testData.EditorOperations.InsertNewLine()
+                testData.EditorOperations.MoveLineDown(False)
+                Dim expected = <Code>
+Class C
+    Sub S()
+        Dim Test = 1
+        Try
+            ' When fixed but Test not
+        Catch ex As Exception When Test = 1
+
+        End Try
+    End Sub
+End Class
+</Code>
+                Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
     End Class
 End Namespace
+

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -1145,7 +1145,6 @@ Class C
     Sub S()
         Dim Test = 1
         Do
-            ' While fixed but Test not
         Loop while test = 1$$
     End Sub
 End Class
@@ -1160,7 +1159,6 @@ Class C
     Sub S()
         Dim Test = 1
         Do
-            ' While fixed but Test not
         Loop While Test = 1
 
     End Sub
@@ -1180,7 +1178,7 @@ End Class
 Class C
     Sub S()
         Dim Test = 1
-        If Test = 1 Then
+           If test = 1 Then ' test should not be fixed but indenting should be fixed
 
         ElseIf test = 2 Then$$
         End If
@@ -1196,7 +1194,7 @@ End Class
 Class C
     Sub S()
         Dim Test = 1
-        If Test = 1 Then
+        If test = 1 Then ' test should not be fixed but indenting should be fixed
 
         ElseIf Test = 2 Then
 
@@ -1291,7 +1289,6 @@ Class C
     Sub S()
         Dim Test = 1
         Try
-            ' When fixed but Test not
         Catch ex As Exception when test = 1$$
         End Try
     End Sub
@@ -1307,7 +1304,6 @@ Class C
     Sub S()
         Dim Test = 1
         Try
-            ' When fixed but Test not
         Catch ex As Exception When Test = 1
 
         End Try
@@ -1317,7 +1313,5 @@ End Class
                 Assert.Equal(expected.NormalizedValue, testData.Workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText())
             End Using
         End Sub
-
     End Class
 End Namespace
-


### PR DESCRIPTION
Added additional tests to cover the equivalent of C# Block Syntax formatting and added call to check if parent of MatchingBlockConstruct IsExecutableBlock. If it is a block the we use Semantic Formatting.