### PR TITLE
Avoid creating dependent slots in NullableWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Force a variable to have a slot.  Returns -1 if the variable has an empty struct type.
         /// </summary>
-        protected virtual int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
+        protected virtual int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false, bool createIfMissing = true)
         {
             Debug.Assert(containingSlot >= 0);
             Debug.Assert(symbol != null);
@@ -139,6 +139,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Since analysis may proceed in multiple passes, it is possible the slot is already assigned.
             if (!_variableSlot.TryGetValue(identifier, out slot))
             {
+                if (!createIfMissing)
+                {
+                    return -1;
+                }
+
                 var variableType = symbol.GetTypeOrReturnType().Type;
                 if (!forceSlotEvenIfEmpty && IsEmptyStructType(variableType))
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1369,19 +1369,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#if DEBUG
 #if REPORT_MAX
-        private static (Symbol, int) _maxSlots;
+        private static (Symbol symbol, int slots) s_maxSlots;
+#endif
 #endif
 
         private SharedWalkerState SaveSharedState()
         {
+#if DEBUG
 #if REPORT_MAX
             int slots = _variableSlot.Count;
-            if (slots > _maxSlots.Item2)
+            if (slots > s_maxSlots.slots)
             {
-                _maxSlots = (_symbol, slots);
+                s_maxSlots = (_symbol, slots);
                 Debug.WriteLine("{0}: {1}", slots, _symbol);
             }
+#endif
 #endif
             return new SharedWalkerState(
                 _variableSlot.ToImmutableDictionary(),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -2068,7 +2068,12 @@ class C
 }
 ");
             c.VerifyDiagnostics(
-                );
+                // (13,17): warning CS8602: Dereference of a possibly null reference.
+                //                 c.c.c.c.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.c.c").WithLocation(13, 17),
+                // (13,17): warning CS8602: Dereference of a possibly null reference.
+                //                 c.c.c.c.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.c.c.c").WithLocation(13, 17));
         }
 
         [Fact]


### PR DESCRIPTION
Avoid creating dependent slots in `NullableWalker.MarkDependentSlotsNotNull`.

When compiling src/Compilers/CSharp/Portable, reduces elapsed time by ~13% and reduces total allocations by ~20%.