### PR TITLE
Slightly delay inline tags so that they don't immediately appear when user it typing a longer shortcut.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorTaggerProvider.cs
@@ -71,8 +71,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
             ITextView textView, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                new EditorFormatMapChangedEventSource(_editorFormatMap, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate));
+                new EditorFormatMapChangedEventSource(_editorFormatMap, TaggerDelay.Immediate),
+                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.Immediate));
         }
 
         protected override async Task ProduceTagsAsync(TaggerContext<LineSeparatorTag> context, DocumentSnapshotSpan documentSnapshotSpan, int? caretPosition)

--- a/src/EditorFeatures/Core.Wpf/Structure/AbstractStructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Structure/AbstractStructureTaggerProvider.cs
@@ -77,13 +77,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
                 TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.OnIdle),
                 TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.OnIdle),
                 TaggerEventSources.OnWorkspaceRegistrationChanged(subjectBuffer, TaggerDelay.OnIdle),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCodeLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForDeclarationLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCodeLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCommentsAndPreprocessorRegions, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCodeLevelConstructs, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForDeclarationLevelConstructs, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCodeLevelConstructs, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCommentsAndPreprocessorRegions, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, TaggerDelay.Immediate));
         }
 
         /// <summary>

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs
@@ -49,9 +49,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.Immediate),
+                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer, TaggerDelay.Immediate),
+                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.Immediate));
         }
 
         protected override Task ProduceTagsAsync(TaggerContext<BraceHighlightTag> context, DocumentSnapshotSpan documentSnapshotSpan, int? caretPosition)

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             // Note: when the user scrolls, we will try to reclassify as soon as possible.  That way
             // we appear semantically unclassified for a very short amount of time.
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textView, textChangeDelay: Delay, scrollChangeDelay: TaggerDelay.NearImmediate),
+                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textView, textChangeDelay: Delay, scrollChangeDelay: TaggerDelay.Immediate),
                 TaggerEventSources.OnWorkspaceChanged(subjectBuffer, Delay, this.AsyncListener),
                 TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay));
         }

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTaggerProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 
             return TaggerEventSources.Compose(
                 new EventSource(subjectBuffer, TaggerDelay.Short),
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate),
+                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.Immediate),
                 TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, TaggerDelay.Short));
         }
 

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -57,8 +57,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
         {
             return TaggerEventSources.Compose(
                 TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.OnIdle),
-                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer, TaggerDelay.Immediate),
+                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.Immediate));
         }
 
         protected override async Task ProduceTagsAsync(TaggerContext<KeywordHighlightTag> context, DocumentSnapshotSpan documentSnapshotSpan, int? caretPosition)

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         private void OnCaretMoved(object? sender, EventArgs e)
         {
             AssertIsForeground();
-            StartSelectedItemUpdateTask(delay: TaggerConstants.NearImmediateDelay, updateUIWhenDone: true);
+            StartSelectedItemUpdateTask(delay: TaggerConstants.ImmediateDelay, updateUIWhenDone: true);
         }
 
         private void OnViewFocused(object? sender, EventArgs e)

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -59,18 +59,18 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
         protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt, textChangeDelay: TaggerDelay.Short, scrollChangeDelay: TaggerDelay.NearImmediate),
-                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.NearImmediate, _listener),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.DisplayAllOverride, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForOtherParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatMatchMethodIntent, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatDifferOnlyBySuffix, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForTypes, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForImplicitVariableTypes, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLambdaParameterTypes, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt, textChangeDelay: TaggerDelay.Short, scrollChangeDelay: TaggerDelay.Immediate),
+                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.Immediate, _listener),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.DisplayAllOverride, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForParameters, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForOtherParameters, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatMatchMethodIntent, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatDifferOnlyBySuffix, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForTypes, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForImplicitVariableTypes, TaggerDelay.Immediate),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLambdaParameterTypes, TaggerDelay.Immediate));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -61,7 +61,10 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             return TaggerEventSources.Compose(
                 TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt, textChangeDelay: TaggerDelay.Short, scrollChangeDelay: TaggerDelay.Immediate),
                 TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.Immediate, _listener),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.DisplayAllOverride, TaggerDelay.Immediate),
