### PR TITLE
Switch the inline-hints shortcut from ctrl-alt to alt-f1

### DIFF
--- a/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
@@ -13,11 +13,11 @@ namespace Microsoft.CodeAnalysis.InlineHints
 {
     internal static class InlineHintsOptions
     {
-        public static readonly Option2<bool> DisplayAllHintsWhilePressingCtrlAlt =
+        public static readonly Option2<bool> DisplayAllHintsWhilePressingAltF1 =
             new(nameof(InlineHintsOptions),
-                nameof(DisplayAllHintsWhilePressingCtrlAlt),
+                nameof(DisplayAllHintsWhilePressingAltF1),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.Specific.DisplayAllHintsWhilePressingCtrlAlt"));
+                storageLocations: new RoamingProfileStorageLocation("TextEditor.Specific.DisplayAllHintsWhilePressingAltF1"));
 
         public static readonly PerLanguageOption2<bool> ColorHints =
             new(nameof(InlineHintsOptions),
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
         }
 
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            InlineHintsOptions.DisplayAllHintsWhilePressingCtrlAlt,
+            InlineHintsOptions.DisplayAllHintsWhilePressingAltF1,
             InlineHintsOptions.ColorHints,
             InlineHintsOptions.EnabledForParameters,
             InlineHintsOptions.ForLiteralParameters,

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -192,8 +192,8 @@
             <GroupBox x:Uid="InlineHintsGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints_experimental}">
                 <StackPanel>
-                    <CheckBox x:Name="DisplayAllHintsWhilePressingCtrlAlt"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_all_hints_while_pressing_Ctrl_Alt}" />
+                    <CheckBox x:Name="DisplayAllHintsWhilePressingAltF1"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_all_hints_while_pressing_Alt_F1}" />
 
                     <CheckBox x:Name="ColorHints"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Color_hints}" />

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             BindToOption(Editor_color_scheme, ColorSchemeOptions.ColorScheme);
 
-            BindToOption(DisplayAllHintsWhilePressingCtrlAlt, InlineHintsOptions.DisplayAllHintsWhilePressingCtrlAlt);
+            BindToOption(DisplayAllHintsWhilePressingAltF1, InlineHintsOptions.DisplayAllHintsWhilePressingAltF1);
             BindToOption(ColorHints, InlineHintsOptions.ColorHints, LanguageNames.CSharp);
 
             BindToOption(DisplayInlineParameterNameHints, InlineHintsOptions.EnabledForParameters, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -37,8 +37,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Inline_Hints_experimental
             => ServicesVSResources.Inline_Hints_experimental;
 
-        public static string Option_Display_all_hints_while_pressing_Ctrl_Alt
-            => ServicesVSResources.Display_all_hints_while_pressing_Ctrl_Alt;
+        public static string Option_Display_all_hints_while_pressing_Alt_F1
+            => ServicesVSResources.Display_all_hints_while_pressing_Alt_F1;
 
         public static string Option_Color_hints
             => ServicesVSResources.Color_hints;

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1584,8 +1584,8 @@ I agree to all of the foregoing:</value>
   <data name="Color_hints" xml:space="preserve">
     <value>Color hints</value>
   </data>
-  <data name="Display_all_hints_while_pressing_Ctrl_Alt" xml:space="preserve">
-    <value>Display all hints while pressing Ctrl+Alt</value>
+  <data name="Display_all_hints_while_pressing_Alt_F1" xml:space="preserve">
+    <value>Display all hints while pressing Alt+F1</value>
   </data>
   <data name="Enable_pull_diagnostics_experimental_requires_restart" xml:space="preserve">
     <value>Enable 'pull' diagnostics (experimental, requires restart)</value>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Aktuální parametr</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Aktueller Parameter</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Parámetro actual</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Paramètre actuel</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Parametro corrente</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -187,9 +187,9 @@
         <target state="translated">現在のパラメーター</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -187,9 +187,9 @@
         <target state="translated">현재 매개 변수</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Bieżący parametr</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Parâmetro atual</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Текущий параметр</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Geçerli parametre</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -187,9 +187,9 @@
         <target state="translated">当前参数</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -187,9 +187,9 @@
         <target state="translated">目前的參數</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_all_hints_while_pressing_Ctrl_Alt">
-        <source>Display all hints while pressing Ctrl+Alt</source>
-        <target state="new">Display all hints while pressing Ctrl+Alt</target>
+      <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
+        <source>Display all hints while pressing Alt+F1</source>
+        <target state="new">Display all hints while pressing Alt+F1</target>
         <note />
       </trans-unit>
       <trans-unit id="Display_inline_parameter_name_hints">

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -196,8 +196,8 @@
             <GroupBox x:Uid="InlineHintsGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints_experimental}">
                 <StackPanel>
-                    <CheckBox x:Name="DisplayAllHintsWhilePressingCtrlAlt"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_all_hints_while_pressing_Ctrl_Alt}" />
+                    <CheckBox x:Name="DisplayAllHintsWhilePressingAltF1"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_all_hints_while_pressing_Alt_F1}" />
 
                     <CheckBox x:Name="ColorHints"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Color_hints}" />

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -87,7 +87,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             BindToOption(Editor_color_scheme, ColorSchemeOptions.ColorScheme)
 
-            BindToOption(DisplayAllHintsWhilePressingCtrlAlt, InlineHintsOptions.DisplayAllHintsWhilePressingCtrlAlt)
+            BindToOption(DisplayAllHintsWhilePressingAltF1, InlineHintsOptions.DisplayAllHintsWhilePressingAltF1)
             BindToOption(ColorHints, InlineHintsOptions.ColorHints, LanguageNames.VisualBasic)
 
             BindToOption(DisplayInlineParameterNameHints, InlineHintsOptions.EnabledForParameters, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -33,8 +33,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_DisplayLineSeparators As String =
             BasicVSResources.Show_procedure_line_separators
 
-        Public ReadOnly Property Option_Display_all_hints_while_pressing_Ctrl_Alt As String =
-            ServicesVSResources.Display_all_hints_while_pressing_Ctrl_Alt
+        Public ReadOnly Property Option_Display_all_hints_while_pressing_Alt_F1 As String =
+            ServicesVSResources.Display_all_hints_while_pressing_Alt_F1
 
         Public ReadOnly Property Option_Color_hints As String =
             ServicesVSResources.Color_hints


### PR DESCRIPTION
ctrl-alt has the issue that it's the shortcut for 'create and insert multiple carets'.  Switching to a shortcut that doesn't seem to be taken for any existing features.