### PR TITLE
Reduce allocation from data taken in local performance trace

### DIFF
--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -117,6 +117,24 @@ namespace Microsoft.CodeAnalysis
                 return str1.Length - str2.Length;
             }
 
+#if !NET20 && !NETSTANDARD1_3
+            public int Compare(ReadOnlySpan<char> str1, ReadOnlySpan<char> str2)
+            {
+                int len = Math.Min(str1.Length, str2.Length);
+                for (int i = 0; i < len; i++)
+                {
+                    int ordDiff = CompareLowerUnicode(str1[i], str2[i]);
+                    if (ordDiff != 0)
+                    {
+                        return ordDiff;
+                    }
+                }
+
+                // return the smaller string, or 0 if they are equal in length
+                return str1.Length - str2.Length;
+            }
+#endif
+
             private static bool AreEqualLowerUnicode(char c1, char c2)
             {
                 return c1 == c2 || ToLower(c1) == ToLower(c2);
@@ -149,6 +167,26 @@ namespace Microsoft.CodeAnalysis
 
                 return true;
             }
+
+#if !NET20 && !NETSTANDARD1_3
+            public bool Equals(ReadOnlySpan<char> str1, ReadOnlySpan<char> str2)
+            {
+                if (str1.Length != str2.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < str1.Length; i++)
+                {
+                    if (!AreEqualLowerUnicode(str1[i], str2[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+#endif
 
             public static bool EndsWith(string value, string possibleEnd)
             {
@@ -255,6 +293,20 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public static bool Equals(string left, string right) => s_comparer.Equals(left, right);
 
+#if !NET20 && !NETSTANDARD1_3
+        /// <summary>
+        /// Determines if two strings are equal according to Unicode rules for case-insensitive
+        /// identifier comparison (lower-case mapping).
+        /// </summary>
+        /// <param name="left">First identifier to compare</param>
+        /// <param name="right">Second identifier to compare</param>
+        /// <returns>true if the identifiers should be considered the same.</returns>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
+        public static bool Equals(ReadOnlySpan<char> left, ReadOnlySpan<char> right) => s_comparer.Equals(left, right);
+#endif
+
         /// <summary>
         /// Determines if the string 'value' end with string 'possibleEnd'.
         /// </summary>
@@ -282,6 +334,20 @@ namespace Microsoft.CodeAnalysis
         /// These are also the rules used for VB identifier comparison.
         /// </remarks>
         public static int Compare(string left, string right) => s_comparer.Compare(left, right);
+
+#if !NET20 && !NETSTANDARD1_3
+        /// <summary>
+        /// Compares two strings according to the Unicode rules for case-insensitive
+        /// identifier comparison (lower-case mapping).
+        /// </summary>
+        /// <param name="left">First identifier to compare</param>
+        /// <param name="right">Second identifier to compare</param>
+        /// <returns>-1 if <paramref name="left"/> &lt; <paramref name="right"/>, 1 if <paramref name="left"/> &gt; <paramref name="right"/>, 0 if they are equal.</returns>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
+        public static int Compare(ReadOnlySpan<char> left, ReadOnlySpan<char> right) => s_comparer.Compare(left, right);
+#endif
 
         /// <summary>
         /// Gets a case-insensitive hash code for Unicode identifiers.

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -254,17 +254,16 @@ namespace Roslyn.Utilities
 
         internal static int GetCaseInsensitiveFNVHashCode(string text)
         {
-            return GetCaseInsensitiveFNVHashCode(text, 0, text.Length);
+            return GetCaseInsensitiveFNVHashCode(text.AsSpan(0, text.Length));
         }
 
-        internal static int GetCaseInsensitiveFNVHashCode(string text, int start, int length)
+        internal static int GetCaseInsensitiveFNVHashCode(ReadOnlySpan<char> data)
         {
             int hashCode = Hash.FnvOffsetBias;
-            int end = start + length;
 
-            for (int i = start; i < end; i++)
+            for (int i = 0; i < data.Length; i++)
             {
-                hashCode = unchecked((hashCode ^ CaseInsensitiveComparison.ToLower(text[i])) * Hash.FnvPrime);
+                hashCode = unchecked((hashCode ^ CaseInsensitiveComparison.ToLower(data[i])) * Hash.FnvPrime);
             }
 
             return hashCode;

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string
+static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Compare(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> int
+static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> bool

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -71,6 +71,29 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return _builder.ToImmutable();
         }
 
+        /// <summary>
+        /// Realizes the array and clears the collection.
+        /// </summary>
+        public ImmutableArray<T> ToImmutableAndClear()
+        {
+            ImmutableArray<T> result;
+            if (Count == 0)
+            {
+                result = ImmutableArray<T>.Empty;
+            }
+            else if (_builder.Capacity == Count)
+            {
+                result = _builder.MoveToImmutable();
+            }
+            else
+            {
+                result = ToImmutable();
+                Clear();
+            }
+
+            return result;
+        }
+
         public int Count
         {
             get
@@ -281,6 +304,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// </summary>
         public ImmutableArray<T> ToImmutableAndFree()
         {
+            // This is mostly the same as 'MoveToImmutable', but avoids delegating to that method since 'Free' contains
+            // fast paths to avoid caling 'Clear' in some cases.
             ImmutableArray<T> result;
             if (Count == 0)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -17,7 +17,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
-    using ProjectToDocumentMap = Dictionary<Project, MultiDictionary<Document, (ISymbol symbol, IReferenceFinder finder)>>;
+    using ProjectToDocumentMap = Dictionary<Project, Dictionary<Document, HashSet<(ISymbol symbol, IReferenceFinder finder)>>>;
 
     internal partial class FindReferencesSearchEngine
     {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_DocumentProcessing.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_DocumentProcessing.cs
@@ -2,30 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
-    using DocumentMap = MultiDictionary<Document, (ISymbol symbol, IReferenceFinder finder)>;
-
     internal partial class FindReferencesSearchEngine
     {
         private async Task ProcessDocumentQueueAsync(
             Document document,
-            DocumentMap.ValueSet documentQueue)
+            HashSet<(ISymbol symbol, IReferenceFinder finder)> documentQueue)
         {
             await _progress.OnFindInDocumentStartedAsync(document).ConfigureAwait(false);
 
-            SemanticModel model = null;
+            SemanticModel? model = null;
             try
             {
-                model = await document.GetSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
+                model = await document.GetRequiredSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
 
                 // start cache for this semantic model
                 FindReferenceCache.Start(model);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
@@ -2,18 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
-    using DocumentMap = MultiDictionary<Document, (ISymbol symbol, IReferenceFinder finder)>;
+    using DocumentMap = Dictionary<Document, HashSet<(ISymbol symbol, IReferenceFinder finder)>>;
 
     internal partial class FindReferencesSearchEngine
     {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             TSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             TSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -26,13 +26,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         public const string ContainingMemberInfoPropertyName = "ContainingMemberInfo";
 
         public abstract Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
-            ISymbol symbol, Solution solution, IImmutableSet<Project> projects,
+            ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
-        public abstract Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(ISymbol symbol, Solution solution, IImmutableSet<Project> projects, CancellationToken cancellationToken);
+        public abstract Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(ISymbol symbol, Solution solution, IImmutableSet<Project>? projects, CancellationToken cancellationToken);
 
         public abstract Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            ISymbol symbol, Project project, IImmutableSet<Document> documents, FindReferencesSearchOptions options, CancellationToken cancellationToken);
+            ISymbol symbol, Project project, IImmutableSet<Document>? documents, FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
         public abstract ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             ISymbol symbol, Document document, SemanticModel semanticModel, FindReferencesSearchOptions options, CancellationToken cancellationToken);
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return name.TryGetWithoutAttributeSuffix(syntaxFacts.IsCaseSensitive, out result);
         }
 
-        protected static async Task<ImmutableArray<Document>> FindDocumentsAsync(Project project, IImmutableSet<Document> scope, Func<Document, CancellationToken, Task<bool>> predicateAsync, CancellationToken cancellationToken)
+        protected static async Task<ImmutableArray<Document>> FindDocumentsAsync(Project project, IImmutableSet<Document>? scope, Func<Document, CancellationToken, Task<bool>> predicateAsync, CancellationToken cancellationToken)
         {
             // special case for HR
             if (scope != null && scope.Count == 1)
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// </summary>
         protected static Task<ImmutableArray<Document>> FindDocumentsAsync(
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             bool findInGlobalSuppressions,
             CancellationToken cancellationToken,
             params string[] values)
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 
         protected static Task<ImmutableArray<Document>> FindDocumentsAsync(
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             PredefinedType predefinedType,
             CancellationToken cancellationToken)
         {
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 
         protected static Task<ImmutableArray<Document>> FindDocumentsAsync(
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             PredefinedOperator op,
             CancellationToken cancellationToken)
         {
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return allAliasReferences.ToImmutableAndFree();
         }
 
-        protected static Task<ImmutableArray<Document>> FindDocumentsWithPredicateAsync(Project project, IImmutableSet<Document> documents, Func<SyntaxTreeIndex, bool> predicate, CancellationToken cancellationToken)
+        protected static Task<ImmutableArray<Document>> FindDocumentsWithPredicateAsync(Project project, IImmutableSet<Document>? documents, Func<SyntaxTreeIndex, bool> predicate, CancellationToken cancellationToken)
         {
             return FindDocumentsAsync(project, documents, async (d, c) =>
             {
@@ -480,16 +480,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             }, cancellationToken);
         }
 
-        protected static Task<ImmutableArray<Document>> FindDocumentsWithForEachStatementsAsync(Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+        protected static Task<ImmutableArray<Document>> FindDocumentsWithForEachStatementsAsync(Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
             => FindDocumentsWithPredicateAsync(project, documents, predicate: sti => sti.ContainsForEachStatement, cancellationToken);
 
-        protected static Task<ImmutableArray<Document>> FindDocumentsWithDeconstructionAsync(Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+        protected static Task<ImmutableArray<Document>> FindDocumentsWithDeconstructionAsync(Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
             => FindDocumentsWithPredicateAsync(project, documents, predicate: sti => sti.ContainsDeconstruction, cancellationToken);
 
-        protected static Task<ImmutableArray<Document>> FindDocumentsWithAwaitExpressionAsync(Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+        protected static Task<ImmutableArray<Document>> FindDocumentsWithAwaitExpressionAsync(Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
             => FindDocumentsWithPredicateAsync(project, documents, predicate: sti => sti.ContainsAwait, cancellationToken);
 
-        protected static Task<ImmutableArray<Document>> FindDocumentsWithImplicitObjectCreationExpressionAsync(Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+        protected static Task<ImmutableArray<Document>> FindDocumentsWithImplicitObjectCreationExpressionAsync(Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
             => FindDocumentsWithPredicateAsync(project, documents, predicate: sti => sti.ContainsImplicitObjectCreation, cancellationToken);
 
         /// <summary>
@@ -904,14 +904,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected abstract bool CanFind(TSymbol symbol);
 
         protected abstract Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            TSymbol symbol, Project project, IImmutableSet<Document> documents,
+            TSymbol symbol, Project project, IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
         protected abstract ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
             TSymbol symbol, Document document, SemanticModel semanticModel,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
-        public override Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(ISymbol symbol, Solution solution, IImmutableSet<Project> projects, CancellationToken cancellationToken)
+        public override Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(ISymbol symbol, Solution solution, IImmutableSet<Project>? projects, CancellationToken cancellationToken)
         {
             return symbol is TSymbol typedSymbol && CanFind(typedSymbol)
                 ? DetermineProjectsToSearchAsync(typedSymbol, solution, projects, cancellationToken)
@@ -919,7 +919,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         public override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            ISymbol symbol, Project project, IImmutableSet<Document> documents,
+            ISymbol symbol, Project project, IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             return symbol is TSymbol typedSymbol && CanFind(typedSymbol)
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         public override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
-            ISymbol symbol, Solution solution, IImmutableSet<Project> projects,
+            ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             if (options.Cascade &&
@@ -953,14 +953,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         protected virtual Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(
-            TSymbol symbol, Solution solution, IImmutableSet<Project> projects, CancellationToken cancellationToken)
+            TSymbol symbol, Solution solution, IImmutableSet<Project>? projects, CancellationToken cancellationToken)
         {
             return DependentProjectsFinder.GetDependentProjectsAsync(
                 solution, symbol, projects, cancellationToken);
         }
 
         protected virtual Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
-            TSymbol symbol, Solution solution, IImmutableSet<Project> projects,
+            TSymbol symbol, Solution solution, IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyImmutableArray<ISymbol>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IMethodSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IEventSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IEventSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IMethodSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IFieldSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IFieldSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// Implementations of this method must be thread-safe.
         /// </summary>
         Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
-            ISymbol symbol, Solution solution, IImmutableSet<Project> projects,
+            ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// Implementations of this method must be thread-safe.
         /// </summary>
         Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(
-            ISymbol symbol, Solution solution, IImmutableSet<Project> projects, CancellationToken cancellationToken);
+            ISymbol symbol, Solution solution, IImmutableSet<Project>? projects, CancellationToken cancellationToken);
 
         /// <summary>
         /// Called by the find references search engine to determine which documents in the supplied
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// Implementations of this method must be thread-safe.
         /// </summary>
         Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            ISymbol symbol, Project project, IImmutableSet<Document> documents,
+            ISymbol symbol, Project project, IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
     internal class LinkedFileReferenceFinder : IReferenceFinder
     {
         public Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
-            ISymbol symbol, Solution solution, IImmutableSet<Project> projects,
+            ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             return options.Cascade
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         public Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            ISymbol symbol, Project project, IImmutableSet<Document> documents,
+            ISymbol symbol, Project project, IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyImmutableArray<Document>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             ITypeParameterSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             ITypeParameterSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             INamedTypeSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             INamedTypeSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             INamespaceSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IMethodSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol methodSymbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IParameterSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IParameterSymbol parameter,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IMethodSymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            IMethodSymbol symbol, Project project, IImmutableSet<Document> documents,
+            IMethodSymbol symbol, Project project, IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
             // First, find any documents with the full name of the accessor (i.e. get_Goo).

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
             IPropertySymbol symbol,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IPropertySymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
@@ -117,13 +117,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         private static Task<ImmutableArray<Document>> FindDocumentWithElementAccessExpressionsAsync(
-            Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+            Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
         {
             return FindDocumentsWithPredicateAsync(project, documents, info => info.ContainsElementAccessExpression, cancellationToken);
         }
 
         private static Task<ImmutableArray<Document>> FindDocumentWithIndexerMemberCrefAsync(
-            Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+            Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
         {
             return FindDocumentsWithPredicateAsync(project, documents, info => info.ContainsIndexerMemberCref, cancellationToken);
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             ITypeParameterSymbol symbol,
             Project project,
-            IImmutableSet<Document> documents,
+            IImmutableSet<Document>? documents,
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -21,8 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <see cref="BuilderNode"/>s are produced when initially creating our indices.
         /// They store Names of symbols and the index of their parent symbol.  When we
         /// produce the final <see cref="SymbolTreeInfo"/> though we will then convert
-        /// these to <see cref="Node"/>s.  Those nodes will not point to individual 
-        /// strings, but will instead point at <see cref="_concatenatedNames"/>.
+        /// these to <see cref="Node"/>s.
         /// </summary>
         [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
         private struct BuilderNode
@@ -50,9 +49,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private struct Node
         {
             /// <summary>
-            /// Span in <see cref="_concatenatedNames"/> of the Name of this Node.
+            /// The Name of this Node.
             /// </summary>
-            public readonly TextSpan NameSpan;
+            public readonly string Name;
 
             /// <summary>
             /// Index in <see cref="_nodes"/> of the parent Node of this Node.
@@ -61,9 +60,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </summary>
             public readonly int ParentIndex;
 
-            public Node(TextSpan wordSpan, int parentIndex)
+            public Node(string name, int parentIndex)
             {
-                NameSpan = wordSpan;
+                Name = name;
                 ParentIndex = parentIndex;
             }
 
@@ -71,12 +70,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             public void AssertEquivalentTo(Node node)
             {
-                Debug.Assert(node.NameSpan == this.NameSpan);
+                Debug.Assert(node.Name == this.Name);
                 Debug.Assert(node.ParentIndex == this.ParentIndex);
             }
 
             private string GetDebuggerDisplay()
-                => NameSpan + ", " + ParentIndex;
+                => Name + ", " + ParentIndex;
         }
 
         private readonly struct ParameterTypeInfo

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             // find any node that matches case-insensitively
             var startingPosition = BinarySearch(nodes, name);
-            var nameSlice = new StringSlice(name);
+            var nameSlice = name.AsMemory();
 
             if (startingPosition != -1)
             {
@@ -281,10 +281,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        private static StringSlice GetNameSlice(
+        private static ReadOnlyMemory<char> GetNameSlice(
             ImmutableArray<Node> nodes, int nodeIndex)
         {
-            return new StringSlice(nodes[nodeIndex].Name);
+            return nodes[nodeIndex].Name.AsMemory();
         }
 
         private int BinarySearch(string name)
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         private static int BinarySearch(ImmutableArray<Node> nodes, string name)
         {
-            var nameSlice = new StringSlice(name);
+            var nameSlice = name.AsMemory();
             var max = nodes.Length - 1;
             var min = 0;
 
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Checksum checksum, ImmutableArray<Node> sortedNodes)
         {
             return Task.FromResult(new SpellChecker(
-                checksum, sortedNodes.Select(n => new StringSlice(n.Name))));
+                checksum, sortedNodes.Select(n => n.Name.AsMemory())));
         }
 
         private static void SortNodes(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 loadOnly,
                 createAsync: () => CreateMetadataSymbolTreeInfoAsync(solution, checksum, reference),
                 keySuffix: "_Metadata_" + filePath,
-                tryReadObject: reader => TryReadSymbolTreeInfo(reader, checksum, (names, nodes) => GetSpellCheckerAsync(solution, checksum, filePath, names, nodes)),
+                tryReadObject: reader => TryReadSymbolTreeInfo(reader, checksum, nodes => GetSpellCheckerAsync(solution, checksum, filePath, nodes)),
                 cancellationToken: cancellationToken);
             Contract.ThrowIfFalse(result != null || loadOnly == true, "Result can only be null if 'loadOnly: true' was passed.");
             return result;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -14,7 +15,6 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class SymbolTreeInfo : IObjectWritable
     {
         private const string PrefixMetadataSymbolTreeInfo = "<SymbolTreeInfo>";
-        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("20");
+        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("21");
 
         /// <summary>
         /// Loads the SpellChecker for a given assembly symbol (metadata or project).  If the
@@ -33,14 +33,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Solution solution,
             Checksum checksum,
             string filePath,
-            string concatenatedNames,
             ImmutableArray<Node> sortedNodes)
         {
             var result = TryLoadOrCreateAsync(
                 solution,
                 checksum,
                 loadOnly: false,
-                createAsync: () => CreateSpellCheckerAsync(checksum, concatenatedNames, sortedNodes),
+                createAsync: () => CreateSpellCheckerAsync(checksum, sortedNodes),
                 keySuffix: "_SpellChecker_" + filePath,
                 tryReadObject: SpellChecker.TryReadFrom,
                 cancellationToken: CancellationToken.None);
@@ -138,14 +137,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public void WriteTo(ObjectWriter writer)
         {
-            writer.WriteString(_concatenatedNames);
-
             writer.WriteInt32(_nodes.Length);
-            foreach (var node in _nodes)
+            foreach (var group in GroupByName(_nodes.AsMemory()))
             {
-                writer.WriteInt32(node.NameSpan.Start);
-                writer.WriteInt32(node.NameSpan.Length);
-                writer.WriteInt32(node.ParentIndex);
+                writer.WriteString(group.Span[0].Name);
+                writer.WriteInt32(group.Length);
+                foreach (var item in group.Span)
+                {
+                    writer.WriteInt32(item.ParentIndex);
+                }
             }
 
             writer.WriteInt32(_inheritanceMap.Keys.Count);
@@ -181,26 +181,49 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     }
                 }
             }
+
+            // sortedNodes is an array of Node instances which is often sorted by Node.Name by the caller. This method
+            // produces a sequence of spans within sortedNodes for Node instances that all have the same Name, allowing
+            // serialization to record the string once followed by the remaining properties for the nodes in the group.
+            static IEnumerable<ReadOnlyMemory<Node>> GroupByName(ReadOnlyMemory<Node> sortedNodes)
+            {
+                if (sortedNodes.IsEmpty)
+                    yield break;
+
+                var startIndex = 0;
+                var currentName = sortedNodes.Span[0].Name;
+                for (var i = 1; i < sortedNodes.Length; i++)
+                {
+                    var node = sortedNodes.Span[i];
+                    if (node.Name != currentName)
+                    {
+                        yield return sortedNodes[startIndex..i];
+                        startIndex = i;
+                    }
+                }
+
+                yield return sortedNodes[startIndex..sortedNodes.Length];
+            }
         }
 
         private static SymbolTreeInfo TryReadSymbolTreeInfo(
             ObjectReader reader,
             Checksum checksum,
-            Func<string, ImmutableArray<Node>, Task<SpellChecker>> createSpellCheckerTask)
+            Func<ImmutableArray<Node>, Task<SpellChecker>> createSpellCheckerTask)
         {
             try
             {
-                var concatenatedNames = reader.ReadString();
-
                 var nodeCount = reader.ReadInt32();
                 var nodes = ArrayBuilder<Node>.GetInstance(nodeCount);
-                for (var i = 0; i < nodeCount; i++)
+                while (nodes.Count < nodeCount)
                 {
-                    var start = reader.ReadInt32();
-                    var length = reader.ReadInt32();
-                    var parentIndex = reader.ReadInt32();
-
-                    nodes.Add(new Node(new TextSpan(start, length), parentIndex));
+                    var name = reader.ReadString();
+                    var groupCount = reader.ReadInt32();
+                    for (var i = 0; i < groupCount; i++)
+                    {
+                        var parentIndex = reader.ReadInt32();
+                        nodes.Add(new Node(name, parentIndex));
+                    }
                 }
 
                 var inheritanceMap = new OrderPreservingMultiDictionary<int, int>();
@@ -244,9 +267,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 }
 
                 var nodeArray = nodes.ToImmutableAndFree();
-                var spellCheckerTask = createSpellCheckerTask(concatenatedNames, nodeArray);
+                var spellCheckerTask = createSpellCheckerTask(nodeArray);
                 return new SymbolTreeInfo(
-                    checksum, concatenatedNames, nodeArray, spellCheckerTask, inheritanceMap,
+                    checksum, nodeArray, spellCheckerTask, inheritanceMap,
                     receiverTypeNameToExtensionMethodMap);
             }
             catch
@@ -263,8 +286,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ObjectReader reader, Checksum checksum)
             {
                 return TryReadSymbolTreeInfo(reader, checksum,
-                    (names, nodes) => Task.FromResult(
-                        new SpellChecker(checksum, nodes.Select(n => new StringSlice(names, n.NameSpan)))));
+                    nodes => Task.FromResult(new SpellChecker(checksum, nodes.Select(n => new StringSlice(n.Name)))));
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ObjectReader reader, Checksum checksum)
             {
                 return TryReadSymbolTreeInfo(reader, checksum,
-                    nodes => Task.FromResult(new SpellChecker(checksum, nodes.Select(n => new StringSlice(n.Name)))));
+                    nodes => Task.FromResult(new SpellChecker(checksum, nodes.Select(n => n.Name.AsMemory()))));
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 loadOnly,
                 createAsync: () => CreateSourceSymbolTreeInfoAsync(project, checksum, cancellationToken),
                 keySuffix: "_Source_" + project.FilePath,
-                tryReadObject: reader => TryReadSymbolTreeInfo(reader, checksum, (names, nodes) => GetSpellCheckerAsync(project.Solution, checksum, project.FilePath, names, nodes)),
+                tryReadObject: reader => TryReadSymbolTreeInfo(reader, checksum, nodes => GetSpellCheckerAsync(project.Solution, checksum, project.FilePath, nodes)),
                 cancellationToken: cancellationToken);
             Contract.ThrowIfNull(result, "Result should never be null as we passed 'loadOnly: false'.");
             return result;

--- a/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
@@ -27,7 +27,7 @@ namespace Roslyn.Utilities
             _bkTree = bKTree;
         }
 
-        public SpellChecker(Checksum checksum, IEnumerable<StringSlice> corpus)
+        public SpellChecker(Checksum checksum, IEnumerable<ReadOnlyMemory<char>> corpus)
             : this(checksum, BKTree.Create(corpus))
         {
         }

--- a/src/Workspaces/CoreTest/Collections/TemporaryArrayTests.cs
+++ b/src/Workspaces/CoreTest/Collections/TemporaryArrayTests.cs
@@ -1,0 +1,191 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    public class TemporaryArrayTests
+    {
+        [Fact]
+        public void TestEmptyAndDefault()
+        {
+            Assert.Equal(0, TemporaryArray<int>.Empty.Count);
+            Assert.Equal(0, default(TemporaryArray<int>).Count);
+            Assert.Equal(0, new TemporaryArray<int>().Count);
+
+            Assert.Throws<IndexOutOfRangeException>(() => TemporaryArray<int>.Empty[-1]);
+            Assert.Throws<IndexOutOfRangeException>(() =>
+            {
+                using var array = TemporaryArray<int>.Empty;
+                Unsafe.AsRef(in array)[-1] = 1;
+            });
+
+            Assert.Throws<IndexOutOfRangeException>(() => TemporaryArray<int>.Empty[0]);
+            Assert.Throws<IndexOutOfRangeException>(() =>
+            {
+                using var array = TemporaryArray<int>.Empty;
+                Unsafe.AsRef(in array)[0] = 1;
+            });
+
+            Assert.False(TemporaryArray<int>.Empty.GetEnumerator().MoveNext());
+        }
+
+        [Fact]
+        public void TestInlineElements()
+        {
+            using var array = TemporaryArray<int>.Empty;
+            for (var i = 0; i < TemporaryArray<int>.TestAccessor.InlineCapacity; i++)
+            {
+                Assert.Equal(i, array.Count);
+                AddAndCheck();
+                Assert.False(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+                Assert.Equal(i + 1, TemporaryArray<int>.TestAccessor.InlineCount(in array));
+            }
+
+            // The next add forces a transition to dynamic storage
+            Assert.Equal(TemporaryArray<int>.TestAccessor.InlineCapacity, array.Count);
+            Assert.False(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+            AddAndCheck();
+            Assert.True(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+            Assert.Equal(0, TemporaryArray<int>.TestAccessor.InlineCount(in array));
+
+            // The next goes directly to existing dynamic storage
+            Assert.Equal(TemporaryArray<int>.TestAccessor.InlineCapacity + 1, array.Count);
+            AddAndCheck();
+            Assert.True(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+            Assert.Equal(0, TemporaryArray<int>.TestAccessor.InlineCount(in array));
+
+            // Local functions
+            void AddAndCheck()
+            {
+                var i = array.Count;
+                Assert.Throws<IndexOutOfRangeException>(() => array[i]);
+                Assert.Throws<IndexOutOfRangeException>(() => Unsafe.AsRef(in array)[i] = 1);
+
+                array.Add(i);
+                Assert.Equal(i + 1, array.Count);
+                Assert.Equal(i, array[i]);
+                Unsafe.AsRef(in array)[i] = i + 1;
+                Assert.Equal(i + 1, array[i]);
+            }
+        }
+
+        [Fact]
+        public void CannotMutateEmpty()
+        {
+            Assert.Equal(0, TemporaryArray<int>.Empty.Count);
+            TemporaryArray<int>.Empty.Add(0);
+            Assert.Equal(0, TemporaryArray<int>.Empty.Count);
+        }
+
+        [Fact]
+        public void TestDisposeFreesBuilder()
+        {
+            var array = TemporaryArray<int>.Empty;
+            array.AddRange(Enumerable.Range(0, TemporaryArray<int>.TestAccessor.InlineCapacity + 1).ToImmutableArray());
+            Assert.True(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+
+            array.Dispose();
+            Assert.False(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void TestAddRange([CombinatorialRange(0, 6)] int initialItems, [CombinatorialRange(0, 6)] int addedItems)
+        {
+            using var array = TemporaryArray<int>.Empty;
+            for (var i = 0; i < initialItems; i++)
+                array.Add(i);
+
+            Assert.Equal(initialItems, array.Count);
+            array.AddRange(Enumerable.Range(0, addedItems).ToImmutableArray());
+            Assert.Equal(initialItems + addedItems, array.Count);
+
+            if (array.Count > TemporaryArray<int>.TestAccessor.InlineCapacity)
+            {
+                Assert.True(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+                Assert.Equal(0, TemporaryArray<int>.TestAccessor.InlineCount(in array));
+            }
+            else
+            {
+                Assert.False(TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+                Assert.Equal(array.Count, TemporaryArray<int>.TestAccessor.InlineCount(in array));
+            }
+
+            for (var i = 0; i < initialItems; i++)
+                Assert.Equal(i, array[i]);
+
+            for (var i = 0; i < addedItems; i++)
+                Assert.Equal(i, array[initialItems + i]);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void TestClear([CombinatorialRange(0, 6)] int initialItems)
+        {
+            using var array = TemporaryArray<int>.Empty;
+            for (var i = 0; i < initialItems; i++)
+                array.Add(i);
+
+            Assert.Equal(initialItems, array.Count);
+
+            array.Clear();
+            Assert.Equal(0, array.Count);
+
+            // TemporaryArray<T>.Clear does not move from dynamic back to inline storage, so we condition this assertion
+            // on the count prior to calling Clear.
+            Assert.Equal(
+                initialItems > TemporaryArray<int>.TestAccessor.InlineCapacity,
+                TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void TestEnumerator([CombinatorialRange(0, 6)] int initialItems)
+        {
+            using var array = TemporaryArray<int>.Empty;
+            for (var i = 0; i < initialItems; i++)
+                array.Add(i);
+
+            Assert.Equal(initialItems, array.Count);
+
+            var enumerator = array.GetEnumerator();
+            for (var i = 0; i < initialItems; i++)
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Equal(i, enumerator.Current);
+            }
+
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void TestMoveToImmutable([CombinatorialRange(0, 6)] int initialItems)
+        {
+            using var array = TemporaryArray<int>.Empty;
+            for (var i = 0; i < initialItems; i++)
+                array.Add(i);
+
+            Assert.Equal(initialItems, array.Count);
+
+            var immutableArray = array.ToImmutableAndClear();
+            Assert.Equal(Enumerable.Range(0, initialItems), immutableArray);
+
+            Assert.Equal(0, array.Count);
+
+            // TemporaryArray<T>.MoveToImmutable does not move from dynamic back to inline storage, so we condition this
+            // assertion on the count prior to calling Clear.
+            Assert.Equal(
+                initialItems > TemporaryArray<int>.TestAccessor.InlineCapacity,
+                TemporaryArray<int>.TestAccessor.HasDynamicStorage(in array));
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/TemporaryArray`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/TemporaryArray`1.cs
@@ -1,0 +1,313 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Shared.Collections
+{
+    /// <summary>
+    /// Provides temporary storage for a collection of elements. This type is optimized for handling of small
+    /// collections, particularly for cases where the collection will eventually be discarded or used to produce an
+    /// <see cref="ImmutableArray{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This type stores small collections on the stack, with the ability to transition to dynamic storage if/when
+    /// larger number of elements are added.
+    /// </remarks>
+    /// <typeparam name="T">The type of elements stored in the collection.</typeparam>
+    [NonCopyable]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TemporaryArray<T> : IDisposable
+    {
+        /// <summary>
+        /// The number of elements the temporary can store inline. Storing more than this many elements requires the
+        /// array transition to dynamic storage.
+        /// </summary>
+        private const int InlineCapacity = 4;
+
+        /// <summary>
+        /// The first inline element.
+        /// </summary>
+        /// <remarks>
+        /// This field is only used when <see cref="_builder"/> is <see langword="null"/>. In other words, this type
+        /// stores elements inline <em>or</em> stores them in <see cref="_builder"/>, but does not use both approaches
+        /// at the same time.
+        /// </remarks>
+        private T _item0;
+
+        /// <summary>
+        /// The second inline element.
+        /// </summary>
+        /// <seealso cref="_item0"/>
+        private T _item1;
+
+        /// <summary>
+        /// The third inline element.
+        /// </summary>
+        /// <seealso cref="_item0"/>
+        private T _item2;
+
+        /// <summary>
+        /// The fourth inline element.
+        /// </summary>
+        /// <seealso cref="_item0"/>
+        private T _item3;
+
+        /// <summary>
+        /// The number of inline elements held in the array. This value is only used when <see cref="_builder"/> is
+        /// <see langword="null"/>.
+        /// </summary>
+        private int _count;
+
+        /// <summary>
+        /// A builder used for dynamic storage of collections that may exceed the limit for inline elements.
+        /// </summary>
+        /// <remarks>
+        /// This field is initialized to non-<see langword="null"/> the first time the <see cref="TemporaryArray{T}"/>
+        /// needs to store more than four elements. From that point, <see cref="_builder"/> is used instead of inline
+        /// elements, even if items are removed to make the result smaller than four elements.
+        /// </remarks>
+        private ArrayBuilder<T>? _builder;
+
+        private TemporaryArray(in TemporaryArray<T> array)
+        {
+            // Intentional copy used for creating an enumerator
+#pragma warning disable RS0042 // Do not copy value
+            this = array;
+#pragma warning restore RS0042 // Do not copy value
+        }
+
+        public static TemporaryArray<T> Empty => default;
+
+        public readonly int Count => _builder?.Count ?? _count;
+
+        public T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            readonly get
+            {
+                if (_builder is not null)
+                    return _builder[index];
+
+                if ((uint)index >= _count)
+                    ThrowIndexOutOfRangeException();
+
+                return index switch
+                {
+                    0 => _item0,
+                    1 => _item1,
+                    2 => _item2,
+                    _ => _item3,
+                };
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if (_builder is not null)
+                {
+                    _builder[index] = value;
+                    return;
+                }
+
+                if ((uint)index >= _count)
+                    ThrowIndexOutOfRangeException();
+
+                _ = index switch
+                {
+                    0 => _item0 = value,
+                    1 => _item1 = value,
+                    2 => _item2 = value,
+                    _ => _item3 = value,
+                };
+            }
+        }
+
+        public void Dispose()
+        {
+            // Return _builder to the pool if necessary. There is no need to release inline storage since the majority
+            // case for this type is stack-allocated storage and the GC is already able to reclaim objects from the
+            // stack after the last use of a reference to them.
+            Interlocked.Exchange(ref _builder, null)?.Free();
+        }
+
+        public void Add(T item)
+        {
+            if (_builder is not null)
+            {
+                _builder.Add(item);
+            }
+            else if (_count < InlineCapacity)
+            {
+                // Increase _count before assigning a value since the indexer has a bounds check.
+                _count++;
+                this[_count - 1] = item;
+            }
+            else
+            {
+                Debug.Assert(_count == InlineCapacity);
+                MoveInlineToBuilder();
+                _builder.Add(item);
+            }
+        }
+
+        public void AddRange(ImmutableArray<T> items)
+        {
+            if (_builder is not null)
+            {
+                _builder.AddRange(items);
+            }
+            else if (_count + items.Length <= InlineCapacity)
+            {
+                foreach (var item in items)
+                {
+                    // Increase _count before assigning values since the indexer has a bounds check.
+                    _count++;
+                    this[_count - 1] = item;
+                }
+            }
+            else
+            {
+                MoveInlineToBuilder();
+                _builder.AddRange(items);
+            }
+        }
+
+        public void Clear()
+        {
+            if (_builder is not null)
+            {
+                // Keep using a builder even if we now fit in inline storage to avoid churn in the object pools.
+                _builder.Clear();
+            }
+            else
+            {
+                this = Empty;
+            }
+        }
+
+        public readonly Enumerator GetEnumerator()
+        {
+            return new Enumerator(in this);
+        }
+
+        /// <summary>
+        /// Create an <see cref="ImmutableArray{T}"/> with the elements currently held in the temporary array, and clear
+        /// the array.
+        /// </summary>
+        /// <returns></returns>
+        public ImmutableArray<T> ToImmutableAndClear()
+        {
+            if (_builder is not null)
+            {
+                return _builder.ToImmutableAndClear();
+            }
+            else
+            {
+                var result = _count switch
+                {
+                    0 => ImmutableArray<T>.Empty,
+                    1 => ImmutableArray.Create(_item0),
+                    2 => ImmutableArray.Create(_item0, _item1),
+                    3 => ImmutableArray.Create(_item0, _item1, _item2),
+                    4 => ImmutableArray.Create(_item0, _item1, _item2, _item3),
+                    _ => throw ExceptionUtilities.Unreachable,
+                };
+
+                // Since _builder is null on this path, we can overwrite the whole structure to Empty to reset all
+                // inline elements to their default value and the _count to 0.
+                this = Empty;
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Transitions the current <see cref="TemporaryArray{T}"/> from inline storage to dynamic storage storage. An
+        /// <see cref="ArrayBuilder{T}"/> instance is taken from the shared pool, and all elements currently in inline
+        /// storage are added to it. After this point, dynamic storage will be used instead of inline storage.
+        /// </summary>
+        [MemberNotNull(nameof(_builder))]
+        private void MoveInlineToBuilder()
+        {
+            Debug.Assert(_builder is null);
+
+            var builder = ArrayBuilder<T>.GetInstance();
+            for (var i = 0; i < _count; i++)
+            {
+                builder.Add(this[i]);
+
+#if NETCOREAPP
+                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+#endif
+                {
+                    this[i] = default!;
+                }
+            }
+
+            _count = 0;
+            _builder = builder;
+        }
+
+        /// <summary>
+        /// Throws <see cref="IndexOutOfRangeException"/>.
+        /// </summary>
+        /// <remarks>
+        /// This helper improves the ability of the JIT to inline callers.
+        /// </remarks>
+        private static void ThrowIndexOutOfRangeException()
+            => throw new IndexOutOfRangeException();
+
+        public struct Enumerator
+        {
+            private readonly TemporaryArray<T> _array;
+
+            private T _current;
+            private int _nextIndex;
+
+            public Enumerator(in TemporaryArray<T> array)
+            {
+                // Enumerate a copy of the original
+                _array = new TemporaryArray<T>(in array);
+                _current = default!;
+                _nextIndex = 0;
+            }
+
+            public T Current => _current;
+
+            public bool MoveNext()
+            {
+                if (_nextIndex >= _array.Count)
+                {
+                    return false;
+                }
+                else
+                {
+                    _current = _array[_nextIndex];
+                    _nextIndex++;
+                    return true;
+                }
+            }
+        }
+
+        internal static class TestAccessor
+        {
+            public static int InlineCapacity => TemporaryArray<T>.InlineCapacity;
+
+            public static bool HasDynamicStorage(in TemporaryArray<T> array)
+                => array._builder is not null;
+
+            public static int InlineCount(in TemporaryArray<T> array)
+                => array._count;
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -181,6 +181,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeStyle\ParenthesesPreference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\SegmentedArrayHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\SegmentedArray`1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Collections\TemporaryArray`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\IPragmaSuppressionsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedDiagnostic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\Common\EmbeddedSyntaxHelpers.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Builder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Builder.cs
@@ -94,7 +94,7 @@ namespace Roslyn.Utilities
             private readonly Edge[] _compactEdges;
             private readonly BuilderNode[] _builderNodes;
 
-            public Builder(IEnumerable<StringSlice> values)
+            public Builder(IEnumerable<ReadOnlyMemory<char>> values)
             {
                 // TODO(cyrusn): Properly handle unicode normalization here.
                 var distinctValues = values.Where(v => v.Length > 0).Distinct(StringSliceComparer.OrdinalIgnoreCase).ToArray();
@@ -109,7 +109,7 @@ namespace Roslyn.Utilities
                     var value = distinctValues[i];
                     _wordSpans[i] = new TextSpan(characterIndex, value.Length);
 
-                    foreach (var ch in value)
+                    foreach (var ch in value.Span)
                     {
                         _concatenatedLowerCaseWords[characterIndex] = CaseInsensitiveComparison.ToLower(ch);
                         characterIndex++;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.cs
@@ -65,9 +65,9 @@ namespace Roslyn.Utilities
         }
 
         public static BKTree Create(params string[] values)
-            => Create(values.Select(v => new StringSlice(v)));
+            => Create(values.Select(v => v.AsMemory()));
 
-        public static BKTree Create(IEnumerable<StringSlice> values)
+        public static BKTree Create(IEnumerable<ReadOnlyMemory<char>> values)
             => new Builder(values).Create();
 
         public IList<string> Find(string value, int? threshold = null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/StringSlice.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/StringSlice.cs
@@ -2,194 +2,43 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
-    internal struct StringSlice : IEquatable<StringSlice>
-    {
-        private readonly string _underlyingString;
-        private readonly TextSpan _span;
-
-        public StringSlice(string underlyingString, TextSpan span)
-        {
-            _underlyingString = underlyingString;
-            _span = span;
-
-            Debug.Assert(span.Start >= 0);
-            Debug.Assert(span.End <= underlyingString.Length);
-        }
-
-        public StringSlice(string value) : this(value, new TextSpan(0, value.Length))
-        {
-        }
-
-        public int Length => _span.Length;
-
-        public char this[int index] => _underlyingString[_span.Start + index];
-
-        public Enumerator GetEnumerator()
-            => new(this);
-
-        public override bool Equals(object obj) => Equals((StringSlice)obj);
-
-        public bool Equals(StringSlice other) => EqualsOrdinal(other);
-
-        internal bool EqualsOrdinal(StringSlice other)
-        {
-            if (this._span.Length != other._span.Length)
-            {
-                return false;
-            }
-
-            var end = this._span.End;
-            for (int i = this._span.Start, j = other._span.Start; i < end; i++, j++)
-            {
-                if (this._underlyingString[i] != other._underlyingString[j])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        internal bool EqualsOrdinalIgnoreCase(StringSlice other)
-        {
-            if (this._span.Length != other._span.Length)
-            {
-                return false;
-            }
-
-            var end = this._span.End;
-            for (int i = this._span.Start, j = other._span.Start; i < end; i++, j++)
-            {
-                var thisChar = this._underlyingString[i];
-                var otherChar = other._underlyingString[j];
-
-                if (!EqualsOrdinalIgnoreCase(thisChar, otherChar))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static bool EqualsOrdinalIgnoreCase(char thisChar, char otherChar)
-        {
-            // Do a fast check first before converting to lowercase characters.
-            return
-                thisChar == otherChar ||
-                CaseInsensitiveComparison.ToLower(thisChar) == CaseInsensitiveComparison.ToLower(otherChar);
-        }
-
-        public override int GetHashCode() => GetHashCodeOrdinal();
-
-        internal int GetHashCodeOrdinal()
-            => Hash.GetFNVHashCode(this._underlyingString, this._span.Start, this._span.Length);
-
-        internal int GetHashCodeOrdinalIgnoreCase()
-            => Hash.GetCaseInsensitiveFNVHashCode(this._underlyingString, this._span.Start, this._span.Length);
-
-        internal int CompareToOrdinal(StringSlice other)
-        {
-            var thisEnd = this._span.End;
-            var otherEnd = other._span.End;
-            for (int i = this._span.Start, j = other._span.Start;
-                 i < thisEnd && j < otherEnd;
-                 i++, j++)
-            {
-                var diff = this._underlyingString[i] - other._underlyingString[j];
-                if (diff != 0)
-                {
-                    return diff;
-                }
-            }
-
-            // Choose the one that is shorter if their prefixes match so far.
-            return this.Length - other.Length;
-        }
-
-        internal int CompareToOrdinalIgnoreCase(StringSlice other)
-        {
-            var thisEnd = this._span.End;
-            var otherEnd = other._span.End;
-            for (int i = this._span.Start, j = other._span.Start;
-                 i < thisEnd && j < otherEnd;
-                 i++, j++)
-            {
-                var diff =
-                    CaseInsensitiveComparison.ToLower(this._underlyingString[i]) -
-                    CaseInsensitiveComparison.ToLower(other._underlyingString[j]);
-                if (diff != 0)
-                {
-                    return diff;
-                }
-            }
-
-            // Choose the one that is shorter if their prefixes match so far.
-            return this.Length - other.Length;
-        }
-
-        public struct Enumerator
-        {
-            private readonly StringSlice _stringSlice;
-            private int index;
-
-            public Enumerator(StringSlice stringSlice)
-            {
-                _stringSlice = stringSlice;
-                index = -1;
-            }
-
-            public bool MoveNext()
-            {
-                index++;
-                return index < _stringSlice.Length;
-            }
-
-            public char Current => _stringSlice[index];
-        }
-    }
-
-    internal abstract class StringSliceComparer : IComparer<StringSlice>, IEqualityComparer<StringSlice>
+    internal abstract class StringSliceComparer : IComparer<ReadOnlyMemory<char>>, IEqualityComparer<ReadOnlyMemory<char>>
     {
         public static readonly StringSliceComparer Ordinal = new OrdinalComparer();
         public static readonly StringSliceComparer OrdinalIgnoreCase = new OrdinalIgnoreCaseComparer();
 
         private class OrdinalComparer : StringSliceComparer
         {
-            public override int Compare(StringSlice x, StringSlice y)
-                => x.CompareToOrdinal(y);
+            public override int Compare(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
+                => x.Span.CompareTo(y.Span, StringComparison.Ordinal);
 
-            public override bool Equals(StringSlice x, StringSlice y)
-                => x.EqualsOrdinal(y);
+            public override bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
+                => x.Span.Equals(y.Span, StringComparison.Ordinal);
 
-            public override int GetHashCode(StringSlice obj)
-                => obj.GetHashCodeOrdinal();
+            public override int GetHashCode(ReadOnlyMemory<char> obj)
+                => Hash.GetFNVHashCode(obj.Span);
         }
 
         private class OrdinalIgnoreCaseComparer : StringSliceComparer
         {
-            public override int Compare(StringSlice x, StringSlice y)
-                => x.CompareToOrdinalIgnoreCase(y);
+            public override int Compare(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
+                => CaseInsensitiveComparison.Compare(x.Span, y.Span);
 
-            public override bool Equals(StringSlice x, StringSlice y)
-                => x.EqualsOrdinalIgnoreCase(y);
+            public override bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
+                => CaseInsensitiveComparison.Equals(x.Span, y.Span);
 
-            public override int GetHashCode(StringSlice obj)
-                => obj.GetHashCodeOrdinalIgnoreCase();
+            public override int GetHashCode(ReadOnlyMemory<char> obj)
+                => Hash.GetCaseInsensitiveFNVHashCode(obj.Span);
         }
 
-        public abstract int Compare(StringSlice x, StringSlice y);
-        public abstract bool Equals(StringSlice x, StringSlice y);
-        public abstract int GetHashCode(StringSlice obj);
+        public abstract int Compare(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y);
+        public abstract bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y);
+        public abstract int GetHashCode(ReadOnlyMemory<char> obj);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             var currentServicesMap = _languageServicesMap;
             if (!currentServicesMap.TryGetValue(languageName, out var languageServices))
             {
-                languageServices = ImmutableInterlocked.GetOrAdd(ref _languageServicesMap, languageName, _ => new MefLanguageServices(this, languageName));
+                languageServices = ImmutableInterlocked.GetOrAdd(ref _languageServicesMap, languageName, static (languageName, self) => new MefLanguageServices(self, languageName), this);
             }
 
             if (languageServices.HasServices)


### PR DESCRIPTION
* 00b15ac saves over 100MB allocations in 100 seconds
* 1745e06 and 4d8ba5617e8f1ab9cb72d517a37ecf8ae0d776f5 save over 3GB allocations

I can separate refactoring 7e6b174fcd281e5f49f0c8619e952e4844d8d38d if desired.