+                // Ctrl-alt is the initial trigger for a lot of features (like ctrl-alt-p, attach to debugger). So bring
+                // this up not quite immediately so that users don't get flashes of this appearing when running other
+                // commands.
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.DisplayAllOverride, TaggerDelay.NearImmediate),
                 TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForParameters, TaggerDelay.Immediate),
                 TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters, TaggerDelay.Immediate),
                 TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters, TaggerDelay.Immediate),

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerConstants.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerConstants.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 {
     internal static class TaggerConstants
     {
-        internal const int NearImmediateDelay = 50;
+        internal const int ImmediateDelay = 50;
         internal const int ShortDelay = 250;
         internal const int MediumDelay = 500;
         internal const int IdleDelay = 1500;
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             switch (behavior)
             {
-                case TaggerDelay.NearImmediate:
-                    return TimeSpan.FromMilliseconds(NearImmediateDelay);
+                case TaggerDelay.Immediate:
+                    return TimeSpan.FromMilliseconds(ImmediateDelay);
                 case TaggerDelay.Short:
                     return TimeSpan.FromMilliseconds(ShortDelay);
                 case TaggerDelay.Medium:

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerConstants.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerConstants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
     internal static class TaggerConstants
     {
         internal const int ImmediateDelay = 50;
+        internal const int NearImmediateDelay = 150;
         internal const int ShortDelay = 250;
         internal const int MediumDelay = 500;
         internal const int IdleDelay = 1500;
@@ -29,19 +30,13 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         }
 
         internal static TimeSpan ComputeTimeDelay(this TaggerDelay behavior)
-        {
-            switch (behavior)
+            => behavior switch
             {
-                case TaggerDelay.Immediate:
-                    return TimeSpan.FromMilliseconds(ImmediateDelay);
-                case TaggerDelay.Short:
-                    return TimeSpan.FromMilliseconds(ShortDelay);
-                case TaggerDelay.Medium:
-                    return TimeSpan.FromMilliseconds(MediumDelay);
-                case TaggerDelay.OnIdle:
-                default:
-                    return TimeSpan.FromMilliseconds(IdleDelay);
-            }
-        }
+                TaggerDelay.Immediate => TimeSpan.FromMilliseconds(ImmediateDelay),
+                TaggerDelay.NearImmediate => TimeSpan.FromMilliseconds(NearImmediateDelay),
+                TaggerDelay.Short => TimeSpan.FromMilliseconds(ShortDelay),
+                TaggerDelay.Medium => TimeSpan.FromMilliseconds(MediumDelay),
+                _ => TimeSpan.FromMilliseconds(IdleDelay),
+            };
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 var allSpans = NormalizedSnapshotSpanCollection.Union(currentSpans, changedSpans);
                 _snapshotVersionToSpansMap[version] = allSpans;
 
-                EnqueueNotificationRequest(TaggerDelay.NearImmediate);
+                EnqueueNotificationRequest(TaggerDelay.Immediate);
             }
 
             // We may get a flurry of 'Notify' calls if we've enqueued a lot of work and it's now just
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 }
 
                 var currentTick = Environment.TickCount;
-                if (Math.Abs(currentTick - _lastReportTick) > TaggerDelay.NearImmediate.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds)
+                if (Math.Abs(currentTick - _lastReportTick) > TaggerDelay.Immediate.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds)
                 {
                     _lastReportTick = currentTick;
                     this.NotifyEditor();

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // notifications for when those options change.
                 var optionChangedEventSources =
                     _dataSource.Options.Concat<IOption>(_dataSource.PerLanguageOptions)
-                        .Select(o => TaggerEventSources.OnOptionChanged(_subjectBuffer, o, TaggerDelay.NearImmediate)).ToList();
+                        .Select(o => TaggerEventSources.OnOptionChanged(_subjectBuffer, o, TaggerDelay.Immediate)).ToList();
 
                 if (optionChangedEventSources.Count == 0)
                 {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -145,8 +145,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     // Now report them back to the UI on the main thread.
 
                     // We ask to update UI immediately for removed tags
-                    NotifyEditors(change.Value.Removed, initialTags ? TaggerDelay.NearImmediate : _tagSource.RemovedTagNotificationDelay);
-                    NotifyEditors(change.Value.Added, initialTags ? TaggerDelay.NearImmediate : _tagSource.AddedTagNotificationDelay);
+                    NotifyEditors(change.Value.Removed, initialTags ? TaggerDelay.Immediate : _tagSource.RemovedTagNotificationDelay);
+                    NotifyEditors(change.Value.Added, initialTags ? TaggerDelay.Immediate : _tagSource.AddedTagNotificationDelay);
                 }
             }
 
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     return;
                 }
 
