### PR TITLE
Restore retry on integration tests

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -370,6 +370,7 @@ function TestUsingOptimizedRunner() {
     # integration tests in CI.
     if ($ci) {
       $dlls += @(Get-Item (GetProjectOutputBinary "Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.dll"))
+      $args += " --retry"
     }
 
     $dlls += @(Get-ChildItem -Recurse -Include "*.IntegrationTests.dll" $binDir)

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -358,7 +358,6 @@ function TestUsingOptimizedRunner() {
   $args += " --logs `"$LogDir`""
   $args += " --secondaryLogs `"$secondaryLogDir`""
   $args += " --tfm net472"
-  $args += " --html"
 
   if ($testDesktop -or $testIOperation) {
     if ($test32) {

--- a/src/Tools/Source/RunTests/ITestExecutor.cs
+++ b/src/Tools/Source/RunTests/ITestExecutor.cs
@@ -17,8 +17,9 @@ namespace RunTests
         internal string? NoTrait { get; }
         internal bool IncludeHtml { get; }
         internal bool TestVsi { get; }
+        internal bool Retry { get; }
 
-        internal TestExecutionOptions(string dotnetFilePath, ProcDumpInfo? procDumpInfo, string testResultsDirectory, string? trait, string? noTrait, bool includeHtml, bool testVsi)
+        internal TestExecutionOptions(string dotnetFilePath, ProcDumpInfo? procDumpInfo, string testResultsDirectory, string? trait, string? noTrait, bool includeHtml, bool testVsi, bool retry)
         {
             DotnetFilePath = dotnetFilePath;
             ProcDumpInfo = procDumpInfo;
@@ -27,6 +28,7 @@ namespace RunTests
             NoTrait = noTrait;
             IncludeHtml = includeHtml;
             TestVsi = testVsi;
+            Retry = retry;
         }
     }
 

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -69,6 +69,11 @@ namespace RunTests
         public TimeSpan? Timeout { get; set; }
 
         /// <summary>
+        /// Retry tests on failure 
+        /// </summary>
+        public bool Retry { get; set; }
+
+        /// <summary>
         /// Whether or not to use proc dump to monitor running processes for failures.
         /// </summary>
         public bool UseProcDump { get; set; }
@@ -129,6 +134,7 @@ namespace RunTests
             var includeHtml = false;
             var targetFramework = "net472";
             var sequential = false;
+            var retry = false;
             string? traits = null;
             string? noTraits = null;
             int? timeout = null;
@@ -155,6 +161,7 @@ namespace RunTests
                 { "display=", "Display", (Display d) => display = d },
                 { "procdumpPath=", "Path to procdump", (string s) => procDumpFilePath = s },
                 { "useProcdump", "Whether or not to use procdump", o => useProcDump = o is object },
+                { "retry", "Retry failed test a few times", o => retry = o is object },
             };
 
             List<string> assemblyList;
@@ -178,6 +185,12 @@ namespace RunTests
             if (useProcDump && string.IsNullOrEmpty(procDumpFilePath))
             {
                 Console.WriteLine($"The option 'useprocdump' was specified but 'procdumppath' was not provided");
+                return null;
+            }
+
+            if (retry && includeHtml)
+            {
+                Console.WriteLine($"Cannot specify both --retry and --html");
                 return null;
             }
 

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -95,7 +95,7 @@ namespace RunTests
             var result = await RunTestAsyncInternal(assemblyInfo, retry: false, cancellationToken);
 
             // For integration tests (TestVsi), we make one more attempt to re-run failed tests.
-            if (Options.TestVsi && !Options.IncludeHtml && !result.Succeeded)
+            if (Options.Retry && !Options.IncludeHtml && !result.Succeeded)
             {
                 return await RunTestAsyncInternal(assemblyInfo, retry: true, cancellationToken);
             }

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -332,7 +332,8 @@ namespace RunTests
                 trait: options.Trait,
                 noTrait: options.NoTrait,
                 includeHtml: options.IncludeHtml,
-                testVsi: options.TestVsi);
+                testVsi: options.TestVsi,
+                retry: options.Retry);
             return new ProcessTestExecutor(testExecutionOptions);
         }
 


### PR DESCRIPTION
The retry mechanism on integration tests is predicated on not having the
`--html` option passed to RunTests. PR #48686 changed it to be
unconditionally passed which ended up breaking retry. Undoing the
unconditional passing of `--html` to fix retry.