### PR TITLE
Use a stack instead of recursion for walking a node hierarchy

### DIFF
--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
                 {
                     // The first time through, we already have a node. After that, we will get our
                     // node by popping a container from the stack and deconstructing it.
-                    if (node == null)
+                    if (node is null)
                     {
                         var item = stack.Pop();
                         if (item.IsNode)

--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
 
                     // Ignore null nodes, they are never relevant when building up the sequence of
                     // pieces in this chained expression.
-                    if (node == null)
+                    if (node is null)
                     {
                         continue;
                     }


### PR DESCRIPTION
Decompose was calling itself recursively. This caused us to run out of stack space when processing an extremely long chained statement.