### PR TITLE
Generate constructor support implicit object creation

### DIFF
--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -207,6 +207,34 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
             => compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
 
+        /// <summary>
+        /// Find the constructor that our newly generated constructor should delegate to, if any, instead of creating members.
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// This method is called multiple times, for different numbers of arguments, and different types to create, until
+        /// it finds a valid match for an existing constructor that can be delegated to. For example given:
+        /// </para>
+        /// <code>
+        /// class Base
+        /// {
+        ///     Base(int x) { }
+        /// }
+        /// 
+        /// class Derived : Base
+        /// {
+        /// }
+        /// </code>
+        /// <para>
+        /// If the user types <c>new Derived(1, 2)</c> then this method will be called 4 times, to try to find a constructor
+        /// on Derived that takes two ints, then that takes one int, then a constructor on Base that takes two ints, then that
+        /// takes one int.
+        /// </para>
+        /// <para>
+        /// This class takes the original syntax node that the user typed and creates a new node, for whichever form is being
+        /// tried, places that in the surrounding context, and then uses the speculative semantic model to see if it can be bound.
+        /// </para>
+        /// </returns>
         protected override IMethodSymbol GetDelegatingConstructor(
             State state,
             SemanticDocument document,

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -280,9 +280,6 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
                     return CanDelegeteThisConstructor(state, document, delegatingConstructor, cancellationToken) ? delegatingConstructor : null;
                 }
             }
-            else if (oldToken.Parent is ImplicitObjectCreationExpressionSyntax)
-            {
-            }
             else
             {
                 var oldNode = oldToken.Parent

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
                     .Where(node => SpeculationAnalyzer.CanSpeculateOnNode(node))
                     .LastOrDefault();
 
-                var newTypeName = GenerateConstructorInvocation(state.TypeToGenerateIn, namedType, (TypeSyntax)oldToken.Parent, out var typeNameToReplace);
+                var newTypeName = GetConstructorInvocationWithCorrectTypeName(state.TypeToGenerateIn, namedType, (TypeSyntax)oldToken.Parent, out var typeNameToReplace);
 
                 var newNode = oldNode.ReplaceNode(typeNameToReplace, newTypeName);
                 newTypeName = (TypeSyntax)newNode.GetAnnotatedNodes(s_annotation).Single();
@@ -320,28 +320,28 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
         /// a normal creation expression we just find the typename part of the expression and
         /// make sure its the type we want.
         /// </summary>
-        private static SyntaxNode GenerateConstructorInvocation(INamedTypeSymbol typeToGenerateIn, INamedTypeSymbol namedType, TypeSyntax typeName, out TypeSyntax typeNameToReplace)
+        private static SyntaxNode GetConstructorInvocationWithCorrectTypeName(INamedTypeSymbol typeToGenerateIn, INamedTypeSymbol desiredTypeName, TypeSyntax existingTypeName, out SyntaxNode nodeToReplace)
         {
-            typeNameToReplace = typeName;
+            nodeToReplace = existingTypeName;
 
             TypeSyntax newTypeName;
-            if (!Equals(namedType, typeToGenerateIn))
+            if (!Equals(desiredTypeName, typeToGenerateIn))
             {
                 while (true)
                 {
-                    if (!(typeNameToReplace.Parent is TypeSyntax parentType))
+                    if (nodeToReplace.Parent is not TypeSyntax parentType)
                     {
                         break;
                     }
 
-                    typeNameToReplace = parentType;
+                    nodeToReplace = parentType;
                 }
 
-                newTypeName = namedType.GenerateTypeSyntax().WithAdditionalAnnotations(s_annotation);
+                newTypeName = desiredTypeName.GenerateTypeSyntax().WithAdditionalAnnotations(s_annotation);
             }
             else
             {
-                newTypeName = typeNameToReplace.WithAdditionalAnnotations(s_annotation);
+                newTypeName = existingTypeName.WithAdditionalAnnotations(s_annotation);
             }
             return newTypeName;
         }

--- a/src/Features/CSharp/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
 
         protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
-            return node is ObjectCreationExpressionSyntax ||
+            return node is BaseObjectCreationExpressionSyntax ||
                    node is ConstructorInitializerSyntax ||
                    node is AttributeSyntax;
         }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -97,6 +97,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     if (!await TryInitializeSimpleNameGenerationAsync(node, cancellationToken).ConfigureAwait(false))
                         return false;
                 }
