### PR TITLE
Rename tuple fields in more places

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
@@ -59,15 +59,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return new FailureInlineRenameInfo(EditorFeaturesResources.You_cannot_rename_this_element);
             }
 
-            // see https://github.com/dotnet/roslyn/issues/10898
-            // we are disabling rename for tuple fields for now
-            // 1) compiler does not return correct location information in these symbols
-            // 2) renaming tuple fields seems a complex enough thing to require some design
-            if (triggerSymbol.ContainingType?.IsTupleType == true)
-            {
-                return new FailureInlineRenameInfo(EditorFeaturesResources.You_cannot_rename_this_element);
-            }
-
             // If rename is invoked on a member group reference in a nameof expression, then the
             // RenameOverloads option should be forced on.
             var forceRenameOverloads = tokenRenameInfo.IsMemberGroup;

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2196,5 +2196,217 @@ class [|C|]
                 Await VerifyTagsAreCorrect(workspace, "BarGoo")
             End Using
         End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameTupleElement1(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="9.0">
+                            <Document>
+                                class C
+                                {
+                                    T M&lt;T&gt;(T a, T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = ([|$$a|]: t1, b: t2);
+                                      var ac = ([|a|], c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.[|a|]);
+                                      return default;
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "bcd")
+
+                session.Commit()
+
+                Await WaitForRename(workspace)
+                Dim replacedText = workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText()
+                Assert.Equal("
+                                class C
+                                {
+                                    T M<T>(T a, T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = (bcda: t1, b: t2);
+                                      var ac = (bcda, c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.bcda);
+                                      return default;
+                                    }
+                                }
+                            ", replacedText)
+
+                Await VerifyTagsAreCorrect(workspace, "bcda")
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameTupleElement2(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="9.0">
+                            <Document>
+                                class C
+                                {
+                                    T M&lt;T&gt;(T [|$$a|], T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = ([|a|]: t1, b: t2);
+                                      var ac = ([|a|], c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.[|a|]);
+                                      return default;
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "bcd")
+
+                session.Commit()
+
+                Await WaitForRename(workspace)
+                Dim replacedText = workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText()
+                Assert.Equal("
+                                class C
+                                {
+                                    T M<T>(T bcda, T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = (bcda: t1, b: t2);
+                                      var ac = (bcda, c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.bcda);
+                                      return default;
+                                    }
+                                }
+                            ", replacedText)
+
+                Await VerifyTagsAreCorrect(workspace, "abcd")
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameTupleElement3(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="9.0">
+                            <Document>
+                                class C
+                                {
+                                    T M&lt;T&gt;(T [|a|], T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = ([|a|]: t1, b: t2);
+                                      var ac = ([|$$a|], c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.[|a|]);
+                                      return default;
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "bcd")
+
+                session.Commit()
+
+                Await WaitForRename(workspace)
+                Dim replacedText = workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText()
+                Assert.Equal("
+                                class C
+                                {
+                                    T M<T>(T a, T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = (bcda: t1, b: t2);
+                                      var ac = (bcda, c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.bcda);
+                                      return default;
+                                    }
+                                }
+                            ", replacedText)
+
+                Await VerifyTagsAreCorrect(workspace, "abcd")
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameTupleElement4(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="9.0">
+                            <Document>
+                                class C
+                                {
+                                    T M&lt;T&gt;(T [|a|], T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = ([|a|]: t1, b: t2);
+                                      var ac = ([|a|], c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.[|$$a|]);
+                                      return default;
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "bcd")
+
+                session.Commit()
+
+                Await WaitForRename(workspace)
+                Dim replacedText = workspace.Documents.Single().GetTextBuffer().CurrentSnapshot.GetText()
+                Assert.Equal("
+                                class C
+                                {
+                                    T M<T>(T a, T t2)
+                                    {
+                                      T t1 = default;
+                                      var ab = (bcda: t1, b: t2);
+                                      var ac = (bcda, c: t2);
+                                      var x = M(ab, ac);
+                                      Console.WriteLine(x.bcda);
+                                      return default;
+                                    }
+                                }
+                            ", replacedText)
+
+                Await VerifyTagsAreCorrect(workspace, "abcd")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2130,5 +2130,71 @@ class [|C|]
                 Await VerifyTagsAreCorrect(workspace, "BarGoo")
             End Using
         End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameTupleElement_FromDeclaration(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="9.0">
+                            <Document>
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var g = ([|$$Goo|]: 1, Bar: 2);
+                                        var gb = g.[|Goo|];
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                ' Type a bit in the file
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "Bar")
+
+                session.Commit()
+
+                Await VerifyTagsAreCorrect(workspace, "BarGoo")
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameTupleElement_FromUse(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="9.0">
+                            <Document>
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var g = ([|Goo|]: 1, Bar: 2);
+                                        var gb = g.[|$$Goo|];
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                ' Type a bit in the file
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Insert(caretPosition, "Bar")
+
+                session.Commit()
+
+                Await VerifyTagsAreCorrect(workspace, "BarGoo")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3657,6 +3657,28 @@ class C
                 result.AssertLabeledSpansAre("conflict", type:=RelatedLocationType.UnresolvedConflict)
             End Using
         End Sub
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub ConflictWhenRenamingTupleField(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void M()
+    {
+        var x = ({|conflict:$$a|}: 1, {|conflict:b|});
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="b")
+
+                result.AssertLabeledSpansAre("conflict", type:=RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
     End Class
 End Namespace
 

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -215,7 +215,10 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             try
             {
                 var projectOpt = conflictResolution.CurrentSolution.GetProject(renamedSymbol.ContainingAssembly, cancellationToken);
-                if (renamedSymbol.ContainingSymbol.IsKind(SymbolKind.NamedType))
+
+                // For tuple fields the ContainingAssembly is System.ValueTuple, so we can't get a project
+                // but fortunately we know there are no methods or parameterized properties either
+                if (renamedSymbol.ContainingSymbol.IsKind(SymbolKind.NamedType) && !renamedSymbol.IsTupleField())
                 {
                     Contract.ThrowIfNull(projectOpt);
                     var otherThingsNamedTheSame = renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name)
@@ -267,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                 }
 
                 // Some types of symbols (namespaces, cref stuff, etc) might not have ContainingAssemblies
-                if (renamedSymbol.ContainingAssembly != null)
+                if (renamedSymbol.ContainingAssembly != null && !renamedSymbol.IsTupleField())
                 {
                     Contract.ThrowIfNull(projectOpt);
                     // There also might be language specific rules we need to include


### PR DESCRIPTION
Fixes #14115 as a follow up to https://github.com/dotnet/roslyn/pull/48914

This covers the more advanced tuple field rename scenarios.