### PR TITLE
Add ProjectSystem APIs for UnusedReferences

### DIFF
--- a/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/IProjectSystemReferenceCleanupService.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/IProjectSystemReferenceCleanupService.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api
+{
+    // Interface to be implemented and MEF exported by Project System
+    internal interface IProjectSystemReferenceCleanupService
+    {
+        /// <summary>
+        /// Return the set of direct Project and Package References for the given project. This 
+        /// is used to get the initial state of the TreatAsUsed attribute for each reference.
+        /// </summary>
+        Task<ImmutableArray<ProjectSystemReferenceInfo>> GetProjectReferencesAsync(
+            string projectPath,
+            string targetFrameworkMoniker,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Updates the project’s references by removing or marking references as
+        /// TreatAsUsed in the project file.
+        /// </summary>
+        /// <returns>True, if the reference was updated.</returns>
+        Task<bool> TryUpdateReferenceAsync(
+            string projectPath,
+            string targetFrameworkMoniker,
+            ProjectSystemReferenceUpdate referenceUpdate,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemReferenceInfo.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemReferenceInfo.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api
+{
+    internal sealed class ProjectSystemReferenceInfo
+    {
+        /// <summary>
+        /// Indicates the type of reference.
+        /// </summary>
+        public ProjectSystemReferenceType ReferenceType { get; }
+
+        /// <summary>
+        /// Uniquely identifies the reference.
+        /// </summary>
+        /// <remarks>
+        /// Should match the Include or Name attribute used in the project file.
+        /// </remarks>
+        public string ItemSpecification { get; }
+
+        /// <summary>
+        /// Indicates that this reference should be treated as if it were used.
+        /// </summary>
+        public bool TreatAsUsed { get; }
+
+        public ProjectSystemReferenceInfo(ProjectSystemReferenceType referenceType, string itemSpecification, bool treatAsUsed)
+        {
+            ReferenceType = referenceType;
+            ItemSpecification = itemSpecification;
+            TreatAsUsed = treatAsUsed;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemReferenceType.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemReferenceType.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api
+{
+    internal enum ProjectSystemReferenceType
+    {
+        /// <summary>
+        /// Unknown reference type
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Individual assembly reference `&lt;Reference ... /&gt;`
+        /// </summary>
+        Assembly,
+
+        /// <summary>
+        /// NuGet package reference `&lt;PackageReference ... /&gt;`
+        /// </summary>
+        Package,
+
+        /// <summary>
+        /// Project reference `&lt;ProjectReference ... /&gt;`
+        /// </summary>
+        Project,
+
+        /// <summary>
+        /// SDK reference
+        /// </summary>
+        SDK,
+    }
+}

--- a/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemReferenceUpdate.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemReferenceUpdate.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api
+{
+    internal sealed class ProjectSystemReferenceUpdate
+    {
+        /// <summary>
+        /// Indicates action to perform on the reference.
+        /// </summary>
+        public ProjectSystemUpdateAction Action { get; }
+
+        /// <summary>
+        /// Gets the reference to be updated.
+        /// </summary>
+        public ProjectSystemReferenceInfo ReferenceInfo { get; }
+
+        public ProjectSystemReferenceUpdate(ProjectSystemUpdateAction action, ProjectSystemReferenceInfo referenceInfo)
+        {
+            Action = action;
+            ReferenceInfo = referenceInfo;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemUpdateAction.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/ProjectSystem/Api/ProjectSystemUpdateAction.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.ProjectSystem.Api
+{
+    internal enum ProjectSystemUpdateAction
+    {
+        /// <summary>
+        /// Indicates the reference should be updated with `TreatAsUsed="true"`
+        /// </summary>
+        SetTreatAsUsed,
+
+        /// <summary>
+        /// Indicates the reference should be updated with `TreatAsUsed="false"`
+        /// </summary>
+        UnsetTreatAsUsed,
+
+        /// <summary>
+        /// Indicates the reference should be removed from the project.
+        /// </summary>
+        Remove,
+    }
+}


### PR DESCRIPTION
Adding these to unblock the ProjectSystem team from inserting
 their implementation.

These APIs were previously merged into features/UsedAssemblyReference in https://github.com/dotnet/roslyn/pull/47136