### PR TITLE
Feature/disambiguate using keyword

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -381,7 +381,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
             if (token.IsKind(SyntaxKind.UsingKeyword) && token.Parent is UsingStatementSyntax)
             {
-                text = Keyword("usingstatement");
+                text = Keyword("using-statement");
                 return true;
             }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -379,7 +379,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
-            if (token.IsKind(SyntaxKind.UsingKeyword) && token.Parent is UsingStatementSyntax)
+            if (token.IsKind(SyntaxKind.UsingKeyword) && token.Parent is UsingStatementSyntax or LocalDeclarationStatementSyntax)
             {
                 text = Keyword("using-statement");
                 return true;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -325,8 +325,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     text = "protectedinternal_CSharpKeyword";
                     return true;
 
-                case SyntaxKind.UsingKeyword when token.GetNextToken().IsKind(SyntaxKind.StaticKeyword):
-                case SyntaxKind.StaticKeyword when token.GetPreviousToken().IsKind(SyntaxKind.UsingKeyword):
+                case SyntaxKind.UsingKeyword when token.Parent is UsingDirectiveSyntax:
+                    text = (token.GetNextToken().IsKind(SyntaxKind.StaticKeyword)
+                        ? "using-static_CSharpKeyword"
+                        : "using_CSharpKeyword");
+                    return true;
+                case SyntaxKind.StaticKeyword when token.Parent is UsingDirectiveSyntax:
                     text = "using-static_CSharpKeyword";
                     return true;
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -326,9 +326,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     return true;
 
                 case SyntaxKind.UsingKeyword when token.Parent is UsingDirectiveSyntax:
-                    text = (token.GetNextToken().IsKind(SyntaxKind.StaticKeyword)
+                    text = token.GetNextToken().IsKind(SyntaxKind.StaticKeyword)
                         ? "using-static_CSharpKeyword"
-                        : "using_CSharpKeyword");
+                        : "using_CSharpKeyword";
                     return true;
                 case SyntaxKind.StaticKeyword when token.Parent is UsingDirectiveSyntax:
                     text = "using-static_CSharpKeyword";

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -376,6 +376,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             if (token.IsKind(SyntaxKind.StructKeyword) && token.Parent is ClassOrStructConstraintSyntax)
             {
                 text = Keyword("structconstraint");
+                return true;
+            }
+
+            if (token.IsKind(SyntaxKind.UsingKeyword) && token.Parent is UsingStatementSyntax)
+            {
+                text = Keyword("usingstatement");
                 return true;
             }
 

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1125,6 +1125,21 @@ class C
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestUsingDeclaration()
+        {
+            await Test_KeywordAsync(
+@"using namespace.Class;
+
+class C
+{ 
+    void Method(String someString) {
+        us[||]ing var reader = new StringReader(someString);
+    }
+}", "using-statement");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestUsingStaticOnStaticKeyword()
         {
             await Test_KeywordAsync(

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1104,6 +1104,23 @@ static class C
 
     static void Method() {}
 }", "using");
+        }
+
+        [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestUsingStatement()
+        {
+            await Test_KeywordAsync(
+@"using namespace.Class;
+
+class C
+{ 
+    void Method(String someString) {
+        us[||]ing (var reader = new StringReader(someString))
+        {
+        }
+    }
+}", "usingstatement");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1120,7 +1120,7 @@ class C
         {
         }
     }
-}", "usingstatement");
+}", "using-statement");
         }
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1093,7 +1093,7 @@ static class C
 
         [WorkItem(48392, "https://github.com/dotnet/roslyn/issues/48392")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestNormalUsing()
+        public async Task TestNormalUsingDirective()
         {
             await Test_KeywordAsync(
 @"us[||]ing namespace.Class;


### PR DESCRIPTION
This PR adds a separate `f1_keyword` for the using-statement semantics of the `using` keyword. This allows the F1 help to route to the appropriate page based on the context, rather than having to route to a generic using page.  It also updates the logic detecting a `using-static` to also catch the normal using directive, since it already knows at that point and doesn't need to waste time doing other checks before falling through to the using keyword.

Fixes part of #48392

Related docs PR:
dotnet/docs#21209