### PR TITLE
[LSP] Disable signature help in cloud scenario

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_ComputeModel.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -63,6 +64,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                         if (document == null)
                         {
                             return currentModel;
+                        }
+
+                        // Let LSP handle signature help in the cloud scenario
+                        var workspaceContextService = document.Project.Solution.Workspace.Services.GetRequiredService<IWorkspaceContextService>();
+                        if (workspaceContextService.IsCloudEnvironmentClient())
+                        {
+                            return null;
                         }
 
                         if (triggerInfo.TriggerReason == SignatureHelpTriggerReason.RetriggerCommand)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1229667/
Roslyn on the client was providing signature help in addition to LSP providing signature help, causing double signature helps to appear. This change disables signature help from Roslyn in the cloud scenario.