-                if (delay == TaggerDelay.NearImmediate)
+                if (delay == TaggerDelay.Immediate)
                 {
                     // if delay is immediate, we let notifier knows about the change right away
                     _batchChangeNotifier.EnqueueChanges(changes);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -77,12 +77,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// <summary>
         /// This controls what delay tagger will use to let editor know about newly inserted tags
         /// </summary>
-        protected virtual TaggerDelay AddedTagNotificationDelay => TaggerDelay.NearImmediate;
+        protected virtual TaggerDelay AddedTagNotificationDelay => TaggerDelay.Immediate;
 
         /// <summary>
         /// This controls what delay tagger will use to let editor know about just deleted tags.
         /// </summary>
-        protected virtual TaggerDelay RemovedTagNotificationDelay => TaggerDelay.NearImmediate;
+        protected virtual TaggerDelay RemovedTagNotificationDelay => TaggerDelay.Immediate;
 
 #if DEBUG
         public readonly string StackTrace;

--- a/src/EditorFeatures/Core/Tagging/TaggerDelay.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerDelay.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// expects the tag immediately after typing a character or moving the caret, then this
         /// delay should be used.
         /// </summary>
-        NearImmediate,
+        Immediate,
 
         /// <summary>
         /// Not as fast as NearImmediate.  A user typing quickly or navigating quickly should not

--- a/src/EditorFeatures/Core/Tagging/TaggerDelay.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerDelay.cs
@@ -13,13 +13,19 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
     internal enum TaggerDelay
     {
         /// <summary>
-        /// Indicates that the tagger should retag after a short, but imperceptible delay.  This is
-        /// for features that want to appear instantaneous to the user, but which can wait a short
-        /// while until a batch of changes has occurred before processing.  Specifically, if a user
-        /// expects the tag immediately after typing a character or moving the caret, then this
-        /// delay should be used.
+        /// Indicates that the tagger should retag after a short, but user imperceptible delay.  This is for features
+        /// that want to appear instantaneous to the user, but which can wait a short while until a batch of changes has
+        /// occurred before processing.  Specifically, if a user expects the tag immediately after typing a character or
+        /// moving the caret, then this delay should be used.
         /// </summary>
         Immediate,
+
+        /// <summary>
+        /// Indicates that the tagger should retag very quickly, but with a slightly perceptible delay.  A user typing
+        /// quickly should not trigger this.  But it also shouldn't feel like they have to wait a long time if they
+        /// explicitly want to see these tags.
+        /// </summary>
+        NearImmediate,
 
         /// <summary>
         /// Not as fast as NearImmediate.  A user typing quickly or navigating quickly should not

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
         private sealed class TestTaggerEventSource : AbstractTaggerEventSource
         {
             public TestTaggerEventSource()
-                : base(delay: TaggerDelay.NearImmediate)
+                : base(delay: TaggerDelay.Immediate)
             {
             }
 


### PR DESCRIPTION
A couple of people have mentioned that inline-tags appear as they're typing `ctrl-alt-<some-other-char>`.  For example `ctrl-alt-p` is a debugger shortcut.  This can be distracting/annoying/flashing.

I've tweaked things to put inline-hints on a slightly longer delay.  Manual testing here found adding a 100ms delay here struck a sweet spot of having these no longer appear when typing another shortcut, while still feeling like they come up quickly when you do want them.  

If this  isn't a suitable fix in practice, we can consider a different trigger chord that either isn't the prefix of other commands, or is only a prefix for a suitably tiny set of rare commands such that users will be very unlikely to see this.

This PR sholud be reviewed commit by commit.  The first commit is a rename for clarity.  The second introduces the new behavior.