### PR TITLE
Avoid duplicate GetHashCode() values in TokenMap

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -348,5 +348,32 @@ class Program
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
         }
+
+        [Fact]
+        [WorkItem(48886, "https://github.com/dotnet/roslyn/issues/48886")]
+        public void ArrayInitializationAnonymousTypes()
+        {
+            const int nTypes = 250;
+            const int nItemsPerType = 1000;
+
+            var builder = new StringBuilder();
+            for (int i = 0; i < nTypes; i++)
+            {
+                builder.AppendLine($"class C{i}");
+                builder.AppendLine("{");
+                builder.AppendLine("    static object[] F = new[]");
+                builder.AppendLine("    {");
+                for (int j = 0; j < nItemsPerType; j++)
+                {
+                    builder.AppendLine($"        new {{ Id = {j} }},");
+                }
+                builder.AppendLine("    };");
+                builder.AppendLine("}");
+            }
+
+            var source = builder.ToString();
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }

--- a/src/Compilers/Core/Portable/IReferenceOrISignature.cs
+++ b/src/Compilers/Core/Portable/IReferenceOrISignature.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
 
         public override bool Equals(object? obj) => false;
 
-        public override int GetHashCode() => _item.GetHashCode();
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(_item);
 
         public override string ToString() => _item.ToString() ?? "null";
     }


### PR DESCRIPTION
`TokenMap` stores symbols used in code generation in a dictionary mapped to index. The symbols are compared by reference* so, ideally, the hash codes for the symbols should be distinct if the symbols are distinct instances.

Fixes #48886.

In the bug repro, many symbols are added to the map for the same method (a `SubstitutedMethodSymbol` for an anonymous type constructor). The map was using `SubstitutedMethodSymbol.GetHashCode()` for those symbols so the dictionary performed poorly  (in `ConcurrentDictionary<IReferenceOrSignature, uint>.TryAdd(TKey, TValue)` in particular) since many items had the same hash code value.

_*There is a separate question of whether `TokenMap` should contain separate entries for multiple instances of the same symbol. I will confirm._

[Thanks to @jaredpar for suggesting hashcode collisions as the issue.]