+                else if (_service.IsImplicitObjectCreation(_document, node, cancellationToken))
+                {
+                    if (!await TryInitializeImplicitObjectCreationAsync(node, cancellationToken).ConfigureAwait(false))
+                        return false;
+                }
                 else
                 {
                     return false;
@@ -271,6 +276,23 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     IsConstructorInitializerGeneration = true;
 
                     var semanticInfo = _document.SemanticModel.GetSymbolInfo(constructorInitializer, cancellationToken);
+                    if (semanticInfo.Symbol == null)
+                        return await TryDetermineTypeToGenerateInAsync(typeToGenerateIn, cancellationToken).ConfigureAwait(false);
+                }
+
+                return false;
+            }
+
+            private async Task<bool> TryInitializeImplicitObjectCreationAsync(SyntaxNode implicitObjectCreation, CancellationToken cancellationToken)
+            {
+                if (_service.TryInitializeImplicitObjectCreation(
+                        _document, implicitObjectCreation, cancellationToken,
+                        out var token, out var arguments, out var typeToGenerateIn))
+                {
+                    Token = token;
+                    _arguments = arguments;
+
+                    var semanticInfo = _document.SemanticModel.GetSymbolInfo(implicitObjectCreation, cancellationToken);
                     if (semanticInfo.Symbol == null)
                         return await TryDetermineTypeToGenerateInAsync(typeToGenerateIn, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -27,7 +27,9 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
         protected abstract bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType);
         protected abstract bool IsSimpleNameGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract bool IsConstructorInitializerGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
+        protected abstract bool IsImplicitObjectCreation(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken);
 
+        protected abstract bool TryInitializeImplicitObjectCreation(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeSimpleNameGenerationState(SemanticDocument document, SyntaxNode simpleName, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeConstructorInitializerGeneration(SemanticDocument document, SyntaxNode constructorInitializer, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeSimpleAttributeNameGenerationState(SemanticDocument document, SyntaxNode simpleName, CancellationToken cancellationToken, out SyntaxToken token, out ImmutableArray<TArgumentSyntax> arguments, out ImmutableArray<TAttributeArgumentSyntax> attributeArguments, out INamedTypeSymbol typeToGenerateIn);

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -22,6 +22,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
         Public Sub New()
         End Sub
 
+        Protected Overrides Function IsImplicitObjectCreation(document As SemanticDocument, node As SyntaxNode, cancellationToken As CancellationToken) As Boolean
+            Return False
+        End Function
+
+        Protected Overrides Function TryInitializeImplicitObjectCreation(document As SemanticDocument, node As SyntaxNode, cancellationToken As CancellationToken, ByRef token As SyntaxToken, ByRef arguments As ImmutableArray(Of ArgumentSyntax), ByRef typeToGenerateIn As INamedTypeSymbol) As Boolean
+            token = Nothing
+            arguments = Nothing
+            typeToGenerateIn = Nothing
+            Return False
+        End Function
+
         Protected Overrides Function ContainingTypesOrSelfHasUnsafeKeyword(containingType As INamedTypeSymbol) As Boolean
             Return False
         End Function


### PR DESCRIPTION
Fixes #47928

At the risk of invoking touched-it-last rules, commit-by-commit makes the most sense for the delegating constructor bit at least.

Kids, this is what software development is all about: I stared at it for two days to write 3 lines of code.