### PR TITLE
Use ISB-based API for retrieving solution assets in AssetSynchronizationSevice

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -42,6 +42,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             => solution.WithChangedOptionsFrom(remoteWorkpace.Options);
 
         [Fact]
+        [Obsolete]
         public void TestRemoteHostCreation()
         {
             var remoteLogger = new TraceSource("inprocRemoteClient");

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -243,7 +243,9 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
                 ServiceBrokerClient = new ServiceBrokerClient(ServiceBroker);
 #pragma warning restore
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 RegisterService(WellKnownServiceHubService.RemoteHost, (s, p, o) => new RemoteHostService(s, p));
+#pragma warning restore
                 RegisterInProcBrokeredService(SolutionAssetProvider.ServiceDescriptor, () => new SolutionAssetProvider(workspaceServices));
                 RegisterRemoteBrokeredService(new RemoteAssetSynchronizationService.Factory());
                 RegisterRemoteBrokeredService(new RemoteAsynchronousOperationListenerService.Factory());

--- a/src/Workspaces/Remote/ServiceHub/ExternalAccess/Pythia/Api/PythiaServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/ExternalAccess/Pythia/Api/PythiaServiceBase.cs
@@ -12,6 +12,8 @@ using Microsoft.CodeAnalysis.Remote;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+#pragma warning disable CS0618 // Type or member is obsolete - this should become error once we provide infra for migrating to ISB (https://github.com/dotnet/roslyn/issues/44326)
+
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 {
     internal abstract class PythiaServiceBase : ServiceBase

--- a/src/Workspaces/Remote/ServiceHub/ExternalAccess/UnitTesting/Api/UnitTestingServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/ExternalAccess/UnitTesting/Api/UnitTestingServiceBase.cs
@@ -11,6 +11,8 @@ using Microsoft.CodeAnalysis.Remote;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+#pragma warning disable CS0618 // Type or member is obsolete - this should become error once we provide infra for migrating to ISB (https://github.com/dotnet/roslyn/issues/44326)
+
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     internal abstract class UnitTestingServiceBase : ServiceBase

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         // TODO: remove
+        [Obsolete("Supports non-brokered services")]
         internal IAssetSource GetAssetSource()
         {
             Contract.ThrowIfNull(_solutionAssetSource, "Storage not initialized");
@@ -50,6 +51,7 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         // TODO: remove
+        [Obsolete("Supports non-brokered services")]
         internal void InitializeAssetSource(IAssetSource assetSource)
         {
             Contract.ThrowIfFalse(_solutionAssetSource == null);

--- a/src/Workspaces/Remote/ServiceHub/Services/AsynchronousOperationListener/RemoteAsynchronousOperationListenerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/AsynchronousOperationListener/RemoteAsynchronousOperationListenerService.cs
@@ -11,8 +11,14 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
-    internal class RemoteAsynchronousOperationListenerService : BrokeredServiceBase, IRemoteAsynchronousOperationListenerService
+    internal sealed class RemoteAsynchronousOperationListenerService : BrokeredServiceBase, IRemoteAsynchronousOperationListenerService
     {
+        internal sealed class Factory : FactoryBase<IRemoteAsynchronousOperationListenerService>
+        {
+            protected override IRemoteAsynchronousOperationListenerService CreateService(in ServiceConstructionArguments arguments)
+                => new RemoteAsynchronousOperationListenerService(in arguments);
+        }
+
         public RemoteAsynchronousOperationListenerService(in ServiceConstructionArguments arguments)
             : base(in arguments)
         {
@@ -49,12 +55,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 await listenerProvider.WaitAllAsync(workspace, featureNames.ToArray()).ConfigureAwait(false);
             }, cancellationToken);
-        }
-
-        internal sealed class Factory : FactoryBase<IRemoteAsynchronousOperationListenerService>
-        {
-            protected override IRemoteAsynchronousOperationListenerService CreateService(in ServiceConstructionArguments arguments)
-                => new RemoteAsynchronousOperationListenerService(in arguments);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.Remote
     /// 
     /// basically, this is used to manage lifetime of the service hub.
     /// </summary>
+    [Obsolete("Supports non-brokered services")]
     internal partial class RemoteHostService : ServiceBase, IRemoteHostService, IAssetSource
     {
         private static readonly TimeSpan s_reportInterval = TimeSpan.FromMinutes(2);

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
@@ -13,6 +13,8 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Roslyn.Utilities;
 
+#pragma warning disable CS0618 // Type or member is obsolete - this should become error once we provide infra for migrating to ISB (https://github.com/dotnet/roslyn/issues/44326)
+
 namespace Microsoft.CodeAnalysis.Remote
 {
     /// <summary>


### PR DESCRIPTION
Plus a minor refactoring to align with other remote services:

- Each service should be defined in a subdirectory.
- Factory should be defined at the top of the service type.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1223216