### PR TITLE
Fix a couple infra issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,13 +19,13 @@ jobs:
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Debug
-    testArtifactName: Test_Windows_Debug
+    testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Release
-    testArtifactName: Test_Windows_Release
+    testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
 
 - template: eng/pipelines/test-windows-job.yml
@@ -33,7 +33,7 @@ jobs:
     testRunName: 'Test Windows Desktop Debug 32'
     jobName: Test_Windows_Desktop_Debug_32
     buildJobName: Build_Windows_Debug
-    testArtifactName: Test_Windows_Debug
+    testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     testArguments: -testDesktop -test32
 
@@ -42,7 +42,7 @@ jobs:
     testRunName: 'Test Windows Desktop Spanish Debug 32'
     jobName: Test_Windows_Desktop_Spanish_Debug_32
     buildJobName: Build_Windows_Debug
-    testArtifactName: Test_Windows_Debug
+    testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     testArguments: -testDesktop -test32
     queueName: 'BuildPool.Windows.10.Amd64.ES.VS2017.Open'
@@ -52,7 +52,7 @@ jobs:
     testRunName: 'Test Windows Desktop Debug 64'
     jobName: Test_Windows_Desktop_Debug_64
     buildJobName: Build_Windows_Debug
-    testArtifactName: Test_Windows_Debug
+    testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     testArguments: -testDesktop -test64
 
@@ -61,7 +61,7 @@ jobs:
     testRunName: 'Test Windows CoreClr Debug'
     jobName: Test_Windows_CoreClr_Debug
     buildJobName: Build_Windows_Debug
-    testArtifactName: Test_Windows_Debug
+    testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     testArguments: -testCoreClr
 
@@ -70,7 +70,7 @@ jobs:
     testRunName: 'Test Windows Desktop Release 32'
     jobName: Test_Windows_Desktop_Release_32
     buildJobName: Build_Windows_Release
-    testArtifactName: Test_Windows_Release
+    testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     testArguments: -testDesktop -test32
 
@@ -79,7 +79,7 @@ jobs:
     testRunName: 'Test Windows Desktop Release 64'
     jobName: Test_Windows_Desktop_Release_64
     buildJobName: Build_Windows_Release
-    testArtifactName: Test_Windows_Release
+    testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     testArguments: -testDesktop -test64
 
@@ -88,7 +88,7 @@ jobs:
     testRunName: 'Test Windows CoreClr Release'
     jobName: Test_Windows_CoreClr_Release
     buildJobName: Build_Windows_Release
-    testArtifactName: Test_Windows_Release
+    testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     testArguments: -testCoreClr
 
@@ -96,7 +96,7 @@ jobs:
 - template: eng/pipelines/build-unix-job.yml
   parameters:
     jobName: Build_Unix_Debug
-    testArtifactName: Test_Unix_Debug
+    testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
     vmImageName: 'ubuntu-16.04'
 
@@ -105,7 +105,7 @@ jobs:
     testRunName: 'Test Linux Debug'
     jobName: Test_Linux_Debug
     buildJobName: Build_Unix_Debug
-    testArtifactName: Test_Unix_Debug
+    testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
     testArguments: --testCoreClr
     queueName: 'BuildPool.Ubuntu.1604.amd64.Open'
@@ -115,7 +115,7 @@ jobs:
     testRunName: 'Test OSX Debug'
     jobName: Test_OSX_Debug
     buildJobName: Build_Unix_Debug
-    testArtifactName: Test_Unix_Debug
+    testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
     testArguments: --testCoreClr
     vmImageName: 'macOS-10.14'

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -356,7 +356,7 @@ function TestUsingOptimizedRunner() {
   $args += " --dotnet `"$dotnetExe`""
   $args += " --out `"$testResultsDir`""
   $args += " --logs `"$LogDir`""
-  $args += " --secondaryLogs `"$secondaryLogDir`""
+  $args += " --secondarylogs `"$secondaryLogDir`""
   $args += " --tfm net472"
 
   if ($testDesktop -or $testIOperation) {
@@ -406,8 +406,8 @@ function TestUsingOptimizedRunner() {
 
   if ($procdump) {
     $procdumpFilePath = Ensure-ProcDump
-    $args += " --procDumpPath $procDumpFilePath"
-    $args += " --useProDdump";
+    $args += " --procdumppath $procDumpFilePath"
+    $args += " --useprocdump";
   }
 
   if ($test64) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -406,8 +406,8 @@ function TestUsingOptimizedRunner() {
 
   if ($procdump) {
     $procdumpFilePath = Ensure-ProcDump
-    $args += " --procdumppath $procDumpFilePath"
-    $args += " --useprocdump";
+    $args += " --procDumpPath $procDumpFilePath"
+    $args += " --useProDdump";
   }
 
   if ($test64) {

--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -16,3 +16,10 @@ steps:
     continueOnError: true
     condition: not(succeeded())
 
+  - task: PublishPipelineArtifact@1
+    displayName: Publish Dumps
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)/artifacts/log2/${{ parameters.configuration }}'
+      artifactName: '${{ parameters.jobName }} Dumps'
+    continueOnError: true
+    condition: not(succeeded())

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -44,7 +44,7 @@ jobs:
       displayName: Run Unit Tests
       inputs:
         filePath: eng/build.ps1
-        arguments: -ci -configuration ${{ parameters.configuration }} ${{ parameters.testArguments }}
+        arguments: -ci -configuration ${{ parameters.configuration }} ${{ parameters.testArguments }} -procdump
 
     - task: PublishTestResults@2
       displayName: Publish xUnit Test Results

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -153,14 +153,14 @@ namespace RunTests
                 { "html", "Include HTML file output", o => includeHtml = o is object },
                 { "sequential", "Run tests sequentially", o => sequential = o is object },
                 { "traits=", "xUnit traits to include (semicolon delimited)", (string s) => traits = s },
-                { "noTraits=", "xUnit traits to exclude (semicolon delimited)", (string s) => noTraits = s },
+                { "notraits=", "xUnit traits to exclude (semicolon delimited)", (string s) => noTraits = s },
                 { "timeout=", "Minute timeout to limit the tests to", (int i) => timeout = i },
                 { "out=", "Test result file directory", (string s) => resultFileDirectory = s },
                 { "logs=", "Log file directory", (string s) => logFileDirectory = s },
-                { "secondaryLogs=", "Log secondary file directory", (string s) => logFileSecondaryDirectory = s },
+                { "secondarylogs=", "Log secondary file directory", (string s) => logFileSecondaryDirectory = s },
                 { "display=", "Display", (Display d) => display = d },
-                { "procdumpPath=", "Path to procdump", (string s) => procDumpFilePath = s },
-                { "useProcdump", "Whether or not to use procdump", o => useProcDump = o is object },
+                { "procdumppath=", "Path to procdump", (string s) => procDumpFilePath = s },
+                { "useprocdump", "Whether or not to use procdump", o => useProcDump = o is object },
                 { "retry", "Retry failed test a few times", o => retry = o is object },
             };
 


### PR DESCRIPTION
Issues
- Use procdump in the unit test legs
- Use `Transport_Artifact` prefix for the artifacts transported from
  build to test machines

The name change on the second item is in response to several people
confusing them with actual test failure artifacts.